### PR TITLE
fix(deps): Dependabot-friendly cellpycore dev wiring

### DIFF
--- a/.cursor/rules/cellpy-core-migration.mdc
+++ b/.cursor/rules/cellpy-core-migration.mdc
@@ -17,9 +17,10 @@ Key invariants from that doc:
 
 - **Branch, don't fork.** Integration work goes on a branch of this repo (optionally a
   `git worktree`), never a fresh clone.
-- **Dev wiring:** `[tool.uv.sources]` gives an editable path to `../cellpy-core` for local
-  dev; the `git+https…@<ref>` reference in `[project.dependencies]` stays the
-  release/consumer truth. Pin a tag/commit for releases.
+- **Dev wiring:** PyPI pin in `[project.dependencies]` is release/consumer truth. For local
+  dual-repo work: `uv sync --no-sources` then `uv pip install -e ../cellpy-core` (or
+  `scripts/dev_sync.sh`). Do not commit `[tool.uv.sources]` path overrides — they break
+  Dependabot lock updates. Regenerate lock with `UV_NO_SOURCES=1 uv lock`.
 - **Parity is enforced by tests** (legacy header/unit contract tests + golden parquet
   fixtures), not by vigilance. Target the `OldCellpyCellCore` legacy bridge first.
 - **Metadata boundary:** core may own metadata *scaffolding and tooling* but must NOT

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot updates uv.lock from PyPI pins in pyproject.toml.
+# cellpycore is pinned deliberately after cellpy-core releases — see
+# .issueflows/04-designs-and-guides/release-procedure.md.
+# Do not add [tool.uv.sources] path overrides to pyproject.toml; Dependabot
+# cannot resolve sibling checkouts when regenerating the lockfile.
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "cellpycore"

--- a/.issueflows/04-designs-and-guides/release-procedure.md
+++ b/.issueflows/04-designs-and-guides/release-procedure.md
@@ -90,8 +90,8 @@ inspect `dist/` metadata.
 - [ ] **`cellpycore` pin** in `[project.dependencies]` reflects the intended core revision.
       Use `UV_NO_SOURCES=1 uv lock` so the lock resolves from PyPI, not the editable path.
 - [ ] **`uv run pytest -m essential`** (or full suite) green locally with `UV_NO_SOURCES=1`.
