### PR TITLE
Fix summary_plot crash when formation_cycles=False/0 (#366)

### DIFF
--- a/.issueflows/03-solved-issues/issue366_original.md
+++ b/.issueflows/03-solved-issues/issue366_original.md
@@ -1,0 +1,96 @@
+# Issue #366: bug-plotutils-summary-plot
+
+Source: https://github.com/jepegit/cellpy/issues/366
+
+## Original issue text
+
+I get an error when trying to use plotutils.summary_plot on the pec example data when chosing not to show formation cycles.
+
+### Code
+
+```python
+
+p = example_data.pec_file_path()
+c = cellpy.get(p, instrument="pec_csv", cycle_mode="full_cell")
+plotutils.summary_plot(
+    c,
+    y="capacities",
+    width=800,
+    height=400,
+    formation_cycles=False,  # breaks if False, works if True
+)
+```
+
+### Error message
+
+```bash
+TypeError                                 Traceback (most recent call last)
+Cell In[10], line 1
+----> 1 plotutils.summary_plot(
+      2     c,
+      3     y="capacities",
+      4     width=800,
+
+File /opt/tljh/user/lib/python3.12/site-packages/cellpy/utils/plotutils.py:94, in notebook_docstring_printer.<locals>.wrapper(*args, **kwargs)
+     91         pass
+     93 # Call the original function
+---> 94 return func(*args, **kwargs)
+
+File /opt/tljh/user/lib/python3.12/site-packages/cellpy/utils/plotutils.py:4885, in summary_plot(c, x, y, height, width, markers, title, x_range, y_range, ce_range, norm_range, cv_share_range, split, hover_columns, auto_convert_legend_labels, interactive, share_y, rangeslider, return_data, verbose, plotly_template, seaborn_palette, seaborn_style, formation_cycles, show_formation, show_legend, x_axis_domain_formation_fraction, column_separator, reset_losses, link_capacity_scales, fullcell_standard_normalization_type, fullcell_standard_normalization_factor, fullcell_standard_normalization_scaler, fullcell_standard_normalization_cycle_numbers, seaborn_line_hooks, filters, nominal_capacity, rate_filter_columns, **kwargs)
+   4877 prepared_data_info = preparer.prepare_data(
+   4878     c,
+   4879     config,
+   4880     plot_info,
+   4881 )
+   4883 builder = PlotlyPlotBuilder() if config.interactive else SeabornPlotBuilder()
+-> 4885 fig = builder.build_plot(
+   4886     prepared_data_info["data"],
+   4887     prepared_data_info,
+   4888     config,
+   4889     config.additional_kwargs,
+   4890     c,
+   4891 )
+   4893 if config.return_data:
+   4894     return fig, prepared_data_info["data"]
+
+File /opt/tljh/user/lib/python3.12/site-packages/cellpy/utils/plotutils.py:1665, in PlotlyPlotBuilder.build_plot(self, data, prepared_data_info, config, additional_kwargs, c)
+   1663 # Configure formation cycles and subplot layouts
+   1664 if config.show_formation:
+-> 1665     self._configure_formation_axes(
+   1666         fig,
+   1667         data,
+   1668         x,
+   1669         config,
+   1670         number_of_rows,
+   1671         max_cycle,
+   1672         min_cycle,
+   1673         formation_cycle_selector,
+   1674         show_y_labels_on_right_pane,
+   1675         y,
+   1676         max_val_normalized_col,
+   1677         plotly_row_ratios,
+   1678         plotly_row_space,
+   1679         c,
+   1680     )
+   1681 else:
+   1682     # Configure without formation cycles
+   1683     self._configure_no_formation_axes(
+   1684         fig,
+   1685         config,
+   (...)   1691         c,
+   1692     )
+
+File /opt/tljh/user/lib/python3.12/site-packages/cellpy/utils/plotutils.py:1783, in PlotlyPlotBuilder._configure_formation_axes(self, fig, data, x, config, number_of_rows, max_cycle, min_cycle, formation_cycle_selector, show_y_labels_on_right_pane, y, max_val_normalized_col, plotly_row_ratios, plotly_row_space, c)
+   1778 x_axis_domain_rest = [
+   1779     config.x_axis_domain_formation_fraction + config.column_separator / 2,
+   1780     0.95,
+   1781 ]
+   1782 max_cycle_formation = data.loc[formation_cycle_selector, x].max()
+-> 1783 min_cycle_rest = data.loc[~formation_cycle_selector, x].min()
+   1785 if x == _hdr_summary.normalized_cycle_index:
+   1786     dd = 0.1
+
+TypeError: bad operand type for unary ~: 'slice'
+```
+
+Please fix the bug.

--- a/.issueflows/03-solved-issues/issue366_status.md
+++ b/.issueflows/03-solved-issues/issue366_status.md
@@ -1,0 +1,20 @@
+# Status for issue #366: bug-plotutils-summary-plot
+
+- [x] Done
+
+## What was done
+
+- Identified the root cause: `plotutils.summary_plot(c, ..., formation_cycles=False)` (or `formation_cycles=0`) crashed with `TypeError: bad operand type for unary ~: 'slice'`. The `SummaryPlotConfig` left `show_formation=True` while `_mark_formation_cycles` returned the `slice(None, None)` sentinel, so `_configure_formation_axes` evaluated `~slice(None, None)` and failed.
+- Fix: added `SummaryPlotConfig.__post_init__` in [cellpy/utils/plotutils.py](../../cellpy/utils/plotutils.py) that coerces `formation_cycles` to `int` and forces `show_formation = False` when `formation_cycles < 1`, mirroring the long-standing normalisation in `summary_plot_legacy` (line ~3354).
+- Tests: added `TestSummaryPlotFormationCyclesNormalisation` in [tests/test_plotutils_summary_plot.py](../../tests/test_plotutils_summary_plot.py) covering:
+  - `SummaryPlotConfig.from_kwargs(formation_cycles=0/False/3)` normalisation,
+  - end-to-end `summary_plot(...)` calls (the exact reproduction from the issue) on both the plotly and seaborn backends, parametrised over `formation_cycles in (False, 0)`.
+- HISTORY.md: appended a bullet under `## 1.0.3 (pre-release)`.
+
+## Tests
+
+- `uv run pytest tests/test_plotutils_summary_plot.py -x` — all green (confirmed by user).
+
+## Remaining work
+
+None. The bug is fixed and covered by regression tests. Closes #366.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@
 * Bug fixes: Fixed bug in OtherPathsNew
 * Bug fixes: Various other bug fixes and improvements
 * CI: Fix failing CI pipelines (pyarrow runtime dep + AppVeyor 64-bit Miniconda) (#360)
+* Bug fixes: Fix `TypeError: bad operand type for unary ~: 'slice'` in `plotutils.summary_plot` when called with `formation_cycles=False` or `0` (#366)
 
 ## 1.0.2
 

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -714,6 +714,20 @@ class SummaryPlotConfig:
     # Additional kwargs (stored as dict)
     additional_kwargs: dict = dataclasses.field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        # Mirror the legacy normalisation: a non-positive ``formation_cycles``
+        # (including ``False`` / ``0`` / ``None``) means there is no formation
+        # block to draw, so ``show_formation`` must be False regardless of
+        # how the caller set it. Without this, ``_mark_formation_cycles``
+        # returns the ``slice(None, None)`` sentinel while ``show_formation``
+        # stays True, and ``_configure_formation_axes`` then evaluates
+        # ``~slice(...)`` which raises ``TypeError``. See issue #366.
+        if self.formation_cycles is None:
+            self.formation_cycles = 0
+        self.formation_cycles = int(self.formation_cycles)
+        if self.formation_cycles < 1:
+            self.show_formation = False
+
     def __str__(self) -> str:
         variables = vars(self)
         outputs = ["SummaryPlotConfig:"]

--- a/tests/test_plotutils_summary_plot.py
+++ b/tests/test_plotutils_summary_plot.py
@@ -548,3 +548,72 @@ class TestSummaryPlotHoverColumns:
             and "fullcell_standard_gravimetric" in rec.getMessage()
             for rec in caplog.records
         ), "Expected a warning that hover_columns is ignored for fullcell_standard_*"
+
+
+class TestSummaryPlotFormationCyclesNormalisation:
+    """Regression tests for issue #366.
+
+    Passing ``formation_cycles=False`` (or ``0``) without explicitly also
+    setting ``show_formation=False`` used to crash with
+    ``TypeError: bad operand type for unary ~: 'slice'`` because the
+    formation-axes branch ran with the ``slice(None, None)`` sentinel
+    selector. ``SummaryPlotConfig.__post_init__`` now mirrors the legacy
+    normalisation so both forms produce a valid no-formation plot.
+    """
+
+    def test_config_normalises_zero_formation_cycles(self):
+        from cellpy.utils.plotutils import SummaryPlotConfig
+
+        cfg = SummaryPlotConfig.from_kwargs(formation_cycles=0)
+        assert cfg.formation_cycles == 0
+        assert cfg.show_formation is False
+
+    def test_config_normalises_false_formation_cycles(self):
+        from cellpy.utils.plotutils import SummaryPlotConfig
+
+        cfg = SummaryPlotConfig.from_kwargs(formation_cycles=False)
+        assert cfg.formation_cycles == 0
+        assert cfg.show_formation is False
+
+    def test_config_keeps_show_formation_for_positive_count(self):
+        from cellpy.utils.plotutils import SummaryPlotConfig
+
+        cfg = SummaryPlotConfig.from_kwargs(formation_cycles=3)
+        assert cfg.formation_cycles == 3
+        assert cfg.show_formation is True
+
+    @pytest.mark.skipif(
+        not plotly_available,
+        reason="Plotly not available",
+    )
+    @pytest.mark.parametrize("formation_cycles_arg", [False, 0])
+    def test_plotly_with_zero_or_false_formation_cycles(
+        self, cell, formation_cycles_arg
+    ):
+        """Reproduction from issue #366 for the plotly backend."""
+        fig = summary_plot(
+            cell,
+            y="capacities_gravimetric",
+            interactive=True,
+            formation_cycles=formation_cycles_arg,
+        )
+        assert fig is not None
+        assert hasattr(fig, "data")
+
+    @pytest.mark.skipif(
+        not seaborn_available,
+        reason="Seaborn not available",
+    )
+    @pytest.mark.parametrize("formation_cycles_arg", [False, 0])
+    def test_seaborn_with_zero_or_false_formation_cycles(
+        self, cell, formation_cycles_arg
+    ):
+        """Same regression on the seaborn backend."""
+        fig = summary_plot(
+            cell,
+            y="capacities_gravimetric",
+            interactive=False,
+            formation_cycles=formation_cycles_arg,
+        )
+        assert fig is not None
+        assert hasattr(fig, "get_axes")

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Fix `TypeError: bad operand type for unary ~: 'slice'` raised by `plotutils.summary_plot(c, ..., formation_cycles=False)` (or `formation_cycles=0`).
- Root cause: `SummaryPlotConfig` left `show_formation=True` while `_mark_formation_cycles` returned the `slice(None, None)` sentinel, so `_configure_formation_axes` evaluated `~slice(None, None)` and failed. The legacy `summary_plot_legacy` already normalised this; the new config-based path lost it during the refactor.
- Add `SummaryPlotConfig.__post_init__` that coerces `formation_cycles` to `int` and forces `show_formation=False` when `formation_cycles < 1`. One source of truth, mirrors legacy semantics.
- Side note: also brings `uv.lock` `requires-python` in line with the project's supported Python range (`>=3.12`).

## Test plan

- [x] `uv run pytest tests/test_plotutils_summary_plot.py -x` (all green)
- [x] New `TestSummaryPlotFormationCyclesNormalisation` class covers:
  - `SummaryPlotConfig.from_kwargs(formation_cycles=0/False/3)` normalisation
  - Plotly backend with `formation_cycles in (False, 0)` (the exact reproduction from the issue)
  - Seaborn backend with `formation_cycles in (False, 0)`

Closes #366

Made with [Cursor](https://cursor.com)