### PR TITLE
Update BDF exporter to use source units from `data.raw_units` instead of `cellpy_units`. This change ensures correct unit conversions for instruments reporting in non-default units, such as `batmo_bdf` which uses `Ah`. Adjusted related documentation and tests to reflect this update, including new tests for handling raw units directly. Closes #365.

### DIFF
--- a/.issueflows/04-designs-and-guides/bdf-export.md
+++ b/.issueflows/04-designs-and-guides/bdf-export.md
@@ -76,9 +76,21 @@ All non-datetime unit conversions go through
 nominal-capacity arithmetic). The exporter does not maintain its own
 factor table - it just declares each column's BDF target unit
 (`"A"`, `"Ah"`, `"V"`, `"s"`, `"Wh"`, `"W"`, `"ohm"`) and lets pint
-compute the multiplier from the cell's current `CellpyUnits`. As a
-result, users who customise units (e.g. `cellpy_units.current = "mA"`,
-`cellpy_units.energy = "kWh"`) get the right numbers automatically.
+compute the multiplier from the cell's `data.raw_units` (set by the
+instrument loader). As a result, instruments that report raw data in
+non-default units (e.g. `batmo_bdf` stores charge in `Ah`) get the
+right numbers automatically.
+
+**Source units come from `cell.data.raw_units`, not
+`cell.cellpy_units`.** The `data.raw` frame is always in the
+instrument loader's raw units; `cellpy_units` describes the summary
+frame and user-facing meta-data only. See the `CellpyUnits` docstring
+in `cellpy/parameters/internal_settings.py`. (The previous version of
+this exporter incorrectly read source units from `cellpy_units`,
+producing values off by the `raw_units / cellpy_units` ratio whenever
+the loader's raw units differed from the cellpy-units defaults — most
+visibly for instruments like `batmo_bdf` whose `raw_units.charge =
+"Ah"` does not match `cellpy_units.charge = "mAh"`.)
 
 The `date_time` column is the one exception: pint does not handle wall
 clocks, so cellpy's pandas timestamps are converted to UTC Unix seconds
@@ -91,8 +103,8 @@ Issue [#365](https://github.com/jepegit/cellpy/issues/365) added a
 `CellpyCell.to_bdf`. It accepts a
 [`CellpyUnits`](../../cellpy/parameters/internal_settings.py) object
 whose attributes control the **units written into the BDF file** (not
-the source side — `cell.data.raw` is still assumed to be in
-`cell.cellpy_units`).
+the source side — `cell.data.raw` is assumed to be in
+`cell.data.raw_units`, as set by the instrument loader).
 
 Semantics:
 
@@ -126,16 +138,22 @@ BDF-spec defaults.
 Source of truth: `_COLUMN_MAP` in
 [cellpy/exporters/bdf.py](../../cellpy/exporters/bdf.py).
 
-| cellpy `HeadersNormal` field | Preferred label | Machine name | Tier | Cellpy default unit | BDF unit | Factor |
+Source units are read per-cell from `data.raw_units` (set by the
+instrument loader). The "Default raw unit" column below is the cellpy
+default (`get_default_raw_units()`); instrument loaders override these
+per-channel (e.g. `batmo_bdf` keeps `charge="Ah"` instead of the
+factor-1e-3 case shown here).
+
+| cellpy `HeadersNormal` field | Preferred label | Machine name | Tier | Default raw unit | BDF unit | Factor (defaults) |
 |---|---|---|---|---|---|---|
 | `test_time_txt` | `Test Time / s` | `test_time_second` | required | `sec` | `s` | 1 |
 | `voltage_txt` | `Voltage / V` | `voltage_volt` | required | `V` | `V` | 1 |
-| `current_txt` | `Current / A` | `current_ampere` | required | `A` | `A` | 1 (or 1e-3 if cellpy `current="mA"`) |
+| `current_txt` | `Current / A` | `current_ampere` | required | `A` | `A` | 1 |
 | `datetime_txt` | `Unix Time / s` | `unix_time_second` | recommended | `datetime64` | `s` (Unix) | UTC seconds |
 | `cycle_index_txt` | `Cycle Count / 1` | `cycle_count` | recommended | int | dimensionless | 1 |
 | `step_index_txt` | `Step Index / 1` | `step_index` | optional | int | dimensionless | 1 |
