### PR TITLE
fix(ci): UV_NO_SOURCES on release test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
   test:
     needs: validate
     runs-on: ubuntu-latest
+    env:
+      UV_NO_SOURCES: 1
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,7 +65,7 @@ jobs:
       - run: uv python install 3.13
 
       - name: Sync dependencies (PyPI cellpycore only)
-        run: UV_NO_SOURCES=1 uv sync
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest -m essential --ignore=tests/test_plotutils_summary_plot.py


### PR DESCRIPTION
Fixes failed v1.0.4a1 publish (test job could not find ../cellpy-core on CI).

Made with [Cursor](https://cursor.com)