### PR TITLE
ci: interim unblock for hanging nbmake notebook step (#394)

### DIFF
--- a/.github/workflows/pytest_posix.yml
+++ b/.github/workflows/pytest_posix.yml
@@ -39,9 +39,14 @@ jobs:
       - name: pytest
         run: pytest --ignore=tests/test_plotutils_summary_plot.py
 
+      # NOTE: interim unblock for #394 - the `b.plot(rate=True)` cell in this
+      # notebook hangs headlessly on Linux and times out. `continue-on-error`
+      # keeps master green while the hang is investigated; the timeout is
+      # lowered so the step fails fast instead of burning the full hour.
       - name: pytest with nbmake (cellpy_batch_processing)
+        continue-on-error: true
         run: |
           python -m pip install -e .
           python -m pip install kaleido==0.1.*
           python -m ipykernel install --user --name=cellpy_dev
-          pytest -v --nbmake  --nbmake-timeout=3600 --nbmake-kernel=cellpy_dev "examples/cellpy batch utility/cellpy_batch_processing.ipynb"
+          pytest -v --nbmake  --nbmake-timeout=600 --nbmake-kernel=cellpy_dev "examples/cellpy batch utility/cellpy_batch_processing.ipynb"


### PR DESCRIPTION
## Summary

`master` CI has been red because the `pytest_posix.yml` workflow's **"pytest with nbmake (cellpy_batch_processing)"** step hangs and times out. As diagnosed in #394, the single offending cell is:

```python
b.plot(rate=True)
```

which blocks for the full `--nbmake-timeout=3600` on the headless Linux runner (the `pytest` step itself passes on all Python versions).

This is an **interim unblock** so `master` goes green again while the underlying `b.plot(rate=True)` hang is investigated separately (tracked in #394):

- Mark the nbmake step `continue-on-error: true` so its failure no longer fails the job.
- Lower `--nbmake-timeout` from `3600` to `600` so the step fails fast (~10 min) instead of burning the full hour on every run.

The notebook step still runs, so the failure remains visible as a step-level warning; it just no longer blocks CI.

## Test plan

- [ ] `pytest_posix.yml` runs and the job concludes **green** (the nbmake step shows a non-blocking warning).
- [ ] Job wall time drops (nbmake step now caps at ~600s instead of ~3600s).

Refs #394

Made with [Cursor](https://cursor.com)