### PR TITLE
Bump pandas to 3.0.3

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -14,3 +14,69 @@ case "$OSTYPE" in
         fi
         ;;
 esac
+
+# `release [patch|minor|major]`
+#
+# Cuts a GitHub release whose tag matches the *committed* project version, so
+# the git history and the published tags can never drift apart.
+#
+#   release              # tag the already-committed version (e.g. after `/issue-close patch`)
+#   release patch        # bump -> commit -> push -> tag, all in one consistent step
+#   release minor|major  # same, for the other bump levels
+#
+# Guards:
+#   - refuses to tag while a version bump is still uncommitted (the old alias
+#     silently dropped uncommitted bumps from history -> tag/repo drift);
+#   - refuses if the target tag already exists locally or on origin
+#     (this is what produced the confusing "tag already exists" error after a
+#     double bump from `/issue-close` + the release ritual).
+release() {
+    local level="${1:-}"
+
+    if [ -n "$level" ]; then
+        case "$level" in
+            patch|minor|major) ;;
+            *) echo "release: unknown bump level '$level' (use patch|minor|major)"; return 1 ;;
+        esac
+        if [ -n "$(git status --porcelain)" ]; then
+            echo "release: working tree is not clean; commit or stash before bumping."; return 1
+        fi
+        uv version --bump "$level" || return 1
+    fi
+
+    # Derive the version from pyproject AFTER any bump.
+    local ver
+    ver="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")" || return 1
+    local tag="v$ver"
+
+    # Commit the bump (if we made one) so the tag points at committed history.
+    if [ -n "$(git status --porcelain -- pyproject.toml uv.lock)" ]; then
+        if [ -n "$level" ]; then
+            git add pyproject.toml uv.lock || return 1
+            git commit -m "$tag" || return 1
+        else
+            echo "release: pyproject.toml/uv.lock has an uncommitted version change."
+            echo "         commit it first, or run: release patch|minor|major"
+            return 1
+        fi
+    fi
+
+    # Never re-create an existing tag.
+    if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1 \
+       || git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+        echo "release: tag $tag already exists. Bump the version first (release patch|minor|major)."
+        return 1
+    fi
+
+    git push || return 1
+    gh release create "$tag" --generate-notes
+}
+
+# `acp "commit message"` — stage all, commit, push
+acp() {
+    if [ $# -lt 1 ]; then
+        echo 'acp: usage: acp "commit message"'
+        return 1
+    fi
+    git add -A && git commit -m "$1" && git push
+}

--- a/.cursor/rules/issueflow-rules.mdc
+++ b/.cursor/rules/issueflow-rules.mdc
@@ -1,7 +1,8 @@
 ---
-description: Issue-flow workflow rules for LLMs
+description: Issue-flow workflow rules for cellpy
 globs:
-alwaysApply: true
+  - "**/*"
+alwaysApply: false
 ---
 
 
@@ -124,9 +125,15 @@ The full slash-command lifecycle is:
 Issue labels can select the flow: when an issue picked via `/iflow-pick` carries the **`yolo`** label, it is routed through `/iflow-yolo` (one combined confirmation). Controlled by `label_flows` (default `true`) and `yolo_label` (default `"yolo"`) under `[issueflow]` in `.issueflows/config.toml`; re-run `issue-flow update` after changing them.
 
 
+
+Lifecycle skills include a **`### MODEL & EXECUTION DIRECTIVE`** section that tells agents whether to prioritize **economy** (speed) or **reasoning** (depth) for that step. Toggle with `step_directives` under `[issueflow]`; override per step via `[issueflow.step_profiles]`; optional label hints during `/iflow-pick` via `model_label_flows`, `deep_model_label`, and `fast_model_label`. Re-run `issue-flow update` after changing any of these.
+
+
 `/iflow-fix` opens an interactive iterative-fixes session: it creates one GitHub issue + long-lived branch, then loops over many small fixes (each gets a short plan and is implemented only on confirmation, recorded as a dated bullet in `issue<N>_status.md`), and ends with `/iflow-close`. It is off-path (never auto-dispatched); while a session is active, drive it with `/iflow-fix` + `/iflow-close`, not `/iflow`.
 
 `/iflow-status` prints a **read-only** overview of where every issue stands — the local tracking state under `.issueflows/` (focus / parked / solved) plus open GitHub issues cross-referenced against it. It is off-path (never auto-dispatched) and changes nothing.
+
+`/iflow-archive` condenses old solved issue groups under `.issueflows/03-solved-issues/` into a single dated `YYYY-MM-DD_archived_issues.md` summary file (recording the pre-archive git ref for recovery via `git show <ref>:<path>`), then deletes the original `issue<N>_*` files. It is off-path and destructive: nothing is deleted before one consolidated confirmation.
 
 > On tools without project slash commands (e.g. Codex CLI), invoke the mirrored Agent Skills instead (for example `iflow-init` in place of `/iflow-init`).
 
@@ -179,6 +186,16 @@ Long-lived design docs, design decisions, and project "good practices" live unde
 - **Before planning or implementing**, skim `.issueflows/04-designs-and-guides/` for existing docs relevant to the current issue and follow them (cite them in the plan when they influence the approach).
 - **When a non-trivial design decision is made** during `/iflow-plan` or `/iflow-start`, add or update a markdown file here. Keep entries terse: context, the decision, alternatives considered, and a link back to the issue.
 - **Never overwritten by `issue-flow update`.** The folder is recreated if missing, but existing files are left alone.
+
+
+### Multi-root workspaces
+
+When an editor workspace contains **multiple sibling repositories**, each with its own `.issueflows/` scaffold:
+
+- **Resolve the target repo first** — explicit `root:` / `repo:` hints, then `issue-flow agent resolve`, then branch/single-scaffold heuristics; **ask** when ambiguous. Never let `git` or `gh` infer the repo from cwd alone.
+- **Scoped rules** — this repo's `issueflow-rules` apply under this project root only (path globs). Put **toolchain-specific** run/test commands in `.issueflows/04-designs-and-guides/this-project.md`, not in shared boilerplate that every repo merges.
+- **Per-repo lifecycle** — `/iflow-cleanup`, branch hygiene, and focus issue folders are **per repository**; repeat commands in each repo when needed.
+- **Design doc** — see `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` when present (issue #67).
 
 
 ### Branch hygiene

--- a/.cursor/skills/caveman/SKILL.md
+++ b/.cursor/skills/caveman/SKILL.md
@@ -31,7 +31,7 @@ English only. Caveman applies to English output; do not garble other languages.
 
 ## Intensity
 
-Single level: **full**. Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations.
+Single level: **full**. Classic caveman — every rule above applies at full strength; there is no milder setting.
 
 Example — "Why React component re-render?"
 - "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."

--- a/.cursor/skills/iflow-archive/SKILL.md
+++ b/.cursor/skills/iflow-archive/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: iflow-archive
+description: >-
+  Condense old solved issue groups into one dated summary file, then delete
+  the originals. Destructive, one consolidated confirm.
+disable-model-invocation: true
+---
+
+# issue-flow — archive solved issues (`/iflow-archive`)
+
+Follow this skill to **shrink the solved-issues archive**:
+old `issue<N>_*` groups under `.issueflows/03-solved-issues/` are
+summarised into one dated markdown file and the originals are deleted (they
+stay recoverable through git history).
+
+Do **not** use this to park or close an active issue — that is `/iflow-pause` / `/iflow-close`. This skill only touches `.issueflows/03-solved-issues/`.
+
+## Input
+
+- **(nothing)** — smart default: propose archiving every solved group **except the 5 most recent** (highest issue numbers).
+- **`keep <K>`** — same, but keep the `<K>` most recent groups instead.
+- **an explicit list** (e.g. `12 13 24`) — archive exactly those issues.
+- **`all`** — archive every solved group.
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+## Instructions
+
+> **CLI fast path (optional).** If the `issue-flow` CLI is on `PATH`, the
+> mechanical deletion step has a deterministic shortcut:
+> `issue-flow agent archive <N> [<N> ...]` (add `--dry-run` to preview,
+> `--json` for a machine-readable object). It removes the chosen groups'
+> files and reports the pre-archive HEAD sha — you still select candidates,
+> confirm with the user, and write the summary file yourself. The CLI is
+> optional: if it is missing or errors, fall back to the manual instructions
+> below.
+
+1. **Preflight.** Require a **clean working tree** (`git status --porcelain`); if dirty, **stop** and ask the user to commit or stash first — the recovery ref is only meaningful when the deletion lands as its own commit. Capture the pre-archive ref: `git rev-parse HEAD`.
+
+2. **Select candidates.** List every `issue<N>_*` group in `.issueflows/03-solved-issues/` with its number and title (from the `# Issue #N: <title>` heading of `issue<N>_original.md`). Apply the input rule (default: all except the 5 most recent by issue number). Show the resulting candidate list — number, title, file names — and let the user add/remove issues.
+
+3. **Consolidated confirm** (destructive — written in normal prose, never shortened). One prompt covering exactly: which issues get summarised, that their files will be **deleted**, and that recovery relies on git history via the recorded ref. Do not proceed without a clear yes.
+
+4. **Summarise (before deleting).** Append to `.issueflows/03-solved-issues/YYYY-MM-DD_archived_issues.md` (today's date; create the file if missing). Structure:
+
+   ```markdown
+   # Archived issues — YYYY-MM-DD
+
+   Pre-archive git ref: `<sha>`
+   Recover any archived file with `git show <sha>:<path>` (or browse `git log -- <path>`).
+
+   ## Issue #<N>: <title>
+
+   - Source: <GitHub issue URL, from the original file>
+   - Archived files: issue<N>_original.md, issue<N>_plan.md, issue<N>_status.md
+   - Summary: 2–4 sentences distilled from the original / plan / status files —
+     what the issue was, what was done, and the outcome.
+   ```
+
+   One `## Issue` section per archived issue. If the dated file already exists (same-day rerun), append a `---` separator followed by a fresh `Pre-archive git ref:` line for this run, then the new issue sections. The dated filename deliberately does **not** match `issue<N>_*`, so it never interferes with issue grouping.
+
+5. **Delete.** Remove the archived groups' files — CLI fast path (`issue-flow agent archive ...`), or manually `git rm .issueflows/03-solved-issues/issue<N>_*` per issue.
+
+6. **Commit offer.** Propose a single commit, e.g. `chore(iflow): archive <count> solved issues (pre-archive ref <short-sha>)`, including the new/updated dated file and the deletions. Ask before committing; never push from this skill.
+
+7. **Report.** Summarise: how many issues were archived, the dated file path, the pre-archive ref, and the one-line recovery recipe.
+
+## Constraints
+
+- **Off-path.** Never auto-dispatch from `/iflow`, `/iflow-start`, or `/iflow-close`. The user opts in explicitly.
+- **Destructive, so gated.** Never delete anything before the consolidated confirm in step 3, and never delete files that were not summarised in step 4.
+- Only `.issueflows/03-solved-issues/` is touched — never `01-current-issues/`, `02-partly-solved-issues/`, `00-tools/`, or `04-designs-and-guides/`.
+- Requires a clean working tree; the deletion should land as its own commit so `git show <ref>:<path>` recovery always works.
+- Summaries are interpretive (agent judgment); the CLI only ever does the mechanical deletion.

--- a/.cursor/skills/iflow-cleanup/SKILL.md
+++ b/.cursor/skills/iflow-cleanup/SKILL.md
@@ -1,24 +1,53 @@
 ---
 name: iflow-cleanup
 description: >-
-  Run the /iflow-cleanup workflow: detect merge status, switch to the default
-  branch, and — with a single consolidated confirm — delete every local branch
-  already reachable from origin/<default> (including squash-merges). Never -D.
+  Post-merge branch hygiene: switch to the default branch and delete merged
+  local branches under one consolidated confirm. Never -D.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue cleanup (`/iflow-cleanup`)
 
-Follow this skill when the user wants to **run post-merge branch hygiene** after a PR has been merged.
+Follow this skill to **run post-merge branch hygiene** after a PR has been merged (typically the PR opened by `/iflow-close`).
 
-## When to use
 
-- The user runs `/iflow-cleanup`, mentions **issue-cleanup**, or asks you to delete local branches whose PRs have merged.
-- The PR opened by `/iflow-close` just merged and the user wants the standard post-merge tidy-up.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 
-1. **Detect the default branch.** Prefer `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, else `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`.
+1. **Detect the default branch.** Prefer `gh repo view --repo <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`, else `git -C <project_root> symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`.
 
 2. **Identify the target branch.** If the user named a branch after `/iflow-cleanup`, use it. Else use the current branch (`git branch --show-current`). If the current branch **is** the default, skip to step 4 (folder sweep only).
 
@@ -34,7 +63,7 @@ Follow this skill when the user wants to **run post-merge branch hygiene** after
 
 5. **Optional folder sweep** (safe; no destructive git). In `.issueflows/01-current-issues/`, for each `issue<N>_*` group whose status file contains `- [x] Done` (case-insensitive on `done`), move the group to `.issueflows/03-solved-issues/`. Leave groups without a checked `Done` in place — routing them to `.issueflows/02-partly-solved-issues/` is `/iflow-pause`'s job.
 
-6. **Report.** Summarize: default branch, PR/merge status, commands run, branches deleted, branches skipped (with reason), folder sweep result.
+6. **Report.** Summarize: default branch, PR/merge status, commands run, branches deleted, branches skipped (with reason), folder sweep result. If `issue-flow agent resolve --json` reports `sibling_roots`, list them and remind the user that **each scaffolded repo needs its own `/iflow-cleanup`** — do not loop automatically in this step.
 
 ## Constraints
 

--- a/.cursor/skills/iflow-close/SKILL.md
+++ b/.cursor/skills/iflow-close/SKILL.md
@@ -1,33 +1,26 @@
 ---
 name: iflow-close
 description: >-
-  Run the /iflow-close workflow: verify tests, optional uv semver bump, update
-  issue status and folder locations, commit, push, and open a PR with a clear
-  summary. Post-merge branch cleanup now lives in /iflow-cleanup.
+  Finish and land the focus issue: tests, optional version bump, status
+  update, commit, push, and PR.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue close (`/iflow-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.
+Follow this skill to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.
 
-Post-merge branch hygiene now lives in `/iflow-cleanup` — this skill no longer deletes branches.
-
-## When to use
-
-- The user runs `/iflow-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
+Post-merge branch hygiene lives in `/iflow-cleanup` — this skill never deletes branches.
 
 ## Optional version bump (command input)
 
 If the user included text after `/iflow-close` that requests a version bump:
 
-- **`bump`** (no level) → **pre-release-aware default**: stay on the current channel (alpha→`alpha`, beta→`beta`, rc→`rc`, dev→`dev`) or `patch` when the current version is already stable.
-- **A named level** → `uv version --bump <level>` for any uv level: `patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev` (`dev` must be paired, e.g. `--bump patch --bump dev`).
-- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`, "promote to beta" → `beta`); ask once if ambiguous. Never auto-pick `major`.
+- **`bump`** (no level) → apply the pre-release-aware default.
+- **A named level** (`patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev`) → use exactly that.
+- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`); ask once if ambiguous. Never auto-pick `major`.
 
-The exact semantics and the default rule live in `.cursor/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth.
-
-When a bump applies: read `.cursor/skills/iflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+The exact semantics and the default rule live in `.cursor/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth. When a bump applies: read it, then run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
 
 ## Changelog update tokens (command input)
 
@@ -42,11 +35,46 @@ When a bump applies: read `.cursor/skills/iflow-version-bump/SKILL.md`, run the 
 
 - **`yolo`** (used by `/iflow-yolo`) → close the loop without user input: write the `HISTORY.md` bullet without a confirm prompt (step 3), **merge the PR** right after opening it (step 8a), then switch back to the default branch and `git pull --ff-only` (step 9, unless `stay` was also passed).
 
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
+
 ## Instructions
 
-1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes. Confirm that any design decisions or good practices that emerged from this issue are captured under `.issueflows/04-designs-and-guides/` before committing.
+1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. **Ruff (when present):** if the project uses ruff (`[tool.ruff]` in `pyproject.toml`, ruff in dev dependencies, or `.issueflows/04-designs-and-guides/python-quality-tools.md` exists), run auto-fix lint through the documented Python runner before committing — e.g. `uv run ruff check --fix …` then `uv run ruff format …` (match paths to what the project documents). Skim the diff; avoid bundling unrelated changes. Confirm that any design decisions or good practices that emerged from this issue are captured under `.issueflows/04-designs-and-guides/` before committing.
 
-2. **Optional version bump** — If the user asked for a bump (see above), follow `.cursor/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `.cursor/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <level>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
 3. **Update `HISTORY.md`** — Unless the user passed `nohistory`, follow `.cursor/skills/iflow-history-update/SKILL.md`. If step 2 did not bump the version, append a bullet to the `## [Unreleased]` section. If step 2 bumped the version, promote `## [Unreleased]` to `## [<new_version>] - <YYYY-MM-DD>` and open a fresh empty `## [Unreleased]` above it. Show the diff and confirm once before writing. Skip with a note if `HISTORY.md` does not exist at the project root. With the `yolo` token, do not ask — decide yourself and write the bullet (issue title, or `log "..."` text) directly.
 

--- a/.cursor/skills/iflow-comments/SKILL.md
+++ b/.cursor/skills/iflow-comments/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: iflow-comments
 description: >-
-  Triage a GitHub issue's comment thread into a curated, bucketed summary
-  (additional tasks, clarifications, superseded) for inclusion in
-  issue<N>_original.md. Invoked by /iflow-init; also reusable when re-triaging
-  comments later in an issue's lifecycle.
+  Triage a GitHub issue's comment thread into the curated, bucketed summary
+  section of issue<N>_original.md.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue comments triage
 
-Follow this skill when you need to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `.issueflows/01-current-issues/issue<N>_original.md`.
+Follow this skill to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `.issueflows/01-current-issues/issue<N>_original.md`.
 
-It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments.
+It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments. It also covers re-triage of an already-captured issue when new comments arrive (the issue body text stays unchanged; only the curated section is rewritten).
 
-## When to use
 
-- `/iflow-init` just fetched an issue with a non-empty `comments` array and needs to write the `## Comments (curated summary)` section.
-- You are re-running triage on an already-captured issue because new comments have arrived (the issue body text must stay unchanged; only the curated section is rewritten).
-- Any workflow that needs to understand "what does the comment thread actually ask us to do?" without pasting the raw thread into a file.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
 
 ## Inputs
 
@@ -78,7 +84,6 @@ Formatting rules:
 - Each bucket's bullet is itself a list if there is more than one item — nest concrete bullets under the bold label.
 - **Drop any bucket that is empty** — do not leave `- **Additional tasks**: ` with no content.
 - **Always keep the `_Note: ..._` footer** when the section exists. Use the total `comments` length for `<count>` and the `author.login` + date of the most recent non-dropped comment for `@<login>` / `<date>`.
-- Use UTF-8 markdown. No leading/trailing blank lines inside the section beyond what's shown.
 
 ## Edge cases
 
@@ -92,5 +97,4 @@ Formatting rules:
 ## Constraints
 
 - This skill only writes into the `## Comments (curated summary)` section of `issue<N>_original.md`. It never touches the issue body, the status file, or the plan file.
-- It never calls `gh` itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.
-- It never talks to the network beyond what the caller has already fetched.
+- It never calls `gh` or the network itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.

--- a/.cursor/skills/iflow-fix/SKILL.md
+++ b/.cursor/skills/iflow-fix/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: iflow-fix
 description: >-
-  Run the /iflow-fix interactive session: set up one long-lived branch + GitHub
-  issue for a stream of small iterative fixes, then loop — each fix gets a short
-  plan, is implemented only on confirmation, and is recorded as a dated bullet in
-  issue<N>_status.md. Finish with /iflow-close. Off-path: never auto-dispatched by
-  /iflow. Always creates a GitHub issue (gh); GitLab is not supported.
+  Interactive session: one long-lived branch + GitHub issue for a stream of
+  small iterative fixes, landed together via /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — interactive iterative-fix session (`/iflow-fix`)
 
-Follow this skill when the user wants an **ongoing working session** for many small fixes on one branch, rather than a single well-defined deliverable.
-
-## When to use
-
-- The user runs `/iflow-fix`, mentions "iterative fixes", "small fixes session", or "let's just fix things on a branch".
-- They have a bucket of little improvements (small bugs, typos, chores, polish) to knock out together and land via one PR.
+Follow this skill for an **ongoing working session** of many small fixes (small bugs, typos, chores, polish) on one branch, landed via one PR — rather than a single well-defined deliverable.
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-fix` is explicit-only because it creates GitHub issues and branches and drives an open-ended loop. While a session is active, drive it with `/iflow-fix` + `/iflow-close`, not `/iflow`.
 
@@ -27,6 +19,41 @@ It **coexists** with `/iflow-pick fix`: that command is a one-shot setup back in
 - **a name** (e.g. `polish-cli-output`) — used for the issue title and branch slug.
 - **(nothing)** — default the slug to `iterative-small-fixes` (made unique via the new issue number).
 - **a description** during an active session — run the next fix in the loop.
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 

--- a/.cursor/skills/iflow-graphify/SKILL.md
+++ b/.cursor/skills/iflow-graphify/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: iflow-graphify
 description: >-
-  Run the /iflow-graphify slash command: rebuild the graphify knowledge graph for the
-  project (graphify-out/graph.html, GRAPH_REPORT.md, graph.json) by shelling out
-  to `issue-flow graphify` (or `graphify` directly). Off-path: never auto-dispatched
-  by /iflow. Forwards trailing args verbatim to graphify.
+  Rebuild the graphify knowledge graph (graphify-out/) by shelling out to
+  `issue-flow graphify` or `graphify` directly.
 disable-model-invocation: true
 ---
 
 # issue-flow — graph rebuild (`/iflow-graphify`)
 
-Follow this skill when the user wants to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph.
-
-## When to use
-
-- The user runs `/iflow-graphify`, mentions "rebuild the graph", "refresh graphify", "regenerate `GRAPH_REPORT.md`", or similar.
-- The project has a `graphify-out/` folder that is stale (large refactor, new modules, new docs/papers added) and the user asks to update it.
-- The user installed `graphifyy` for the first time and wants to produce the initial graph.
+Follow this skill to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph — a stale `graphify-out/` after a large refactor, or the initial graph after installing `graphifyy`.
 
 Do **not** use this skill from `/iflow-start`, `/iflow-close`, or `/iflow`. `/iflow-graphify` is opt-in only.
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
 
 ## Instructions
 

--- a/.cursor/skills/iflow-history-update/SKILL.md
+++ b/.cursor/skills/iflow-history-update/SKILL.md
@@ -1,26 +1,33 @@
 ---
 name: iflow-history-update
 description: >-
-  Keep HISTORY.md (or equivalent changelog) up to date when landing an issue:
-  append a bullet to [Unreleased], or promote [Unreleased] to a new [x.y.z]
-  release section when a version bump happened. Invoked from /iflow-close.
+  Update the changelog when landing an issue: append a bullet to
+  [Unreleased], or promote it to a release section after a version bump.
 disable-model-invocation: true
 ---
 
 # issue-flow — history update
 
-Use this skill to update the project's changelog file (default **`HISTORY.md`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step.
+Use this skill to update the project's changelog file (default **`HISTORY.md`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step, and does not run when the user passed `nohistory` / `skip history`.
 
-## When to use
 
-- `/iflow-close` is landing an issue and the project has a changelog file in the repo root.
-- The user did **not** pass `nohistory` / `skip history` on the command line.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
 
 ## Preconditions
 
 1. The changelog file (`HISTORY.md`) exists at the **project root**. If it does not, **skip** this step, print "no `HISTORY.md` — skipping changelog update" and continue the rest of `/iflow-close`. Never create the file from this skill.
 2. The file is in **Keep a Changelog** shape: a top-level `## [Unreleased]` heading, with released versions below as `## [x.y.z] - YYYY-MM-DD` headings. If the shape does not match, **stop and report the mismatch** instead of guessing — let the user fix the file or pass `nohistory`.
-3. UTF-8 read/write with explicit encoding.
 
 ## Inputs from `/iflow-close`
 
@@ -78,7 +85,6 @@ When `/iflow-close` reaches its commit step:
 
 - Read/write only `HISTORY.md` at the project root. Do not touch any other file from this skill.
 - Never create `HISTORY.md` from scratch — scaffolding a starter changelog is out of scope for `issue-flow init` / `update`.
-- If the user passed `nohistory` (or `skip history`) to `/iflow-close`, don't run this skill at all.
 - If the confirm prompt in mode A or mode B is declined, leave `HISTORY.md` untouched and print a short "skipped changelog update" note. The rest of `/iflow-close` continues normally.
 - Preserve existing formatting conventions (bullet style, sentence case, trailing punctuation). Match the style of the nearest existing entries when in doubt.
 - The new bullet's `(#<N>)` suffix is always GitHub issue `#N`, matching the focus issue's number in `.issueflows/01-current-issues/issue<N>_original.md`.

--- a/.cursor/skills/iflow-init/SKILL.md
+++ b/.cursor/skills/iflow-init/SKILL.md
@@ -1,29 +1,56 @@
 ---
 name: iflow-init
 description: >-
-  Run the /iflow-init workflow: resolve GitHub issue reference, fetch body
-  and comments with gh, triage the comments via the iflow-comments
-  skill, write issue<number>_original.md under
-  .issueflows/01-current-issues/, and archive other
-  current issues by done status.
+  Capture a GitHub issue locally as issue<number>_original.md and archive
+  other current issues by done status.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue init (`/iflow-init`)
 
-Follow this skill when the user wants to **capture a GitHub issue locally**.
+Follow this skill to **capture a GitHub issue locally** under `.issueflows/01-current-issues/`.
 
-## When to use
 
-- The user runs `/iflow-init`, mentions **issue-init**, or asks to pull an issue into `.issueflows/01-current-issues/`.
-- You need a repeatable checklist without opening the command file.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 
-> **CLI fast path (optional).** If the `issue-flow` CLI is on `PATH`, two
-> mechanical steps have a deterministic shortcut:
-> - **Fetch + write (steps 3 & 5):** `issue-flow agent capture <N>` (use `--repo owner/repo` to override the resolved remote, `--force` to overwrite). It writes the `## Original issue text` body deterministically and prints the comments payload — you still triage comments (step 3a) and add the curated section yourself.
-> - **Archive (step 4):** `issue-flow agent sweep --except <N>` (add `--dry-run` to preview).
+> **CLI fast path (optional).** If the `issue-flow` CLI is on `PATH`:
+> - **Resolve root + repo (step 0):** `issue-flow agent resolve [--from-file <active-file>] [--json]` — use `project_root` and `repo` for all steps below.
+> - **Fetch + write (steps 3 & 5):** `issue-flow agent capture <N> -C <project_root>` (use `--repo owner/repo` to override the resolved remote, `--force` to overwrite). It writes the `## Original issue text` body deterministically and prints the comments payload — you still triage comments (step 3a) and add the curated section yourself.
+> - **Archive (step 4):** `issue-flow agent sweep --except <N> -C <project_root>` (add `--dry-run` to preview).
 >
 > The CLI is optional: if it is missing or errors, fall back to the manual
 > instructions below. (`issue-flow` is only present when the user installed it,
@@ -33,19 +60,13 @@ Follow this skill when the user wants to **capture a GitHub issue locally**.
 
 2. **Resolve the reference**
    - **URL** — Parse `owner`, `repo`, issue number.
-   - **Number only** — Use `git remote get-url origin` (HTTPS or SSH) to derive `owner/repo`. If parsing fails, ask for a full URL or `owner/repo`.
-   - **Empty / whitespace** — Run `git branch --show-current`. If empty or `main`/`master` (case-insensitive), **stop** and ask for a number, URL, or `owner/repo/#n`. If the branch is an **issue-style branch** matching `^\d+-.+`, ask: "You have not provided an issue reference. Should I use issue #NN from the current branch `<branchname>`?" Do not proceed without a clear yes/no.
+   - **Number only** — After resolving `<project_root>`, run `git -C <project_root> remote get-url origin` (HTTPS or SSH) to derive `owner/repo`. If parsing fails, ask for a full URL or `owner/repo`.
+   - **Empty / whitespace** — Run `git -C <project_root> branch --show-current`. If empty or `main`/`master` (case-insensitive), **stop** and ask for a number, URL, or `owner/repo/#n`. If the branch is an **issue-style branch** matching `^\d+-.+`, ask: "You have not provided an issue reference. Should I use issue #NN from the current branch `<branchname>`?" Do not proceed without a clear yes/no.
    - **Archived-issue guard** — Before writing, check `.issueflows/02-partly-solved-issues/` and `.issueflows/03-solved-issues/` for existing `issue<n>_*` files. If the issue is already archived, warn and require a second explicit confirmation before re-opening it in `.issueflows/01-current-issues/`.
 
 3. **Fetch** — `gh issue view <n> --repo owner/repo --json title,body,url,number,comments`. The `comments` field returns an array of `{author.login, body, createdAt, ...}` that step 3a consumes. On failure, report the error and suggest `gh auth login`. After confirming `owner/repo`, change the chat/agent tab title to reflect the issue topic on the form "Issue <issue number> <short description of issue>" (e.g. "Issue 74 cell info").
 
-3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill. Summary of rules:
-   - Process comments chronologically; **later comments win conflicts** with earlier ones.
-   - Sort points into three buckets: **Additional tasks**, **Clarifications / constraints**, **Superseded / retracted**.
-   - Collapse duplicates; drop chit-chat, emoji-only, "LGTM" and bot messages.
-   - Paraphrase — this section is an interpretive summary, not a verbatim dump.
-   - If all comments are noise, skip the curated section entirely.
-   - On open disagreement with no clear winner, log it under *Clarifications* rather than picking a side.
+3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill — it owns the triage rules (chronological precedence, three buckets, noise filtering) and the exact shape of the `## Comments (curated summary)` section.
 
 3.5 **Branch status preflight** (report only) — Run `git fetch --prune`. Report current branch, clean/dirty working tree, and ahead/behind counts vs `origin/<default>` (detect default via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, else `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`). If the current branch matches `^(\d+)-.+` and files for that issue already live in `.issueflows/02-partly-solved-issues/` or `.issueflows/03-solved-issues/`, note that the branch looks stale. Never delete or move anything at this step.
 
@@ -80,4 +101,3 @@ Follow this skill when the user wants to **capture a GitHub issue locally**.
 ## Constraints
 
 - Allowed file operations: create/update the target `*_original.md`, and move pre-existing issue groups per the archive rules. Do not modify unrelated project files.
-- Use UTF-8 for markdown output.

--- a/.cursor/skills/iflow-pause/SKILL.md
+++ b/.cursor/skills/iflow-pause/SKILL.md
@@ -1,20 +1,49 @@
 ---
 name: iflow-pause
 description: >-
-  Run the /iflow-pause workflow: update the status file with remaining work,
-  move the issue group to .issueflows/02-partly-solved-issues/,
-  and optionally make a WIP commit and switch to the default branch.
+  Park work on the current issue without closing it: update status, move
+  the group to 02-partly-solved-issues/, optional WIP commit.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue pause (`/iflow-pause`)
 
-Follow this skill when the user wants to **park work on the current issue** without closing it.
+Follow this skill to **park work on the current issue** without closing it. The issue is **not** done — this is not `/iflow-close`.
 
-## When to use
 
-- The user runs `/iflow-pause`, mentions **issue-pause**, or asks to park / stash / shelve work on an issue to switch context.
-- The issue is **not** done — this is not `/iflow-close`.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 

--- a/.cursor/skills/iflow-pick/SKILL.md
+++ b/.cursor/skills/iflow-pick/SKILL.md
@@ -1,23 +1,14 @@
 ---
 name: iflow-pick
 description: >-
-  Run the /iflow-pick front door: help the user choose the next issue (parked
-  work in 02-partly-solved-issues/ first, else rank open GitHub issues by
-  milestone, labels, and topical similarity to recently solved work), optionally
-  create a new general-fixes issue on `fix`, create the issue branch, run
-  /iflow-init, then hand off to /iflow-plan. Off-path: never auto-dispatched by
-  /iflow. Does not auto-create sub-issues.
+  Front door: choose the next issue, create the issue branch, and run
+  /iflow-init.
 disable-model-invocation: true
 ---
 
 # issue-flow — pick next issue (`/iflow-pick`)
 
-Follow this skill when the user wants help **choosing what to work on next** and getting set up to start.
-
-## When to use
-
-- The user runs `/iflow-pick`, mentions "pick the next issue", "what should I work on next?", or "find me an issue".
-- The user is on the default branch with nothing in progress and wants a candidate plus a ready branch.
+Follow this skill to help the user **choose what to work on next** (parked work first, else ranked open GitHub issues) and get set up to start.
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-pick` is explicit-only because it creates GitHub issues and branches.
 
@@ -26,6 +17,41 @@ Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/if
 - **(nothing)** — survey candidates and ask which to pick.
 - **`fix`** — create a **new** general-fixes GitHub issue (a fresh one every time) and use it.
 - **a hint** (milestone / label / topic) — bias the candidate ranking.
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 
@@ -42,6 +68,9 @@ Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/if
 
 7. **Label-driven yolo flow.** If the chosen issue carries the **`yolo`** label (case-insensitive), announce it and fold `/iflow-yolo`'s consolidated confirm into the pick confirmation (one prompt: branch + full `init → plan → start → close yolo` chain). On yes, run Phase 2 then follow the `iflow-yolo` skill **instead of** the Phase 3 handoff — its preflight still applies, but do not re-ask its confirm. Configurable via `label_flows` / `yolo_label` under `[issueflow]` in `.issueflows/config.toml` (re-run `issue-flow update` after changing).
 
+
+
+### Phase 2 — create the branch
 
 1. **Require a clean tree** (`git status --porcelain`). If dirty, **stop** and ask the user to commit/stash.
 2. **Branch off the default** — switch to default, fast-forward, then `git switch -c <N>-<short-slug>` (GitHub numeric convention). Confirm a non-obvious slug.

--- a/.cursor/skills/iflow-plan/SKILL.md
+++ b/.cursor/skills/iflow-plan/SKILL.md
@@ -1,21 +1,49 @@
 ---
 name: iflow-plan
 description: >-
-  Run the /iflow-plan workflow: read the focus issue in
-  .issueflows/01-current-issues/, draft a structured plan
-  in issue<N>_plan.md, and get explicit user confirmation before any
-  implementation starts.
+  Draft a structured plan in issue<N>_plan.md and get explicit user
+  confirmation before any implementation starts.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue plan (`/iflow-plan`)
 
-Follow this skill when the user wants to **design the approach** for an issue before touching code.
+Follow this skill to **design the approach** for the focus issue before touching code, and to get the plan confirmed ahead of `/iflow-start`.
 
-## When to use
 
-- The user runs `/iflow-plan`, mentions **issue-plan**, or asks you to design the approach / write a plan for the current issue.
-- You want a clear, confirmed plan before `/iflow-start` begins editing code.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 

--- a/.cursor/skills/iflow-start/SKILL.md
+++ b/.cursor/skills/iflow-start/SKILL.md
@@ -1,20 +1,49 @@
 ---
 name: iflow-start
 description: >-
-  Run the /iflow-start workflow: pick the current issue, read issue<N>_plan.md
-  (offer to run /iflow-plan if missing), then implement with the project's
-  documented conventions (e.g. uv run, or inside an activated conda env).
+  Implement the confirmed plan for the focus issue using the project's
+  documented conventions.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue start (`/iflow-start`)
 
-Follow this skill when the user wants to **begin implementation** from issue notes and project rules. Planning itself lives in `/iflow-plan`; this skill is now implementation-only.
+Follow this skill to **begin implementation** from issue notes and project rules. Planning itself lives in `/iflow-plan`; this skill is implementation-only. Stay aligned with `.cursor/rules/issueflow-rules.mdc` when present.
 
-## When to use
 
-- The user runs `/iflow-start`, mentions **issue-start**, or asks to implement from `.issueflows/01-current-issues/`.
-- Work should follow the issue-flow markdown workflow and stay aligned with `.cursor/rules/issueflow-rules.mdc` when present.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 
@@ -44,6 +73,7 @@ Follow this skill when the user wants to **begin implementation** from issue not
 
 7. **Project conventions**
    - Use the project's **documented Python toolchain**, not bare `python`. Default to `uv run` (scripts, pytest, tools) and `uv add` / `uv remove` / `uv sync` for dependencies, **unless** the project documents otherwise — e.g. a conda project runs scripts and `pytest` inside the **activated conda environment** (`conda activate <env>` or `conda run -n <env> …`). Honour existing project rules over these defaults.
+   - **Ruff (when present).** If the project uses ruff (`[tool.ruff]` in `pyproject.toml`, ruff in dev dependencies, or `.issueflows/04-designs-and-guides/python-quality-tools.md` exists), run auto-fix lint after substantive code changes — e.g. `uv run ruff check --fix …` then `uv run ruff format …` (match paths to what the project documents).
    - **Toolbox** — Before writing a one-off helper script, check `.issueflows/00-tools/` (start with its `README.md` index) for an existing tool. If you build something reusable during this issue, save it into `.issueflows/00-tools/` and add a one-line entry to that README's index (name, what it does, when to use it) for the next agent.
    - If `.issueflows/04-designs-and-guides/this-project.md` exists, read it for project-specific context before implementing; then skim relevant design docs under `.issueflows/04-designs-and-guides/`.
    - As you iterate, re-read and keep `issue<N>_status.md` current — move items between **What's done** and **Remaining work**, leaving `- [ ] Done` unchecked until fully resolved.

--- a/.cursor/skills/iflow-status/SKILL.md
+++ b/.cursor/skills/iflow-status/SKILL.md
@@ -1,24 +1,50 @@
 ---
 name: iflow-status
 description: >-
-  Run the /iflow-status report: a read-only snapshot of where every issue stands
-  — local issue-flow tracking state under .issueflows/ (focus / parked /
-  solved) plus open GitHub issues cross-referenced against the local folders.
-  Off-path: never auto-dispatched by /iflow. Writes nothing.
+  Read-only snapshot of where every issue stands, locally and on GitHub.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue status overview (`/iflow-status`)
 
-Follow this skill when the user wants a bird's-eye view of every issue's status
-rather than acting on the single focus issue.
-
-## When to use
-
-- The user runs `/iflow-status`, mentions "status of issues", "what's the state of all issues", "where do things stand", or asks for an issue overview / dashboard.
-- You want to see parked work, the focus issue's lifecycle stage, and open GitHub issues in one place.
+Follow this skill for a bird's-eye view of every issue's status — local tracking state (focus / parked / solved) plus open GitHub issues — rather than acting on the single focus issue.
 
 Do **not** use this skill to *change* anything. It is read-only and off-path; for acting on the focus issue use `/iflow`, and to choose the next issue use `/iflow-pick`.
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 

--- a/.cursor/skills/iflow-version-bump/SKILL.md
+++ b/.cursor/skills/iflow-version-bump/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: iflow-version-bump
 description: >-
-  Bump the project version in pyproject.toml using uv. Supports every uv bump
-  level (major, minor, patch, stable, alpha, beta, rc, post, dev) and a
-  pre-release-aware default when no level is given. Runs from the project root.
+  Bump the project version in pyproject.toml using uv, with a
+  pre-release-aware default when no level is given.
 disable-model-invocation: true
 ---
 
 # issue-flow — version bump
 
-Use when the user wants to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`).
+Use this skill to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`) — either at a specific level, or with the default rule below when none is given. It targets a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field.
 
-## When to use
 
-- The user asks for a version bump — either a specific level, or just "bump" / "release" with no level (use the default rule below).
-- The repo is a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field (standard for packages using issue-flow).
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
 
 ## Preconditions
 

--- a/.cursor/skills/iflow-yolo/SKILL.md
+++ b/.cursor/skills/iflow-yolo/SKILL.md
@@ -1,23 +1,51 @@
 ---
 name: iflow-yolo
 description: >-
-  Run the /iflow-yolo workflow: preflight (no default branch, clean tree,
-  passing tests), single consolidated confirm, then chain init → plan → start
-  → close yolo (hands-off close: auto changelog, PR merge, default-branch
-  pull) for small, low-risk issues. Stops on any ambiguity.
+  Chain init → plan → start → close yolo for a small, low-risk issue under
+  one consolidated confirm. Stops on any ambiguity.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue yolo (`/iflow-yolo`)
 
-Follow this skill when the user wants to **blast through a small, low-risk issue** in one shot.
+Follow this skill to **blast through a small, low-risk issue** in one shot, with no mid-run confirmation checkpoints beyond the single consolidated confirm.
 
 Use only for minor fixes, doc tweaks, and similar low-risk changes. Anything non-trivial should go through the individual commands.
 
-## When to use
 
-- The user runs `/iflow-yolo`, `/issue-fast`, mentions **issue-yolo**, or asks to "just do it" for a small issue.
-- The task is obviously small and the user has accepted that there will be no mid-run confirmation checkpoints.
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: reasoning** — Prioritize deep thinking and careful trade-offs over speed or token economy.
+
+In Cursor: switch to a thinking-capable model before invoking this step (not Auto-only).
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Preflight (abort on any failure)
 

--- a/.cursor/skills/iflow/SKILL.md
+++ b/.cursor/skills/iflow/SKILL.md
@@ -1,24 +1,51 @@
 ---
 name: iflow
 description: >-
-  Run the /iflow smart dispatcher: detect where the focus issue stands in the
-  lifecycle (via files in .issueflows/01-current-issues/ and
-  status markers) and dispatch to /iflow-init, /iflow-plan, /iflow-start, or
-  /iflow-close. Forwards trailing args verbatim. Never auto-dispatches to
-  /iflow-pause, /iflow-cleanup, or /iflow-yolo.
+  Smart dispatcher: detect where the focus issue stands and dispatch to
+  /iflow-init, /iflow-plan, /iflow-start, or /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — iflow smart dispatcher (`/iflow`)
 
-Follow this skill when the user wants to run **the right next step** in the issue-flow lifecycle without remembering which specific command applies.
-
-## When to use
-
-- The user runs `/iflow`, mentions **iflow**, or asks "what's the next step?" during an issue-flow lifecycle.
-- You want a single entry point that routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close` based on current state.
+Follow this skill to run **the right next step** in the issue-flow lifecycle: it detects state and routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close`, forwarding trailing args verbatim.
 
 Do **not** use this skill for `/iflow-pick`, `/iflow-pause`, `/iflow-cleanup`, `/iflow-yolo`, or `/iflow-fix`. Those are explicit-only commands. (`/iflow-pick` is the front door *before* `/iflow-init`, for when no issue has been chosen yet. `/iflow-fix` runs an interactive iterative-fixes session, driven by `/iflow-fix` + `/iflow-close`.)
+
+
+### MODEL & EXECUTION DIRECTIVE
+
+
+**Profile: economy** — Prioritize speed and token economy over deep reasoning.
+
+In Cursor: use **Auto** or a fast model before invoking this step.
+
+
+
+Keep scope tight to what this step requires.
+
+
+
+
+### Resolve project root (multi-root workspaces)
+
+Before any `git`, `gh`, or `.issueflows/` path operation in this workflow:
+
+**Resolution order** (stop when unambiguous):
+
+1. **Explicit hints** in slash input — `root:<path>`, `repo:<folder-basename>` (directory name, e.g. `cellpy-core`), or `repo:owner/name`.
+2. **CLI fast path** — `issue-flow agent resolve [-C <start>] [--from-file <active-file>] [--json]`. Use the returned `project_root` and `repo`; pass `-C <project_root>` to other `issue-flow agent …` subcommands.
+3. **Branch context** — exactly one workspace repo whose branch matches `^\d+-` → that root.
+4. **Single scaffold** — exactly one `.issueflows/` tree visible in the workspace → that root.
+5. **Ambiguous** → **stop and ask**; never guess between sibling repos.
+
+After resolution, treat the result as `<project_root>` and `<owner/repo>`:
+
+- **Git:** `git -C <project_root> …` (or `issue-flow agent … -C <project_root>` for supported ops).
+- **GitHub:** always `gh … --repo <owner/repo>` — never rely on `gh`'s implicit cwd default.
+- **Paths:** all `.issueflows/…` paths are under `<project_root>`.
+
+When `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` exists, read it for layout and cross-repo guidance.
 
 ## Instructions
 

--- a/.issueflows/03-solved-issues/issue415_original.md
+++ b/.issueflows/03-solved-issues/issue415_original.md
@@ -1,0 +1,7 @@
+# Issue #415: Bump pandas
+
+Source: https://github.com/jepegit/cellpy/issues/415
+
+## Original issue text
+
+Bump pandas from 2.3.3 to 3.0.3 results in broken tests - in particular bdf export functionallity. Fix it.

--- a/.issueflows/03-solved-issues/issue415_plan.md
+++ b/.issueflows/03-solved-issues/issue415_plan.md
@@ -1,0 +1,92 @@
+# Issue #415 plan — Bump pandas to 3.0.3
+
+## Goal
+
+Raise the `pandas` dependency from 2.3.3 to 3.0.3 and fix all test regressions so the suite is green. Primary breakage called out in the issue is BDF export (`cellpy.exporters.bdf`); reproduction shows **42 failures** across four test modules on pandas 3.0.3.
+
+## Constraints
+
+- Keep BDF export behaviour byte-identical for the default path (no change to column map, unit conversion, or header semantics).
+- Respect [bdf-export.md](../04-designs-and-guides/bdf-export.md): no new `cellpy.utils` imports in `cellpy.exporters.bdf`.
+- Regenerate `uv.lock` with `UV_NO_SOURCES=1 uv lock` after changing `pyproject.toml` (per cellpy-core migration rules when touching deps).
+- Minimal diffs — replace removed APIs, don't refactor surrounding code.
+
+### Prior art
+
+- [`cellpy/exporters/bdf.py`](../../cellpy/exporters/bdf.py) — `_datetime_to_unix_seconds` uses `Series.view("int64")` (removed in pandas 3).
+- [`cellpy/readers/instruments/processors/post_processors.py`](../../cellpy/readers/instruments/processors/post_processors.py) — same `.view("int64")` pattern on datetime columns (not hit by BDF tests but will break instrument post-processing).
+- [`cellpy/utils/batch_tools/batch_journals.py`](../../cellpy/utils/batch_tools/batch_journals.py) — `.values.flatten()` on string columns; pandas 3 returns `ArrowStringArray` which has no `.flatten()` (5 failures in batch/easyplot).
+- [bdf-export.md](../04-designs-and-guides/bdf-export.md) — design doc for BDF layer; no code changes needed unless behaviour shifts.
+- `00-tools/` — empty index; no reusable helpers.
+- Graphify — not consulted (grep + targeted pytest sufficient).
+
+## Approach
+
+### 1. Bump dependency
+
+In `pyproject.toml`, change `"pandas<3"` → `"pandas>=3.0.3,<4"` (or pin `==3.0.3` if that matches project convention for core deps). Run `uv lock` and `uv sync`.
+
+### 2. Fix BDF datetime conversion (30 test failures)
+
+In `_datetime_to_unix_seconds` ([`bdf.py:334`](../../cellpy/exporters/bdf.py)):
+
+```python
+# before (pandas 3: AttributeError — Series.view removed)
+return ts.view("int64") / 1e9
+
+# after
+return ts.astype("int64") / 1e9
+```
+
+`astype("int64")` is the documented replacement; Unix-second values stay identical for timezone-aware `datetime64[ns]`.
+
+### 3. Fix post-processor datetime re-interpretation (proactive)
+
+In `post_processors.py` lines 196 and 212, replace `.view("int64")` with `.astype("int64")` on the same datetime64→nanoseconds path. Same root cause as BDF; prevents silent runtime failures on instrument loads.
+
+### 4. Fix batch journal string extraction (5 test failures)
+
+In `batch_journals.py` (~439, 444, 449), replace:
+
+```python
+list(col.dropna().values.flatten())
+```
+
+with `.dropna().tolist()` (1-D Series; no flatten needed). Applies to `bad_cells`, `starred`, and `notes` columns. Pandas 3 string dtype is backed by PyArrow; `.values` is an `ArrowStringArray` without `.flatten()`.
+
+### 5. Investigate plotutils summary_plot (7 test failures)
+
+`tests/test_plotutils_summary_plot.py::TestSummaryPlotBasic` — figure returned but lacks `get_axes` and `show`. Likely `summary_plot` returns a Plotly figure when seaborn/matplotlib path is expected, or a wrapper type changed under pandas 3. Reproduce after steps 1–4; inspect return type from `cellpy.utils.plotutils.summary_plot` and adjust either the implementation or the test assertion (prefer fixing the implementation if a pandas-3 dtype change broke the seaborn branch).
+
+## Files to touch
+
+| File | Change |
+|------|--------|
+| `pyproject.toml` | Relax/pin pandas to 3.0.3 |
+| `uv.lock` | Regenerate |
+| `cellpy/exporters/bdf.py` | `view` → `astype` in `_datetime_to_unix_seconds` |
+| `cellpy/readers/instruments/processors/post_processors.py` | `view` → `astype` (2 sites) |
+| `cellpy/utils/batch_tools/batch_journals.py` | `.values.flatten()` → `.tolist()` (3 sites) |
+| `cellpy/utils/plotutils.py` (TBD) | Only if step 5 investigation finds a real bug |
+
+## Test strategy
+
+Primary command (conda recommended per project rules; `uv run pytest` also valid):
+
+```bash
+cd cellpy
+uv sync
+uv run pytest tests/test_exporters_bdf.py -q          # 33 tests — must all pass
+uv run pytest tests/test_batch.py tests/test_easyplot.py -q
+uv run pytest tests/test_plotutils_summary_plot.py -q
+uv run pytest -q                                       # full suite (~447+ pass, 0 fail)
+```
+
+Confirm pandas version: `uv run python -c "import pandas; print(pandas.__version__)"` → `3.0.3`.
+
+No new tests strictly required — existing BDF and batch tests already cover the broken paths. Optional: add a one-liner unit test on `_datetime_to_unix_seconds` if we want isolation from the heavy `CellpyCell` fixture (not required for this fix).
+
+## Open questions
+
+1. **Pin vs range** — Pin `pandas==3.0.3` exactly, or allow `>=3.0.3,<4`? Recommend `>=3.0.3,<4` unless Dependabot/issue author wants exact pin.
+2. **Plotutils scope** — If the 7 plotutils failures pre-exist on pandas 2.3.3 (environment flake), treat as out-of-scope for #415. Will verify during `/iflow-start` before editing plot code.

--- a/.issueflows/03-solved-issues/issue415_status.md
+++ b/.issueflows/03-solved-issues/issue415_status.md
@@ -1,0 +1,16 @@
+# Issue #415 status
+
+- [x] Done
+
+## What's done
+
+- Bumped `pandas` constraint to `>=3.0.3,<4` in `pyproject.toml`; regenerated `uv.lock`
+- Fixed `_datetime_to_unix_seconds` in `cellpy/exporters/bdf.py` — epoch delta + `total_seconds()` (pandas 3 default datetime unit is `us`)
+- Fixed `Series.view("int64")` → `astype("int64")` in `post_processors.py` (2 sites)
+- Fixed `ArrowStringArray.flatten` in `batch_journals.py` — `.dropna().tolist()` (3 sites)
+- Added missing `@pytest.mark.skipif(not seaborn_available)` on `TestSummaryPlotBasic`
+- Full suite: 477 passed, 61 skipped, 0 failed
+
+## Remaining work
+
+- None

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,15 @@ The full slash-command lifecycle is:
 Issue labels can select the flow: when an issue picked via `/iflow-pick` carries the **`yolo`** label, it is routed through `/iflow-yolo` (one combined confirmation). Controlled by `label_flows` (default `true`) and `yolo_label` (default `"yolo"`) under `[issueflow]` in `.issueflows/config.toml`; re-run `issue-flow update` after changing them.
 
 
+
+Lifecycle skills include a **`### MODEL & EXECUTION DIRECTIVE`** section that tells agents whether to prioritize **economy** (speed) or **reasoning** (depth) for that step. Toggle with `step_directives` under `[issueflow]`; override per step via `[issueflow.step_profiles]`; optional label hints during `/iflow-pick` via `model_label_flows`, `deep_model_label`, and `fast_model_label`. Re-run `issue-flow update` after changing any of these.
+
+
 `/iflow-fix` opens an interactive iterative-fixes session: it creates one GitHub issue + long-lived branch, then loops over many small fixes (each gets a short plan and is implemented only on confirmation, recorded as a dated bullet in `issue<N>_status.md`), and ends with `/iflow-close`. It is off-path (never auto-dispatched); while a session is active, drive it with `/iflow-fix` + `/iflow-close`, not `/iflow`.
 
 `/iflow-status` prints a **read-only** overview of where every issue stands — the local tracking state under `.issueflows/` (focus / parked / solved) plus open GitHub issues cross-referenced against it. It is off-path (never auto-dispatched) and changes nothing.
+
+`/iflow-archive` condenses old solved issue groups under `.issueflows/03-solved-issues/` into a single dated `YYYY-MM-DD_archived_issues.md` summary file (recording the pre-archive git ref for recovery via `git show <ref>:<path>`), then deletes the original `issue<N>_*` files. It is off-path and destructive: nothing is deleted before one consolidated confirmation.
 
 > On tools without project slash commands (e.g. Codex CLI), invoke the mirrored Agent Skills instead (for example `iflow-init` in place of `/iflow-init`).
 
@@ -173,6 +179,16 @@ Long-lived design docs, design decisions, and project "good practices" live unde
 - **Before planning or implementing**, skim `.issueflows/04-designs-and-guides/` for existing docs relevant to the current issue and follow them (cite them in the plan when they influence the approach).
 - **When a non-trivial design decision is made** during `/iflow-plan` or `/iflow-start`, add or update a markdown file here. Keep entries terse: context, the decision, alternatives considered, and a link back to the issue.
 - **Never overwritten by `issue-flow update`.** The folder is recreated if missing, but existing files are left alone.
+
+
+### Multi-root workspaces
+
+When an editor workspace contains **multiple sibling repositories**, each with its own `.issueflows/` scaffold:
+
+- **Resolve the target repo first** — explicit `root:` / `repo:` hints, then `issue-flow agent resolve`, then branch/single-scaffold heuristics; **ask** when ambiguous. Never let `git` or `gh` infer the repo from cwd alone.
+- **Scoped rules** — this repo's `issueflow-rules` apply under this project root only (path globs). Put **toolchain-specific** run/test commands in `.issueflows/04-designs-and-guides/this-project.md`, not in shared boilerplate that every repo merges.
+- **Per-repo lifecycle** — `/iflow-cleanup`, branch hygiene, and focus issue folders are **per repository**; repeat commands in each repo when needed.
+- **Design doc** — see `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` when present (issue #67).
 
 
 ### Branch hygiene

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix: bump pandas to 3.0.3 — BDF Unix-time export, batch journal string extraction, and post-processor datetime handling (#415)
 * CI: move Windows conda pytest from AppVeyor to GitHub Actions (ACE x64 install with cache) (#407)
 * Testing: new offline unit tests for `utils/helpers.py` (outlier removal, group names, rate column) and `readers/filefinder.py` (tmp-path raw-file trees) (#372)
 * Fix: local `OtherPath.rglob()` did not recurse into subdirectories, so `search_for_files(..., sub_folders=True)` missed files in subfolders (#372)

--- a/cellpy/exporters/bdf.py
+++ b/cellpy/exporters/bdf.py
@@ -36,7 +36,6 @@ from typing import TYPE_CHECKING, Callable, Literal, Optional, Union
 import pandas as pd
 
 from cellpy.filters import filter_cycles
-from cellpy.parameters.internal_settings import get_headers_normal
 from cellpy.readers import data_structures as core
 
 if TYPE_CHECKING:
@@ -331,7 +330,8 @@ def _datetime_to_unix_seconds(series: pd.Series) -> pd.Series:
         ts = ts.dt.tz_localize("UTC", nonexistent="NaT", ambiguous="NaT")
     else:
         ts = ts.dt.tz_convert("UTC")
-    return ts.view("int64") / 1e9
+    epoch = pd.Timestamp("1970-01-01", tz="UTC")
+    return (ts - epoch).dt.total_seconds()
 
 
 def _resolve_filename(filename: Union[str, Path, None], cell: "CellpyCell", fmt: BdfFormat) -> Path:

--- a/cellpy/readers/instruments/processors/post_processors.py
+++ b/cellpy/readers/instruments/processors/post_processors.py
@@ -14,11 +14,9 @@ the ``config_params.post_processor[<name of post processor>]``.
 
 import datetime
 import logging
-import sys
 import warnings
 
 import pandas as pd
-import numpy as np
 
 from cellpy.parameters.internal_settings import headers_normal
 from cellpy.parameters.prms import _minimum_columns_to_keep_for_raw_if_exists
@@ -163,7 +161,7 @@ def convert_date_time_to_datetime(data: Data, config_params: ModelParameters) ->
     hdr_date_time = headers_normal.datetime_txt
     try:
         data.raw[hdr_date_time] = pd.to_datetime(data.raw[hdr_date_time])
-    except ValueError as e:
+    except ValueError:
         warnings.warn(
             "Could not convert date_time to datetime. Will try mixed format (slow)."
         )
@@ -193,7 +191,7 @@ def convert_step_time_to_timedelta(data: Data, config_params: ModelParameters) -
     hdr_step_time = headers_normal.step_time_txt
     if data.raw[hdr_step_time].dtype == "datetime64[ns]":
         logging.debug("already datetime64[ns] - need to convert to back first")
-        data.raw[hdr_step_time] = data.raw[hdr_step_time].view("int64")
+        data.raw[hdr_step_time] = data.raw[hdr_step_time].astype("int64")
         data.raw[hdr_step_time] = (
             data.raw[hdr_step_time] - data.raw[hdr_step_time].iloc[0]
         )
@@ -209,7 +207,7 @@ def convert_test_time_to_timedelta(data: Data, config_params: ModelParameters) -
     hdr_test_time = headers_normal.test_time_txt
     if data.raw[hdr_test_time].dtype == "datetime64[ns]":
         logging.debug("already datetime64[ns] - need to convert to back first")
-        data.raw[hdr_test_time] = data.raw[hdr_test_time].view("int64")
+        data.raw[hdr_test_time] = data.raw[hdr_test_time].astype("int64")
         data.raw[hdr_test_time] = (
             data.raw[hdr_test_time] - data.raw[hdr_test_time].iloc[0]
         )

--- a/cellpy/utils/batch_tools/batch_journals.py
+++ b/cellpy/utils/batch_tools/batch_journals.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pathlib
-import platform
 import shutil
 import tempfile
 from typing import Union, Any
@@ -22,7 +21,7 @@ from cellpy.parameters.legacy.update_headers import (
 )
 from cellpy.readers import dbreader, json_dbreader
 from cellpy.utils.batch_tools.batch_core import BaseJournal
-from cellpy.utils.batch_tools.engines import simple_db_engine, sql_db_engine
+from cellpy.utils.batch_tools.engines import simple_db_engine
 from cellpy.utils.batch_tools import batch_helpers
 
 hdr_journal = get_headers_journal()
@@ -436,17 +435,17 @@ class LabJournal(BaseJournal, ABC):
             bcn2 = []
 
         try:
-            bc2 = list(session["bad_cells"]["cell_name"].dropna().values.flatten())
+            bc2 = session["bad_cells"]["cell_name"].dropna().tolist()
         except KeyError:
             bc2 = []
 
         try:
-            s2 = list(session["starred"]["cell_name"].dropna().values.flatten())
+            s2 = session["starred"]["cell_name"].dropna().tolist()
         except KeyError:
             s2 = []
 
         try:
-            n2 = list(session["notes"]["txt"].dropna().values.flatten())
+            n2 = session["notes"]["txt"].dropna().tolist()
         except KeyError:
             n2 = []
 

--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -8,6 +8,8 @@ This repo uses Cursor **Agent Skills** under `.cursor/skills/` that line up with
 
 It also seeds `.issueflows/00-tools/README.md` — the index of the project's **shared toolbox**. Drop reusable helper scripts there during issue work and add a one-line index entry; check the folder before writing a new one-off helper. Like the project brief, this README is never overwritten by `issue-flow update`, so its index grows over time.
 
+**Multi-root workspaces:** when several sibling repos share one editor workspace, resolve the target repo first (`root:` / `repo:` hints, or `issue-flow agent resolve`). Never let `git` or `gh` infer the repository from cwd alone. See `.issueflows/04-designs-and-guides/multi-repo-workspaces.md` when present.
+
 
 | Entry point | File | Role |
 |--------|------|------|
@@ -22,6 +24,7 @@ It also seeds `.issueflows/00-tools/README.md` — the index of the project's **
 | `/iflow-yolo` | `iflow-yolo/SKILL.md` | All-in-one for small, low-risk issues: chains `init → plan → start → close` with up-front safeguards and a single confirmation. |
 | `/iflow-fix` | `iflow-fix/SKILL.md` | **Off-path.** Interactive iterative-fixes session: create one issue + long-lived branch, then loop over many small fixes (short plan each, recorded in `issue<N>_status.md`), ending with `/iflow-close`. |
 | `/iflow-status` | `iflow-status/SKILL.md` | **Off-path, read-only.** Snapshot of where every issue stands — local tracking state (focus / parked / solved) plus open GitHub issues cross-referenced against it. Changes nothing. |
+| `/iflow-archive` | `iflow-archive/SKILL.md` | **Off-path, destructive (gated).** Condense old solved issue groups into a dated `YYYY-MM-DD_archived_issues.md` summary (recording the pre-archive git ref for recovery), then delete the original files after one consolidated confirm. |
 | `/iflow-graphify` | `iflow-graphify/SKILL.md` | **Off-path.** Rebuild the [graphify](https://iflow-graphify.net) knowledge graph (`graphify-out/graph.html`, `GRAPH_REPORT.md`, `graph.json`). Wraps `issue-flow graphify` / `graphify`. Optional: only meaningful when `graphifyy` is installed. |
 
 
@@ -45,11 +48,15 @@ It also seeds `.issueflows/00-tools/README.md` — the index of the project's **
 | `iflow-yolo` | `/iflow-yolo` | Chain `init → plan → start → close` with safeguards. |
 | `iflow-fix` | `/iflow-fix` | Same flow as `/iflow-fix`: set up an interactive iterative-fixes session, loop over small fixes, finish with `/iflow-close`. Off-path. |
 | `iflow-status` | `/iflow-status` | Same flow as `/iflow-status`: read-only overview of focus / parked / solved issues plus open GitHub issues. Off-path; writes nothing. |
+| `iflow-archive` | `/iflow-archive` | Same flow as `/iflow-archive`: summarise selected solved issue groups into a dated archive file (with the pre-archive git ref), then delete the originals. Off-path; destructive with one consolidated confirm. |
 | `iflow-version-bump` | `@iflow-version-bump` (often used from `/iflow-close`) | Bump `[project]` version in `pyproject.toml` via `uv version --bump <level>` (any uv level: `major`/`minor`/`patch`/`stable`/`alpha`/`beta`/`rc`/`post`/`dev`); a bare `bump` stays on the current pre-release channel. |
 | `iflow-history-update` | `@iflow-history-update` (used from `/iflow-close`) | Append an entry to `## [Unreleased]` in `HISTORY.md`, or promote it to a new `## [x.y.z] - YYYY-MM-DD` release section when a version bump happened. |
 | `iflow-graphify` | `/iflow-graphify` | Same flow as `/iflow-graphify`: rebuild the graphify knowledge graph for the project. Off-path; never auto-dispatched. |
 
 Each skill sets `disable-model-invocation: true` so it is included when you **explicitly** invoke it, not on every chat. See [Agent Skills](https://cursor.com/help/customization/skills) in the Cursor docs.
+
+Lifecycle skills also carry a **`### MODEL & EXECUTION DIRECTIVE`** — **economy** (speed/token savings) or **reasoning** (design depth) — baked at `issue-flow update` from `[issueflow]` / `[issueflow.step_profiles]` in `.issueflows/config.toml`. `/iflow-pick` can announce label-based session overrides when `model_label_flows` is enabled (`deep_model_label` / `fast_model_label`).
+
 
 ---
 
@@ -101,7 +108,7 @@ All workflows that touch git also run a short **branch-status preflight**: `git 
 
 **Focus-issue resolution:** prefer the leading digits of the current branch when it matches `^<N>-.+`; else the single group in `.issueflows/01-current-issues/`; else ask.
 
-**Not auto-dispatched:** `/iflow-pause`, `/iflow-cleanup`, `/iflow-yolo`, `/iflow-fix`, and `/iflow-status`. `/iflow` will mention them in its output when relevant (e.g. "after the PR merges, run `/iflow-cleanup`") but never picks them for you.
+**Not auto-dispatched:** `/iflow-pause`, `/iflow-cleanup`, `/iflow-yolo`, `/iflow-fix`, `/iflow-status`, and `/iflow-archive`. `/iflow` will mention them in its output when relevant (e.g. "after the PR merges, run `/iflow-cleanup`") but never picks them for you.
 
 **Result:** One of the four linear commands runs, with its own normal checkpoints intact.
 
@@ -309,6 +316,27 @@ The bump runs **after** tests and **before** issue-folder moves and **before** c
 
 ---
 
+## 11. `/iflow-archive` — condense the solved-issues archive (destructive, gated)
+
+**When:** `.issueflows/03-solved-issues/` has grown large and most of its `issue<N>_*` groups are no longer worth keeping as individual files.
+
+**What you pass:** Nothing (archive all but the 5 most recent solved groups), `keep <K>` (keep the `<K>` most recent), an explicit list of issue numbers, or `all`.
+
+**What the assistant does:**
+
+1. **Preflight** — requires a **clean working tree** (stop if dirty) and records the pre-archive ref via `git rev-parse HEAD`.
+2. **Select** — lists every solved group (number + title), applies your input rule, and shows the candidate list for you to adjust.
+3. **Consolidated confirm** — one prompt covering exactly which issues get summarised and that their files will be **deleted**; nothing proceeds without a clear yes.
+4. **Summarise** — appends to `.issueflows/03-solved-issues/YYYY-MM-DD_archived_issues.md`: a header with the pre-archive ref and recovery recipe (`git show <ref>:<path>`), then one section per issue with source URL, archived file names, and a 2–4 sentence outcome summary.
+5. **Delete** — removes the archived groups' files (`issue-flow agent archive <N> ...` when the CLI is installed, else `git rm`).
+6. **Commit offer** — proposes a single commit so the deletion lands right after the recorded ref; asks first, never pushes.
+
+**Off-path:** `/iflow` never auto-dispatches to `/iflow-archive`. It deletes files, so you opt in explicitly.
+
+**Result:** One dated summary file replaces the archived groups; every original file remains recoverable from git history via the recorded ref.
+
+---
+
 ## End-to-end flow
 
 Tip: at any point in the linear flow below, you can just run `/iflow` and it will dispatch to the right step based on current state.
@@ -342,6 +370,7 @@ Detours:
   /iflow-yolo   — chain init → plan → start → close for tiny fixes (safeguarded)
   /iflow-fix    — interactive session: one branch, many small fixes, then /iflow-close
   /iflow-status — read-only overview of all issues (focus / parked / solved + GitHub)
+  /iflow-archive — condense old solved issues into a dated summary file (gated deletion)
 ```
 
 The skill packages under `.cursor/skills/` are the primary workflow surface. This document is a readable overview only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "scipy",
     "numpy",
-    "pandas<3",
+    "pandas>=3.0.3,<4",
     "python-box",
     "setuptools",
     "ruamel.yaml",

--- a/tests/test_plotutils_summary_plot.py
+++ b/tests/test_plotutils_summary_plot.py
@@ -25,6 +25,10 @@ seaborn_available = importlib.util.find_spec("seaborn") is not None
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(
+    not seaborn_available,
+    reason="seaborn not available",
+)
 class TestSummaryPlotBasic:
     """Test basic functionality of summary_plot with different plot types."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -442,7 +446,7 @@ requires-dist = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "openpyxl" },
-    { name = "pandas", specifier = "<3" },
+    { name = "pandas", specifier = ">=3.0.3,<4" },
     { name = "pint" },
     { name = "plotly", marker = "extra == 'all'" },
     { name = "plotly", marker = "extra == 'batch'" },
@@ -2219,42 +2223,46 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.3.3"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
-    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
-    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
-    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
-    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
-    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
-    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
-    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
-    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
-    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
-    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
-    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -2314,7 +2322,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Raise the `pandas` dependency from 2.x to `>=3.0.3,<4` and regenerate `uv.lock`.
- Fix BDF export Unix-time conversion for pandas 3's microsecond datetime resolution (`total_seconds()` instead of removed `Series.view`).
- Replace remaining `Series.view("int64")` calls in post-processors and fix batch journal string extraction for PyArrow-backed string arrays.
- Skip `TestSummaryPlotBasic` when seaborn is not installed (consistent with other plotutils test classes).

Closes #415

## Test plan

- [x] `uv run pytest tests/test_exporters_bdf.py`
- [x] `uv run pytest tests/test_batch.py tests/test_easyplot.py`
- [x] `uv run pytest` — 477 passed, 61 skipped

Made with [Cursor](https://cursor.com)