### PR TITLE
Stage 0.10: Conventions bootstrap — deprecation helper, exception tree, DEPRECATIONS registry

### DIFF
--- a/.issueflows/03-solved-issues/issue437_original.md
+++ b/.issueflows/03-solved-issues/issue437_original.md
@@ -1,0 +1,44 @@
+# Issue #437: Stage 0.10: Conventions bootstrap — deprecation helper, exception tree, DEPRECATIONS registry
+
+Source: https://github.com/jepegit/cellpy/issues/437
+
+## Original issue text
+
+> Part of **Stage 0 — foundations for cellpy 2** (see the tracking issue). Plan documents live in the shared workspace: `cellpy-workspace/architecture-plan/` (the [architecture-plan repo](https://github.com/cellpy/architecture-plan); formerly `architecture-plan/`) (alongside the `cellpy` and `cellpy-core` repos).
+
+## Goal
+
+Land the shared conventions machinery every later shim imports:
+
+- `cellpy._deprecation.warn_once(name, replacement, removal="2.1")` (once-per-site registry,
+  `stacklevel` correct),
+- self-registering deprecation table rendered to `DEPRECATIONS.md`,
+- exception-tree skeleton: `cellpy/exceptions.py` re-exports `cellpycore.exceptions.CellpyError`
+  as the root; `CorruptCellpyFile`, `ConfigurationError`, `UnitsError`, `LoaderError` stubs,
+- test-convention checklist line ("warnings emitted once, registered in DEPRECATIONS.md")
+  added to the contributing docs.
+
+Logging changes (no import-time config) are **not** in this issue — they ride with the
+config plan's import-time-I/O removal.
+
+## Why
+
+The config, header-migration, unit and utils plans all introduce shims with warnings. If the
+helper does not exist before the first shim lands, we get four ad-hoc warning styles and a
+deprecation table that is stale on arrival (conventions plan §5).
+
+## Links
+
+- `architecture-plan/cellpy2-conventions-plan.md` (§1, §3, §5)
+
+## Acceptance
+
+- Helper + registry in tree with tests (warn exactly once; registry renders).
+- First consumer wired (can be an existing deprecation, e.g. `helpers.make_new_cell`).
+
+## Comments (curated summary)
+
+- **Clarifications / constraints**: #456 (Stage 1.11) describes the same deliverable from the Stage-1 side — implement here and close both together.
+- **Superseded / retracted**: (none)
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-09._

--- a/.issueflows/03-solved-issues/issue437_plan.md
+++ b/.issueflows/03-solved-issues/issue437_plan.md
@@ -1,0 +1,48 @@
+# Issue #437 — plan
+
+## Goal
+
+Bootstrap shared conventions machinery: `warn_once` deprecation helper with registry, `DEPRECATIONS.md` rendering, exception-tree stubs, and a contributing-doc checklist line.
+
+## Constraints
+
+- No import-time logging changes (out of scope).
+- Keep existing `cellpy.exceptions` classes importable (backward compatible).
+- Logging helper must warn once per call site, not per invocation loop.
+- Plan reference: `architecture-plan/cellpy2-conventions-plan.md` §1, §3, §5.
+
+### Prior art
+
+- `cellpy/exceptions.py` — legacy flat exception tree rooted at `Error`.
+- `cellpy/utils/helpers.py::make_new_cell` — ad-hoc `warnings.warn(..., DeprecationWarning)`.
+- `cellpycore.exceptions.CellpyError`, `NoDataFound` — core root exceptions.
+- `tests/test_cell_readers.py::test_deprecations` — xfail deprecation test (unrelated path).
+- None in `00-tools/` for deprecation rendering.
+
+## Approach
+
+1. Add `cellpy/_deprecation.py` with `warn_once`, in-memory registry, `render_deprecations_md()`, and `write_deprecations_md()`.
+2. Wire `helpers.make_new_cell` as first consumer via `warn_once`.
+3. Extend `cellpy/exceptions.py`: re-export `CellpyError`; add stub subclasses `CorruptCellpyFile`, `ConfigurationError`, `UnitsError`, `LoaderError`; keep legacy exceptions unchanged.
+4. Commit generated `DEPRECATIONS.md` (seed known entry for `make_new_cell`).
+5. Add `tests/test_deprecation_conventions.py` covering once-per-site warnings, registry render, and exception stubs.
+6. Add one checklist line to `CONTRIBUTING.md` under pull-request guidelines.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/_deprecation.py` | New helper module |
+| `cellpy/exceptions.py` | Re-export `CellpyError`, add stub exceptions |
+| `cellpy/utils/helpers.py` | Use `warn_once` in `make_new_cell` |
+| `DEPRECATIONS.md` | Generated deprecation table |
+| `tests/test_deprecation_conventions.py` | New tests |
+| `CONTRIBUTING.md` | Test-convention checklist line |
+
+## Test strategy
+
+`uv run pytest tests/test_deprecation_conventions.py -m essential` and `uv run pytest -m essential`.
+
+## Open questions
+
+- None — scope is bounded to bootstrap machinery per issue acceptance criteria.

--- a/.issueflows/03-solved-issues/issue437_status.md
+++ b/.issueflows/03-solved-issues/issue437_status.md
@@ -1,0 +1,17 @@
+# Issue #437 — status
+
+- [x] Done
+
+## What's done
+
+- Branch `437-conventions-bootstrap` created from `master`.
+- Plan confirmed in `issue437_plan.md`.
+- Added `cellpy/_deprecation.py` with `warn_once`, registry, and `DEPRECATIONS.md` renderer.
+- Extended `cellpy/exceptions.py`: re-export `CellpyError` / `NoDataFound`, stub exceptions.
+- Wired `helpers.make_new_cell` as first `warn_once` consumer.
+- Added `tests/test_deprecation_conventions.py` (5 essential tests).
+- Committed `DEPRECATIONS.md` and contributing checklist line in `CONTRIBUTING.md`.
+
+## Remaining work
+
+- None.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,9 @@ This builds the wheel inside a fresh container, installs it, and smoke-tests
 Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
-2. The pull request should not include any gluten.
+2. Deprecation shims must use ``cellpy._deprecation.warn_once`` (warn once per call site)
+   and register in ``DEPRECATIONS.md``.
+3. The pull request should not include any gluten.
 
 ## Tips
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,11 @@
+# Deprecations
+
+Auto-generated table of registered deprecations. Regenerate with:
+
+```shell
+uv run python -m cellpy._deprecation
+```
+
+| Name | Replacement | Introduced | Removal |
+| --- | --- | --- | --- |
+| `make_new_cell` | `CellpyCell.vacant` | 2.0 | 2.1 |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Conventions: `cellpy._deprecation.warn_once` helper, `DEPRECATIONS.md` registry, exception-tree stubs (`CellpyError` re-export plus `CorruptCellpyFile`, `ConfigurationError`, `UnitsError`, `LoaderError`), and `make_new_cell` wired as first consumer (#437, closes #456)
 * Testing: legacy v4/v5 cellpy-file loads now covered in the v4–v7 characterization matrix (removed stale TypeError pin) (#466)
 * CI: retry `setup-miniconda` in scheduled workflow on transient conda-forge download failures (#465)
 * Testing: Stage 0.9 benchmark harness — opt-in `pytest-benchmark` suite under `benchmarks/`, committed v1.x baseline JSON, and dedicated CI job with ±20% regression gate (#436)

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -1,0 +1,101 @@
+"""Deprecation helper: once-per-call-site warnings and DEPRECATIONS.md registry."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Set, Tuple
+
+CallSite = Tuple[str, str, int]
+
+
+@dataclass(frozen=True)
+class DeprecationEntry:
+    name: str
+    replacement: str
+    removal: str
+    introduced: str = "2.0"
+
+
+_REGISTRY: Dict[str, DeprecationEntry] = {}
+_WARNED_SITES: Set[CallSite] = set()
+
+
+def _register(name: str, replacement: str, *, removal: str = "2.1", introduced: str = "2.0") -> None:
+    if name not in _REGISTRY:
+        _REGISTRY[name] = DeprecationEntry(
+            name=name,
+            replacement=replacement,
+            removal=removal,
+            introduced=introduced,
+        )
+
+
+def warn_once(
+    name: str,
+    replacement: str,
+    *,
+    removal: str = "2.1",
+    introduced: str = "2.0",
+    stacklevel: int = 2,
+) -> None:
+    """Emit a DeprecationWarning once per call site and register in the table."""
+    _register(name, replacement, removal=removal, introduced=introduced)
+
+    frame = inspect.currentframe()
+    if frame is None or frame.f_back is None:
+        site: CallSite = (name, "<unknown>", 0)
+    else:
+        caller = frame.f_back
+        site = (name, caller.f_code.co_filename, caller.f_lineno)
+
+    if site in _WARNED_SITES:
+        return
+    _WARNED_SITES.add(site)
+
+    message = f"{name} is deprecated; use {replacement} instead (removed in {removal})"
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel + 1)
+
+
+def get_registry() -> Dict[str, DeprecationEntry]:
+    """Return a copy of the registered deprecations (for tests and rendering)."""
+    return dict(_REGISTRY)
+
+
+def render_deprecations_md() -> str:
+    """Render the deprecation table as markdown."""
+    lines = [
+        "# Deprecations",
+        "",
+        "Auto-generated table of registered deprecations. Regenerate with:",
+        "",
+        "```shell",
+        "uv run python -m cellpy._deprecation",
+        "```",
+        "",
+        "| Name | Replacement | Introduced | Removal |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entry in sorted(_REGISTRY.values(), key=lambda item: item.name):
+        lines.append(
+            f"| `{entry.name}` | `{entry.replacement}` | {entry.introduced} | {entry.removal} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_deprecations_md(path: str | Path) -> None:
+    """Write the rendered deprecation table to *path*."""
+    Path(path).write_text(render_deprecations_md(), encoding="utf-8")
+
+
+def _seed_known_deprecations() -> None:
+    """Register deprecations that exist before any runtime call (for doc generation)."""
+    _register("make_new_cell", "CellpyCell.vacant", removal="2.1")
+
+
+if __name__ == "__main__":
+    _seed_known_deprecations()
+    write_deprecations_md(Path(__file__).resolve().parents[1] / "DEPRECATIONS.md")

--- a/cellpy/exceptions.py
+++ b/cellpy/exceptions.py
@@ -1,8 +1,10 @@
-"""Exceptions defined within cellpy"""
+"""Exceptions defined within cellpy."""
+
+from cellpycore.exceptions import CellpyError, NoDataFound
 
 
 class Error(Exception):
-    """Base class for other exceptions"""
+    """Base class for other exceptions (legacy; prefer :class:`CellpyError`)."""
 
     pass
 
@@ -37,6 +39,30 @@ class WrongFileVersion(Error):
     pass
 
 
+class CorruptCellpyFile(IOError, CellpyError):
+    """Raised when a cellpy file is structurally corrupt."""
+
+    pass
+
+
+class ConfigurationError(CellpyError):
+    """Raised when configuration validation fails."""
+
+    pass
+
+
+class UnitsError(ValueError, CellpyError):
+    """Raised when unit labels or scales are invalid."""
+
+    pass
+
+
+class LoaderError(CellpyError):
+    """Raised when instrument ingestion fails."""
+
+    pass
+
+
 class DeprecatedFeature(Error):
     """Raised when the feature is recently deprecated"""
 
@@ -61,14 +87,29 @@ class NullData(Error):
     pass
 
 
-class NoDataFound(Error):
-    """Raised when there are no cells, but a data is needed."""
-
-    pass
-
-
 class UnderDefined(Error):
     """Raised when trying something that requires you to set
     a missing prm on environment variable first"""
 
     pass
+
+
+__all__ = [
+    "CellpyError",
+    "NoDataFound",
+    "Error",
+    "ConfigFileNotWritten",
+    "ConfigFileNotRead",
+    "FileNotFound",
+    "SearchError",
+    "WrongFileVersion",
+    "CorruptCellpyFile",
+    "ConfigurationError",
+    "UnitsError",
+    "LoaderError",
+    "DeprecatedFeature",
+    "ExportFailed",
+    "IOError",
+    "NullData",
+    "UnderDefined",
+]

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -200,9 +200,9 @@ def update_journal_cellpy_data_dir(
 
 def make_new_cell():
     """create an empty CellpyCell object."""
-    warnings.warn(
-        "make_new_cell is deprecated, use CellpyCell.vacant instead", DeprecationWarning
-    )
+    from cellpy._deprecation import warn_once
+
+    warn_once("make_new_cell", "CellpyCell.vacant")
     new_cell = cellpy.cellreader.CellpyCell(initialize=True)
     return new_cell
 

--- a/tests/test_deprecation_conventions.py
+++ b/tests/test_deprecation_conventions.py
@@ -1,0 +1,86 @@
+"""Tests for cellpy deprecation conventions (issue #437)."""
+
+import warnings
+
+import pytest
+
+from cellpy import _deprecation
+from cellpy._deprecation import warn_once
+from cellpy.exceptions import (
+    CellpyError,
+    ConfigurationError,
+    CorruptCellpyFile,
+    LoaderError,
+    UnitsError,
+)
+from cellpy.utils.helpers import make_new_cell
+
+
+@pytest.mark.essential
+def test_warn_once_emits_once_per_call_site():
+    _deprecation._WARNED_SITES.clear()
+    _deprecation._REGISTRY.clear()
+
+    def _call():
+        warn_once("demo_fn", "replacement.fn")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        _call()
+        _call()
+
+    assert len(caught) == 1
+    assert "demo_fn is deprecated" in str(caught[0].message)
+    assert "replacement.fn" in str(caught[0].message)
+
+
+@pytest.mark.essential
+def test_warn_once_registers_for_deprecations_md():
+    _deprecation._WARNED_SITES.clear()
+    _deprecation._REGISTRY.clear()
+
+    warn_once("other_fn", "new_api", removal="2.2")
+
+    registry = _deprecation.get_registry()
+    assert "other_fn" in registry
+    assert registry["other_fn"].replacement == "new_api"
+    assert registry["other_fn"].removal == "2.2"
+
+    rendered = _deprecation.render_deprecations_md()
+    assert "`other_fn`" in rendered
+    assert "`new_api`" in rendered
+
+
+@pytest.mark.essential
+def test_make_new_cell_uses_warn_once():
+    _deprecation._WARNED_SITES.clear()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        make_new_cell()
+        make_new_cell()
+
+    assert len(caught) == 1
+    assert "make_new_cell is deprecated" in str(caught[0].message)
+    assert "CellpyCell.vacant" in str(caught[0].message)
+
+
+@pytest.mark.essential
+def test_exception_tree_stubs():
+    assert issubclass(CorruptCellpyFile, CellpyError)
+    assert issubclass(ConfigurationError, CellpyError)
+    assert issubclass(UnitsError, CellpyError)
+    assert issubclass(LoaderError, CellpyError)
+
+
+@pytest.mark.essential
+def test_deprecations_md_matches_renderer():
+    _deprecation._REGISTRY.clear()
+    _deprecation._seed_known_deprecations()
+
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    on_disk = (repo_root / "DEPRECATIONS.md").read_text(encoding="utf-8")
+    rendered = _deprecation.render_deprecations_md()
+    assert on_disk == rendered


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bootstrap shared conventions machinery for cellpy 2 Stage 0:

- `cellpy._deprecation.warn_once` — once-per-call-site `DeprecationWarning` helper with self-registering table
- `DEPRECATIONS.md` — rendered registry (regenerate via `uv run python -m cellpy._deprecation`)
- `cellpy/exceptions.py` — re-export `CellpyError` / `NoDataFound` from cellpycore; add stub exceptions (`CorruptCellpyFile`, `ConfigurationError`, `UnitsError`, `LoaderError`)
- `helpers.make_new_cell` wired as first consumer
- Contributing checklist line for deprecation shims

Closes #437. Also closes #456 (same deliverable noted in issue comment).

## Test plan

- [x] `uv run pytest tests/test_deprecation_conventions.py -m essential` (5 passed)
- [x] `uv run pytest -m essential` (76 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c77-333b-712f-9edc-f7d4a5e456bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c77-333b-712f-9edc-f7d4a5e456bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

