### PR TITLE
fix(ci): retry setup-miniconda on transient conda-forge failures (#465)

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -61,13 +61,13 @@ jobs:
           Write-Host "ACE installer exit code: $($proc.ExitCode)"
           if ($proc.ExitCode -ne 0) { throw "ACE install failed" }
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Setup miniconda (retry transient conda-forge errors)
+        uses: Wandalen/wretry.action@v3.5.0
         with:
-          auto-update-conda: true
-          miniconda-version: latest
-          activate-environment: cellpy_dev
-          environment-file: github_actions_environment.yml
-          python-version: "3.13"
+          action: conda-incubator/setup-miniconda@v3
+          with: '{"auto-update-conda":true,"miniconda-version":"latest","activate-environment":"cellpy_dev","environment-file":"github_actions_environment.yml","python-version":"3.13"}'
+          attempt_limit: 3
+          attempt_delay: 30000
 
       - name: Install mdbtools (Linux)
         if: matrix.os == 'linux'
@@ -99,12 +99,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Setup miniconda (retry transient conda-forge errors)
+        uses: Wandalen/wretry.action@v3.5.0
         with:
-          auto-update-conda: true
-          activate-environment: cellpy_dev
-          environment-file: github_actions_environment.yml
-          python-version: "3.13"
+          action: conda-incubator/setup-miniconda@v3
+          with: '{"auto-update-conda":true,"activate-environment":"cellpy_dev","environment-file":"github_actions_environment.yml","python-version":"3.13"}'
+          attempt_limit: 3
+          attempt_delay: 30000
 
       - name: Install mdbtools
         run: |
@@ -188,12 +189,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Setup miniconda (retry transient conda-forge errors)
+        uses: Wandalen/wretry.action@v3.5.0
         with:
-          auto-update-conda: true
-          activate-environment: cellpy_dev
-          environment-file: github_actions_environment.yml
-          python-version: "3.13"
+          action: conda-incubator/setup-miniconda@v3
+          with: '{"auto-update-conda":true,"activate-environment":"cellpy_dev","environment-file":"github_actions_environment.yml","python-version":"3.13"}'
+          attempt_limit: 3
+          attempt_delay: 30000
 
       - name: Install cellpy from conda-forge
         run: |

--- a/.issueflows/03-solved-issues/issue465_original.md
+++ b/.issueflows/03-solved-issues/issue465_original.md
@@ -1,0 +1,61 @@
+# Issue #465: conda pytest windows failed
+
+Source: https://github.com/jepegit/cellpy/issues/465
+
+## Original issue text
+
+Ci schedueled failed:
+
+
+Info from agent:
+
+## Issue Analysis
+
+The job failed during the conda environment setup step due to a **502 Bad Gateway error** when trying to download package metadata from the conda-forge repository:
+
+```
+requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: 
+https://conda.anaconda.org/conda-forge/linux-64/1bde174b2b1b538da03d3e12ddb119cf61030b0cd0b41f7f3ea4d998ab916a9b.msgpack.zst
+```
+
+This is a **transient network/service issue**, not a code problem. The conda-forge server was temporarily unavailable when the job tried to fetch package metadata.
+
+## Solution
+
+This type of failure is intermittent and typically resolves itself. Here are your options:
+
+1. **Rerun the job** - The simplest solution. Click "Re-run jobs" in the GitHub Actions UI. The conda-forge server should be available on the next attempt.
+
+2. **Add retry logic to the workflow** (if you want automated resilience):
+
+   Update the conda environment setup step in [`.github/workflows/ci-scheduled.yml`](https://github.com/jepegit/cellpy/blob/e984a9d6727054c9ac8ae5b70717eeb048547788/.github/workflows/ci-scheduled.yml) to retry on failure:
+
+   ```yaml
+   - uses: conda-incubator/setup-miniconda@v3
+     with:
+       auto-update-conda: true
+       miniconda-version: latest
+       activate-environment: cellpy_dev
+       environment-file: github_actions_environment.yml
+       python-version: "3.13"
+   ```
+
+   Or wrap it with a retry mechanism using a shell script:
+
+   ```yaml
+   - name: Setup conda (with retry)
+     run: |
+       for i in {1..3}; do
+         echo "Attempt $i..."
+         if conda env update --name cellpy_dev --file github_actions_environment.yml; then
+           echo "Success!"
+           break
+         fi
+         if [ $i -lt 3 ]; then
+           echo "Failed, retrying in 30 seconds..."
+           sleep 30
+         fi
+       done
+   ```
+
+**Recommendation:** Start by rerunning the job. If it fails again with the same error, then consider adding retry logic.

--- a/.issueflows/03-solved-issues/issue465_plan.md
+++ b/.issueflows/03-solved-issues/issue465_plan.md
@@ -1,0 +1,18 @@
+# Plan: issue #465 — conda CI retry for transient conda-forge 502s
+
+## Goal
+
+Harden `ci-scheduled.yml` against transient conda-forge metadata/download failures (502 Bad Gateway) during `setup-miniconda`, without changing test scope.
+
+## Approach
+
+Wrap each `conda-incubator/setup-miniconda@v3` step in `Wandalen/wretry.action@v3.5.0` (3 attempts, 30s delay). Failures were infra flakiness on `linux-64` repodata fetch — retry is the durable fix recommended in the issue.
+
+## Files to touch
+
+- `.github/workflows/ci-scheduled.yml` — three miniconda setup sites (`conda-pytest`, `nbmake-linux`, `conda-forge`)
+
+## Test strategy
+
+- YAML change only; no runtime code paths.
+- Verify workflow file parses; rely on GHA on merge.

--- a/.issueflows/03-solved-issues/issue465_status.md
+++ b/.issueflows/03-solved-issues/issue465_status.md
@@ -1,0 +1,7 @@
+# Issue #465 — status
+
+- [x] Done
+
+## What's done
+
+- Wrapped all three `setup-miniconda` steps in `ci-scheduled.yml` with `Wandalen/wretry.action` (3 attempts, 30s delay) for transient conda-forge 502s.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* CI: retry `setup-miniconda` in scheduled workflow on transient conda-forge download failures (#465)
 * Testing: Stage 0.9 benchmark harness — opt-in `pytest-benchmark` suite under `benchmarks/`, committed v1.x baseline JSON, and dedicated CI job with ±20% regression gate (#436)
 * Docs: Stage-0 AST inventory scanners (`scan_member_usage.py`, `scan_hardcoded_headers.py`) in `.issueflows/00-tools/` for consumer/header reports (#435) (`tests/parity.py::assert_value_parity`) — legacy vs native frames compared through `cellpycore.legacy.mapping` with dtype-tolerant mapped-column equality, named exception list, and trivial-pass essential tests on the current bridge (#434)
 * Testing: curve-extraction golden snapshots for `get_cap` / `get_ccap` / `get_dcap` / `get_ocv` on the canonical Arbin cell, including labeled/interpolated/multi-cycle variants and NullData edge cases (#433)


### PR DESCRIPTION
## Summary

- Wraps all three `setup-miniconda` steps in `ci-scheduled.yml` with `Wandalen/wretry.action` (3 attempts, 30s delay).
- Handles transient conda-forge 502 Bad Gateway errors during repodata/metadata download without changing test scope.

Closes #465.

## Test plan

- [x] Workflow YAML only — no application code changes
- [ ] Scheduled CI green on next run (or manual `workflow_dispatch` of CI scheduled)

Made with [Cursor](https://cursor.com)