### PR TITLE
395 no of files to be merged config file

### DIFF
--- a/cellpy/parameters/.cellpy_prms_default.conf
+++ b/cellpy/parameters/.cellpy_prms_default.conf
@@ -96,6 +96,7 @@ Reader:
   capacity_interpolation_step: 2.0
   use_cellpy_stat_file: false
   auto_dirs: true
+  max_raw_files_to_merge: 20
   jupyter_executable:
 Materials:
   cell_class: LIB

--- a/cellpy/parameters/prms.py
+++ b/cellpy/parameters/prms.py
@@ -144,6 +144,7 @@ class ReaderClass(CellPyConfig):
     auto_dirs: bool = (
         True  # v2.0 search in prm-file for res and hdf5 dirs in cellpy.get()
     )
+    max_raw_files_to_merge: int = 20  # guard against accidentally passing too many files
     jupyter_executable: str = "jupyter"
 
 

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1345,8 +1345,7 @@ class CellpyCell:
         except AttributeError:
             logging.debug("could not set instrument name")
 
-        # TODO: include this into prms (and config-file):
-        max_raw_files_to_merge = 20
+        max_raw_files_to_merge = prms.Reader.max_raw_files_to_merge
         if len(self.file_names) > max_raw_files_to_merge:
             logging.debug("ERROR? Too many files to merge")
             raise ValueError(

--- a/cellpy/readers/instruments/pec_csv.py
+++ b/cellpy/readers/instruments/pec_csv.py
@@ -305,7 +305,8 @@ class DataLoader(BaseLoader):
 
         for col in base_columns_int:
             if col in data.raw.columns:
-                data.raw[col] = pd.to_numeric(data.raw[col], errors="coerce").astype("int64")
+                # fillna before int cast — numpy int64 has no NaN representation
+                data.raw[col] = pd.to_numeric(data.raw[col], errors="coerce").fillna(0).astype("int64")
             elif col in [self.headers_normal[k] for k in self._MUST_HAVE_RAW_COLUMNS]:
                 missing_must_have_columns.append(col)
 
@@ -313,6 +314,23 @@ class DataLoader(BaseLoader):
             raise IOError(
                 f"Missing needed columns: {missing_must_have_columns}\nAborting!"
             )
+
+        # Drop rows where essential columns are NaN — unparseable rows (empty
+        # trailing rows, footer lines) would otherwise cause RuntimeWarning from
+        # numpy cumsum in make_summary/make_step_table.
+        must_have_cols = [
+            self.headers_normal[k]
+            for k in self._MUST_HAVE_RAW_COLUMNS
+            if self.headers_normal[k] in data.raw.columns
+        ]
+        n_before = len(data.raw)
+        data.raw = data.raw.dropna(subset=must_have_cols).reset_index(drop=True)
+        n_dropped = n_before - len(data.raw)
+        if n_dropped:
+            logging.warning(
+                "pec_csv: dropped %d row(s) with NaN in essential columns", n_dropped
+            )
+
         return data
 
     def _load_pec_data(self):

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -189,6 +189,7 @@ Reader:
         capacity_interpolation_step: 2.0
         use_cellpy_stat_file: false
         auto_dirs: true
+        max_raw_files_to_merge: 20
 
 # settings related to the instrument loader
 # (each instrument can have its own set of settings)

--- a/examples/09_loading_pec_data.ipynb
+++ b/examples/09_loading_pec_data.ipynb
@@ -151,10 +151,15 @@
    "cell_type": "markdown",
    "id": "171684c2",
    "metadata": {},
-   "source": [
-    "# Loading Multiple tests for the same CellID\n",
-    "In PEC testers setup at IFE, have LotID to differentiate between cells and tests performed on that cell in terms of TestID. "
-   ]
+   "source": "# Loading Multiple tests for the same CellID\nIn PEC testers setup at IFE, have LotID to differentiate between cells and tests performed on that cell in terms of TestID.\n\nBy default, cellpy allows merging up to **20 files** in a single `cellpy.get()` call. This limit exists to catch accidental over-selection (e.g. a glob matching hundreds of files). If you genuinely need to merge more files, raise the limit before loading — either in your script or in your config file."
+  },
+  {
+   "cell_type": "code",
+   "id": "26c7d64d",
+   "source": "# Raise the merge limit if you need to combine more than 20 files.\n# Option A — change it for the current session only:\nfrom cellpy.parameters import prms\nprms.Reader.max_raw_files_to_merge = 50  # or whatever you need\n\n# Option B — set it permanently in your config file (~/.cellpy_prms_USERNAME.conf):\n#   Reader:\n#     max_raw_files_to_merge: 50",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -193,7 +198,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cellpy (3.12.12)",
+   "display_name": "cellpy (3.12.12.final.0)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
moved number of files to be merged (originally as a parameter in cellreader.py) into default config file. Now we can increase the limit for cases where there are more than 20 files. 