### PR TITLE
Migrate off cellpycore create_selector (unblocks cellpy-core#45)

### DIFF
--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -70,7 +70,6 @@ from cellpy.parameters.internal_settings import (
 # old headers/units (identical to cellpy.parameters.internal_settings) that cellpy
 # still expects. cellpy-core's __init__ is intentionally empty, so import submodules.
 from cellpycore.cell_core import OldCellpyCellCore
-from cellpycore import selectors as core_selectors
 
 DIGITS_C_RATE = 5
 
@@ -5661,15 +5660,27 @@ class CellpyCell:
             nom_cap_specifics (str): gravimetric, areal, or volumetric.
             old (bool): if True, the old summary method will be used.
             create_copy (bool): if True, a copy of the cellpy object will be returned.
-            exclude_types (list of str): exclude these types from the summary.
-            exclude_steps (list of int): exclude these steps from the summary.
-            selector_type (str): select based on type (e.g. "non-cv", "non-rest", "non-ocv", "only-cv").
-            selector (callable): custom selector function.
+            exclude_types (list of str): deprecated, has no effect.
+            exclude_steps (list of int): deprecated, has no effect.
+            selector_type (str): deprecated, has no effect.
+            selector (callable): deprecated, has no effect.
             **kwargs: additional keyword arguments sent to internal method (check source for info).
 
         Returns:
             cellpy.CellpyData: cellpy object with the summary added to it.
         """
+        if any(
+            v is not None
+            for v in (selector, selector_type, exclude_types, exclude_steps)
+        ):
+            warnings.warn(
+                "The 'selector', 'selector_type', 'exclude_types' and "
+                "'exclude_steps' arguments to make_summary are deprecated and "
+                "have no effect: the cellpy-core summary engine selects "
+                "cycle-end data points internally and ignores custom selectors.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # TODO: @jepe  - make it is possible to update only new data by implementing
         #  from_cycle (only calculate summary from a given cycle number).
@@ -5726,10 +5737,6 @@ class CellpyCell:
             nom_cap=nom_cap,
             nom_cap_specifics=nom_cap_specifics,
             create_copy=create_copy,
-            exclude_types=exclude_types,
-            exclude_steps=exclude_steps,
-            selector_type=selector_type,
-            selector=selector,
             **kwargs,
         )
         if create_copy:
@@ -5755,10 +5762,6 @@ class CellpyCell:
         use_cellpy_stat_file=False,
         normalization_cycles=None,
         create_copy=True,
-        exclude_types=None,
-        exclude_steps=None,
-        selector_type=None,
-        selector=None,
         **kwargs,
     ):
         # ---------------- discharge loss --------------------------------------
@@ -5790,19 +5793,6 @@ class CellpyCell:
                 self.cycle_mode = cell_type.lower()
             else:
                 warnings.warn(f"Unknown keyword argument: {k}")
-
-        if selector is None:
-            # cellpy-core seam: build the summary selector via the core. The core's
-            # create_selector handles the selector_type -> exclude_types mapping
-            # (non-cv / non-rest / non-ocv / only-cv) internally and is equivalent
-            # to cellpy's legacy self._select_without.
-            selector = core_selectors.create_selector(
-                self.data,
-                self.core.schema,
-                selector_type=selector_type,
-                exclude_types=exclude_types,
-                exclude_steps=exclude_steps,
-            )
 
         # TODO: add this to arguments and possible prms:
         if nom_cap_specifics is None:
@@ -5887,14 +5877,12 @@ class CellpyCell:
                 )
 
         # cellpy-core seam: delegate the per-cycle summary pipeline to the core.
-        # ``make_core_summary`` builds the base summary (selector + index reset +
-        # column pruning) and the absolute / IR / end-voltage / C-rate columns;
-        # ``add_scaled_summary_columns`` adds the meta-dependent (equivalent-cycle
-        # and gravimetric/areal/absolute) columns. cellpy keeps the selector setup,
-        # nominal-capacity resolution, step-table/dedup handling above and the
-        # column sort / index post-processing below.
-        # Note: the deprecated ``use_cellpy_stat_file`` path now simply runs the
-        # selector (the stat-file has not been properly supported for a long time).
+        # ``make_core_summary`` builds the base summary (cycle-end selection +
+        # index reset + column pruning) and the absolute / IR / end-voltage /
+        # C-rate columns; ``add_scaled_summary_columns`` adds the meta-dependent
+        # (equivalent-cycle and gravimetric/areal/absolute) columns. cellpy keeps
+        # the nominal-capacity resolution, step-table/dedup handling above and
+        # the column sort / index post-processing below.
         # cellpy-core takes unit conversions by value: cellpy (the consumer, which
         # owns cellpy_units and pint) computes the factors and passes them in, so
         # the core summary engine needs no pint.
@@ -5914,7 +5902,6 @@ class CellpyCell:
         }
         data = self.core.make_core_summary(
             data,
-            selector=selector,
             find_ir=find_ir,
             find_end_voltage=find_end_voltage,
             select_columns=select_columns,

--- a/tests/test_slim.py
+++ b/tests/test_slim.py
@@ -14,7 +14,6 @@ import pytest
 
 from cellpy import log
 from cellpycore.cell_core import OldCellpyCellCore
-from cellpycore import selectors as core_selectors
 
 log.setup_logging(default_level="DEBUG", testing=True)
 
@@ -88,13 +87,21 @@ def test_direct_core_make_core_summary(cpi, parameters):
     cpi.make_step_table()
 
     data = cpi.data
-    selector = core_selectors.create_selector(data, cpi.core.schema)
-    data = cpi.core.make_core_summary(
-        data, selector, find_ir=True, find_end_voltage=True
-    )
+    data = cpi.core.make_core_summary(data, find_ir=True, find_end_voltage=True)
 
     h = cpi.headers_summary
     assert data.summary is not None
     assert not data.summary.empty
     assert h.charge_capacity in data.summary.columns
     assert h.discharge_capacity in data.summary.columns
+
+
+def test_make_summary_selector_kwargs_deprecated(cpi, parameters):
+    """The legacy selector kwargs are accepted but warn and have no effect."""
+    cpi.set_instrument("arbin_res")
+    cpi.from_raw(parameters.res_file_path)
+    cpi.mass = 1.0
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        cpi.make_summary(selector_type="non-cv")
+    assert cpi.data.summary is not None
+    assert not cpi.data.summary.empty


### PR DESCRIPTION
## Summary

- Remove the `cellpycore.selectors` import and the `create_selector` call in `_make_summary`: the selector has been a silent no-op since the core seam landed (`make_core_summary` never used it; the polars engine selects cycle-end datapoints internally).
- Keep the public `make_summary` kwargs `selector` / `selector_type` / `exclude_types` / `exclude_steps` but emit a `DeprecationWarning` when supplied.
- Update `tests/test_slim.py` (drop selector usage, add a deprecation-warning test).

This unblocks the dead-code removal in cellpy/cellpy-core#45 — **merge this PR first**, then the cellpy-core one (cellpy pins `cellpycore @ git+…@main`).

The exclude-types summary feature the old selector carried (non-cv / non-rest / non-ocv / only-cv) is tracked for native reimplementation in cellpy/cellpy-core#54.

## Test plan

- [x] `pytest tests/test_slim.py` — 6 passed (incl. new deprecation test)
- [x] `pytest -k summary` — 79 passed, 1 skipped, 1 xfailed
- [x] Full suite (excl. `test_ica.py` / `test_ocv_relax.py` / `test_plotutils_summary_plot.py`, which crash on a pre-existing scipy/BLAS DLL fault in the local env) — 428 passed, 17 skipped, 11 xfailed
- [x] End-to-end against cellpy-core with the removal applied (editable path source): all green

Made with [Cursor](https://cursor.com)