-- [ ] **`[tool.uv.sources]`** editable override is **not** relied on for the release artifact
-      (it never ships in the wheel; CI uses `UV_NO_SOURCES=1`).
+- [ ] **No `[tool.uv.sources]` path override** in committed `pyproject.toml` (CI and
+      Dependabot use PyPI via `UV_NO_SOURCES=1`).
 - [ ] **`HISTORY.md`** updated (Keep a Changelog) before or with the release PR.
 - [ ] Tag name follows **`vX.Y.Z`** going forward (legacy inconsistent tags still tolerated
       by `uv-dynamic-versioning` but avoid adding new ones).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,28 @@ Ready to contribute? Here's how to set up ``cellpy`` for local development.
 
 3. Create the development environment with [uv](https://docs.astral.sh/uv/) (recommended).
    This creates ``.venv`` and installs the project plus the ``dev`` dependency group
-   from the locked ``uv.lock``:
+   from the locked ``uv.lock`` (``cellpycore`` resolves from PyPI):
 
     ```shell
-    uv sync
+    uv sync --no-sources
     ```
+
+   **Dual-repo development** (cellpy + a sibling ``cellpy-core`` checkout): after sync,
+   install core editable so local core changes are picked up immediately:
+
+    ```shell
+    uv pip install -e ../cellpy-core
+    ```
+
+   Or run the helper script (expects ``../cellpy-core`` relative to the cellpy root):
+
+    ```shell
+    scripts/dev_sync.sh
+    ```
+
+   Do **not** commit a ``[tool.uv.sources]`` path override in ``pyproject.toml`` — it
+   breaks Dependabot ``uv.lock`` updates. Regenerate the lock from PyPI pins with
+   ``UV_NO_SOURCES=1 uv lock`` before pushing lockfile changes.
 
    Or create a plain virtual environment manually:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,9 @@ dependencies = [
     "isal",
     # cellpy-core is released on PyPI (issue cellpy/cellpy-core#44). Pin an
     # exact version (==) before tagging a cellpy release so the release maps to
-    # a known core revision.
+    # a known core revision. For dual-repo development, install the sibling
+    # checkout editable after sync (see CONTRIBUTING.md); do not commit a
+    # [tool.uv.sources] path override — it breaks Dependabot lock updates.
     "cellpycore==0.1.4",
 ]
 
@@ -92,15 +94,6 @@ dev = [
     "pytest-benchmark",
     "pytest-timeout",
 ]
-
-[tool.uv.sources]
-# Local editable override for development only: resolve cellpycore from the
-# sibling working copy instead of the PyPI release pinned in
-# [project.dependencies]. uv does NOT write this into the built wheel metadata,
-# so a released/installed cellpy still uses the PyPI version. Remove this
-# (or rely on the PyPI pin) for reproducible release builds. See the migration
-# guide: cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-migration.md.
-cellpycore = { path = "../cellpy-core", editable = true }
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/scripts/dev_sync.sh
+++ b/scripts/dev_sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Sync cellpy from uv.lock (PyPI cellpycore) and overlay a local editable
+# cellpy-core checkout. Use when developing both repos side by side.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CORE="../cellpy-core"
+if [[ ! -f "${CORE}/pyproject.toml" ]]; then
+  echo "error: expected cellpy-core checkout at ${CORE} (relative to cellpy root)" >&2
+  exit 1
+fi
+
+uv sync --no-sources
+uv pip install -e "${CORE}"
+echo "Dev env ready: cellpy editable + cellpycore from ${CORE}"

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cellpycore", editable = "../cellpy-core" },
+    { name = "cellpycore", specifier = "==0.1.4" },
     { name = "charset-normalizer" },
     { name = "click" },
     { name = "cookiecutter" },
@@ -487,31 +487,16 @@ dev = [
 
 [[package]]
 name = "cellpycore"
-version = "0.1.2"
-source = { editable = "../cellpy-core" }
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pint", marker = "extra == 'units'", specifier = ">=0.25" },
-    { name = "polars", specifier = ">=1.29.0" },
-    { name = "pyarrow", specifier = ">=20.0.0" },
-]
-provides-extras = ["units"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "marimo", specifier = ">=0.23.10" },
-    { name = "matplotlib", specifier = ">=3.10.6" },
-    { name = "pint", specifier = ">=0.25" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-benchmark", specifier = ">=5.2.3" },
-    { name = "ruff", specifier = ">=0.11.8" },
+sdist = { url = "https://files.pythonhosted.org/packages/e7/f9/e5fa27d05c4f9fbc6d4aea4b34e21725d451aaaf3dc0372e77fb118e9681/cellpycore-0.1.4.tar.gz", hash = "sha256:e7b19202febd8fdb0bcc7f2f8dab03707a3eb9ab4efb819eceeb745c9d3e8989", size = 611839, upload-time = "2026-07-04T21:54:43.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/f5/27a903e26a33ed38027940c819be13099ba783a0966174b75497117d2a2e/cellpycore-0.1.4-py3-none-any.whl", hash = "sha256:30707c3ce6d23dbe9dc6b6508a5400a1c2f9597d2f400fba75df15688eb6fc95", size = 70485, upload-time = "2026-07-04T21:54:41.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Remove committed `[tool.uv.sources]` path override that blocked Dependabot `uv.lock` updates
- Regenerate `uv.lock` from PyPI (`cellpycore==0.1.4`) via `UV_NO_SOURCES=1`
- Add `.github/dependabot.yml` (weekly uv updates; `cellpycore` ignored for manual pin bumps)
- Document dual-repo workflow in `CONTRIBUTING.md` and add `scripts/dev_sync.sh`

## Test plan
- [ ] `UV_NO_SOURCES=1 uv sync` succeeds on a clean checkout
- [ ] `scripts/dev_sync.sh` installs editable `../cellpy-core` when sibling repo exists
- [ ] Dependabot uv ecosystem runs without `path_dependencies_not_reachable`

Companion docs PR: cellpy/cellpy-core (branch `docs-dependabot-dev-wiring`)

Made with [Cursor](https://cursor.com)