### PR TITLE
Stage 0.8: Extend consumer scans to filters/, exporters/, internals/

### DIFF
--- a/.issueflows/00-tools/README.md
+++ b/.issueflows/00-tools/README.md
@@ -26,4 +26,5 @@ to grow over time.
 
 | Tool | What it does | When to use |
 | --- | --- | --- |
-| _(none yet)_ | | |
+| `scan_member_usage.py` | AST scan for `Data` / `CellpyCell` `.member` access in given package paths | Stage-0/1 consumer inventory reports (e.g. issue #435) |
+| `scan_hardcoded_headers.py` | AST scan for canonical header string literals in column-access contexts | Stage-0 header inventory / migration planning |

--- a/.issueflows/00-tools/scan_hardcoded_headers.py
+++ b/.issueflows/00-tools/scan_hardcoded_headers.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""AST scan for hard-coded column-header string literals.
+
+Compares string literals in column-access-like contexts against canonical header
+values from ``cellpy.parameters.internal_settings``.
+
+Usage (from cellpy repo root)::
+
+    uv run .issueflows/00-tools/scan_hardcoded_headers.py cellpy/filters cellpy/exporters
+
+Emits a markdown findings table to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Ensure cellpy is importable when run via uv from repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from cellpy.parameters import internal_settings as iset  # noqa: E402
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    literal: str
+    context: str
+    header_class: str
+
+
+def _canonical_values() -> dict[str, set[str]]:
+    groups = {
+        "HeadersNormal": iset.get_headers_normal(),
+        "HeadersSummary": iset.get_headers_summary(),
+        "HeadersStepTable": iset.get_headers_step_table(),
+        "HeadersJournal": iset.get_headers_journal(),
+    }
+    out: dict[str, set[str]] = {}
+    for name, obj in groups.items():
+        vals: set[str] = set()
+        for key, val in vars(obj).items():
+            if key.startswith("_"):
+                continue
+            if isinstance(val, str) and val:
+                vals.add(val)
+        out[name] = vals
+    return out
+
+
+def _all_canonical(flat: dict[str, set[str]]) -> dict[str, str]:
+    """Map literal -> header class name (first match)."""
+    mapping: dict[str, str] = {}
+    for cls, vals in flat.items():
+        for v in vals:
+            mapping.setdefault(v, cls)
+    return mapping
+
+
+def _context_label(node: ast.AST, parent: ast.AST | None) -> str:
+    if isinstance(parent, ast.Subscript) and parent.slice is node:
+        return "subscript key"
+    if isinstance(parent, ast.keyword):
+        return f"kwarg {parent.arg!r}"
+    if isinstance(parent, ast.Compare):
+        return "comparison"
+    if isinstance(parent, ast.Dict):
+        return "dict key/value"
+    if isinstance(parent, ast.Tuple) and isinstance(parent.ctx, ast.Load):
+        return "tuple default"
+    if isinstance(parent, ast.List) and isinstance(parent.ctx, ast.Load):
+        return "list literal"
+    return type(parent).__name__ if parent else "literal"
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self, path: Path, canonical: dict[str, str]) -> None:
+        self.path = path
+        self.canonical = canonical
+        self.findings: list[Finding] = []
+        self._parent_stack: list[ast.AST] = []
+
+    def visit(self, node: ast.AST) -> None:
+        self._parent_stack.append(node)
+        parent = self._parent_stack[-2] if len(self._parent_stack) > 1 else None
+
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            lit = node.value
+            if lit in self.canonical and self._is_interesting(parent, node):
+                self.findings.append(
+                    Finding(
+                        path=self.path,
+                        line=node.lineno,
+                        literal=lit,
+                        context=_context_label(node, parent),
+                        header_class=self.canonical[lit],
+                    )
+                )
+
+        self.generic_visit(node)
+        self._parent_stack.pop()
+
+    def _is_interesting(self, parent: ast.AST | None, node: ast.Constant) -> bool:
+        if parent is None:
+            return False
+        # Column subscript: df["col"]
+        if isinstance(parent, ast.Subscript) and parent.slice is node:
+            return True
+        # Keyword args to pandas-ish calls
+        if isinstance(parent, ast.keyword) and parent.arg in {
+            "by",
+            "subset",
+            "x",
+            "y",
+            "color",
+            "column",
+            "index",
+            "columns",
+        }:
+            return True
+        # Default column tuples in signatures / calls
+        if isinstance(parent, (ast.Tuple, ast.List)):
+            return True
+        # String keys in small dicts used as rename maps — conservative
+        if isinstance(parent, ast.Dict):
+            return True
+        return False
+
+
+def _scan_file(path: Path, canonical: dict[str, str]) -> list[Finding]:
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        print(f"WARN: skip {path}: {exc}", file=sys.stderr)
+        return []
+    visitor = _Visitor(path, canonical)
+    visitor.visit(tree)
+    return visitor.findings
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _emit_markdown(findings: list[Finding], repo_root: Path) -> None:
+    if not findings:
+        print("No hard-coded canonical header literals in column-access contexts.")
+        return
+
+    print("| File | Line | Literal | Header class | Context |")
+    print("|---|---|---|---|---|")
+    for f in sorted(findings, key=lambda x: (x.path, x.line, x.literal)):
+        print(
+            f"| `{_rel(f.path, repo_root)}` | {f.line} | `{f.literal}` | "
+            f"`{f.header_class}` | {f.context} |"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+
+    flat = _canonical_values()
+    canonical = _all_canonical(flat)
+
+    files: list[Path] = []
+    for p in args.paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.py")))
+        elif p.suffix == ".py":
+            files.append(p)
+
+    all_findings: list[Finding] = []
+    for f in files:
+        if f.name == "__init__.py" and f.stat().st_size < 600:
+            continue
+        all_findings.extend(_scan_file(f, canonical))
+
+    _emit_markdown(all_findings, args.repo_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.issueflows/00-tools/scan_member_usage.py
+++ b/.issueflows/00-tools/scan_member_usage.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""AST scan for Data / CellpyCell member access in Python source trees.
+
+Usage (from cellpy repo root)::
+
+    uv run .issueflows/00-tools/scan_member_usage.py cellpy/filters cellpy/exporters
+
+Emits a markdown summary to stdout. Used for Stage-0 consumer inventory reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Receivers treated as non-cellpy (false-positive guards from the utils report).
+_SKIP_RECEIVER_ROOTS = frozenset(
+    {
+        "logging",
+        "logger",
+        "pd",
+        "np",
+        "plt",
+        "fig",
+        "json",
+        "os",
+        "sys",
+        "pathlib",
+        "re",
+        "warnings",
+        "shutil",
+        "stat",
+        "tempfile",
+        "time",
+        "fnmatch",
+    }
+)
+
+_CELL_RECEIVER_ROOTS = frozenset({"cell", "c", "cpobj", "cell_data", "cellpydata"})
+
+_IO_MEMBERS = frozenset({"to_csv", "to_bdf", "save", "load", "from_raw"})
+
+_DATA_MEMBERS = frozenset(
+    {
+        "raw",
+        "steps",
+        "summary",
+        "raw_units",
+        "meta_common",
+        "raw_data_files",
+        "loaded_from",
+        "nom_cap",
+        "cell_name",
+        "loading",
+        "empty",
+        "mass",
+        "tot_mass",
+    }
+)
+
+_CELLPYCELL_MEMBERS = frozenset(
+    {
+        "data",
+        "empty",
+        "cell_name",
+        "mass",
+        "active_mass",
+        "tot_mass",
+        "nominal_capacity",
+        "nom_cap_specifics",
+        "raw_units",
+        "cellpy_units",
+        "headers_normal",
+        "headers_summary",
+        "headers_step_table",
+        "get_cap",
+        "get_ccap",
+        "get_dcap",
+        "get_ocv",
+        "get_cycle_numbers",
+        "make_summary",
+        "make_step_table",
+        "save",
+        "load",
+        "from_raw",
+        "to_csv",
+        "to_bdf",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Hit:
+    path: Path
+    line: int
+    chain: str
+    member: str
+    target: str  # "CellpyCell" or "Data"
+
+
+def _receiver_root(node: ast.AST) -> str | None:
+    """Return the leftmost name in an attribute chain, if it is a simple Name."""
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        return cur.id
+    return None
+
+
+def _attr_chain(node: ast.Attribute) -> str:
+    parts: list[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    elif isinstance(cur, ast.Call):
+        parts.append("<call>")
+    else:
+        parts.append("<expr>")
+    return ".".join(reversed(parts))
+
+
+def _classify_member(chain: str, member: str, root: str | None) -> str | None:
+    if member in _DATA_MEMBERS and ".data." in chain:
+        return "Data"
+    if member not in _CELLPYCELL_MEMBERS:
+        return None
+    if root in _SKIP_RECEIVER_ROOTS:
+        return None
+    if member in _IO_MEMBERS and root not in _CELL_RECEIVER_ROOTS:
+        return None
+    if member == "empty" and root not in _CELL_RECEIVER_ROOTS:
+        return None
+    if root not in _CELL_RECEIVER_ROOTS:
+        return None
+    return "CellpyCell"
+
+
+def _scan_file(path: Path) -> list[Hit]:
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        print(f"WARN: skip {path}: {exc}", file=sys.stderr)
+        return []
+
+    hits: list[Hit] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        root = _receiver_root(node)
+        if root in _SKIP_RECEIVER_ROOTS:
+            continue
+        target = _classify_member(_attr_chain(node), node.attr, root)
+        if target is None:
+            continue
+        hits.append(
+            Hit(
+                path=path,
+                line=node.lineno,
+                chain=_attr_chain(node),
+                member=node.attr,
+                target=target,
+            )
+        )
+    return hits
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _emit_markdown(hits: list[Hit], repo_root: Path) -> None:
+    if not hits:
+        print("No Data / CellpyCell member accesses found.")
+        return
+
+    by_member: dict[tuple[str, str], list[Hit]] = {}
+    for hit in hits:
+        key = (hit.target, hit.member)
+        by_member.setdefault(key, []).append(hit)
+
+    print("| Target | Member | Sites | Notes |")
+    print("|---|---|---|---|")
+    for (target, member), group in sorted(by_member.items()):
+        sites = ", ".join(
+            f"`{_rel(h.path, repo_root)}:{h.line}`"
+            for h in sorted(group, key=lambda x: (x.path, x.line))
+        )
+        chains = sorted({h.chain for h in group})
+        note = f"receivers: {', '.join(f'`{c}`' for c in chains[:4])}"
+        if len(chains) > 4:
+            note += f" (+{len(chains) - 4} more)"
+        print(f"| `{target}` | `{member}` | {sites} | {note} |")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Package directories or .py files to scan",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repo root for relative paths in output (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    files: list[Path] = []
+    for p in args.paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.py")))
+        elif p.suffix == ".py":
+            files.append(p)
+
+    all_hits: list[Hit] = []
+    for f in files:
+        if f.name == "__init__.py" and f.stat().st_size < 600:
+            continue
+        all_hits.extend(_scan_file(f))
+
+    # Deduplicate identical line+member
+    seen: set[tuple[str, int, str]] = set()
+    unique: list[Hit] = []
+    for h in all_hits:
+        key = (_rel(h.path, args.repo_root), h.line, h.member)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(h)
+
+    _emit_markdown(unique, args.repo_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.issueflows/03-solved-issues/issue435_original.md
+++ b/.issueflows/03-solved-issues/issue435_original.md
@@ -1,0 +1,36 @@
+# Issue #435: Stage 0.8: Extend consumer scans to filters/, exporters/, internals/
+
+Source: https://github.com/jepegit/cellpy/issues/435
+
+## Original issue text
+
+> Part of **Stage 0 â€” foundations for cellpy 2** (see the tracking issue). Plan documents live in the shared workspace: `cellpy-workspace/architecture-plan/` (the [architecture-plan repo](https://github.com/cellpy/architecture-plan); formerly `architecture-plan/`) (alongside the `cellpy` and `cellpy-core` repos).
+
+## Goal
+
+Re-run the two inventory scans over the packages the original reports skipped â€”
+`cellpy/filters/`, `cellpy/exporters/`, `cellpy/internals/` (consumers only) â€” and append
+the findings to the existing reports:
+
+- Data/CellpyCell member usage (which parts of the core API these packages touch),
+- hard-coded column-header literals.
+
+## Why
+
+Gap item G5: `filters/` shows up in the polars index findings but is in no migration
+inventory; `exporters/` has been scanned by nobody. Every later wave plans work from these
+reports â€” a blind spot here surfaces as surprise breakage in utils wave 1. Half a day,
+pure prevention.
+
+## Links
+
+- `architecture-plan/cellpy2-plans-gap-analysis.md` (G5)
+- `architecture-plan/data-and-cellpycell-usage-in-cellpy-utils.md` (append here)
+- `architecture-plan/hardcoded-column-headers-report.md` (append here)
+- `architecture-plan/cellpy2-utils-migration-plan.md` (wave 0 â€” this issue is that wave)
+
+## Acceptance
+
+- Both reports carry a dated addendum section covering the three packages.
+- The utils-migration triage table gains rows for anything discovered in `exporters/`.
+

--- a/.issueflows/03-solved-issues/issue435_plan.md
+++ b/.issueflows/03-solved-issues/issue435_plan.md
@@ -1,0 +1,134 @@
+# Plan: issue #435 — Stage 0.8 consumer scans (filters / exporters / internals)
+
+## Goal
+
+Close gap **G5** by re-running the two Stage-0 inventory scans over `cellpy/filters/`,
+`cellpy/exporters/`, and `cellpy/internals/` (Data/CellpyCell consumers only), then
+append dated addenda to the existing reports and enrich the utils-migration triage table
+for anything found in `exporters/`.
+
+## Constraints
+
+- **Documentation deliverable** — no production-code refactors in this issue; only scan
+  tooling (optional but recommended) and report updates in `architecture-plan/`.
+- **Match prior methodology** — same AST rules and classification buckets as
+  [data-and-cellpycell-usage-in-cellpy-utils.md](../../architecture-plan/data-and-cellpycell-usage-in-cellpy-utils.md)
+  and [hardcoded-column-headers-report.md](../../architecture-plan/hardcoded-column-headers-report.md)
+  (receiver-aware member matching; header literals vs `internal_settings` canonical values;
+  column-access context filtering; false-positive exclusions).
+- **`internals/` scope** — issue text says *consumers only*; path/SSH helpers
+  (`otherpath.py`, `connections.py`) are out of scope for the usage report unless they
+  touch `Data` / `CellpyCell` (spot-check suggests they do not).
+- **Plan docs live in** `architecture-plan/` (authoritative); issue tracked in
+  `jepegit/cellpy`.
+- **Half-day budget** — keep scanners minimal; manual spot-check is acceptable on this
+  tiny surface (~6 `.py` files).
+
+### Prior art
+
+- [data-and-cellpycell-usage-in-cellpy-utils.md](../../architecture-plan/data-and-cellpycell-usage-in-cellpy-utils.md) — AST member-usage inventory for `utils/` only (2026-07-08); methodology to mirror.
+- [hardcoded-column-headers-report.md](../../architecture-plan/hardcoded-column-headers-report.md) — whole-package AST header scan (2026-07-08); filters/exporters/internals were not broken out.
+- [cellpy2-utils-migration-plan.md](../../architecture-plan/cellpy2-utils-migration-plan.md) — wave 0 already describes this scan; `exporters/*` row is **“Inventory then port/park”**; `filters/*` already **Port (wave 1)**.
+- [pandas-to-polars-index-usage-report.md](../../architecture-plan/pandas-to-polars-index-usage-report.md) §2.12 — `filters/` mask pattern; §2.14 — `exporters/bdf.py` `reset_index`.
+- `cellpy/filters/cycles.py` — generic DataFrame helper; default cycle column via `get_headers_normal()` (clean).
+- `cellpy/filters/summary.py` — generic DataFrame helper; default `rate_columns=("charge_c_rate", "discharge_c_rate")` are hard-coded summary header names.
+- `cellpy/exporters/bdf.py` — sole real `CellpyCell` consumer: `cell.data.raw`, `cell.data.raw_units`, `cell.headers_normal`, `cell.cell_name`; delegates cycle filter to `filter_cycles`.
+- `cellpy/internals/{connections,otherpath}.py` — no `Data` / `CellpyCell` usage (negative finding expected).
+- `.issueflows/00-tools/` — empty index; original scans were not committed as scripts.
+
+## Approach
+
+### 1. Add minimal, reproducible scanners (cellpy repo)
+
+Write two small stdlib-AST scripts under `.issueflows/00-tools/` (no new dependencies):
+
+| Script | Purpose |
+| --- | --- |
+| `scan_member_usage.py` | Extract `Data` / `CellpyCell` public API; walk `.py` trees; classify `.member` access by receiver (same exclusions as utils report: `logging`, `str`, plotly, etc.). |
+| `scan_hardcoded_headers.py` | Load canonical header values from `cellpy.parameters.internal_settings`; AST-match string literals in column-access contexts; apply same verdict categories (fix / semi-OK / not a finding). |
+
+CLI shape (keep simple):
+
+```bash
+uv run .issueflows/00-tools/scan_member_usage.py cellpy/filters cellpy/exporters cellpy/internals
+uv run .issueflows/00-tools/scan_hardcoded_headers.py cellpy/filters cellpy/exporters cellpy/internals
+```
+
+Emit markdown fragments to stdout (or `-o` temp files) for paste into addenda. Register both in `00-tools/README.md`.
+
+**Fallback:** if script time runs long, the surface is small enough to complete inventory manually with `rg` + AST spot-checks; still document methodology in the addendum footer.
+
+### 2. Run scans and triage
+
+**Packages scanned:**
+
+| Package | Files | Expected usage-report headline |
+| --- | --- | --- |
+| `filters/` | `cycles.py`, `summary.py` | **No `CellpyCell` / `Data` access** — operates on caller-supplied DataFrames. Note dependency on canonical header names only via defaults. |
+| `exporters/` | `bdf.py` (+ thin `__init__.py`) | **`CellpyCell` consumer** — `data.raw`, `data.raw_units`, `headers_normal`, `cell_name`; thin utils contract slice. |
+| `internals/` | `connections.py`, `otherpath.py` | **No consumers** — document explicitly so G5 is closed. |
+
+**Expected hardcoded-headers headline:**
+
+- `filters/cycles.py` — clean (uses `get_headers_normal()`).
+- `filters/summary.py` — default `rate_columns` tuple uses summary header literals → map to `HeadersSummary.charge_c_rate` / `.discharge_c_rate`.
+- `exporters/bdf.py` — mostly attribute-driven via `headers_normal` + `_COLUMN_MAP` `cellpy_field` suffixes; verify no raw `df["voltage"]`-style literals slipped in; cross-check polars report lines 538/589 (`reset_index`).
+- `internals/` — no column-header findings expected.
+
+### 3. Append dated addenda (architecture-plan repo)
+
+Add a section to each report (date **2026-07-10**, scope line naming the three packages):
+
+**`data-and-cellpycell-usage-in-cellpy-utils.md`** — new **§9 Addendum: filters / exporters / internals**:
+
+- Per-package summary table (mirror §4 style where useful).
+- `exporters/bdf.py` member table: `cell_name`, `headers_normal`, `data.raw`, `data.raw_units` (and note `cellpy_units` appears only in docs — export converts from `raw_units`).
+- Explicit “no usage” statement for `filters/` and `internals/`.
+- Cross-link to utils contract §5 observations (filters stay generic; exporters are thin IO on raw).
+
+**`hardcoded-column-headers-report.md`** — new **§9 Addendum** (or renumber if cleaner):
+
+- Findings tables for `filters/summary.py` defaults and any `exporters/bdf.py` hits.
+- Verdict + suggested `HeadersSummary` / `HeadersNormal` replacements.
+- Note `internals/` clean.
+
+### 4. Update utils-migration triage
+
+In [cellpy2-utils-migration-plan.md](../../architecture-plan/cellpy2-utils-migration-plan.md) §2 table:
+
+- Split or enrich `exporters/*` row → **`exporters/bdf.py` | Port (wave 1)** with notes from scan (depends on `data.raw`, `raw_units`, `headers_normal`, `filter_cycles`; BDF column map already header-attribute-based).
+- Confirm `filters/cycles.py` + `filters/summary.py` rows stay **Port (wave 1)**; add one-line note that summary defaults need `HeadersSummary` at call sites or as defaults.
+
+Mark wave 0 (**G5 scan**) as done in a short footnote under §3.
+
+### 5. Verification
+
+- Re-run scanners after writing; compare output to manual `rg` pass.
+- Sanity-check addenda against acceptance criteria in `issue435_original.md`.
+- No pytest required; optional smoke: scanners exit 0 on the three package paths.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `architecture-plan/data-and-cellpycell-usage-in-cellpy-utils.md` | Dated addendum §9 |
+| `architecture-plan/hardcoded-column-headers-report.md` | Dated addendum |
+| `architecture-plan/cellpy2-utils-migration-plan.md` | Enrich `exporters/` + `filters/` triage rows; wave-0 done note |
+| `cellpy/.issueflows/00-tools/scan_member_usage.py` | New — reusable scanner |
+| `cellpy/.issueflows/00-tools/scan_hardcoded_headers.py` | New — reusable scanner |
+| `cellpy/.issueflows/00-tools/README.md` | Index entries for both tools |
+| `cellpy/.issueflows/01-current-issues/issue435_status.md` | Created during `/iflow-start` (not this step) |
+
+**Repos / PRs:** expect changes in **both** `jepegit/cellpy` (scanners + issue-flow) and `cellpy/architecture-plan` (reports). Can be one PR each or combined — see open question.
+
+## Test strategy
+
+- `uv run .issueflows/00-tools/scan_*.py …` — scanners run clean from `cellpy` root.
+- Manual cross-check: `rg 'CellpyCell|\.data\.|get_headers' cellpy/{filters,exporters,internals}` matches usage addendum.
+- No library test changes; documentation-only acceptance.
+
+## Open questions
+
+1. **PR split** — one PR per repo (recommended: cellpy scanners + architecture-plan docs) or single cross-repo PR? Issue is on `cellpy` but most user-visible diff is `architecture-plan`.
+2. **Branch** — plan on `master` today (only `issue435_original.md` untracked). Create `435-extend-consumer-scans` before `/iflow-start`?
+3. **Scanner permanence** — commit scripts to `00-tools` for future re-runs (recommended) vs one-off manual inventory? Plan assumes **commit**.

--- a/.issueflows/03-solved-issues/issue435_status.md
+++ b/.issueflows/03-solved-issues/issue435_status.md
@@ -1,0 +1,18 @@
+# Issue #435 — status
+
+- [x] Done
+
+## What's done
+
+- Branch `435-extend-consumer-scans` on `cellpy` (and matching branch on `architecture-plan`).
+- Added `.issueflows/00-tools/scan_member_usage.py` and `scan_hardcoded_headers.py` + README index.
+- Ran scans on `cellpy/filters`, `cellpy/exporters`, `cellpy/internals`.
+- Appended **§9 addenda** (2026-07-10) to:
+  - `architecture-plan/data-and-cellpycell-usage-in-cellpy-utils.md`
+  - `architecture-plan/hardcoded-column-headers-report.md`
+- Updated `architecture-plan/cellpy2-utils-migration-plan.md` triage rows + wave-0 done footnote.
+- Essential tests passed (`uv run pytest -m essential`).
+
+## Remaining work
+
+- None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Testing: value-parity comparator (`tests/parity.py::assert_value_parity`) — legacy vs native frames compared through `cellpycore.legacy.mapping` with dtype-tolerant mapped-column equality, named exception list, and trivial-pass essential tests on the current bridge (#434)
+* Docs: Stage-0 AST inventory scanners (`scan_member_usage.py`, `scan_hardcoded_headers.py`) in `.issueflows/00-tools/` for consumer/header reports (#435) (`tests/parity.py::assert_value_parity`) — legacy vs native frames compared through `cellpycore.legacy.mapping` with dtype-tolerant mapped-column equality, named exception list, and trivial-pass essential tests on the current bridge (#434)
 * Testing: curve-extraction golden snapshots for `get_cap` / `get_ccap` / `get_dcap` / `get_ocv` on the canonical Arbin cell, including labeled/interpolated/multi-cycle variants and NullData edge cases (#433)
 * Testing: per-loader golden snapshots for tier-1 loaders (`arbin_res`, `maccor_txt`, `neware_txt`, `pec_csv`, `custom`) — raw frame, `raw_units`, and loader meta oracles under `tests/data/goldens/loader_*/` with parametrized essential regression tests (#432)
 * Testing: prms configuration characterization tests — inventory parity contract, config round-trip/precedence, OtherPath coercion, `.env_cellpy` pickup, and `cellpy setup` dir/file creation (#430)


### PR DESCRIPTION
## Summary

- Add reproducible AST scanners (`scan_member_usage.py`, `scan_hardcoded_headers.py`) under `.issueflows/00-tools/` for Stage-0 consumer inventory work.
- Close issue-flow tracking for #435 (moved to `03-solved-issues/`).
- Changelog entry under `[Unreleased]`.

Companion PR in `cellpy/architecture-plan` appends §9 addenda to the usage and hardcoded-header reports and marks wave-0 (G5) complete in the utils migration plan.

## Test plan

- [x] `uv run pytest -m essential` (71 passed)
- [x] `uv run .issueflows/00-tools/scan_member_usage.py cellpy/filters cellpy/exporters cellpy/internals`
- [x] `uv run .issueflows/00-tools/scan_hardcoded_headers.py cellpy/filters cellpy/exporters cellpy/internals`

Closes #435

Made with [Cursor](https://cursor.com)