### PR TITLE
Add basic support for reading parquet for custom instruments

### DIFF
--- a/cellpy/readers/instruments/custom.py
+++ b/cellpy/readers/instruments/custom.py
@@ -113,6 +113,9 @@ class DataLoader(AutoLoader, ABC):
                 "table_name", default_value="sheet 1", **kwargs
             )
 
+        elif self.file_format == "parquet":
+            self.engine = self._config_sub_parser("engine", default_value='auto', **kwargs)
+
         elif self.file_format == "json":
             print("json not implemented yet")
             sys.exit()
@@ -179,6 +182,15 @@ class DataLoader(AutoLoader, ABC):
                 logging.debug(f"read sheet: {sheet_name}")
                 return raw_frame[matching[0]]
             raise IOError(f"Could not find the sheet {sheet_name} in {name}")
+
+        elif self.file_format == 'parquet':
+            logging.debug(f"parsing with pandas.read_parquet: {name}")
+            logging.critical(
+                f"{self.engine=}"
+            )
+            data_df = pd.read_parquet(
+                path=name, engine=self.engine,
+            )
 
         elif self.file_format == "json":
             raise IOError(


### PR DESCRIPTION
This PR adds basic support for parquet-files for custom instruments, in addition to the already existing formats .csv, .xls and .xlsx, through the use of the pandas.read_parquet().

Only allows specification of the engine (auto (default), pyarrow or fastparquet), but additional parameters could be added later if needed.

Have not included any additional requirements, as the relevant engine is imported from within pandas, but if file_format is set to parquet in the instrument YAML-file without the user having installed either pyarrow or fastparquet, it will fail.  


