### PR TITLE
ci: GitHub release → PyPI workflow and release branching docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Validate release tag vs branch
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch origin master v2
+
+          on_branch() {
+            git merge-base --is-ancestor HEAD "origin/$1"
+          }
+
+          if [[ "$TAG" =~ ^v1\. ]]; then
+            on_branch master || {
+              echo "::error::1.x release $TAG must point to a commit on master"
+              exit 1
+            }
+          elif [[ "$TAG" =~ ^v2\.0\.0(a|b|rc) ]]; then
+            on_branch v2 || {
+              echo "::error::v2.0 pre-release $TAG must point to a commit on v2"
+              exit 1
+            }
+          elif [[ "$TAG" =~ ^v2\. ]]; then
+            on_branch master || {
+              echo "::error::v2.x stable release $TAG must point to a commit on master"
+              exit 1
+            }
+          else
+            echo "::error::Tag $TAG is not allowed. Use v1.* (master), v2.0.0a/b/rc* (v2), or v2.* stable (master)."
+            exit 1
+          fi
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y mdbtools
+
+      - run: uv python install 3.13
+
+      - name: Sync dependencies (PyPI cellpycore only)
+        run: UV_NO_SOURCES=1 uv sync
+
+      - name: Run tests
+        run: uv run pytest -m essential --ignore=tests/test_plotutils_summary_plot.py
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.issueflows/04-designs-and-guides/build-and-versioning.md
+++ b/.issueflows/04-designs-and-guides/build-and-versioning.md
@@ -14,6 +14,13 @@ Context: issue #354 ("update build procedure").
   builds the wheel in a clean container, installs it, and smoke-tests import + CLI.
 
 ## How to release
+
+Automated path (recommended): publish a **GitHub release** on the correct branch; CI builds
+and uploads to PyPI. See **[`release-procedure.md`](release-procedure.md)** for tag/branch
+rules, checklist, and cellpy-core pin coordination.
+
+Manual fallback:
+
 1. Tag the commit as `vX.Y.Z` (use this consistent prefix going forward).
 2. `uv build` produces the sdist + wheel with the version taken from that tag.
 3. Publish (e.g. `uv publish` / twine).
@@ -22,8 +29,8 @@ Between tags, `uv build` yields a dev version like `1.0.3a13.post5.dev0+<hash>` 
 
 ## Notes / alternatives considered
 - `bumpver` + a static `_version.py` was dropped in favour of tag-based versioning.
-- Direct git dependency `cellpycore @ git+...` requires
-  `[tool.hatch.metadata] allow-direct-references = true` until cellpy-core is on PyPI.
+- Direct git dependency was replaced by PyPI `cellpycore` (see `release-procedure.md` for pin
+  discipline at release time).
 - Existing tags are inconsistent (`v.0.3.0`, `v0.4.2`, `1.0.3a13`); the
   `pattern = "default-unprefixed"` setting tolerates them. Standardize on `vX.Y.Z`.
 - Out of scope for #354 (follow-up): migrating CI workflows to uv and retiring the

--- a/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
+++ b/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
@@ -13,14 +13,19 @@ How to develop **v2** without disrupting **1.x** work on `master`. Companion to
 
 **Golden rule:** Same repo, same issues/CI — branch, don't fork (no `cellpy-next` clone).
 
+**Parity goal (both directions):** `master` and `v2` should not drift. Stable, shared work
+belongs on **`master` as soon as it is verified** — not only at v2.0. The `v2` branch carries
+v2-only design ahead of release; everything else should flow through `master` promptly.
+
 ## Who branches from where
 
 ```
 master  ──►  391-batch-collector-default     ──►  master     (v1 maintenance / features)
-master  ──►  384-bump-core-parity           ──►  master     (Phase 0, if behaviour-neutral)
+master  ──►  384-bump-core-parity           ──►  master     (Phase 0 — preferred if 1.x-safe)
 v2      ──►  402-v2-testmeta-on-data        ──►  v2         (v2 epic themes V2-01+)
-master  ──periodic merge──►  v2              (bring v1 fixes into v2)
-v2      ──once at release──►  master        (v2.0 launch only)
+master  ──merge before each v2 issue──►  v2   (1.x fixes into integration line)
+v2      ──backport when stable──►  master    (shared fixes/cleanup — see below)
+v2      ──once at release──►  master          (full v2.0 integration merge only)
 ```
 
 ### Default PR target
