### PR TITLE
generalize timestamp

### DIFF
--- a/cellpy/readers/instruments/arbin_sql.py
+++ b/cellpy/readers/instruments/arbin_sql.py
@@ -114,14 +114,14 @@ normal_headers_renaming_dict = {
 
 
 def from_arbin_to_datetime(n):
-    # This is a hack that I have not verified yet
-    # (what is so special with 1976.08.23? I have only encountered 1900.01.01 and 1970.01.01 before)
-    # (or is the internal clock in our arbin machine set to 2014?)
-    n /= 1_000_000_000_000
-    temp = datetime.datetime(1976, 8, 23)
-    delta = datetime.timedelta(days=n)
-    time_object = temp + delta
-    time_in_str = time_object.strftime("%y-%m-%d %H:%M:%S:%f")
+    if isinstance(n, int):
+        n = str(n)
+
+    ms_component = n[-7:]
+    date_time_component = n[:-7]
+    temp = f"{date_time_component}.{ms_component}"
+    datetime_object = datetime.datetime.fromtimestamp(float(temp))
+    time_in_str = datetime_object.strftime("%y-%m-%d %H:%M:%S:%f")
     return time_in_str
 
 


### PR DESCRIPTION
Quick functionality to get the correct timestamp on any machine. This timestamp is formatted pretty poorly inside this database.

I have a bunch of other functionality ive discovered this past week Id love to contribute once its more formalised.

Let me know what you guys think here....workflow was pretty much as follows:

I had a test that started on July 1st 2022...

the arbin timestamps in the database look like this: 16566949984405000
Now to convert...
```py
>>> datetime.fromtimestamp(16566949984405000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: year 524987715 is out of range
```

3 decimal places in...
```py
>>> datetime.fromtimestamp(16566949984405.000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: year 526955 is out of range
```

3 more in...
```py
>>> datetime.fromtimestamp(16566949984.405000)
datetime.datetime(2494, 12, 25, 21, 33, 4, 405001)
```

turns out its 7 decimal points...
```
>>> datetime.fromtimestamp(1656694998.4405000)
datetime.datetime(2022, 7, 1, 13, 3, 18, 440500)
```