### PR TITLE
fix bug in pands.ExcelWriter call

### DIFF
--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -3414,6 +3414,8 @@ class CellpyCell:
         if get_cap_kwargs is not None:
             get_cap_method_kwargs.update(get_cap_kwargs)
 
+        print(externals)
+
         border = externals.openpyxl.styles.Border()
         face_color = "00EEEEEE"
         meta_alignment_left = externals.openpyxl.styles.Alignment(horizontal="left", vertical="bottom")
@@ -3437,7 +3439,7 @@ class CellpyCell:
 
         meta_common_frame = externals.pandas.concat([meta_common_frame, cellpy_units, raw_units])
 
-        with externals.pandas.ExcelWriter(filename, engine="externals.openpyxl") as writer:
+        with externals.pandas.ExcelWriter(filename, engine="openpyxl") as writer:
             meta_common_frame.to_excel(writer, sheet_name="meta_common", **to_excel_method_kwargs)
             meta_test_dependent_frame.to_excel(writer, sheet_name="meta_test_dependent", **to_excel_method_kwargs)
             summary_frame.to_excel(writer, sheet_name="summary", **to_excel_method_kwargs)

--- a/tests/test_cell_readers.py
+++ b/tests/test_cell_readers.py
@@ -835,6 +835,28 @@ def test_save_cvs(cellpy_data_instance, parameters):
     # assert not os.path.isfile(tmp_file)
 
 
+def test_save_excel(cellpy_data_instance, parameters):
+    cellpy_data_instance.from_raw(parameters.res_file_path)
+    cellpy_data_instance.make_summary(find_ir=True)
+    cellpy_data_instance.make_step_table()
+    temp_dir = pathlib.Path(tempfile.mkdtemp())
+    filename = temp_dir / "test.xlsx"
+    cellpy_data_instance.to_excel(
+        filename=filename,
+        cycles=None,
+        raw=False,
+        steps=True,
+        nice=True,
+        get_cap_kwargs=None,
+        to_excel_kwargs=None,
+    )
+    shutil.rmtree(temp_dir)
+    # cellpy_data_instance.save(tmp_file)
+    # assert os.path.isfile(tmp_file)
+    # os.remove(tmp_file)
+    # assert not os.path.isfile(tmp_file)
+
+
 def test_str_cellpy_data_object(dataset):
     assert str(dataset.data).find("silicon") >= 0
     assert str(dataset.data).find("rosenborg") < 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch Excel exports to use the openpyxl engine and add a test to validate to_excel.
> 
> - **Excel export**:
>   - Use `pandas.ExcelWriter(..., engine="openpyxl")` in `cellpy/readers/cellreader.py` for `.to_excel`.
> - **Tests**:
>   - Add `test_save_excel` to verify `.to_excel` writes an `.xlsx` file successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ca1412ab3daa55f1ed49a64b1f034e0d2732e44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->