@@ -32,19 +37,103 @@ v2      ──once at release──►  master        (v2.0 launch only)
 
 | Work | Branch | Rationale |
 |------|--------|-----------|
-| Bugfixes, docs, plot/batch/CLI tweaks | `master` | 1.x contract |
-| Phase 0 gate (#384, #385, STEP-12 units) | `master` **if** parity tests show no behaviour change | Shared cleanup benefits 1.x |
-| Phase 0 that might change output | `v2` or split PR | Protect 1.x users |
-| V2-01 … V2-15 (metadata, merge, API, file format) | **`v2` only** | Breaking / v2-only surface |
-| `cellpycore` pin bump | `master` with conservative range; `v2` may pin exact | See dependency policy below |
+| Bugfixes, docs, plot/batch/CLI tweaks | **`master` first** | 1.x users get fixes immediately; merge into `v2` before next v2 issue |
+| Phase 0 gate (#384, #385, STEP-12 units) | **`master` first** when parity tests show no behaviour change | Shared cleanup — ideal on `master` ASAP |
+| Phase 0 that might change output | `v2` first, then **backport** to `master` only after proven stable | Protect 1.x until verified |
+| V2-01 … V2-15 (metadata, merge, API, file format) | **`v2` only** | Breaking / v2-only surface — do not backport |
+| `cellpycore` pin bump | **`master`** once essential + full suite green; mirror on `v2` at next sync | 1.x line stays current |
 
 ## Keeping 1.x safe on `master`
 
 1. **No v2 data model or file-format work on `master`** — even behind flags, if persistence or public API changes.
 2. **CI must pass** before merge (`uv run pytest`; use `-m essential` for inner loop).
 3. **Conservative core pin on `master`:** e.g. `cellpycore>=0.1.2,<0.2` until v2 needs a newer API.
-4. **Merge `master` → `v2` regularly** (weekly or before each v2 PR) so v2 does not diverge.
-5. **Never merge `v2` → `master`** except the single v2.0 release merge.
+4. **Do not wholesale-merge `v2` → `master`** except the single v2.0 release — but **do
+   backport** stable, 1.x-safe commits promptly (see below).
+
+## Backporting stable work to `master`
+
+When work lands on `v2` first but is **100% stable** and **does not depend on v2-only design**
+(metadata model, file format v2, breaking API), get it onto **`master` as soon as possible**
+— do not wait for v2.0.
+
+### Prefer `master` first (best case)
+
+If you already know a change is behaviour-neutral for 1.x (bugfix, CI, docs, Phase 0 cleanup
+with green `-m essential` + full suite):
+
+1. Branch from **`master`**, PR to **`master`**
+2. After merge, sync into `v2` (`git merge origin/master` on `v2`)
+
+This keeps the source of truth for shared code on the line everyone uses.
+
+### Backport from `v2` (when work started there)
+
+If a merged `v2` PR contains **only** 1.x-safe commits (or a subset of a PR):
+
+1. **Cherry-pick** those commits onto a branch from `master`, or open a **dedicated backport
+   PR** with the same diff scoped to shared files
+2. Run **`uv run pytest -m essential`** (minimum) and full suite before merging to `master`
+3. Reference the original `v2` PR in the backport PR body
+
+| Safe to backport to `master` | Never backport (v2-only until release) |
+|------------------------------|----------------------------------------|
+| Bugfixes in shared modules | `TestMetaCollection` / keyed metadata |
+| Phase 0 engine cleanup (#384, #385) after parity proof | HDF5 / cellpy file format v2 |
+| Unit delegation to `cellpycore.units` | Public API removals / deprecations shipped as v2 |
+| Tests, CI, docs (non-v2) | Multi-test merge behaviour |
+| Conservative `cellpycore` pin bump | Native-schema opt-in defaults |
+
+**Rule of thumb:** if a 1.x user would not notice the change (or only benefits), it belongs
+on `master` now. If it requires v2 metadata or breaks saved files, keep it on `v2`.
+
+### Split PRs when mixed
+
+If one piece of work touches both shared cleanup and v2-only design, **split into two PRs**:
+
+- PR A → `master` (stable slice, merge first)
+- PR B → `v2` (v2-only slice, branch after syncing `v2` with updated `master`)
+
+## Before starting a v2 issue
+
+**Always update `v2` from `master` before you create an issue branch.** Do not branch from a
+stale `v2` — you will miss 1.x bugfixes and make the eventual v2.0 merge harder.
+
+```bash
+git fetch origin
+git checkout v2
+git pull --ff-only origin v2
+git merge origin/master   # bring 1.x fixes into the integration line
+# resolve conflicts (see below), then:
+uv sync
+uv run pytest -m essential
+git checkout -b 402-v2-testmeta-on-data
+```
+
+### What to take from `master`
+
+| From `master` | Action on `v2` |
+|---------------|----------------|
+| Bugfixes, CI, docs, behaviour-neutral refactors | **Take** — keep v2 current |
+| Phase 0 shared cleanup (#384, #385) if already on `master` | **Take** if parity tests still pass on `v2` |
+| 1.x-only behaviour you intentionally changed on `v2` | **Resolve in favour of `v2`** during the merge |
+| New 1.x features that **conflict with the v2 epic** (e.g. alternate data model, API v2 rejects) | **Do not blindly keep** — resolve consciously; prefer the v2 design and drop or re-implement the 1.x path on `v2` only |
+
+There is no automatic “exclude list”. During `git merge origin/master`, read conflicting
+commits: if a `master` change **directly works against a v2 goal** documented in
+[`cellpy-v2-epic.md`](cellpy-v2-epic.md), keep the **`v2` side** (or a v2-appropriate rewrite),
+not the 1.x version. When unsure, note the conflict in the PR and link epic #402.
+
+### What not to do
+
+- **Do not** wholesale-merge the **`v2` branch** into `master` until v2.0 (backport **commits**, not the integration branch).
+- **Do not** let stable shared fixes **only** live on `v2` — backport or land on `master` first.
+- **Do not** branch a v2 issue from `master` — branch from **updated `v2`**.
+- **Do not** assume `git pull` on `v2` alone is enough if `master` has moved; you must
+  **merge `origin/master` into `v2`** (or rebase `v2` onto `master` if the team agrees —
+  merge is the default here).
+
+After your issue branch is done, open the PR against **`v2`**, not `master`.
 
 ## Reality check: what “1.x on master” means today
 
@@ -52,15 +141,26 @@ v2      ──once at release──►  master        (v2.0 launch only)
 `cellpycore` dependency. “1.x” here means **post-seam 1.x** — not pre-core cellpy. v2 adds
 metadata, multi-test merge, API cleanup, and file-format changes on top.
 
-## Releases and versioning
+## Releases and PyPI
 
-- **1.x:** tag on `master` (`v1.0.4`, …); version from git tags via `uv-dynamic-versioning`
-  (see [`build-and-versioning.md`](build-and-versioning.md)).
-- **v2 development:** no consumer release from `v2` until ready; optional pre-release tags on
-  `v2` only (`v2.0.0-a1`) for alpha installs.
-- **v2.0 launch:** merge `v2` → `master`, tag `v2.0.0`, publish.
-- **Extended 1.x support (optional):** after v2 ships, branch `release/1.x` from the last 1.x
-  tag for critical fixes only — only if the team commits to maintaining it.
+Full procedure: [`release-procedure.md`](release-procedure.md). Summary:
+
+| Line | GitHub release from | Tag examples | PyPI |
+|------|---------------------|--------------|------|
+| **1.x (now)** | **`master`** | `v1.0.4` | stable |
+| **v2 integration** | **`v2`** (optional) | `v2.0.0a1` | pre-release only (`--pre`) |
+| **2.x (after v2.0 merge)** | **`master`** | `v2.0.0`, `v2.1.0` | stable |
+
+**Workflow:** `release: published` → validate tag/branch → test (`UV_NO_SOURCES=1`) →
+`uv build` → PyPI trusted publish (`.github/workflows/release.yml`).
+
+**Two-way parity + releases:** stable fixes should land on **`master` first** (or backport
+immediately) so the next **`v1.x.y` GitHub release** on `master` ships them to PyPI. Do not
+accumulate 1.x-safe fixes only on `v2`.
+
+**Versioning:** tag name = version (`uv-dynamic-versioning`); no separate bump in
+`pyproject.toml`. Pin exact `cellpycore==…` in the release commit on `master` when cutting
+1.x tags.
 
 ## Local development
 
@@ -76,13 +176,17 @@ uv run pytest -m essential   # fast smoke
 
 ### v2 work
 
+**Prerequisite:** merge `origin/master` into `v2` first — see
+[Before starting a v2 issue](#before-starting-a-v2-issue).
+
 ```bash
 git fetch origin
 git checkout v2
-git pull --ff-only
-git checkout -b 402-v2-testmeta-on-data
+git pull --ff-only origin v2
+git merge origin/master          # sync 1.x fixes; resolve conflicts (v2 wins on v2-only design)
 uv sync
 uv run pytest -m essential
+git checkout -b 402-v2-testmeta-on-data
 ```
 
 ### Side-by-side with worktrees
@@ -134,5 +238,6 @@ on for the release build (PyPI pin is consumer truth — see cellpy-core migrati
 ## Tracking
 
 - **Epic:** [#402](https://github.com/jepegit/cellpy/issues/402)
+- **Release procedure:** [`release-procedure.md`](release-procedure.md)
 - **Architecture:** [`cellpy-v2-architecture.excalidraw`](cellpy-v2-architecture.excalidraw)
 - **Epic doc:** [`cellpy-v2-epic.md`](cellpy-v2-epic.md)

--- a/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
+++ b/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
@@ -147,7 +147,7 @@ Full procedure: [`release-procedure.md`](release-procedure.md). Summary:
 
 | Line | GitHub release from | Tag examples | PyPI |
 |------|---------------------|--------------|------|
-| **1.x (now)** | **`master`** | `v1.0.4` | stable |
+| **1.x (now)** | **`master`** | `v1.0.4a1` → `v1.0.4` | alpha first, then stable |
 | **v2 integration** | **`v2`** (optional) | `v2.0.0a1` | pre-release only (`--pre`) |
 | **2.x (after v2.0 merge)** | **`master`** | `v2.0.0`, `v2.1.0` | stable |
 

--- a/.issueflows/04-designs-and-guides/cellpy-v2-epic.md
+++ b/.issueflows/04-designs-and-guides/cellpy-v2-epic.md
@@ -29,7 +29,10 @@ line for other contributors. PRs for epic #402 and child issues **target `v2`**,
 `master`. Phase 0 gate work (#384, #385) may land on `master` when parity tests prove
 behaviour is unchanged.
 
-Full conventions: [`cellpy-v2-branching.md`](cellpy-v2-branching.md).
+Full conventions: [`cellpy-v2-branching.md`](cellpy-v2-branching.md) — including **two-way
+parity**: merge `master` → `v2` before each v2 issue; land **stable shared work on `master`
+ASAP** (prefer `master` first, or backport from `v2`); resolve conflicts so v2-only design
+is not overwritten by 1.x paths.
 
 ## Relationship to the core integration roadmap
 
@@ -170,7 +173,7 @@ I/O, plotting hooks — not compute.
 |-------|------------------|------|-----------|
 | **V2-13** cellpy file format v2 | HDF5 layer | Version bump; serialize `TestMetaCollection`; migration from v1 files | Round-trip test v1→v2→read |
 | **V2-14** Metadata persistence policy | cellpy (not core) | Implement real `save_archive` / load paths cellpy needs (core stubs stay stubs) | User can save merged campaign metadata |
-| **V2-15** Release discipline | `pyproject.toml` | Pin exact `cellpycore==` before tagging v2.0; changelog + migration guide | Reproducible release artifact |
+| **V2-15** Release discipline | `pyproject.toml`, GitHub releases | Pin exact `cellpycore==`; use [`release-procedure.md`](release-procedure.md) (GitHub release → PyPI) | Reproducible release artifact |
 
 ### Phase 5 — Hardening (parallel, both repos)
 
@@ -288,6 +291,7 @@ Parent epic issue on GitHub: [#402](https://github.com/jepegit/cellpy/issues/402
 
 - **GitHub epic:** [#402](https://github.com/jepegit/cellpy/issues/402) — PRs target **`v2`**
 - **Branching:** [`cellpy-v2-branching.md`](cellpy-v2-branching.md) · integration branch **`v2`**
+- **Release procedure:** [`release-procedure.md`](release-procedure.md)
 - **Architecture diagram:** [`cellpy-v2-architecture.excalidraw`](cellpy-v2-architecture.excalidraw)
 - **This document:** `.issueflows/04-designs-and-guides/cellpy-v2-epic.md`
 - **Integration roadmap (engine):** `cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`

--- a/.issueflows/04-designs-and-guides/release-procedure.md
+++ b/.issueflows/04-designs-and-guides/release-procedure.md
@@ -1,0 +1,109 @@
+# Release procedure — GitHub release → PyPI
+
+**Context.** cellpy publishes to **PyPI as `cellpy`**. A published GitHub release triggers
+`.github/workflows/release.yml`: test → build → PyPI trusted publishing. Pattern mirrors
+[`cellpy-core/release-procedure.md`](../../cellpy-core/.issueflows/04-designs-and-guides/release-procedure.md).
+
+Branch policy for releases lives in [`cellpy-v2-branching.md`](cellpy-v2-branching.md)
+(Releases and PyPI).
+
+## The moving parts
+
+- **Version** is derived from **git tags** via `uv-dynamic-versioning` (see
+  [`build-and-versioning.md`](build-and-versioning.md)). There is no hand-edited
+  `project.version` in `pyproject.toml`. The **GitHub release tag** (`vX.Y.Z`) is the version
+  source at build time.
+- **Cut a release** by creating a GitHub release on the correct branch (usually `master` for
+  1.x). The tag name must match the version you intend to ship (`v1.0.4` → PyPI `1.0.4`).
+- **`.github/workflows/release.yml`** runs on `release: published`:
+  - **validate** — tag/branch rules (1.x on `master`, v2.0 pre-releases on `v2`, stable 2.x on
+    `master`)
+  - **test** — `UV_NO_SOURCES=1 uv sync` (PyPI `cellpycore` only) → `pytest -m essential`
+  - **publish** — `uv build` → PyPI **trusted publishing** (`pypi` environment,
+    `id-token: write` — configure once in GitHub repo settings, same as cellpy-core)
+
+## Which branch to release from
+
+| Tag pattern | Branch | PyPI channel |
+|-------------|--------|--------------|
+| `v1.x.y` (stable 1.x) | **`master`** | stable (default `pip install cellpy`) |
+| `v1.x.yaN` / `bN` / `rcN` (1.x pre) | **`master`** | pre-release (`pip install cellpy --pre`) |
+| `v2.0.0aN` / `bN` / `rcN` | **`v2`** | pre-release (v2 integration testing only) |
+| `v2.0.0` and later `v2.x.y` | **`master`** (after v2 merge) | stable |
+
+The workflow **fails** if e.g. `v1.0.5` points at a commit that is not on `origin/master`.
+
+## Cutting a 1.x release (happy path)
+
+```bash
+git switch master && git pull --ff-only
+
+# 1. Ensure dependency pin is release-ready
+#    Pin exact cellpycore for the release if needed (see checklist below).
+UV_NO_SOURCES=1 uv lock
+UV_NO_SOURCES=1 uv sync
+uv run pytest -m essential
+
+# 2. Clean tree — everything for this release is merged on master
+git status   # must be clean
+
+# 3. Create the GitHub release (tag = version)
+gh release create v1.0.4 --target master --generate-notes
+
+# 4. Watch CI
+gh run watch --workflow release.yml
+```
+
+**Version preview locally** (optional): checkout the tag you plan to ship, then `uv build` and
+inspect `dist/` metadata.
+
+### Failure modes
+
+- **Test job red:** fix on `master`, merge, cut a **new** patch tag — tags are not reused.
+- **Publish job red but release exists:** PyPI may not have the version; fix and release
+  `v1.0.5` (or next appropriate tag).
+- **Wrong branch:** validation job fails; delete the GitHub release/tag and recreate on the
+  correct branch.
+
+## Pre-release checklist
+
+- [ ] All changes for this release are merged to **`master`** (or **`v2`** for v2.0 alphas only).
+- [ ] **`cellpycore` pin** in `[project.dependencies]` reflects the intended core revision.
+      Use `UV_NO_SOURCES=1 uv lock` so the lock resolves from PyPI, not the editable path.
+- [ ] **`uv run pytest -m essential`** (or full suite) green locally with `UV_NO_SOURCES=1`.
+- [ ] **`[tool.uv.sources]`** editable override is **not** relied on for the release artifact
+      (it never ships in the wheel; CI uses `UV_NO_SOURCES=1`).
+- [ ] **`HISTORY.md`** updated (Keep a Changelog) before or with the release PR.
+- [ ] Tag name follows **`vX.Y.Z`** going forward (legacy inconsistent tags still tolerated
+      by `uv-dynamic-versioning` but avoid adding new ones).
+
+## cellpy-core coordination
+
+After each **cellpy-core** PyPI release, update cellpy's consumer pin on **`master`**:
+
+1. Bump `cellpycore` in `[project.dependencies]` (exact `==` before a cellpy release).
+2. `UV_NO_SOURCES=1 uv lock && UV_NO_SOURCES=1 uv sync`
+3. `uv run pytest -m essential` / seam tests
+4. Merge to `master`, then include in the next cellpy GitHub release
+
+See `cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-migration.md` §2.
+
+## v2 branch and PyPI
+
+- **No stable PyPI releases from `v2`** until v2.0 merges to `master`.
+- Optional **v2.0 alphas** (`v2.0.0a1`, …) from `v2` for early testers (`pip install cellpy --pre`).
+- Stable shared fixes discovered on `v2` should **backport to `master`** and ship on the next
+  **1.x** tag — do not leave 1.x users waiting for v2.0.
+
+## One-time GitHub setup (maintainers)
+
+1. **PyPI trusted publisher** for `cellpy` → GitHub repo `jepegit/cellpy`, workflow
+   `release.yml`, environment `pypi` (mirror cellpy-core setup).
+2. **GitHub environment `pypi`** with protection rules if desired (optional approval gate).
+
+## Tracking
+
+- Workflow: `.github/workflows/release.yml`
+- Branching + release line policy: [`cellpy-v2-branching.md`](cellpy-v2-branching.md)
+- Build/versioning basics: [`build-and-versioning.md`](build-and-versioning.md)
+- Epic: [#402](https://github.com/jepegit/cellpy/issues/402)

--- a/.issueflows/04-designs-and-guides/release-procedure.md
+++ b/.issueflows/04-designs-and-guides/release-procedure.md
@@ -33,6 +33,23 @@ Branch policy for releases lives in [`cellpy-v2-branching.md`](cellpy-v2-branchi
 
 The workflow **fails** if e.g. `v1.0.5` points at a commit that is not on `origin/master`.
 
+## Bootstrap: first automated PyPI release
+
+After merging PR #403 (or whenever `release.yml` first lands on `master`), cut an **alpha**
+before the first **stable** 1.x tag:
+
+| Step | Tag | Why |
+|------|-----|-----|
+| 1 | **`v1.0.4a1`** on `master` | Smoke-test trusted publishing + workflow; stays off default `pip install` |
+| 2 | `v1.0.4a2`, … | Fix-ups if the pipeline or PyPI metadata needs iteration |
+| 3 | **`v1.0.4`** on `master` | Stable 1.x once CI publish is proven and you are happy with the tree |
+
+This matches the current line: latest tag is `v1.0.3a6`, `HISTORY.md` still documents 1.0.3
+as pre-release, and post-seam / `cellpycore` integration has not yet shipped on a stable
+PyPI tag.
+
+Install the alpha with `pip install cellpy --pre` (or `pip install cellpy==1.0.4a1`).
+
 ## Cutting a 1.x release (happy path)
 
 ```bash
@@ -48,7 +65,9 @@ uv run pytest -m essential
 git status   # must be clean
 
 # 3. Create the GitHub release (tag = version)
-gh release create v1.0.4 --target master --generate-notes
+#    First automated publish: use v1.0.4a1 (alpha) before v1.0.4 stable — see Bootstrap above.
+gh release create v1.0.4a1 --target master --generate-notes   # alpha
+# gh release create v1.0.4 --target master --generate-notes  # stable, after alpha is green
 
 # 4. Watch CI
 gh run watch --workflow release.yml


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml`: on GitHub **release published** → validate tag/branch → test → PyPI trusted publish (mirrors cellpy-core).
- Add `.issueflows/04-designs-and-guides/release-procedure.md` with happy path, checklist, and cellpy-core pin coordination.
- Extend `cellpy-v2-branching.md` with **Releases and PyPI** (master = 1.x stable line; optional v2.0 alphas from `v2`; two-way parity ↔ PyPI).
- Link from `build-and-versioning.md` and `cellpy-v2-epic.md`.

## Tag / branch rules (enforced in CI)

| Tag | Branch |
|-----|--------|
| `v1.*` | `master` |
| `v2.0.0a/b/rc*` | `v2` |
| `v2.*` stable | `master` (post v2.0 merge) |

## Test job

- `UV_NO_SOURCES=1 uv sync` — resolves `cellpycore` from PyPI (no sibling editable path)
- `pytest -m essential` (verified locally)

## Maintainer setup (one-time, not in this PR)

Configure PyPI **trusted publishing** for `cellpy` → repo `jepegit/cellpy`, workflow `release.yml`, environment `pypi` (same pattern as cellpy-core).

## Test plan

- [ ] Review workflow YAML and branch validation logic
- [ ] Merge to `master`
- [ ] Configure PyPI trusted publisher + `pypi` environment
- [ ] Dry-run: cut a patch GitHub release on `master` and confirm workflow runs (or wait for next real release)

Related: epic #402


Made with [Cursor](https://cursor.com)