### PR TITLE
Update simple_reader_cellpy.py

### DIFF
--- a/examples/simple_reader_cellpy.py
+++ b/examples/simple_reader_cellpy.py
@@ -51,5 +51,5 @@ summary = d.cell.summary
 print(summary.head())
 
 fig, ax = plt.subplots(1, 1)
-ax.plot(summary["Cycle_Index"], summary["Cumulated_Coulombic_Difference(mAh/g)"])
+ax.plot(summary.index, summary["cumulated_coulombic_difference_u_mAh_g"])
 plt.show()


### PR DESCRIPTION
Using `summary["Cycle_Index"]` would result in https://github.com/jepegit/cellpy/issues/228 and likewise `summary["Cumulated_Coulombic_Difference(mAh/g)"]`. Adding
`print(summary.columns)`
show possible column names,
```
Index(['data_point', 'test_time', 'date_time', 'end_voltage_charge_u_V',
       'end_voltage_discharge_u_V', 'charge_capacity', 'discharge_capacity',
       'discharge_capacity_u_mAh_g', 'charge_capacity_u_mAh_g',
       'cumulated_discharge_capacity_u_mAh_g',
       'cumulated_charge_capacity_u_mAh_g',
       'coulombic_efficiency_u_percentage', 'coulombic_difference_u_mAh_g',
       'cumulated_coulombic_efficiency_u_percentage',
       'cumulated_coulombic_difference_u_mAh_g',
       'discharge_capacity_loss_u_mAh_g',
       'cumulated_discharge_capacity_loss_u_mAh_g',
       'charge_capacity_loss_u_mAh_g',
       'cumulated_charge_capacity_loss_u_mAh_g', 'low_level_u_percentage',
       'high_level_u_percentage', 'cumulated_ric_u_none',
       'cumulated_ric_sei_u_none', 'cumulated_ric_disconnect_u_none',
       'shifted_charge_capacity_u_mAh_g', 'shifted_discharge_capacity_u_mAh_g',
       'normalized_cycle_index', 'charge_c_rate', 'discharge_c_rate'],
      dtype='object')
```
which is use to replace the previous column keys.

Test on 
openSUSE Tumbleweed 20221107
Spyder 5.4.0
Python version: 3.10.8
cellpy: 0.4.2.post1
pandas: 1.5.1