-| `charge_capacity_txt` | `Charging Capacity / Ah` | `charging_capacity_ah` | optional | `mAh` | `Ah` | 1e-3 |
-| `discharge_capacity_txt` | `Discharging Capacity / Ah` | `discharging_capacity_ah` | optional | `mAh` | `Ah` | 1e-3 |
+| `charge_capacity_txt` | `Charging Capacity / Ah` | `charging_capacity_ah` | optional | `Ah` | `Ah` | 1 |
+| `discharge_capacity_txt` | `Discharging Capacity / Ah` | `discharging_capacity_ah` | optional | `Ah` | `Ah` | 1 |
 | `charge_energy_txt` | `Charging Energy / Wh` | `charging_energy_wh` | optional | `Wh` | `Wh` | 1 |
 | `discharge_energy_txt` | `Discharging Energy / Wh` | `discharging_energy_wh` | optional | `Wh` | `Wh` | 1 |
 | `power_txt` | `Power / W` | `power_watt` | optional | `W` | `W` | 1 |

--- a/cellpy/exporters/bdf.py
+++ b/cellpy/exporters/bdf.py
@@ -404,6 +404,12 @@ def to_bdf(
             An incompatible unit (e.g. ``charge="kg"``) raises
             :class:`ValueError` rather than emitting wrong-unit numbers.
 
+            *Source units*: the conversion source is
+            ``cell.data.raw_units`` (set by the instrument loader), **not**
+            ``cell.cellpy_units``. The ``data.raw`` frame is always stored
+            in the loader's raw units; ``cellpy_units`` describes the
+            summary frame and user-facing meta-data only.
+
             Example::
 
                 from cellpy.parameters.internal_settings import CellpyUnits
@@ -420,7 +426,7 @@ def to_bdf(
         ValueError: If ``cell.data.raw`` is empty, any BDF *required*
             column is missing, or ``bdf_units`` specifies a unit that is
             not convertible from the cell's source unit (e.g.
-            ``charge="kg"`` while ``cell.cellpy_units.charge == "mAh"``).
+            ``charge="kg"`` while ``cell.data.raw_units.charge == "Ah"``).
     """
     raw = cell.data.raw
     if raw is None or raw.empty:
@@ -428,7 +434,7 @@ def to_bdf(
         raise ValueError(msg)
 
     headers = cell.headers_normal
-    cellpy_units = cell.cellpy_units
+    source_units = cell.data.raw_units
     target_units = _resolve_target_units(bdf_units)
     strict_units = bdf_units is not None
 
@@ -442,7 +448,7 @@ def to_bdf(
         raw = preprocess_fn(raw)
 
     out_df, missing_recommended, extras_added, non_default_units = _build_bdf_frame(
-        raw, headers, cellpy_units, header_style, extras, target_units, strict_units
+        raw, headers, source_units, header_style, extras, target_units, strict_units
     )
     for col_name in missing_recommended:
         logger.warning("to_bdf: BDF-recommended column %r is not present in data.raw; skipped.", col_name)
@@ -474,7 +480,7 @@ def to_bdf(
 def _build_bdf_frame(
     raw: pd.DataFrame,
     headers,
-    cellpy_units,
+    source_units,
     header_style: HeaderStyle,
     extras: ExtrasArg,
     target_units: dict[str, Optional[str]],
@@ -515,9 +521,9 @@ def _build_bdf_frame(
         elif spec.unit_kind is None:
             converted = series
         else:
-            cellpy_unit = getattr(cellpy_units, spec.unit_kind, None)
+            source_unit = getattr(source_units, spec.unit_kind, None)
             target_unit = target_units.get(spec.unit_kind, spec.bdf_unit)
-            factor = _conversion_factor(cellpy_unit, target_unit, strict=strict_units)
+            factor = _conversion_factor(source_unit, target_unit, strict=strict_units)
             converted = series * factor if factor != 1.0 else series
             if (
                 strict_units
@@ -583,3 +589,62 @@ def _append_extras(
         out[col] = raw[col].reset_index(drop=True)
         added.append(col)
     return added
+
+
+if __name__ == "__main__":
+    import cellpy
+    import pathlib
+    import pandas as pd
+
+    raw_data_path = pathlib.Path(r"local\data\combined_protocol_results_realistic.bdf.csv")
+    out_path = pathlib.Path(r"local\out\batmo_bdf\out.bdf.csv")
+    assert raw_data_path.exists()
+
+    c = cellpy.get(
+        raw_data_path,
+        instrument="batmo_bdf",
+        cycle_mode="full_cell",
+        mass=1.0,
+        nominal_capacity=120.0,
+        nom_cap_specifics="absolute",
+        refuse_copying=True,
+    )
+
+    c.to_bdf(out_path)
+
+    print(f"Wrote BDF file to {out_path}")
+
+    print("Now we should check the input and output files")
+    print("--------------------------------")
+    r_cha, r_dch = 'Charge Capacity / Ah', 'Discharge Capacity / Ah'
+    c_cha, c_dch = 'charge_capacity', 'discharge_capacity'
+    o_cha, o_dch =  'Charging Capacity / Ah', 'Discharging Capacity / Ah'
+    print("INPUT FILE:")
+    df_raw = pd.read_csv(raw_data_path)
+    print(df_raw.head())
+    print(df_raw[r_cha].max())
+    print(df_raw[r_dch].max())
+
+
+    print("CELLPY CELL:")
+    print(c.data.raw.head())
+    print(c.data.raw[c_cha].max())
+    print(c.data.raw[c_dch].max())
+
+    print("OUTPUT FILE:")
+    df_out = pd.read_csv(out_path)
+    print(df_out.head())
+    print(df_out[o_cha].max())
+    print(df_out[o_dch].max())
+
+    print("--------------------------------")
+    print("Checking if the values are the same")
+    print(f"Input {r_cha}: {df_raw[r_cha].max()} vs Output {c_cha}: {c.data.raw[c_cha].max()}")
+    print(f"Input {r_dch}: {df_raw[r_dch].max()} vs Output {c_dch}: {c.data.raw[c_dch].max()}")
+
+    print("--------------------------------")
+    print("Checking if the values are the same")
+    print(f"Input {r_cha}: {df_raw[r_cha].max()} vs Output {o_cha}: {df_out[o_cha].max()}")
+    print(f"Input {r_dch}: {df_raw[r_dch].max()} vs Output {o_dch}: {df_out[o_dch].max()}")
+
+    print(c.data.raw_units)

--- a/tests/test_exporters_bdf.py
+++ b/tests/test_exporters_bdf.py
@@ -80,8 +80,9 @@ def test_machine_headers(tmp_path: Path) -> None:
 
 
 def test_capacity_unit_mAh_to_Ah(tmp_path: Path) -> None:
+    """Source unit comes from ``data.raw_units``: mAh -> Ah scales by 1e-3."""
     cell = _make_synthetic_cell()
-    assert cell.cellpy_units.charge == "mAh"
+    cell.data.raw_units.charge = "mAh"
 
     out = cell.to_bdf(tmp_path / "out.bdf.csv", header_style="machine")
     df = pd.read_csv(out)
@@ -90,14 +91,30 @@ def test_capacity_unit_mAh_to_Ah(tmp_path: Path) -> None:
     assert df["discharging_capacity_ah"].max() == pytest.approx(0.1)
 
 
+def test_capacity_unit_passes_through_when_raw_already_Ah(tmp_path: Path) -> None:
+    """Regression: when the loader's ``raw_units.charge == "Ah"`` (as for
+    instruments like ``batmo_bdf``) the raw column is already in Ah and
+    must not be re-scaled by the ``cellpy_units`` charge default (mAh).
+    """
+    cell = _make_synthetic_cell()
+    cell.data.raw_units.charge = "Ah"
+    cell.cellpy_units.charge = "mAh"
+
+    out = cell.to_bdf(tmp_path / "out.bdf.csv", header_style="machine")
+    df = pd.read_csv(out)
+
+    assert df["charging_capacity_ah"].max() == pytest.approx(100.0)
+    assert df["discharging_capacity_ah"].max() == pytest.approx(100.0)
+
+
 def test_non_default_current_unit_uses_pint(tmp_path: Path) -> None:
-    """Override cellpy_units.current to mA and verify pint scales A->A correctly.
+    """Override raw_units.current to mA and verify pint scales mA->A correctly.
 
     Locks in that unit conversion is delegated to cellpy.readers.core.Q
     (pint) rather than a hand-rolled factor table.
     """
     cell = _make_synthetic_cell()
