### PR TITLE
Exporters: bdf_units= keyword to control target units in to_bdf (#365)

### DIFF
--- a/.issueflows/03-solved-issues/issue365_original.md
+++ b/.issueflows/03-solved-issues/issue365_original.md
@@ -1,0 +1,9 @@
+# Issue #365: units when exporting in bdf
+
+Source: https://github.com/jepegit/cellpy/issues/365
+
+## Original issue text
+
+Is it possible to specify units when using .to_bdf exporter?
+If not could you implement it. For example by adding a keyword argument that takes a CellpyUnit object?
+And also provide an example in the doc-string on how to do it. 

--- a/.issueflows/03-solved-issues/issue365_plan.md
+++ b/.issueflows/03-solved-issues/issue365_plan.md
@@ -1,0 +1,130 @@
+# Plan for issue #365: units when exporting in bdf
+
+## Goal
+
+Let callers of `CellpyCell.to_bdf` (and the underlying `cellpy.exporters.bdf.to_bdf`) pass a `CellpyUnits` object as a keyword argument that controls the **units written into the BDF file** (both column labels and column values). When omitted, current behaviour is unchanged — strict BDF spec units (`A`, `V`, `Ah`, `Wh`, `s`, `W`, `ohm`).
+
+> **Important**: providing this kwarg with anything other than the BDF defaults makes the file *not strictly BDF-compliant* (BDF locks units per column). We accept that explicitly — same trade-off the existing `extras=True` knob already makes — and call it out in the docstring and design doc.
+
+## Constraints
+
+- KISS: one new kwarg, one helper to synthesize column labels from a unit symbol; no new public class.
+- Back-compat: existing callers that omit the new kwarg get **byte-for-byte identical** output (same labels, same machine names, same values).
+- Layering rule from `.issueflows/04-designs-and-guides/bdf-export.md` stays intact: `cellreader` → `exporters` → `filters` → `internal_settings`; no `cellpy.utils` import.
+- Do not mutate the passed-in `CellpyUnits` object and do not mutate `cell.cellpy_units`.
+- Fail loud, not silent: if the user's unit symbol is not pint-compatible with the underlying dimension (e.g. `charge="kg"`), raise — do *not* fall back to factor 1.0 (the current pint-failure branch is only safe for *spec defaults* and quietly emits wrong values otherwise).
+
+## Approach
+
+### Column map refactor (small, local)
+
+`_COLUMN_MAP` rows currently embed the BDF default label and machine name as constants:
+
+```python
+_BdfColumn("charge_capacity_txt", "Charging Capacity / Ah", "charging_capacity_ah", "optional", "charge", "Ah"),
+```
+
+Split the label into a unitless **base** plus the unit symbol so we can rebuild both forms for any unit:
+
+```python
+_BdfColumn(
+    cellpy_field="charge_capacity_txt",
+    base_preferred="Charging Capacity",     # no unit
+    base_machine="charging_capacity",       # no unit suffix
+    tier="optional",
+    unit_kind="charge",
+    bdf_unit="Ah",                          # BDF spec default
+)
+```
+
+Add a tiny helper:
+
+```python
+def _resolve_column_names(spec, effective_unit):
+    # Byte-for-byte identical to today when effective_unit == bdf_unit.
+    if effective_unit is None:
+        return f"{spec.base_preferred} / 1", spec.base_machine
+    if effective_unit == spec.bdf_unit:
+        return _BDF_DEFAULT_LABELS[spec.cellpy_field]   # frozen pairs
+    return (
+        f"{spec.base_preferred} / {effective_unit}",
+        f"{spec.base_machine}_{_slug(effective_unit)}",
+    )
+```
+
+`_BDF_DEFAULT_LABELS` is a frozen `dict` keyed by `cellpy_field` holding the exact strings we ship today (`"Charging Capacity / Ah"`, `"charging_capacity_ah"`, ...). That guarantees the no-override path is unchanged and pins the existing BDF-spec spellings (which are inconsistent: `volt`, `ampere`, `watt` vs `ah`, `wh`, `ohm` — we keep them, don't try to "fix" them).
+
+`_slug(unit)` lowercases and strips non-alphanumerics: `"mAh" → "mah"`, `"kWh" → "kwh"`, `"min" → "min"`.
+
+### Entry point (`cellpy/exporters/bdf.py:to_bdf`)
+
+- Add `bdf_units: Optional[CellpyUnits] = None` kwarg (name choice — see open questions; `bdf_units` is my recommendation, but I'll change to whatever you pick).
+- Build an `effective_unit_map: dict[unit_kind, str]` (e.g. `{"charge": "mAh", "current": "A", ...}`):
+  - default: read each `unit_kind` from `_BDF_DEFAULT_TARGET_UNITS` (== the current `bdf_unit` per column);
+  - when `bdf_units is not None`: for each unit kind present on `CellpyUnits`, look it up and override the default.
+- Pass `effective_unit_map` into `_build_bdf_frame`.
+- Re-purpose `_conversion_factor`: factor = ratio from `cell.cellpy_units` to `effective_unit_map[unit_kind]`. The pint call is the same shape as today; only the second argument changes.
+- On pint failure with an explicit override, raise `ValueError("to_bdf: cannot convert charge from 'mAh' to 'kg': ...")`. With no override (legacy path), keep today's warn-and-skip-conversion behaviour intact.
+
+### Class layer (`cellpy/readers/cellreader.py:CellpyCell.to_bdf`)
+
+- Add the same `bdf_units=None` kwarg and forward to `_to_bdf(...)`.
+- Docstring update — add the `Args:` entry and an Example block:
+
+  ```python
+  from cellpy.parameters.internal_settings import CellpyUnits
+
+  custom = CellpyUnits(charge="mAh", current="mA")
+  cell.to_bdf("out.bdf.csv", bdf_units=custom)
+  # column headers become "Charging Capacity / mAh", "Current / mA"
+  # values are scaled to mAh / mA accordingly
+  ```
+
+- Mirror the example in `cellpy/exporters/bdf.py:to_bdf`'s docstring as the issue explicitly requested.
+
+### Design doc (`.issueflows/04-designs-and-guides/bdf-export.md`)
+
+- New short subsection under "Unit conversion" titled e.g. **"Overriding target units (`bdf_units=`)"**, explaining: (a) what it does, (b) that it produces a non-strictly-BDF file (parallel to `extras=True`), (c) failure mode on incompatible units. Cross-link to issue #365.
+- Add a Q7 row to the **Locked decisions** table: target unit override knob, default = strict BDF spec.
+
+## Files to touch
+
+- `cellpy/exporters/bdf.py` — refactor `_BdfColumn` fields, add `_resolve_column_names` + `_slug` + `_BDF_DEFAULT_LABELS` + `_BDF_DEFAULT_TARGET_UNITS`, add `bdf_units` kwarg, strict-failure on incompatible units, docstring example.
+- `cellpy/readers/cellreader.py` — pass-through kwarg on `CellpyCell.to_bdf`, docstring example.
+- `tests/test_exporters_bdf.py` — new tests (see below).
+- `.issueflows/04-designs-and-guides/bdf-export.md` — Q7 row, target-unit subsection, cross-link to #365.
+
+## Test strategy
+
+Re-run the existing exporters suite first to confirm no regression from the refactor:
+
+```bash
+uv run pytest tests/test_exporters_bdf.py -q
+```
+
+Add the following targeted tests to `tests/test_exporters_bdf.py`:
+
+- `test_bdf_units_none_matches_default_path` — explicit `bdf_units=None` produces a frame identical to the default-kwarg call (same columns, same values).
+- `test_bdf_units_overrides_charge_to_mAh` — pass `CellpyUnits(charge="mAh")`; expect column `Charging Capacity / mAh` (machine: `charging_capacity_mah`) with values 100x the `Ah` values (since the synthetic cell's source charge is mAh, factor 1.0, but the *label* changes to mAh and values stay raw mAh).
+- `test_bdf_units_overrides_current_to_mA` — pass `CellpyUnits(current="mA")`, source `cell.cellpy_units.current == "A"`. Expect `Current / mA` column with values 1000× the `A` values. Header machine name = `current_ma`.
+- `test_bdf_units_overrides_time_to_minutes` — `CellpyUnits(time="min")`; expect `Test Time / min` and values divided by 60.
+- `test_bdf_units_does_not_mutate_inputs` — capture cell + passed-in `CellpyUnits` before and after; assert neither mutated.
+- `test_bdf_units_incompatible_unit_raises` — pass `CellpyUnits(charge="kg")`; expect `ValueError` mentioning `charge`, `mAh`, `kg`.
+- `test_bdf_units_partial_override_keeps_defaults` — `CellpyUnits(charge="mAh")` only; assert `Voltage / V` and `Current / A` columns are unchanged (still BDF defaults, byte-for-byte against the no-override output).
+
+Wider sweep at close-time:
+
+```bash
+uv run pytest tests/test_exporters_bdf.py tests/test_filters_cycles.py -q
+```
+
+## Open questions
+
+1. **Kwarg name**: my proposal is `bdf_units` ("what units do I want in the BDF file?"). Alternatives:
+   - `output_units` — general but loses the BDF context;
+   - `cellpy_units` — matches the type name but collides with `cell.cellpy_units` (which is the *source* unit set);
+   - `target_units` — accurate but a bit jargon-y.
+   **Pick one.**
+2. **Failure on incompatible unit**: I propose hard-fail (`ValueError`) when the user explicitly overrides to a unit pint cannot convert. Today's silent factor-1.0 fallback only fires on weird custom units in the spec-default path. **OK to fail loud?**
+3. **Strict-BDF flag in the file?** Should we (optionally) emit a small log warning like `"to_bdf: bdf_units override active — file is not strictly BDF-compliant (Charging Capacity in mAh, expected Ah)"`? Mirrors what `extras=True` logs. **OK to add?**
+4. **`CellpyUnits` fields we ignore**: the column map only uses `current`, `voltage`, `time`, `charge`, `energy`, `power`, `resistance`. Other `CellpyUnits` fields (`mass`, `nominal_capacity`, `specific_*`, `temperature`, `pressure`, `frequency`, ...) are silently ignored by `to_bdf` today and stay ignored. **Confirm we don't try to surface temperature / pressure here — that's already listed as out of scope in the design doc.**

--- a/.issueflows/03-solved-issues/issue365_status.md
+++ b/.issueflows/03-solved-issues/issue365_status.md
@@ -1,0 +1,50 @@
+# Status for issue #365: units when exporting in bdf
+
+- [x] Done
+
+## Summary
+
+Added a `bdf_units` keyword argument to `cellpy.exporters.bdf.to_bdf` and `CellpyCell.to_bdf` so callers can control the **units written into the BDF file**. Default behaviour (no kwarg) is unchanged — strict BDF spec.
+
+## What landed
+
+- **`cellpy/exporters/bdf.py`**
+  - `_BdfColumn` now carries canonical BDF spec spellings (`preferred`, `machine`) plus unit-less stems (`base_preferred`, `base_machine`) so non-default unit labels can be synthesized without touching the spec defaults.
+  - New helpers: `_slug`, `_is_unit_equivalent`, `_resolve_column_name`, `_resolve_target_units`.
+  - `_conversion_factor` gained a `strict` flag — when a `bdf_units` override is active it raises `ValueError` on pint-incompatible units rather than silently leaving values unchanged.
+  - `to_bdf` gained `bdf_units: Optional[CellpyUnits] = None`. When set, column labels and values are rebuilt per unit kind; one INFO line announces the file is no longer strictly BDF-compliant.
+  - Worked example added to the docstring (mAh / mA scenario).
+
+- **`cellpy/readers/cellreader.py`**
+  - `CellpyCell.to_bdf` forwards the new `bdf_units` kwarg and mirrors the docstring example.
+
+- **`tests/test_exporters_bdf.py`**
+  - Fresh `CellpyUnits()` per cell in `_make_synthetic_cell` to stop pre-existing leakage from the module-level `cellpy_units` singleton between tests.
+  - 9 new tests: explicit `bdf_units=None` matches default; override charge to mAh (preferred + machine styles); override current to mA; override time to min; partial override keeps unrelated columns byte-for-byte at BDF default; no mutation of `cell.cellpy_units` or the passed-in object; pint-incompatible unit raises; pint-equivalent override keeps canonical label; INFO log on non-strict path.
+
+- **`.issueflows/04-designs-and-guides/bdf-export.md`**
+  - New Q7 row in the *Locked decisions* table.
+  - New **Overriding target units (`bdf_units=`)** subsection under *Unit conversion* with semantics, equivalence rule, failure mode, and pointers to the new helpers; cross-linked to issue #365.
+
+## Tests
+
+`pytest tests/test_exporters_bdf.py -q` → 32 passed locally (31 existing + 9 new − 8 that were already there is the wrong math; actual: 23 pre-existing + 9 new = 32 passed).
+
+## Plan deviations
+
+None. All four `Open questions` resolved as recommended in the plan:
+
+1. Kwarg name: `bdf_units`.
+2. Hard-fail (`ValueError`) on pint-incompatible units when override is active.
+3. Single INFO log line when override is active.
+4. Non-BDF `CellpyUnits` fields stay ignored (out-of-scope per design doc).
+
+One small fixture fix snuck in: `_make_synthetic_cell` now assigns a fresh `CellpyUnits()` to each cell, which sidesteps the pre-existing module-level singleton leak that surfaced when a new test asserted on `cell.cellpy_units.current` defaults. Pre-existing tests unaffected (they mutate `cell.cellpy_units.<field>` per-cell, which still works on the per-cell instance).
+
+## Remaining work
+
+- Run the wider suite at `/issue-close` time.
+- Optional follow-ups (still out of scope here, recorded in the design doc):
+  - Surfacing BDF temperature / pressure columns when `HeadersNormal` grows them.
+  - BDF metadata sidecar (`.json` / `.jsonld`).
+  - Batch-utility `to_bdf` entry point.

--- a/.issueflows/04-designs-and-guides/bdf-export.md
+++ b/.issueflows/04-designs-and-guides/bdf-export.md
@@ -66,6 +66,7 @@ Defining points relevant to cellpy:
 | Q4 | Scope | n/a | raw time-series only; steps/summary/metadata/batch deferred |
 | Q5 | Missing columns | n/a | hard-fail on missing *required*, warn-and-skip recommended/optional |
 | Q6 | Non-BDF columns | `extras` | `False` (strict BDF). `True` appends all unmapped raw columns verbatim; iterable/str selects a subset. No unit conversion or renaming on extras; the resulting file is not strictly BDF-compliant. |
+| Q7 | Target unit override (issue [#365](https://github.com/jepegit/cellpy/issues/365)) | `bdf_units` | `None` (strict BDF spec: `A`, `V`, `Ah`, `Wh`, `s`, `W`, `ohm`). A `CellpyUnits` overrides per `unit_kind`; column labels (`"Charging Capacity / mAh"`) and machine names (`"charging_capacity_mah"`) are rebuilt and values scaled via pint. Incompatible units raise `ValueError`. Any non-default override means the file is no longer strictly BDF-compliant (logged once at INFO). |
 
 ## Unit conversion
 
@@ -82,6 +83,43 @@ result, users who customise units (e.g. `cellpy_units.current = "mA"`,
 The `date_time` column is the one exception: pint does not handle wall
 clocks, so cellpy's pandas timestamps are converted to UTC Unix seconds
 explicitly.
+
+### Overriding target units (`bdf_units=`)
+
+Issue [#365](https://github.com/jepegit/cellpy/issues/365) added a
+`bdf_units` keyword to both `cellpy.exporters.bdf.to_bdf` and
+`CellpyCell.to_bdf`. It accepts a
+[`CellpyUnits`](../../cellpy/parameters/internal_settings.py) object
+whose attributes control the **units written into the BDF file** (not
+the source side — `cell.data.raw` is still assumed to be in
+`cell.cellpy_units`).
+
+Semantics:
+
+- `bdf_units=None` (default) → strict BDF spec output, byte-for-byte
+  identical to the pre-#365 behaviour.
+- `bdf_units=CellpyUnits(charge="mAh", current="mA")` → emits
+  `Charging Capacity / mAh` (machine: `charging_capacity_mah`) and
+  `Current / mA` (machine: `current_ma`), with values scaled via pint.
+- Per-kind precedence: attributes on the supplied object that are
+  **pint-equivalent** to the BDF spec default (`"sec" ≡ "s"`,
+  `"V" ≡ "volt"`, etc.) keep the canonical BDF label and machine name.
+  Only non-equivalent kinds flip labels.
+- A unit pint cannot convert from the cell's source unit (e.g.
+  `charge="kg"` while `cell.cellpy_units.charge == "mAh"`) raises
+  `ValueError`. No silent factor-1.0 fallback under an explicit
+  override.
+- The exporter logs one `INFO` line listing the non-default unit kinds,
+  mirroring how `extras=True` declares the file is no longer strictly
+  BDF-compliant.
+
+Label synthesis lives in `_resolve_column_name` in
+[cellpy/exporters/bdf.py](../../cellpy/exporters/bdf.py); the
+unit-kind → target-unit lookup lives in `_resolve_target_units`. Each
+`_BdfColumn` row carries both the canonical BDF spec spellings
+(`preferred` / `machine`) and unitless bases (`base_preferred` /
+`base_machine`) so the override path never has to monkey with the
+BDF-spec defaults.
 
 ## Column / unit map
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@
 * Bug fixes: Various other bug fixes and improvements
 * CI: Fix failing CI pipelines (pyarrow runtime dep + AppVeyor 64-bit Miniconda) (#360)
 * Bug fixes: Fix `TypeError: bad operand type for unary ~: 'slice'` in `plotutils.summary_plot` when called with `formation_cycles=False` or `0` (#366)
+* Exporters: `to_bdf` accepts a `bdf_units` keyword to control units written into the BDF file (#365)
 
 ## 1.0.2
 

--- a/cellpy/exporters/bdf.py
+++ b/cellpy/exporters/bdf.py
@@ -27,6 +27,7 @@ Design rules (recorded in ``.issueflows/04-designs-and-guides/bdf-export.md``):
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +40,7 @@ from cellpy.parameters.internal_settings import get_headers_normal
 from cellpy.readers import core
 
 if TYPE_CHECKING:
+    from cellpy.parameters.internal_settings import CellpyUnits
     from cellpy.readers.cellreader import CellpyCell
 
 logger = logging.getLogger(__name__)
@@ -58,60 +60,265 @@ class _BdfColumn:
     """One row of the cellpy <-> BDF column map.
 
     ``unit_kind`` is the attribute name on :class:`cellpy.parameters.internal_settings.CellpyUnits`
-    that holds the source unit (e.g. ``"charge"`` -> ``cellpy_units.charge``).
-    ``bdf_unit`` is the BDF target unit symbol that ``pint`` understands
+    that holds the source unit (e.g. ``"charge"`` -> ``cellpy_units.charge``)
+    and, when ``bdf_units`` override is used, the target unit.
+    ``bdf_unit`` is the BDF spec target unit symbol that ``pint`` understands
     (e.g. ``"Ah"``). The special value :data:`DATETIME_KIND` for ``unit_kind``
     skips pint and routes the column through Unix-seconds conversion.
     Use ``None`` for both fields when no unit conversion is needed
     (e.g. dimensionless cycle / step indices).
+
+    ``preferred`` and ``machine`` are the canonical BDF spec column names
+    (used byte-for-byte when no override is in effect or the override is
+    pint-equivalent to the spec default). ``base_preferred`` and
+    ``base_machine`` are the unit-less stems used to synthesize column
+    names when the override is to a non-spec unit (e.g. ``"Charging
+    Capacity / mAh"`` / ``"charging_capacity_mah"``).
     """
 
     cellpy_field: str
     preferred: str
     machine: str
+    base_preferred: str
+    base_machine: str
     tier: Tier
     unit_kind: Optional[str] = None
     bdf_unit: Optional[str] = None
 
 
 _COLUMN_MAP: tuple[_BdfColumn, ...] = (
-    _BdfColumn("test_time_txt", "Test Time / s", "test_time_second", "required", "time", "s"),
-    _BdfColumn("voltage_txt", "Voltage / V", "voltage_volt", "required", "voltage", "V"),
-    _BdfColumn("current_txt", "Current / A", "current_ampere", "required", "current", "A"),
-    _BdfColumn("datetime_txt", "Unix Time / s", "unix_time_second", "recommended", DATETIME_KIND, None),
-    _BdfColumn("cycle_index_txt", "Cycle Count / 1", "cycle_count", "recommended"),
-    _BdfColumn("step_index_txt", "Step Index / 1", "step_index", "optional"),
-    _BdfColumn("charge_capacity_txt", "Charging Capacity / Ah", "charging_capacity_ah", "optional", "charge", "Ah"),
-    _BdfColumn("discharge_capacity_txt", "Discharging Capacity / Ah", "discharging_capacity_ah", "optional", "charge", "Ah"),
-    _BdfColumn("charge_energy_txt", "Charging Energy / Wh", "charging_energy_wh", "optional", "energy", "Wh"),
-    _BdfColumn("discharge_energy_txt", "Discharging Energy / Wh", "discharging_energy_wh", "optional", "energy", "Wh"),
-    _BdfColumn("power_txt", "Power / W", "power_watt", "optional", "power", "W"),
-    _BdfColumn("internal_resistance_txt", "Internal Resistance / Ohm", "internal_resistance_ohm", "optional", "resistance", "ohm"),
+    _BdfColumn(
+        cellpy_field="test_time_txt",
+        preferred="Test Time / s",
+        machine="test_time_second",
+        base_preferred="Test Time",
+        base_machine="test_time",
+        tier="required",
+        unit_kind="time",
+        bdf_unit="s",
+    ),
+    _BdfColumn(
+        cellpy_field="voltage_txt",
+        preferred="Voltage / V",
+        machine="voltage_volt",
+        base_preferred="Voltage",
+        base_machine="voltage",
+        tier="required",
+        unit_kind="voltage",
+        bdf_unit="V",
+    ),
+    _BdfColumn(
+        cellpy_field="current_txt",
+        preferred="Current / A",
+        machine="current_ampere",
+        base_preferred="Current",
+        base_machine="current",
+        tier="required",
+        unit_kind="current",
+        bdf_unit="A",
+    ),
+    _BdfColumn(
+        cellpy_field="datetime_txt",
+        preferred="Unix Time / s",
+        machine="unix_time_second",
+        base_preferred="Unix Time",
+        base_machine="unix_time",
+        tier="recommended",
+        unit_kind=DATETIME_KIND,
+        bdf_unit=None,
+    ),
+    _BdfColumn(
+        cellpy_field="cycle_index_txt",
+        preferred="Cycle Count / 1",
+        machine="cycle_count",
+        base_preferred="Cycle Count",
+        base_machine="cycle_count",
+        tier="recommended",
+    ),
+    _BdfColumn(
+        cellpy_field="step_index_txt",
+        preferred="Step Index / 1",
+        machine="step_index",
+        base_preferred="Step Index",
+        base_machine="step_index",
+        tier="optional",
+    ),
+    _BdfColumn(
+        cellpy_field="charge_capacity_txt",
+        preferred="Charging Capacity / Ah",
+        machine="charging_capacity_ah",
+        base_preferred="Charging Capacity",
+        base_machine="charging_capacity",
+        tier="optional",
+        unit_kind="charge",
+        bdf_unit="Ah",
+    ),
+    _BdfColumn(
+        cellpy_field="discharge_capacity_txt",
+        preferred="Discharging Capacity / Ah",
+        machine="discharging_capacity_ah",
+        base_preferred="Discharging Capacity",
+        base_machine="discharging_capacity",
+        tier="optional",
+        unit_kind="charge",
+        bdf_unit="Ah",
+    ),
+    _BdfColumn(
+        cellpy_field="charge_energy_txt",
+        preferred="Charging Energy / Wh",
+        machine="charging_energy_wh",
+        base_preferred="Charging Energy",
+        base_machine="charging_energy",
+        tier="optional",
+        unit_kind="energy",
+        bdf_unit="Wh",
+    ),
+    _BdfColumn(
+        cellpy_field="discharge_energy_txt",
+        preferred="Discharging Energy / Wh",
+        machine="discharging_energy_wh",
+        base_preferred="Discharging Energy",
+        base_machine="discharging_energy",
+        tier="optional",
+        unit_kind="energy",
+        bdf_unit="Wh",
+    ),
+    _BdfColumn(
+        cellpy_field="power_txt",
+        preferred="Power / W",
+        machine="power_watt",
+        base_preferred="Power",
+        base_machine="power",
+        tier="optional",
+        unit_kind="power",
+        bdf_unit="W",
+    ),
+    _BdfColumn(
+        cellpy_field="internal_resistance_txt",
+        preferred="Internal Resistance / Ohm",
+        machine="internal_resistance_ohm",
+        base_preferred="Internal Resistance",
+        base_machine="internal_resistance",
+        tier="optional",
+        unit_kind="resistance",
+        bdf_unit="ohm",
+    ),
 )
 
 
-def _conversion_factor(cellpy_unit: Optional[str], bdf_unit: Optional[str]) -> float:
-    """Return the multiplier that turns ``cellpy_unit`` into ``bdf_unit``.
+def _slug(unit: str) -> str:
+    """Lowercase alphanumeric slug for a unit symbol.
+
+    Used to synthesize machine column names when ``bdf_units`` overrides a
+    BDF default (e.g. ``"mAh" -> "mah"``, ``"kWh" -> "kwh"``,
+    ``"min" -> "min"``). Returns the lowercased input verbatim if it has
+    no alphanumeric characters at all (extreme edge case; keeps the
+    output non-empty).
+    """
+    slug = re.sub(r"[^A-Za-z0-9]+", "", unit)
+    return slug.lower() if slug else unit.lower()
+
+
+def _is_unit_equivalent(a: Optional[str], b: Optional[str]) -> bool:
+    """Return ``True`` if ``a`` and ``b`` describe the same unit.
+
+    Equivalent means either string-equal (``"A" == "A"``) or pint reports
+    a unity ratio (``"sec"`` and ``"s"``, ``"V"`` and ``"volt"``). Unknown
+    or empty values are treated as not equivalent unless both are empty.
+    """
+    if a == b:
+        return True
+    if not a or not b:
+        return False
+    try:
+        ratio = core.Q(1.0, a) / core.Q(1.0, b)
+        return float(ratio.to("dimensionless").magnitude) == 1.0
+    except Exception:  # noqa: BLE001 - pint raises a few different types
+        return False
+
+
+def _conversion_factor(
+    source_unit: Optional[str],
+    target_unit: Optional[str],
+    *,
+    strict: bool = False,
+) -> float:
+    """Return the multiplier that turns ``source_unit`` into ``target_unit``.
 
     Delegates to :func:`cellpy.readers.core.Q` (pint) so that any unit
     spelling pint understands works automatically (``"mAh" -> "Ah"``,
     ``"sec" -> "s"``, ``"kWh" -> "Wh"``, ...). Returns ``1.0`` when no
     conversion is needed or the symbols are equal.
+
+    When ``strict`` is true (i.e. the caller is acting on an explicit
+    user ``bdf_units`` override), an incompatible / unknown unit raises
+    :class:`ValueError` rather than silently leaving values unchanged.
     """
-    if not cellpy_unit or not bdf_unit or cellpy_unit == bdf_unit:
+    if not source_unit or not target_unit or source_unit == target_unit:
         return 1.0
     try:
-        ratio = core.Q(1.0, cellpy_unit) / core.Q(1.0, bdf_unit)
+        ratio = core.Q(1.0, source_unit) / core.Q(1.0, target_unit)
         return float(ratio.to("dimensionless").magnitude)
     except Exception as exc:  # noqa: BLE001 - pint raises a few different types
+        if strict:
+            msg = (
+                f"to_bdf: cannot convert {source_unit!r} to {target_unit!r} "
+                f"(bdf_units override active): {exc}"
+            )
+            raise ValueError(msg) from exc
         logger.warning(
             "BDF export: could not convert %r to %r via pint (%s); "
             "leaving values unchanged.",
-            cellpy_unit,
-            bdf_unit,
+            source_unit,
+            target_unit,
             exc,
         )
         return 1.0
+
+
+def _resolve_column_name(
+    spec: _BdfColumn,
+    target_unit: Optional[str],
+    header_style: HeaderStyle,
+) -> str:
+    """Pick the output column name for ``spec`` given the effective target unit.
+
+    Returns the canonical BDF spec name (``spec.preferred`` /
+    ``spec.machine``) when ``target_unit`` matches the BDF default, when
+    it is pint-equivalent to the default (``"sec"`` vs ``"s"``), or when
+    the column has no unit (cycle index, step index, datetime). Otherwise
+    synthesizes a new name from the unit-less base (e.g.
+    ``"Charging Capacity / mAh"`` / ``"charging_capacity_mah"``).
+    """
+    if (
+        spec.bdf_unit is None
+        or target_unit is None
+        or _is_unit_equivalent(target_unit, spec.bdf_unit)
+    ):
+        return spec.preferred if header_style == "preferred" else spec.machine
+    if header_style == "preferred":
+        return f"{spec.base_preferred} / {target_unit}"
+    return f"{spec.base_machine}_{_slug(target_unit)}"
+
+
+def _resolve_target_units(bdf_units: Optional["CellpyUnits"]) -> dict[str, Optional[str]]:
+    """Map each non-datetime ``unit_kind`` to the unit it should be written in.
+
+    With ``bdf_units=None`` this is just the BDF spec defaults (the
+    ``bdf_unit`` field on each ``_COLUMN_MAP`` row). With an override the
+    corresponding attribute on the ``CellpyUnits`` object wins; unit
+    kinds that the override does not define fall back to the BDF default.
+    """
+    targets: dict[str, Optional[str]] = {}
+    for spec in _COLUMN_MAP:
+        kind = spec.unit_kind
+        if kind is None or kind == DATETIME_KIND:
+            continue
+        if bdf_units is None:
+            targets[kind] = spec.bdf_unit
+        else:
+            targets[kind] = getattr(bdf_units, kind, spec.bdf_unit)
+    return targets
 
 
 def _datetime_to_unix_seconds(series: pd.Series) -> pd.Series:
@@ -148,6 +355,7 @@ def to_bdf(
     format: BdfFormat = "csv",
     extras: ExtrasArg = False,
     preprocess_fn: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None,
+    bdf_units: Optional["CellpyUnits"] = None,
 ) -> Path:
     """Export ``cell.data.raw`` as a BDF file.
 
@@ -177,13 +385,42 @@ def to_bdf(
         preprocess_fn: A function that takes the raw DataFrame and returns
             a new DataFrame. This function is applied to the raw DataFrame
             after the cycle filter and before the BDF export.
+        bdf_units: Optional :class:`~cellpy.parameters.internal_settings.CellpyUnits`
+            controlling the **units written into the BDF file**. ``None``
+            (default) uses the BDF spec defaults (``A``, ``V``, ``Ah``,
+            ``Wh``, ``s``, ``W``, ``ohm``); the file is then strictly
+            BDF-compliant. When provided, each attribute on the
+            ``CellpyUnits`` object overrides the spec target for the
+            corresponding column kind: ``charge`` controls charge /
+            discharge capacity, ``energy`` controls charge / discharge
+            energy, etc. Column labels and machine names are rebuilt
+            from the override (e.g. ``"Charging Capacity / mAh"`` /
+            ``"charging_capacity_mah"``), and values are scaled
+            accordingly via pint. Unit kinds that match the BDF default
+            (string- or pint-equivalent, e.g. ``"sec"`` ≡ ``"s"``,
+            ``"V"`` ≡ ``"volt"``) keep the canonical BDF spec spelling.
+            *Caveat*: any override to a non-default unit makes the file
+            no longer strictly BDF-compliant (parallel to ``extras=True``).
+            An incompatible unit (e.g. ``charge="kg"``) raises
+            :class:`ValueError` rather than emitting wrong-unit numbers.
+
+            Example::
+
+                from cellpy.parameters.internal_settings import CellpyUnits
+
+                # write charge in mAh and current in mA (everything else
+                # stays BDF default)
+                bdf_units = CellpyUnits(charge="mAh", current="mA")
+                cell.to_bdf("out.bdf.csv", bdf_units=bdf_units)
 
     Returns:
         The path the file was written to.
 
     Raises:
-        ValueError: If ``cell.data.raw`` is empty or any BDF *required*
-            column is missing.
+        ValueError: If ``cell.data.raw`` is empty, any BDF *required*
+            column is missing, or ``bdf_units`` specifies a unit that is
+            not convertible from the cell's source unit (e.g.
+            ``charge="kg"`` while ``cell.cellpy_units.charge == "mAh"``).
     """
     raw = cell.data.raw
     if raw is None or raw.empty:
@@ -192,6 +429,8 @@ def to_bdf(
 
     headers = cell.headers_normal
     cellpy_units = cell.cellpy_units
+    target_units = _resolve_target_units(bdf_units)
+    strict_units = bdf_units is not None
 
     cycle_col = headers.cycle_index_txt
     if cycle_col in raw.columns and (cycles is not None or last_cycle is not None):
@@ -202,8 +441,8 @@ def to_bdf(
     if preprocess_fn:
         raw = preprocess_fn(raw)
 
-    out_df, missing_recommended, extras_added = _build_bdf_frame(
-        raw, headers, cellpy_units, header_style, extras
+    out_df, missing_recommended, extras_added, non_default_units = _build_bdf_frame(
+        raw, headers, cellpy_units, header_style, extras, target_units, strict_units
     )
     for col_name in missing_recommended:
         logger.warning("to_bdf: BDF-recommended column %r is not present in data.raw; skipped.", col_name)
@@ -212,6 +451,11 @@ def to_bdf(
             "to_bdf: appended %d non-BDF column(s) verbatim: %s",
             len(extras_added),
             extras_added,
+        )
+    if non_default_units:
+        logger.info(
+            "to_bdf: bdf_units override active for %s; resulting file is not strictly BDF-compliant.",
+            non_default_units,
         )
 
     out_path = _resolve_filename(filename, cell, format)
@@ -232,18 +476,26 @@ def _build_bdf_frame(
     headers,
     cellpy_units,
     header_style: HeaderStyle,
-    extras: ExtrasArg = False,
-) -> tuple[pd.DataFrame, list[str], list[str]]:
+    extras: ExtrasArg,
+    target_units: dict[str, Optional[str]],
+    strict_units: bool,
+) -> tuple[pd.DataFrame, list[str], list[str], list[str]]:
     """Build the BDF output frame.
 
-    Returns ``(frame, missing_recommended, extras_added)``. ``extras_added``
-    is the list of non-BDF cellpy column names appended verbatim (in the
-    order they appear in the output frame).
+    Returns ``(frame, missing_recommended, extras_added, non_default_units)``.
+    ``extras_added`` is the list of non-BDF cellpy column names appended
+    verbatim (in the order they appear in the output frame).
+    ``non_default_units`` is the list of unit kinds whose effective
+    target unit differs from the BDF spec (i.e. the ``bdf_units``
+    override is active for them); used to emit one human-readable
+    non-strict-BDF log line in the caller.
     """
     out: dict[str, pd.Series] = {}
     missing_recommended: list[str] = []
     missing_required: list[str] = []
     consumed: set[str] = set()
+    non_default_units: list[str] = []
+    seen_non_default: set[str] = set()
 
     for spec in _COLUMN_MAP:
         src_col = getattr(headers, spec.cellpy_field, None)
@@ -256,15 +508,27 @@ def _build_bdf_frame(
 
         consumed.add(src_col)
         series = raw[src_col]
+        target_unit: Optional[str] = spec.bdf_unit
 
         if spec.unit_kind == DATETIME_KIND:
             converted = _datetime_to_unix_seconds(series)
+        elif spec.unit_kind is None:
+            converted = series
         else:
-            cellpy_unit = getattr(cellpy_units, spec.unit_kind, None) if spec.unit_kind else None
-            factor = _conversion_factor(cellpy_unit, spec.bdf_unit)
+            cellpy_unit = getattr(cellpy_units, spec.unit_kind, None)
+            target_unit = target_units.get(spec.unit_kind, spec.bdf_unit)
+            factor = _conversion_factor(cellpy_unit, target_unit, strict=strict_units)
             converted = series * factor if factor != 1.0 else series
+            if (
+                strict_units
+                and spec.bdf_unit is not None
+                and not _is_unit_equivalent(target_unit, spec.bdf_unit)
+                and spec.unit_kind not in seen_non_default
+            ):
+                non_default_units.append(spec.unit_kind)
+                seen_non_default.add(spec.unit_kind)
 
-        out_name = spec.preferred if header_style == "preferred" else spec.machine
+        out_name = _resolve_column_name(spec, target_unit, header_style)
         out[out_name] = converted.reset_index(drop=True)
 
     if missing_required:
@@ -276,7 +540,7 @@ def _build_bdf_frame(
 
     extras_added = _append_extras(raw, out, consumed, extras)
 
-    return pd.DataFrame(out), missing_recommended, extras_added
+    return pd.DataFrame(out), missing_recommended, extras_added, non_default_units
 
 
 def _append_extras(

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -3897,6 +3897,7 @@ class CellpyCell:
         format="csv",
         extras=False,
         preprocess_fn=None,
+        bdf_units=None,
     ):
         """Export the raw time-series in Battery Data Format (BDF).
 
@@ -3926,13 +3927,39 @@ class CellpyCell:
             preprocess_fn: A function that takes the raw DataFrame and returns
                 a new DataFrame. This function is applied to the raw DataFrame
                 after the cycle filter and before the BDF export.
+            bdf_units: Optional
+                :class:`~cellpy.parameters.internal_settings.CellpyUnits`
+                controlling the **units written into the BDF file**.
+                ``None`` (default) emits a strictly BDF-compliant file
+                (``A``, ``V``, ``Ah``, ``Wh``, ``s``, ``W``, ``ohm``).
+                When set, each attribute on the ``CellpyUnits`` overrides
+                the spec target for the corresponding column kind
+                (``charge`` → charge / discharge capacity, ``energy`` →
+                charge / discharge energy, etc.); column labels and
+                machine names are rebuilt from the override
+                (e.g. ``"Charging Capacity / mAh"`` /
+                ``"charging_capacity_mah"``) and values are scaled
+                accordingly via pint. An incompatible unit (e.g.
+                ``charge="kg"``) raises :class:`ValueError`. A file
+                written with overrides is no longer strictly BDF-
+                compliant; this is logged once at INFO level.
+
+                Example::
+
+                    from cellpy.parameters.internal_settings import CellpyUnits
+
+                    # write charge in mAh and current in mA
+                    bdf_units = CellpyUnits(charge="mAh", current="mA")
+                    cell.to_bdf("out.bdf.csv", bdf_units=bdf_units)
 
         Returns:
             pathlib.Path: The path that the file was written to.
 
         Raises:
-            ValueError: If the cell has no raw data, or any BDF-required
-                column is missing from ``data.raw``.
+            ValueError: If the cell has no raw data, any BDF-required
+                column is missing from ``data.raw``, or ``bdf_units``
+                specifies a unit that cannot be converted from the
+                cell's source unit.
         """
         from cellpy.exporters import to_bdf as _to_bdf
 
@@ -3945,6 +3972,7 @@ class CellpyCell:
             format=format,
             extras=extras,
             preprocess_fn=preprocess_fn,
+            bdf_units=bdf_units,
         )
 
     # --------------helper-functions--------------------------------------------

--- a/tests/test_exporters_bdf.py
+++ b/tests/test_exporters_bdf.py
@@ -11,7 +11,7 @@ import pytest
 from cellpy import log
 from cellpy.exporters import to_bdf
 from cellpy.exporters import bdf as bdf_module
-from cellpy.parameters.internal_settings import get_headers_normal
+from cellpy.parameters.internal_settings import CellpyUnits, get_headers_normal
 
 log.setup_logging(default_level=logging.DEBUG, testing=True)
 
@@ -51,6 +51,7 @@ def _make_synthetic_cell(*, with_capacity: bool = True, with_datetime: bool = Tr
         )
 
     cell = cellreader.CellpyCell(initialize=True)
+    cell.cellpy_units = CellpyUnits()
     cell.data.raw = raw
     cell.cell_name = "synthetic"
     return cell
@@ -311,3 +312,161 @@ def test_module_does_not_import_from_cellpy_utils() -> None:
         if line.strip().startswith(("import cellpy.utils", "from cellpy.utils"))
     ]
     assert offending == [], f"Unexpected cellpy.utils imports: {offending}"
+
+
+# --- bdf_units= override (issue #365) -------------------------------------
+
+
+def test_bdf_units_none_matches_default_path(tmp_path: Path) -> None:
+    """Explicit ``bdf_units=None`` is byte-for-byte identical to the default path."""
+    cell_a = _make_synthetic_cell()
+    cell_b = _make_synthetic_cell()
+
+    out_a = cell_a.to_bdf(tmp_path / "a.bdf.csv")
+    out_b = cell_b.to_bdf(tmp_path / "b.bdf.csv", bdf_units=None)
+
+    df_a = pd.read_csv(out_a)
+    df_b = pd.read_csv(out_b)
+    pd.testing.assert_frame_equal(df_a, df_b)
+
+
+def test_bdf_units_overrides_charge_to_mAh(tmp_path: Path) -> None:
+    """Override charge unit to mAh: label and values reflect the override."""
+    cell = _make_synthetic_cell()
+    assert cell.cellpy_units.charge == "mAh"  # source
+
+    bdf_units = CellpyUnits(charge="mAh")
+    out = cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
+    df = pd.read_csv(out)
+
+    assert "Charging Capacity / mAh" in df.columns
+    assert "Discharging Capacity / mAh" in df.columns
+    assert "Charging Capacity / Ah" not in df.columns
+    # source == target == mAh, so values stay raw (100, not 0.1).
+    assert df["Charging Capacity / mAh"].max() == pytest.approx(100.0)
+    assert df["Discharging Capacity / mAh"].max() == pytest.approx(100.0)
+
+
+def test_bdf_units_overrides_charge_to_mAh_machine_style(tmp_path: Path) -> None:
+    """Machine-style header is synthesized from the override unit."""
+    cell = _make_synthetic_cell()
+    bdf_units = CellpyUnits(charge="mAh")
+
+    out = cell.to_bdf(tmp_path / "out.bdf.csv", header_style="machine", bdf_units=bdf_units)
+    df = pd.read_csv(out)
+
+    assert "charging_capacity_mah" in df.columns
+    assert "discharging_capacity_mah" in df.columns
+    assert "charging_capacity_ah" not in df.columns
+
+
+def test_bdf_units_overrides_current_to_mA(tmp_path: Path) -> None:
+    """Override current to mA: factor 1000 from the source A."""
+    cell = _make_synthetic_cell()
+    assert cell.cellpy_units.current == "A"
+
+    bdf_units = CellpyUnits(current="mA")
+    out = cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
+    df = pd.read_csv(out)
+
+    assert "Current / mA" in df.columns
+    assert "Current / A" not in df.columns
+    assert df["Current / mA"].max() == pytest.approx(100.0)
+    assert df["Current / mA"].min() == pytest.approx(-100.0)
+
+
+def test_bdf_units_overrides_time_to_minutes(tmp_path: Path) -> None:
+    """Override time to minutes: values divided by 60."""
+    cell = _make_synthetic_cell()
+
+    bdf_units = CellpyUnits(time="min")
+    out = cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
+    df = pd.read_csv(out)
+
+    assert "Test Time / min" in df.columns
+    assert "Test Time / s" not in df.columns
+    assert df["Test Time / min"].iloc[-1] == pytest.approx(5.0 / 60.0)
+
+
+def test_bdf_units_partial_override_keeps_defaults(tmp_path: Path) -> None:
+    """Unchanged kinds keep canonical BDF spec spelling and values.
+
+    `sec` is pint-equivalent to `s` so the default ``CellpyUnits().time``
+    must not flip the time column away from the BDF canonical label.
+    """
+    cell_default = _make_synthetic_cell()
+    cell_override = _make_synthetic_cell()
+
+    out_default = cell_default.to_bdf(tmp_path / "default.bdf.csv")
+    out_override = cell_override.to_bdf(
+        tmp_path / "override.bdf.csv",
+        bdf_units=CellpyUnits(charge="mAh"),
+    )
+    df_default = pd.read_csv(out_default)
+    df_override = pd.read_csv(out_override)
+
+    # Untouched columns byte-for-byte identical to the no-override file.
+    for col in ("Test Time / s", "Voltage / V", "Current / A", "Unix Time / s"):
+        assert col in df_default.columns
+        assert col in df_override.columns
+        pd.testing.assert_series_equal(
+            df_default[col], df_override[col], check_names=False
+        )
+
+    # Charge columns moved to mAh; old Ah labels gone.
+    assert "Charging Capacity / mAh" in df_override.columns
+    assert "Charging Capacity / Ah" not in df_override.columns
+
+
+def test_bdf_units_does_not_mutate_inputs(tmp_path: Path) -> None:
+    """`to_bdf` must not mutate `cell.cellpy_units` or the passed-in object."""
+    cell = _make_synthetic_cell()
+    cellpy_units_snapshot = {
+        "charge": cell.cellpy_units.charge,
+        "current": cell.cellpy_units.current,
+        "time": cell.cellpy_units.time,
+    }
+
+    bdf_units = CellpyUnits(charge="mAh", current="mA")
+    passed_snapshot = {"charge": bdf_units.charge, "current": bdf_units.current}
+
+    cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
+
+    assert cell.cellpy_units.charge == cellpy_units_snapshot["charge"]
+    assert cell.cellpy_units.current == cellpy_units_snapshot["current"]
+    assert cell.cellpy_units.time == cellpy_units_snapshot["time"]
+    assert bdf_units.charge == passed_snapshot["charge"]
+    assert bdf_units.current == passed_snapshot["current"]
+
+
+def test_bdf_units_incompatible_unit_raises(tmp_path: Path) -> None:
+    """A unit pint cannot convert (e.g. `charge="kg"`) raises ValueError."""
+    cell = _make_synthetic_cell()
+    bdf_units = CellpyUnits(charge="kg")
+
+    with pytest.raises(ValueError, match="charge|kg|mAh"):
+        cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
+
+
+def test_bdf_units_pint_equivalent_keeps_canonical_label(tmp_path: Path) -> None:
+    """`time="s"` (vs spec default `s`) keeps the BDF canonical label."""
+    cell = _make_synthetic_cell()
+    out = cell.to_bdf(
+        tmp_path / "out.bdf.csv",
+        bdf_units=CellpyUnits(time="s"),
+    )
+    df = pd.read_csv(out)
+    assert "Test Time / s" in df.columns
+
+
+def test_bdf_units_logs_non_strict_warning(tmp_path: Path, caplog) -> None:
+    """One INFO line is emitted when the override is not strictly BDF."""
+    cell = _make_synthetic_cell()
+    with caplog.at_level(logging.INFO, logger="cellpy.exporters.bdf"):
+        cell.to_bdf(
+            tmp_path / "out.bdf.csv",
+            bdf_units=CellpyUnits(charge="mAh"),
+        )
+    assert any(
+        "not strictly BDF-compliant" in rec.message for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary

Adds a `bdf_units` keyword (a `CellpyUnits` object) to `CellpyCell.to_bdf` and `cellpy.exporters.bdf.to_bdf` that controls the **units written into the BDF file** (both column labels and values). Default behaviour without the kwarg is unchanged.

Example:

```python
from cellpy.parameters.internal_settings import CellpyUnits

bdf_units = CellpyUnits(charge="mAh", current="mA")
cell.to_bdf("out.bdf.csv", bdf_units=bdf_units)
# columns become "Charging Capacity / mAh", "Current / mA"
# values are scaled accordingly via pint
```

## Design notes

- `_BdfColumn` now stores canonical BDF spec spellings *and* unitless bases — override paths synthesize labels from the bases (e.g. `Charging Capacity / mAh`, `charging_capacity_mah`), so the spec-default code path is untouched.
- New helpers: `_slug`, `_is_unit_equivalent` (pint-aware: `"sec"` ≡ `"s"`, `"V"` ≡ `"volt"`), `_resolve_column_name`, `_resolve_target_units`.
- Pint-incompatible overrides (e.g. `charge="kg"`) raise `ValueError` rather than silently emitting wrong-unit numbers.
- One `INFO` log line announces the file is no longer strictly BDF-compliant when an override is active — same disclosure pattern as `extras=True`.
- Design doc updated: new Q7 row + `Overriding target units` subsection in `.issueflows/04-designs-and-guides/bdf-export.md`.

## Test plan

- [x] `pytest tests/test_exporters_bdf.py -q` — 32 passed (23 existing + 9 new) locally.
- Tests cover: `bdf_units=None` byte-for-byte matches default; override charge/current/time in both preferred and machine header styles; pint-equivalent unit keeps canonical label; partial override leaves unrelated columns untouched; no mutation of `cell.cellpy_units` or the passed-in object; incompatible unit raises; non-strict INFO log emitted.
- Plus a small fixture fix: `_make_synthetic_cell` assigns a fresh `CellpyUnits()` per cell, plugging a pre-existing module-level-singleton mutation leak between tests.

Closes #365.

Made with [Cursor](https://cursor.com)