### PR TITLE
Add header/unit parity contract tests between cellpy and cellpy-core (#378)

### DIFF
--- a/.issueflows/03-solved-issues/issue378_original.md
+++ b/.issueflows/03-solved-issues/issue378_original.md
@@ -1,0 +1,40 @@
+# Issue #378: Add header/unit parity contract tests between cellpy and cellpy-core
+
+Source: https://github.com/jepegit/cellpy/issues/378
+
+## Original issue text
+
+## Goal
+
+Add **contract tests** that assert the duplicated settings copies in `cellpy-core`'s
+`legacy.py` stay identical to `cellpy`'s authoritative
+`cellpy/parameters/internal_settings.py`. This prevents silent drift once `cellpy`
+delegates processing to `cellpy-core` (see #377).
+
+## Background
+
+`cellpy-core/src/cellpycore/legacy.py` currently carries **verbatim copies** of:
+
+- `HeadersNormal`, `HeadersSummary`, `HeadersStepTable`
+- `CellpyUnits`
+
+Verified field-by-field as identical to `cellpy`'s `internal_settings` today. But nothing
+enforces this — if a header/unit is edited in one repo and not the other, the seam will
+silently produce mismatched column names or units.
+
+## Tasks
+
+- [ ] Add a test (in `cellpy`, which will import both packages) asserting field names and
+      values match for each shared class:
+      `HeadersNormal`, `HeadersSummary`, `HeadersStepTable`, `CellpyUnits`.
+- [ ] Compare via dataclass fields (name + default value), not just `==`, so the failure
+      message points at the drifted field.
+- [ ] Mark the test so it is skipped gracefully if `cellpy-core` is not installed.
+
+## Notes
+
+- This depends on `cellpy` actually having `cellpy-core` as a dependency (#377).
+- Known cosmetic non-issue to NOT trip over: `CellpyUnits.resistance` value is `"ohm"` in
+  both repos; the `"Ohms"` in the docstring is a shared artifact, not a value mismatch.
+- `CellpyLimits` is intentionally NOT yet in `cellpy-core`; add it to this contract test
+  only once it is ported (cellpy/cellpy-core step-table port).

--- a/.issueflows/03-solved-issues/issue378_plan.md
+++ b/.issueflows/03-solved-issues/issue378_plan.md
@@ -1,0 +1,42 @@
+# Plan for issue #378: Header/unit parity contract tests between cellpy and cellpy-core
+
+## Goal
+Prevent silent drift between cellpy's authoritative settings and the verbatim copies in `cellpy-core` by adding a contract test that compares dataclass fields (name + default value) for the shared classes. The test lives in `cellpy` (which imports both packages) and skips when `cellpy-core` is not installed.
+
+## Context / findings
+- Authoritative source: `cellpy/parameters/internal_settings.py` defines `@dataclass` classes `HeadersNormal` (l.466), `HeadersSummary` (l.501), `HeadersStepTable` (l.605), `CellpyUnits` (l.367).
+- Copies: `cellpy-core/src/cellpycore/legacy.py` carries matching `@dataclass` copies of the same four classes (`CellpyUnits` l.137, `HeadersNormal` l.256, `HeadersSummary` l.291, `HeadersStepTable` l.399).
+- Verified the copies match today (e.g. both `CellpyUnits` have `resistance="ohm"` and `pressure="bar"`), so the test passes immediately.
+- `HeadersSummary` has non-field members (`postfixes` class attr, `specific_columns`/`areal_*` properties). `dataclasses.fields()` ignores these, so a field-based comparison is clean and unaffected.
+- `cellpy-core` is available in cellpy's test envs (e.g. `tests/test_slim.py` imports `cellpycore` directly), so the test runs there; `pytest.importorskip` covers CI where it is absent.
+- `CellpyLimits` is intentionally NOT yet ported to `cellpy-core` (the #12 step-table port uses raw-limits by value, no `CellpyLimits` class added), so it is excluded from this contract test per the issue notes.
+
+## Constraints
+- Scope: dataclass fields only (name + default), per the issue. No behavioral/runtime assertions.
+- Fixture-free, fast, deterministic unit test (matches the project's low-cost test guidance in `.issueflows/04-designs-and-guides/testing-and-coverage.md`).
+- Must skip gracefully (not error) when `cellpy-core` is missing.
+- One new test file only; no source changes.
+
+## Approach
+Add one parametrized test module in `cellpy/tests`:
+- `pytest.importorskip("cellpycore.legacy")` at module top so the file is skipped wholesale when cellpy-core is absent.
+- Helper `_field_map(cls) -> dict` built from `dataclasses.fields(cls)` mapping `field.name -> field.default`.
+- Parametrize over the four class names; for each, fetch the class from `cellpy.parameters.internal_settings` and from `cellpycore.legacy`, build both field maps, and assert equality.
+- On mismatch, produce a message that names the drifted fields: keys only in cellpy, keys only in cellpy-core, and keys whose defaults differ (with both values). This makes failures point straight at the drift.
+
+## Files to touch
+- `cellpy/tests/test_core_settings_parity.py` (new) - the parametrized contract test described above.
+
+## Test strategy
+- Run the new test in the env where cellpy-core is installed: `uv run pytest tests/test_core_settings_parity.py` (expected: 4 passed).
+- Graceful skip behavior is covered by `pytest.importorskip` when cellpy-core is absent.
+
+## Status
+- [x] Done
+
+Implemented as `tests/test_core_settings_parity.py`; `uv run pytest tests/test_core_settings_parity.py -v` -> 4 passed.
+
+## Open questions (resolved/deferred)
+- Assert parity of `HeadersSummary.postfixes`/`specific_columns` (behavioral, not dataclass fields)? Deferred - out of issue scope (fields only).
+- Filename: chose `test_core_settings_parity.py`.
+- The cellpy working tree also has uncommitted cellpy-core integration (seam) changes; the #378 deliverable is just this one new file and should be committed on its own.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 1.0.3 (pre-release)
 
 * Refactor: Renamed internal modules accidentally named `core` — `cellpy.readers.core` → `cellpy.readers.data_structures` and `cellpy.internals.core` → `cellpy.internals.connections` — to avoid a name clash with the new cellpy-core package (#381)
+* Testing: Added header/unit parity contract tests asserting cellpy-core's settings copies (HeadersNormal, HeadersSummary, HeadersStepTable, CellpyUnits) stay in sync with cellpy's internal_settings (#378)
 * Build: Migrated packaging to a single `pyproject.toml` (hatchling + git-tag dynamic versioning), managed with `uv`; removed `setup.py`/`requirements*.txt`/`MANIFEST.in` and added a Docker-based local build test (#354)
 * Filters: add filtering possibility to plotters in plotutils (#363)
 * Fix: clear leaky seaborn facet titles (`row = ... | cycle_type = standard`) in multi-row `summary_plot` panes when `show_formation=True`, while preserving x-tick labels on the bottom row (pre-existing bug surfaced by the new `_with_rate` y-sets)

--- a/tests/test_core_settings_parity.py
+++ b/tests/test_core_settings_parity.py
@@ -1,0 +1,63 @@
+"""Contract tests guarding header/unit parity between cellpy and cellpy-core.
+
+``cellpy-core`` keeps verbatim copies of cellpy's authoritative settings classes
+(``HeadersNormal``, ``HeadersSummary``, ``HeadersStepTable``, ``CellpyUnits``) in
+``cellpycore.legacy`` so the integration seam (issue #377) produces identical column
+names and units. These tests assert the copies stay field-for-field identical to
+``cellpy.parameters.internal_settings`` so drift in one repo fails loudly instead of
+silently mismatching columns/units. See issue #378.
+
+The whole module is skipped when ``cellpy-core`` is not installed.
+"""
+
+import dataclasses
+
+import pytest
+
+cellpycore_legacy = pytest.importorskip("cellpycore.legacy")
+
+from cellpy.parameters import internal_settings as cellpy_settings
+
+# Classes that cellpy-core copies verbatim and must stay in sync with cellpy.
+# NOTE: ``CellpyLimits`` is intentionally NOT yet ported to cellpy-core (the
+# step-table port passes raw limits by value), so it is excluded here until ported.
+SHARED_CLASSES = [
+    "HeadersNormal",
+    "HeadersSummary",
+    "HeadersStepTable",
+    "CellpyUnits",
+]
+
+
+def _field_map(cls) -> dict:
+    """Map dataclass field name -> default value (ignores properties/class attrs)."""
+    return {f.name: f.default for f in dataclasses.fields(cls)}
+
+
+def _drift_report(name: str, cellpy_map: dict, core_map: dict) -> str:
+    only_cellpy = sorted(set(cellpy_map) - set(core_map))
+    only_core = sorted(set(core_map) - set(cellpy_map))
+    changed = sorted(
+        k
+        for k in set(cellpy_map) & set(core_map)
+        if cellpy_map[k] != core_map[k]
+    )
+    lines = [f"Settings drift in {name} between cellpy and cellpy-core:"]
+    if only_cellpy:
+        lines.append(f"  fields only in cellpy: {only_cellpy}")
+    if only_core:
+        lines.append(f"  fields only in cellpy-core: {only_core}")
+    for k in changed:
+        lines.append(
+            f"  field {k!r}: cellpy={cellpy_map[k]!r} vs cellpy-core={core_map[k]!r}"
+        )
+    return "\n".join(lines)
+
+
+@pytest.mark.parametrize("name", SHARED_CLASSES)
+def test_settings_parity(name):
+    cellpy_cls = getattr(cellpy_settings, name)
+    core_cls = getattr(cellpycore_legacy, name)
+    cellpy_map = _field_map(cellpy_cls)
+    core_map = _field_map(core_cls)
+    assert cellpy_map == core_map, _drift_report(name, cellpy_map, core_map)


### PR DESCRIPTION
## Summary
- Adds `tests/test_core_settings_parity.py`, a fixture-free contract test that asserts cellpy-core's verbatim settings copies in `cellpycore.legacy` stay field-for-field identical to cellpy's authoritative `cellpy/parameters/internal_settings.py`.
- Covers `HeadersNormal`, `HeadersSummary`, `HeadersStepTable`, and `CellpyUnits` by comparing dataclass fields (name + default value); failures name the exact drifted field.
- Skips gracefully via `pytest.importorskip("cellpycore.legacy")` when cellpy-core is not installed.
- `CellpyLimits` is intentionally excluded until it is ported to cellpy-core.

This guards the cellpy <-> cellpy-core integration seam (#377) against silent header/unit drift.

## Test plan
- [x] `uv run pytest tests/test_core_settings_parity.py` -> 4 passed
- [ ] CI green (test is skipped where cellpy-core is absent)

Closes #378.

Made with [Cursor](https://cursor.com)