### PR TITLE
test(testing): unit-handling characterization (Stage 0.4) (#431)

### DIFF
--- a/.issueflows/03-solved-issues/issue431_original.md
+++ b/.issueflows/03-solved-issues/issue431_original.md
@@ -1,0 +1,42 @@
+# Issue #431: Stage 0.4: Unit-handling test groundwork — registry interop, converter parity, pint-optional guard
+
+Source: https://github.com/jepegit/cellpy/issues/431
+
+## Original issue text
+
+> Part of **Stage 0 — foundations for cellpy 2** (see the tracking issue). Plan documents live in the shared workspace: `cellpy-workspace/code-reviews/` (alongside the `cellpy` and `cellpy-core` repos).
+
+## Goal
+
+Three test deliverables that make the unit consolidation safe to start:
+
+1. **Registry-interop test**: multiply a `Q` from `cellpy.readers.data_structures` with a
+   `Q` from `cellpycore.units` — this **fails today** (two pint registries in one process).
+   Land as `xfail(strict=True)`: it is the executable statement of unit plan Phase 1's
+   target, and flips to a hard pass when the registries are unified.
+2. **Converter parity fixtures**: `get_converter_to_specific` and
+   `nominal_capacity_as_absolute` — legacy (cellreader) vs `cellpycore.units` — equal on
+   golden data for gravimetric / areal / absolute modes.
+3. **pint-optional guard** (cellpy-core side): importing `cellpycore` and running the
+   step/summary engine works with pint **not installed**; helpers raise a clear
+   `ModuleNotFoundError` only when called. Verify whether this already exists in core CI
+   before writing (the roadmap status is stale — see Stage 0.12).
+
+## Why
+
+Unit plan Phase 2 deletes cellpy's duplicated converter bodies; parity fixtures are the
+precondition. The interop test documents the two-registry trap so nobody passes Quantities
+across the boundary before Phase 1 lands. These are also the STEP-12 success criteria in the
+core integration roadmap.
+
+## Links
+
+- `code-reviews/unit-handling-cellpy2-plan.md` (§6 testing strategy, §7 risk 1)
+- `cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md` (STEP-12)
+- Depends on Stage 0.1 (fixtures).
+
+## Acceptance
+
+- Interop test in tree as strict xfail with a comment pointing at unit plan Phase 1.
+- Parity fixtures committed + green; pint-optional guard confirmed or added in cellpy-core.
+

--- a/.issueflows/03-solved-issues/issue431_plan.md
+++ b/.issueflows/03-solved-issues/issue431_plan.md
@@ -1,0 +1,173 @@
+# Issue #431 — Plan
+
+## Goal
+
+Land Stage 0.4 unit-handling test groundwork: a strict-xfail registry-interop test and
+legacy↔core converter parity fixtures in **cellpy**, plus confirmation that the
+**cellpy-core** pint-optional guard from STEP-12 is already covered (add only if a gap
+shows up).
+
+## Constraints
+
+- **Tests only** — no production refactors (Phase 1 registry unification is out of scope).
+- **Depends on Stage 0.1** — reuse golden/oracle style from `#428`; no new parquet goldens
+  required (hand-computed float oracles like core `#40`).
+- **Plan doc paths** — issue says `code-reviews/`; read
+  [`architecture-plan/unit-handling-cellpy2-plan.md`](../../architecture-plan/unit-handling-cellpy2-plan.md)
+  §6 and STEP-12 in
+  [`../cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`](../cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md).
+- **cellpy-core migration** — read
+  [`../cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-migration.md`](../cellpy-core/.issueflows/04-designs-and-guides/cellpy-core-migration.md)
+  before touching the boundary; parity asserts values only, never passes `Quantity` objects
+  across the seam in production code.
+- **Modes** — parity covers **gravimetric / areal / absolute** only (issue acceptance);
+  volumetric stays out until legacy `nominal_capacity_as_absolute` implements it.
+- **Fast PR gate** — mark converter parity parametrization `@pytest.mark.essential`; registry
+  interop stays unmarked (strict xfail is expected-fail, not a merge blocker).
+
+### Prior art
+
+| Hit | Module / file | Reuse |
+|-----|---------------|--------|
+| Legacy unit tests (reimplemented math) | `tests/test_units.py` | **Coexist** — keep; new module adds cross-boundary parity + interop xfail. |
+| Core converter goldens | `cellpy-core/tests/test_units_converters.py` | **Mirror** — reuse same stub inputs / expected floats (mass=2, area=2, default `CellpyUnits`). |
+| Core pint-optional guard | `cellpy-core/tests/test_units_optional.py` (issue #40) | **Confirm** — deliverable #3 likely done; verify in core pytest, document in status. |
+| Two registries | `cellpy/readers/data_structures.py` (`_ureg`, `Q`) vs `cellpycore.units` | **Document** — interop xfail targets unit plan Phase 1. |
+| Legacy converters | `cellpy/readers/cellreader.py` `get_converter_to_specific`, `nominal_capacity_as_absolute` | **Compare** — parity calls these vs `cellpycore.units.*` on identical inputs. |
+| Unit plan §6 | `architecture-plan/unit-handling-cellpy2-plan.md` | **Authoritative** acceptance checklist. |
+| Stage 0 pattern | `issue430_plan.md` (solved) | **Mirror** — `*_support.py` + focused test module + `tests/README.md` subsection. |
+| Toolbox | `.issueflows/00-tools/` | Empty — no helpers to reuse. |
+
+## Approach
+
+### 0. Preflight (cellpy-core deliverable #3)
+
+Before writing cellpy tests, run in sibling `cellpy-core`:
+
+```bash
+uv run pytest tests/test_units_optional.py tests/test_units_converters.py -q
+```
+
+If green: record in `issue431_status.md` that STEP-12 pint-optional + core-side converter
+parity already exist (`test_units_optional.py`, `test_units_converters.py`); **no core code
+changes** for this issue. If a gap appears (e.g. missing `ModuleNotFoundError` message),
+add the minimal test/fix in **cellpy-core** as a follow-up commit on the same branch or a
+paired PR — see Open questions.
+
+### 1. Shared helpers — `tests/unit_parity_support.py`
+
+Small module:
+
+- `GOLDEN_CONVERTER_CASES` — parametrized `(mode, expected)` aligned with core
+  `test_units_converters.py` defaults (gravimetric `500.0`, areal `0.5`, absolute `1.0`).
+- `GOLDEN_NOM_CAP_CASES` — gravimetric / areal / absolute tuples matching core
+  `test_nominal_capacity_as_absolute_*` (e.g. gravimetric `0.006` with nom_cap=3000,
+  mass=2).
+- `make_parity_cell(cellpy_data_instance)` — load or construct a `CellpyCell` whose
+  `data` exposes `mass`, `active_electrode_area`, `nom_cap`, `nom_cap_specifics`,
+  `raw_units`, and `cellpy_units` matching the core `_stub()` defaults (set attrs on a
+  minimal `from_raw` cell or mutate `dataset` fixture).
+- `make_core_stub()` — thin wrapper returning the same numeric/`CellpyUnits` inputs as
+  core's `_stub()` for `cellpycore.units` calls.
+
+### 2. Main test module — `tests/test_unit_handling_stage0.py`
+
+#### A. Registry interop (`xfail(strict=True)`)
+
+```python
+@pytest.mark.xfail(
+    strict=True,
+    reason="Unit plan Phase 1: unify pint registries before cross-boundary Quantity math",
+)
+def test_cellpy_and_cellpycore_quantities_interoperate():
+    ...
+```
+
+Multiply `cellpy.readers.data_structures.Q(1, "mAh")` with `cellpycore.units.Q(1, "h")`
+(or equivalent). Expect pint registry mismatch today; becomes a hard pass after Phase 1.
+Comment in test points at `architecture-plan/unit-handling-cellpy2-plan.md` Phase 1.
+
+#### B. Converter parity (`@pytest.mark.essential`)
+
+For each mode in `GOLDEN_CONVERTER_CASES`:
+
+1. `legacy = cell.get_converter_to_specific(mode=mode)` on parity cell.
+2. `core = cellpycore.units.get_converter_to_specific(make_core_stub(), mode=mode)`.
+3. `assert legacy == pytest.approx(core)`.
+
+For each case in `GOLDEN_NOM_CAP_CASES`:
+
+1. `legacy = cell.nominal_capacity_as_absolute(...)` with matching kwargs.
+2. `core = cellpycore.units.nominal_capacity_as_absolute(...)` with stub/meta.
+3. `assert legacy == pytest.approx(core)`.
+
+Optional one case: raw charge unit mismatch (`A*h` vs `mAh`) — mirrors core
+`test_get_converter_to_specific_charge_unit_mismatch` if legacy behaves the same.
+
+#### C. Coexistence with `tests/test_units.py`
+
+Leave existing tests untouched. Add one-line pointer at top of `test_units.py` or in
+`tests/README.md` → new module.
+
+### 3. Documentation
+
+Add **Unit-handling characterization (Stage 0.4)** subsection to `tests/README.md`:
+
+- Files: `test_unit_handling_stage0.py`, `unit_parity_support.py`
+- Interop xfail semantics (flips on Phase 1)
+- Core STEP-12 verification pointer (`cellpy-core/tests/test_units_optional.py`)
+- How to update golden floats when converter math intentionally changes
+
+## Files to touch
+
+| Path | Repo | Change |
+|------|------|--------|
+| `tests/unit_parity_support.py` | cellpy | **New** — shared golden cases + stub builders |
+| `tests/test_unit_handling_stage0.py` | cellpy | **New** — interop xfail + parity tests |
+| `tests/README.md` | cellpy | Stage 0.4 subsection |
+| `tests/test_units.py` | cellpy | Optional one-line pointer comment |
+| `cellpy-core/tests/*` | cellpy-core | **Only if preflight finds a gap** |
+
+No changes to `cellreader.py`, `data_structures.py`, or `cellpycore.units` for this issue.
+
+## Test strategy
+
+```bash
+# cellpy-core preflight (sibling checkout)
+cd ../cellpy-core && uv run pytest tests/test_units_optional.py tests/test_units_converters.py -q
+
+# cellpy development
+cd ../cellpy
+uv run pytest tests/test_unit_handling_stage0.py -v
+
+# PR gate
+uv run pytest -m essential
+
+# Before merge
+uv run pytest tests/test_unit_handling_stage0.py tests/test_units.py
+```
+
+**Essential budget:** ~3–4 parity parametrizations (one per mode + one nom_cap case). Interop
+xfail excluded from essential count.
+
+## Open questions
+
+1. **Dual-repo PR vs cellpy-only** — **Recommended:** single **cellpy** PR (#431) for
+   deliverables #1–#2; deliverable #3 = verification note in status/README referencing
+   existing core tests. Only open a **cellpy-core** PR if preflight fails.
+2. **Parity cell setup** — **Recommended:** mutate `dataset` fixture attrs to match core
+   `_stub()` rather than new committed golden files (KISS; Stage 0.1 parquet not needed).
+3. **Charge-unit mismatch case** — **Recommended:** include if legacy and core agree today;
+   skip if legacy path differs (document in status).
+
+## Branch
+
+Switch off stale `430-prms-characterization-tests` (merged). Suggest:
+
+```bash
+git switch master && git pull --ff-only
+git switch -c 431-unit-handling-stage0
+```
+
+**Branch preflight (2026-07-09):** on `430-prms-characterization-tests` (stale); dirty
+`graphify-out/`; `issue431_original.md` untracked in `01-current-issues/`.

--- a/.issueflows/03-solved-issues/issue431_status.md
+++ b/.issueflows/03-solved-issues/issue431_status.md
@@ -1,0 +1,18 @@
+# Issue #431 — Status
+
+- [x] Done
+
+## What's done
+
+- Branch `431-unit-handling-stage0` from current `master`.
+- cellpy-core preflight: `test_units_optional.py` + `test_units_converters.py` — **28 passed** (no core PR).
+- `tests/unit_parity_support.py` — golden cases + `make_parity_cell` / `make_core_stub`.
+- `tests/test_unit_handling_stage0.py` — strict-xfail registry interop + essential parity (4) + charge-mismatch + explicit nom_cap.
+- `tests/README.md` — Stage 0.4 subsection; `tests/test_units.py` pointer comment.
+- Pytest: `tests/test_unit_handling_stage0.py` — 6 passed, 1 xfailed; `-m essential` — 30 passed.
+
+## Known limitation (documented)
+
+- `nominal_capacity_as_absolute` areal/absolute parity **not** tested: legacy catches removed
+  `pint.errors.PerformanceWarning` → `AttributeError` masks real conversion errors. Gravimetric
+  parity only until legacy path fixed (out of scope for Stage 0.4).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Testing: unit-handling characterization tests — registry interop strict xfail, legacy↔cellpycore converter parity, and cellpy-core STEP-12 pint-optional guard verification (#431)
 * Testing: prms configuration characterization tests — inventory parity contract, config round-trip/precedence, OtherPath coercion, `.env_cellpy` pickup, and `cellpy setup` dir/file creation (#430)
 * Testing: cellpy-file HDF5 characterization tests — v8 round-trip (fid-populated fixture), limits-prefix trap, `max_cycle` selector, legacy version matrix, and missing-key failure mode (#429)
 * Testing: golden-fixture convention under `tests/data/goldens/`, `dev/regenerate_goldens.py` suite registry, and `pipeline_smoke` essential oracle on the canonical Arbin `.res` (#428)

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,29 @@ code, `LIB` in the template YAML).
 uv run pytest tests/test_prms.py -v
 ```
 
+## Unit-handling characterization (Stage 0.4)
+
+Legacy↔cellpycore converter parity and registry-interop groundwork live in
+[`test_unit_handling_stage0.py`](test_unit_handling_stage0.py) with helpers in
+[`unit_parity_support.py`](unit_parity_support.py). Golden floats mirror
+`cellpy-core/tests/test_units_converters.py` (hand-computed oracles, not parquet).
+
+Four tests are marked `@pytest.mark.essential` (gravimetric / areal / absolute
+`get_converter_to_specific` parity plus gravimetric `nominal_capacity_as_absolute`).
+`test_cellpy_and_cellpycore_quantities_interoperate` is a strict `xfail` until unit-plan
+Phase 1 unifies pint registries (`architecture-plan/unit-handling-cellpy2-plan.md`).
+
+cellpy-core STEP-12 pint-optional guard is already covered in the sibling checkout:
+`cellpy-core/tests/test_units_optional.py` and `test_units_converters.py` (issue #40) —
+no core changes required for Stage 0.4 unless that preflight regresses.
+
+Update `GOLDEN_*_CASES` in `unit_parity_support.py` intentionally when converter math
+changes on either side.
+
+```bash
+uv run pytest tests/test_unit_handling_stage0.py -v
+```
+
 ## `essential` marker
 
 Fast smoke tests — read → step table → summary pipeline and cellpy/cellpy-core parity —

--- a/tests/test_unit_handling_stage0.py
+++ b/tests/test_unit_handling_stage0.py
@@ -1,0 +1,83 @@
+"""Stage 0.4 unit-handling characterization (issue #431).
+
+Cross-boundary registry interop (strict xfail) and legacy↔cellpycore converter parity.
+See architecture-plan/unit-handling-cellpy2-plan.md §6 and tests/README.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pint")
+
+from cellpy.readers.data_structures import Q as cellpy_Q
+from cellpycore import units as core_units
+from cellpycore.units import CellpyUnits, Q as core_Q
+
+from .unit_parity_support import (
+    GOLDEN_CONVERTER_CASES,
+    GOLDEN_NOM_CAP_CASES,
+    apply_parity_units,
+    make_core_stub,
+    make_parity_cell,
+)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Unit plan Phase 1: unify pint registries before cross-boundary Quantity math",
+)
+def test_cellpy_and_cellpycore_quantities_interoperate():
+    """Multiply quantities from separate pint registries; passes after Phase 1."""
+    # Two registries today: cellpy.readers.data_structures vs cellpycore.units.
+    result = (cellpy_Q(1, "mAh") * core_Q(1, "h")).to("mAh")
+    assert result.m == pytest.approx(1.0)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("mode,expected", GOLDEN_CONVERTER_CASES)
+def test_get_converter_to_specific_matches_cellpycore(
+    cellpy_data_instance, mode, expected
+):
+    cell = make_parity_cell(cellpy_data_instance)
+    legacy = cell.get_converter_to_specific(mode=mode)
+    core = core_units.get_converter_to_specific(make_core_stub(), mode=mode)
+    assert legacy == pytest.approx(expected)
+    assert legacy == pytest.approx(core)
+
+
+@pytest.mark.essential
+def test_nominal_capacity_as_absolute_gravimetric_matches_cellpycore(cellpy_data_instance):
+    cell = make_parity_cell(cellpy_data_instance)
+    legacy = cell.nominal_capacity_as_absolute(nom_cap_specifics="gravimetric")
+    core = core_units.nominal_capacity_as_absolute(
+        make_core_stub(), nom_cap_specifics="gravimetric"
+    )
+    assert legacy == pytest.approx(0.006)
+    assert legacy == pytest.approx(core)
+
+
+@pytest.mark.parametrize("kwargs,expected", GOLDEN_NOM_CAP_CASES[1:])
+def test_nominal_capacity_as_absolute_explicit_gravimetric_matches_cellpycore(
+    cellpy_data_instance, kwargs, expected
+):
+    cell = make_parity_cell(cellpy_data_instance)
+    legacy = cell.nominal_capacity_as_absolute(**kwargs)
+    core = core_units.nominal_capacity_as_absolute(make_core_stub(), **kwargs)
+    assert legacy == pytest.approx(expected)
+    assert legacy == pytest.approx(core)
+
+
+def test_get_converter_to_specific_charge_unit_mismatch_matches_cellpycore(
+    cellpy_data_instance,
+):
+    raw = CellpyUnits()
+    raw["charge"] = "A*h"
+    cell = make_parity_cell(cellpy_data_instance)
+    apply_parity_units(cell, raw_units=raw)
+    legacy = cell.get_converter_to_specific(mode="gravimetric")
+    core = core_units.get_converter_to_specific(
+        make_core_stub(raw_units=raw), mode="gravimetric"
+    )
+    assert legacy == pytest.approx(500_000.0)
+    assert legacy == pytest.approx(core)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,9 +1,9 @@
+# Legacy unit math tests; cross-boundary parity lives in test_unit_handling_stage0.py.
 import logging
 
 import pytest
 
-import cellpy.readers.data_structures
-from cellpy import log, prms
+from cellpy import log
 from cellpy.readers.data_structures import Q
 from cellpy.exceptions import NoDataFound
 from cellpy.parameters.internal_settings import get_headers_summary

--- a/tests/unit_parity_support.py
+++ b/tests/unit_parity_support.py
@@ -1,0 +1,69 @@
+"""Shared golden inputs for legacy↔cellpycore unit converter parity (issue #431)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from cellpy.parameters.internal_settings import get_cellpy_units
+from cellpy.readers.cellreader import CellpyCell
+from cellpy.readers.data_structures import Data
+from cellpycore.units import CellpyUnits
+
+# Mirrors cellpy-core/tests/test_units_converters.py defaults (mass=area=volume=2.0).
+GOLDEN_CONVERTER_CASES: list[tuple[str, float]] = [
+    ("gravimetric", 500.0),
+    ("areal", 0.5),
+    ("absolute", 1.0),
+]
+
+# Gravimetric nominal-capacity cases that agree today (areal/absolute legacy path broken;
+# see issue431_status.md).
+GOLDEN_NOM_CAP_CASES: list[tuple[dict[str, Any], float]] = [
+    ({"nom_cap_specifics": "gravimetric"}, 0.006),
+    (
+        {
+            "value": 1000.0,
+            "specific": 0.5,
+            "nom_cap_specifics": "gravimetric",
+        },
+        0.0005,
+    ),
+]
+
+
+def make_core_stub(raw_units: CellpyUnits | None = None, **attrs: Any) -> SimpleNamespace:
+    """Minimal stand-in for ``Data`` exposing only what the converters read."""
+    base: dict[str, Any] = dict(
+        raw_units=raw_units if raw_units is not None else CellpyUnits(),
+        mass=2.0,
+        active_electrode_area=2.0,
+        volume=2.0,
+        nom_cap=3000.0,
+        nom_cap_specifics="gravimetric",
+    )
+    base.update(attrs)
+    return SimpleNamespace(**base)
+
+
+def apply_parity_units(cell: CellpyCell, *, raw_units: CellpyUnits | None = None) -> None:
+    """Align legacy cell units and attrs with core ``_stub()`` defaults."""
+    units = get_cellpy_units()
+    cell.data.raw_units = raw_units if raw_units is not None else CellpyUnits()
+    if raw_units is None:
+        cell.data.raw_units.update(units)
+    cell.cellpy_units = CellpyUnits()
+    cell.cellpy_units.update(units)
+    cell.data.mass = 2.0
+    cell.data.active_electrode_area = 2.0
+    cell.data.volume = 2.0
+    cell.data.nom_cap = 3000.0
+    cell.data.nom_cap_specifics = "gravimetric"
+
+
+def make_parity_cell(cellpy_data_instance: CellpyCell) -> CellpyCell:
+    """Return a ``CellpyCell`` whose data matches core converter goldens."""
+    cell = cellpy_data_instance
+    cell.data = Data()
+    apply_parity_units(cell)
+    return cell


### PR DESCRIPTION
## Summary

- Add `tests/test_unit_handling_stage0.py` and `tests/unit_parity_support.py` for Stage 0.4 unit-handling groundwork.
- Registry interop test (`cellpy.Q` × `cellpycore.Q`) lands as `xfail(strict=True)` — documents unit-plan Phase 1 target.
- Legacy↔cellpycore parity for `get_converter_to_specific` (gravimetric / areal / absolute) and gravimetric `nominal_capacity_as_absolute` on golden inputs; four tests marked `@pytest.mark.essential`.
- cellpy-core STEP-12 pint-optional guard verified via preflight (`test_units_optional.py` + `test_units_converters.py`, 28 passed) — no core PR needed.

## Test plan

- [x] `uv run pytest tests/test_unit_handling_stage0.py -v` — 6 passed, 1 xfailed
- [x] `uv run pytest -m essential` — 30 passed
- [x] `uv run pytest tests/test_unit_handling_stage0.py tests/test_units.py`

Closes #431

Made with [Cursor](https://cursor.com)