-    cell.cellpy_units.current = "mA"
+    cell.data.raw_units.current = "mA"
 
     out = cell.to_bdf(tmp_path / "out.bdf.csv", header_style="machine")
     df = pd.read_csv(out)
@@ -333,7 +350,7 @@ def test_bdf_units_none_matches_default_path(tmp_path: Path) -> None:
 def test_bdf_units_overrides_charge_to_mAh(tmp_path: Path) -> None:
     """Override charge unit to mAh: label and values reflect the override."""
     cell = _make_synthetic_cell()
-    assert cell.cellpy_units.charge == "mAh"  # source
+    cell.data.raw_units.charge = "mAh"  # source
 
     bdf_units = CellpyUnits(charge="mAh")
     out = cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)
@@ -363,7 +380,7 @@ def test_bdf_units_overrides_charge_to_mAh_machine_style(tmp_path: Path) -> None
 def test_bdf_units_overrides_current_to_mA(tmp_path: Path) -> None:
     """Override current to mA: factor 1000 from the source A."""
     cell = _make_synthetic_cell()
-    assert cell.cellpy_units.current == "A"
+    assert cell.data.raw_units.current == "A"
 
     bdf_units = CellpyUnits(current="mA")
     out = cell.to_bdf(tmp_path / "out.bdf.csv", bdf_units=bdf_units)


### PR DESCRIPTION
Closes #365