### PR TITLE
Add option to specify custom_log_path and path to logging config json…

### DIFF
--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -6400,6 +6400,8 @@ def get(
     area: Union[str, numbers.Number] = None,
     estimate_area=True,
     logging_mode=None,
+    custom_log_dir=None,
+    custom_log_config_path=None,
     auto_pick_cellpy_format=True,
     auto_summary=True,
     units=None,
@@ -6508,7 +6510,7 @@ def get(
     summary_kwargs = summary_kwargs or {}
     load_cellpy_file = False
     logging_mode = "DEBUG" if testing else logging_mode
-    log.setup_logging(default_level=logging_mode, testing=testing)
+    log.setup_logging(default_level=logging_mode, testing=testing, custom_log_dir=custom_log_dir, default_json_path=custom_log_config_path)
     logging.debug("-------running-get--------")
     cellpy_instance = CellpyCell(debug=debug, initialize=initialize)
     logging.debug(f"created CellpyCell instance")


### PR DESCRIPTION
… in get()

This PR closes #325 and adds the option to specify `custom_log_path` and `default_json_path` in `log.setup_logger()` when calling `cellpy.readers.cellreader.get()`. The keyword for `default_json_path` in `get()` was changed to `custom_log_config_path` to make it more clear.