### PR TITLE
test: add CellpyLimits to cellpy-core parity contract (STEP-08)

### DIFF
--- a/tests/test_core_settings_parity.py
+++ b/tests/test_core_settings_parity.py
@@ -1,11 +1,12 @@
-"""Contract tests guarding header/unit parity between cellpy and cellpy-core.
+"""Contract tests guarding header/unit/limit parity between cellpy and cellpy-core.
 
 ``cellpy-core`` keeps verbatim copies of cellpy's authoritative settings classes
-(``HeadersNormal``, ``HeadersSummary``, ``HeadersStepTable``, ``CellpyUnits``) in
-``cellpycore.legacy`` so the integration seam (issue #377) produces identical column
-names and units. These tests assert the copies stay field-for-field identical to
+(``HeadersNormal``, ``HeadersSummary``, ``HeadersStepTable``, ``CellpyUnits``,
+``CellpyLimits``) in ``cellpycore.legacy`` so the integration seam (issue #377)
+produces identical column names, units, and step-type detection thresholds. These
+tests assert the copies stay field-for-field identical to
 ``cellpy.parameters.internal_settings`` so drift in one repo fails loudly instead of
-silently mismatching columns/units. See issue #378.
+silently mismatching columns/units/limits. See issue #378.
 
 The whole module is skipped when ``cellpy-core`` is not installed.
 """
@@ -19,13 +20,14 @@ cellpycore_legacy = pytest.importorskip("cellpycore.legacy")
 from cellpy.parameters import internal_settings as cellpy_settings
 
 # Classes that cellpy-core copies verbatim and must stay in sync with cellpy.
-# NOTE: ``CellpyLimits`` is intentionally NOT yet ported to cellpy-core (the
-# step-table port passes raw limits by value), so it is excluded here until ported.
+# ``CellpyLimits`` (step-type detection thresholds) was ported to cellpy-core as part
+# of STEP-08 and is now guarded here too.
 SHARED_CLASSES = [
     "HeadersNormal",
     "HeadersSummary",
     "HeadersStepTable",
     "CellpyUnits",
+    "CellpyLimits",
 ]
 
 


### PR DESCRIPTION
## Summary
- Completes **STEP-08** of the cellpy ⇄ cellpy-core integration roadmap.
- `CellpyLimits` (step-type detection thresholds) is mirrored verbatim in `cellpycore.legacy`; add it to `SHARED_CLASSES` in `tests/test_core_settings_parity.py` so the field-for-field parity contract now guards limits alongside headers/units.
- Updated module docstring/comments to reflect that limits are no longer excluded.

Context: `make_step_table` already delegates fully to `core.make_core_step_table`, so no dead step-table engine code remains in `cellpy` to retire — this test was the last open STEP-08 item.

## Test plan
- [x] `uv run pytest tests/test_core_settings_parity.py -q` → 5 passed (was 4)
- [x] `uv run pytest tests/ -k "step_table or steptable or make_step" -q` → 9 passed (step-table tests stay green via the core seam)

Made with [Cursor](https://cursor.com)