### PR TITLE
test: fix legacy v4/v5 cellpy-file characterization (#466)

### DIFF
--- a/.issueflows/03-solved-issues/issue466_original.md
+++ b/.issueflows/03-solved-issues/issue466_original.md
@@ -1,0 +1,52 @@
+# Issue #466: CI failed on pytest on linux
+
+Source: https://github.com/jepegit/cellpy/issues/466
+
+## Original issue text
+
+CI scheduled failed.
+
+## **Agent suggestion:**
+
+
+The test `test_legacy_v4_v5_currently_raise_typeerror_on_meta_extract` is failing because it expects a `TypeError` to be raised when loading legacy v4/v5 HDF5 files, but the code is no longer raising that exception.
+
+### Root Cause
+
+The test at line 137 in [`tests/test_cellpy_file_roundtrip.py`](https://github.com/jepegit/cellpy/blob/e984a9d6727054c9ac8ae5b70717eeb048547788/tests/test_cellpy_file_roundtrip.py#L137) expects:
+
+```python
+cell = cellreader.CellpyCell()
+with pytest.raises(TypeError):
+    cell.load(path, accept_old=True)
+```
+
+However, the actual behavior has changed—the code is now successfully loading these files without raising a `TypeError`.
+
+### Solution
+
+You have two options:
+
+**Option 1: Update the test to reflect the new behavior**
+
+If the v4/v5 files are now successfully loading, update the test to verify the successful load instead of expecting an exception:
+
+```python
+@pytest.mark.parametrize("label,filename", LEGACY_TYPE_ERROR)
+def test_legacy_v4_v5_currently_raise_typeerror_on_meta_extract(label, filename):
+    """Legacy v4/v5 files now load successfully (previously raised TypeError)."""
+    path = HDF5_DIR / filename
+    if not path.is_file():
+        pytest.skip(f"missing legacy fixture: {path}")
+    
+    cell = load_cellpy_file(path, accept_old=True)
+    # Add assertions to verify successful load
+    assert cell.data.raw.shape[0] > 0
+    assert cell.data.summary.shape[0] > 0
+```
+
+**Option 2: Fix the code to re-raise the TypeError**
+
+If v4/v5 files should still raise `TypeError` during meta extraction, investigate the code path for `cell.load()` and `upgrade_from_to()` to ensure the exception is properly raised when handling these legacy formats.
+
+The comment in the test suggests the issue is related to a missing `upgrade_from_to` call on meta extraction. Check the cellreader's load method to ensure it's being invoked for v4/v5 files.

--- a/.issueflows/03-solved-issues/issue466_plan.md
+++ b/.issueflows/03-solved-issues/issue466_plan.md
@@ -1,0 +1,70 @@
+# Plan: issue #466 — fix legacy v4/v5 cellpy-file roundtrip test
+
+## Goal
+
+Restore green scheduled CI by aligning the v4/v5 characterization test with actual loader
+behavior: legacy v4/v5 files load successfully with `accept_old=True` (same contract as v6/v7).
+
+## Constraints
+
+- **Test-only fix** — do not change `cellpy/readers/cellreader.py`; v4/v5 paths already call
+  `upgrade_from_to=(4|5, CELLPY_FILE_VERSION)` on extract steps and meta.
+- **Stage 0.2 intent** — issue #429 plan §D always expected v4/v5 *successful* load with shape/column
+  asserts; the `TypeError` test was a temporary pin of a bug, noted as stale in #432 status.
+- **Scope** — one test module change; no fixture regen.
+
+### Prior art
+
+| Hit | Relevance |
+|-----|-----------|
+| `tests/test_cellpy_file_roundtrip.py` | `LEGACY_SUCCESS` + `test_legacy_v6_v7_load_shapes_and_columns` — mirror for v4/v5 |
+| `tests/cellpy_file_support.py::load_cellpy_file` | Shared load helper used by v6/v7 test |
+| `cellpy/readers/cellreader.py` `_load_hdf5_v5` / `_load_old_hdf5_v3_to_v4` | v4/v5 loaders with `upgrade_from_to` — explains why load now succeeds |
+| `.issueflows/03-solved-issues/issue429_plan.md` §D | Original matrix: v4/v5 expect successful load + shapes/columns |
+| `.issueflows/03-solved-issues/issue432_status.md` | Documents this test as pre-existing stale failure |
+
+## Approach
+
+**Option 1 (recommended): update the test to match successful load.**
+
+1. Extend `LEGACY_SUCCESS` to include v4 and v5:
+
+   ```python
+   LEGACY_SUCCESS = [
+       ("v4", "20160805_test001_45_cc_v4.h5", 4),
+       ("v5", "20160805_test001_45_cc_v5.h5", 5),
+       ("v6", "20160805_test001_45_cc_v6.h5", 6),
+       ("v7", "20160805_test001_45_cc_v7.h5", 7),
+   ]
+   ```
+
+2. Remove `LEGACY_TYPE_ERROR` and delete `test_legacy_v4_v5_currently_raise_typeerror_on_meta_extract`.
+
+3. Rename parametrized test to `test_legacy_v4_v7_load_shapes_and_columns` (docstring: legacy
+   v4–v7 load succeeds with expected shapes, renamed columns, and `cellpy_file_version` meta).
+
+4. Keep markers unchanged — v4–v7 stay **outside** `@pytest.mark.essential` (same as current v6/v7).
+
+**Rejected: Option 2 (re-raise TypeError in loader).** Would undo working v4/v5 support and
+contradict #429 §D and existing `_load_hdf5_v5` / `_load_old_hdf5_v3_to_v4` implementation.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `tests/test_cellpy_file_roundtrip.py` | Merge v4/v5 into `LEGACY_SUCCESS`; remove TypeError test; rename v6/v7 test |
+
+## Test strategy
+
+```bash
+conda activate cellpy_dev_313   # or uv run
+pytest tests/test_cellpy_file_roundtrip.py -v
+pytest tests/test_cellpy_file_roundtrip.py::test_legacy_v4_v7_load_shapes_and_columns -v
+```
+
+Optional sanity: `pytest -m essential` (unrelated pre-existing failures may remain).
+
+## Open questions
+
+None — Option 1 is the clear fix unless you want v4/v5 promoted to `@pytest.mark.essential`
+(not recommended; keeps essential budget unchanged).

--- a/.issueflows/03-solved-issues/issue466_status.md
+++ b/.issueflows/03-solved-issues/issue466_status.md
@@ -1,0 +1,12 @@
+# Issue #466 — status
+
+- [x] Done
+
+## What's done
+
+- Branch `466-legacy-v4-v5-load-test` created from updated `master`.
+- `tests/test_cellpy_file_roundtrip.py`:
+  - Extended `LEGACY_SUCCESS` with v4/v5; removed TypeError pin test.
+  - Renamed to `test_legacy_v4_v7_load_shapes_and_columns`.
+  - v4/v5: `cycle_index` stays a column (index name unset); v6+ keep index-name assert.
+- `pytest tests/test_cellpy_file_roundtrip.py` — 10 passed.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Testing: legacy v4/v5 cellpy-file loads now covered in the v4–v7 characterization matrix (removed stale TypeError pin) (#466)
 * CI: retry `setup-miniconda` in scheduled workflow on transient conda-forge download failures (#465)
 * Testing: Stage 0.9 benchmark harness — opt-in `pytest-benchmark` suite under `benchmarks/`, committed v1.x baseline JSON, and dedicated CI job with ±20% regression gate (#436)
 * Docs: Stage-0 AST inventory scanners (`scan_member_usage.py`, `scan_hardcoded_headers.py`) in `.issueflows/00-tools/` for consumer/header reports (#435) (`tests/parity.py::assert_value_parity`) — legacy vs native frames compared through `cellpycore.legacy.mapping` with dtype-tolerant mapped-column equality, named exception list, and trivial-pass essential tests on the current bridge (#434)

--- a/tests/test_cellpy_file_roundtrip.py
+++ b/tests/test_cellpy_file_roundtrip.py
@@ -36,13 +36,10 @@ RAW_RES = (
 )
 
 LEGACY_SUCCESS = [
+    ("v4", "20160805_test001_45_cc_v4.h5", 4),
+    ("v5", "20160805_test001_45_cc_v5.h5", 5),
     ("v6", "20160805_test001_45_cc_v6.h5", 6),
     ("v7", "20160805_test001_45_cc_v7.h5", 7),
-]
-
-LEGACY_TYPE_ERROR = [
-    ("v4", "20160805_test001_45_cc_v4.h5"),
-    ("v5", "20160805_test001_45_cc_v5.h5"),
 ]
 
 
@@ -126,21 +123,9 @@ def test_v8_load_selector_max_cycle_truncates_consistently():
     assert len(selected.data.steps) < len(full.data.steps)
 
 
-@pytest.mark.parametrize("label,filename", LEGACY_TYPE_ERROR)
-def test_legacy_v4_v5_currently_raise_typeerror_on_meta_extract(label, filename):
-    """Pin current v4/v5 load failure (missing ``upgrade_from_to`` on meta extract)."""
-    path = HDF5_DIR / filename
-    if not path.is_file():
-        pytest.skip(f"missing legacy fixture: {path}")
-
-    cell = cellreader.CellpyCell()
-    with pytest.raises(TypeError):
-        cell.load(path, accept_old=True)
-
-
 @pytest.mark.parametrize("label,filename,version", LEGACY_SUCCESS)
-def test_legacy_v6_v7_load_shapes_and_columns(label, filename, version):
-    """Legacy v6/v7: load succeeds with expected shapes and renamed columns."""
+def test_legacy_v4_v7_load_shapes_and_columns(label, filename, version):
+    """Legacy v4–v7: load succeeds with expected shapes and renamed columns."""
     path = HDF5_DIR / filename
     if not path.is_file():
         pytest.skip(f"missing legacy fixture: {path}")
@@ -153,7 +138,10 @@ def test_legacy_v6_v7_load_shapes_and_columns(label, filename, version):
     assert cell.data.summary.shape[0] > 0
     assert hn.data_point_txt in cell.data.raw.columns
     assert hn.cycle_index_txt in cell.data.raw.columns
-    assert cell.data.summary.index.name == hs.cycle_index
+    if version >= 6:
+        assert cell.data.summary.index.name == hs.cycle_index
+    else:
+        assert hs.cycle_index in cell.data.summary.columns
     assert hs.data_point in cell.data.summary.columns
     assert hs.discharge_capacity in cell.data.summary.columns
     assert cell.data.meta_common.cellpy_file_version == version


### PR DESCRIPTION
## Summary

- Extends the legacy cellpy-file characterization matrix to include v4 and v5 successful loads (aligned with issue #429 §D intent).
- Removes the stale `TypeError` pin test that no longer matched loader behavior after `upgrade_from_to` support landed.
- v4/v5 keep `cycle_index` as a summary column; v6+ still assert the named index.

Closes #466.

## Test plan

- [x] `pytest tests/test_cellpy_file_roundtrip.py` — 10 passed
- [ ] Scheduled CI `conda pytest (linux)` green on merge

Made with [Cursor](https://cursor.com)