### PR TITLE
Stage 1.1: cellpy-file format spec in cellpy_file/format.py (#446)

### DIFF
--- a/.issueflows/03-solved-issues/issue446_original.md
+++ b/.issueflows/03-solved-issues/issue446_original.md
@@ -1,0 +1,41 @@
+# Issue #446: Stage 1.1: Purge non-config constants from prms.py; create readers/cellpy_file/ with format.py
+
+Source: https://github.com/jepegit/cellpy/issues/446
+
+## Original issue text
+
+> Part of **Stage 1 — behavior-preserving construction** (see the Stage-1 tracking issue). Stage 0: jepegit/cellpy#439. Plan documents live in the shared workspace: `cellpy-workspace/architecture-plan/` (the [architecture-plan repo](https://github.com/cellpy/architecture-plan); formerly `architecture-plan/`) (alongside the `cellpy` and `cellpy-core` repos). Everything in Stage 1 lands on master with the full suite green; nothing flips user-visible behavior.
+
+## Goal
+
+The shared first step of the file-loading and configuration plans, done once:
+
+- Create `cellpy/readers/cellpy_file/` with `format.py`: a frozen `CellpyFileFormat`
+  dataclass (root, table keys, meta dirs, unit/limit prefixes, complib/complevel,
+  per-table pandas formats), one instance per historical file version (v3/4–v8).
+- Move the `_cellpyfile_*` constants out of `prms.py` onto the spec; keep
+  `prms._cellpyfile_*` as aliases during the deprecation window.
+- Move template-registry and example-data URL constants to their owning modules;
+  delete `_globals_status`/`_globals_errors` in favor of explicit returns.
+
+## Why
+
+Constants are not configuration (config plan §1.3.4); the format spec scattered between
+`prms.py` and kwarg defaults inside `_load_hdf5_v7` is drift-prone duplication (file plan
+§1.2, §2.4). Both plans name this as their Step 1 and agreed it is one shared step —
+whoever lands it, the other rebases. **Beware the limits-prefix trap pinned by
+jepegit/cellpy#429**: `_cellpyfile_raw_limit_pre_id == ""` masks an inverted loop in
+`_create_infotable` (cellreader.py:2452–2455); `format.py` must carry the empty prefix
+verbatim or fix the loop deliberately, never both silently.
+
+## Links
+
+- `architecture-plan/cellpy-file-loading-refactor-plan.md` (Step 1, §3.2 format.py)
+- `architecture-plan/cellpy2-configuration-and-parameters-plan.md` (Step 1)
+- Depends on: #429 (characterization green first).
+
+## Acceptance
+
+- Full suite green; zero behavior change (aliases only).
+- `format.py` is the single source for layout knowledge; grep shows no remaining
+  literal `"/CellpyData"` outside it except `batch_helpers.look_up_and_get` (Stage 1.4).

--- a/.issueflows/03-solved-issues/issue446_plan.md
+++ b/.issueflows/03-solved-issues/issue446_plan.md
@@ -1,0 +1,175 @@
+# Issue #446 — plan
+
+## Goal
+
+Extract the cellpy-file layout spec and other non-config `prms.py` constants into
+their proper owning modules, with `prms` aliases preserved so behavior stays
+identical. This is the shared Step 1 of the file-loading and configuration plans.
+
+## Constraints
+
+- **Behavior-preserving:** no user-visible changes; full suite must stay green.
+- **Stage 1 scope only:** create `cellpy_file/format.py` and relocate constants —
+  do **not** move `cellreader.py` I/O methods yet (file-loading plan Steps 2–6).
+- **Limits-prefix trap (#429):** keep `raw_limit_prefix == ""` verbatim in the v8
+  format spec; do not fix the inverted `_create_infotable` loop in this PR.
+- **Alias window:** `prms._cellpyfile_*` remain as module-level aliases pointing
+  at `format.py` (underscore-private, but `batch_helpers`, tests, and scripts may
+  touch them).
+- **Version constants:** re-export `CELLPY_FILE_VERSION` / `MINIMUM_CELLPY_FILE_VERSION`
+  from `format.py` but keep `internal_settings.py` as the canonical definition site
+  (avoids import-cycle with `internal_settings → prms`).
+- **Parent issue:** jepegit/cellpy#459 (Stage 1 tracking); prerequisite Stage 0
+  (#439) is complete on `master` (v1.0.4a4).
+
+### Prior art
+
+- [`architecture-plan/cellpy-file-loading-refactor-plan.md`](../../architecture-plan/cellpy-file-loading-refactor-plan.md) — Step 1 (§4), `CellpyFileFormat` design (§3.2), limits-prefix trap (Step 0).
+- [`architecture-plan/cellpy2-configuration-and-parameters-plan.md`](../../architecture-plan/cellpy2-configuration-and-parameters-plan.md) — Step 1 (§4): purge non-config constants from `prms.py`.
+- **Stage 0 oracles:** [`tests/test_cellpy_file_roundtrip.py`](../../tests/test_cellpy_file_roundtrip.py) (round-trip, legacy matrix, limits-prefix trap `test_v8_limits_stored_unprefixed_in_info_table`), [`tests/cellpy_file_support.py`](../../tests/cellpy_file_support.py).
+- **Prms characterization:** [`tests/test_prms.py`](../../tests/test_prms.py), [`tests/prms_support.py`](../../tests/prms_support.py) — inventory/parity helpers from #430.
+- **Deprecation machinery (#437):** [`cellpy/_deprecation.py`](../../cellpy/_deprecation.py) — available if we want `warn_once` on `prms._cellpyfile_*` access; not required for Step 1 (aliases are silent).
+- **Toolbox:** `.issueflows/00-tools/` — no format-spec helper; `scan_hardcoded_headers.py` is for header literals, not file layout.
+- **Graph (stale at `6faf87c9`):** Communities around `CellpyCell`, `load_cellpy_file`, `prms` inventory tests — confirms `cellreader.py` + `prms.py` as the hot zone; no existing `cellpy_file` package.
+
+## Approach
+
+### 1. Create `cellpy/readers/cellpy_file/` package (format spec only)
+
+Add:
+
+```
+cellpy/readers/cellpy_file/
+    __init__.py    # re-export CellpyFileFormat, FORMAT_* constants, get_format()
+    format.py      # frozen dataclass + version registry
+```
+
+**`CellpyFileFormat`** (frozen dataclass) fields:
+
+| Field | Current source |
+|-------|----------------|
+| `root` | `prms._cellpyfile_root` (`"CellpyData"`) |
+| `raw_dir`, `step_dir`, `summary_dir`, `fid_dir` | prms lines 392–395 |
+| `common_meta_dir`, `test_dependent_meta_dir` | prms lines 396–397 |
+| `raw_unit_prefix`, `raw_limit_prefix` | prms lines 399–400 |
+| `complevel`, `complib` | prms lines 402–403 |
+| `raw_format`, `summary_format`, `stepdata_format`, `infotable_format`, `fidtable_format` | prms lines 404–408 |
+
+**Version registry** — one `CellpyFileFormat` per historical layout (plan §3.2):
+
+| Key | Layout | Notes |
+|-----|--------|-------|
+| `FORMAT_V8` | Modern (`/raw`, `/steps`, …) | Canonical write spec; matches current prms values |
+| `FORMAT_V7`, `FORMAT_V6`, `FORMAT_V5` | Same modern paths | Identical to v8 in today's readers |
+| `FORMAT_V4` | Legacy (`/dfdata`, `/step_table`, `/dfsummary`, `/fidtable`) | From `_load_old_hdf5_v3_to_v4` (cellreader.py:2073–2078) |
+
+Expose `get_format(version: int) -> CellpyFileFormat` mapping 4→`FORMAT_V4`, 5–8→modern
+formats. Re-export version ints from `internal_settings` in `format.py` for convenience.
+
+**Do not** wire `cellreader.py` loaders to `get_format()` in this PR — kwarg defaults
+and inline `"CellpyData"` strings stay until file-loading Step 4. Duplication is
+expected and locked by existing Stage 0 tests.
+
+### 2. Rewire `prms._cellpyfile_*` as aliases
+
+In `prms.py`, delete the literal assignments (lines 391–408) and replace with aliases
+to `FORMAT_V8` fields, e.g.:
+
+```python
+from cellpy.readers.cellpy_file.format import FORMAT_V8 as _fmt
+_cellpyfile_root = _fmt.root
+_cellpyfile_raw = _fmt.raw_dir
+# … etc.
+```
+
+Zero call-site edits needed (`cellreader.py`, `batch_core.py`, tests keep using
+`prms._cellpyfile_*`).
+
+### 3. Move template-registry constants
+
+Move `_github_templates_repo`, `_standard_template_uri`, `_registered_templates` from
+`prms.py` to a small owning module — **`cellpy/utils/template_registry.py`** (new,
+~15 lines). Update `cli.py` (two call sites) to import from there.
+
+Optional: keep `prms._registered_templates` as a deprecated alias for one release
+window. Only `cli.py` uses it today — direct import is enough; skip prms alias unless
+you want belt-and-suspenders.
+
+### 4. Move example-data URL constants
+
+Move `_url_example_data`, `_url_example_data_download_with_progressbar`,
+`_example_data_in_example_folder_if_available` into **`cellpy/utils/example_data.py`**
+(module-level private constants). Update the three internal references in that file;
+drop `prms` indirection.
+
+### 5. Delete dead `_globals_*` state
+
+`_globals_status`, `_globals_errors`, `_globals_message` (prms.py:424–426) have **zero**
+callers in the repo. Delete all three — no replacement needed (already unused).
+
+### 6. Ordering within the PR
+
+1. Add `format.py` + tests locking values.
+2. Switch `prms._cellpyfile_*` to aliases; run essential suite.
+3. Move template + example-data constants; update `cli.py` / `example_data.py`.
+4. Delete `_globals_*` and moved constant definitions from `prms.py`.
+5. Full suite + grep verification.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `cellpy/readers/cellpy_file/__init__.py` | **New** — public re-exports |
+| `cellpy/readers/cellpy_file/format.py` | **New** — `CellpyFileFormat`, `FORMAT_V4`…`FORMAT_V8`, `get_format()` |
+| `cellpy/parameters/prms.py` | Replace `_cellpyfile_*` literals with aliases; remove moved constants + `_globals_*` |
+| `cellpy/utils/template_registry.py` | **New** — template registry dict + GitHub URI |
+| `cellpy/utils/example_data.py` | Own the example-data URL constants internally |
+| `cellpy/cli.py` | Import template registry from new module (2 sites) |
+| `tests/test_cellpy_file_format.py` | **New** — format spec parity + limits-prefix + version dispatch smoke |
+
+**Explicitly not touched this PR:** `cellreader.py` (I/O stays), `batch_helpers.py`
+(hard-coded `"/CellpyData"` → Stage 1.4 / file-loading Step 6).
+
+## Test strategy
+
+**Commands** (per project convention):
+
+```bash
+uv run pytest -m essential
+uv run pytest tests/test_cellpy_file_roundtrip.py tests/test_cellpy_file_format.py -v
+uv run pytest   # full suite before merge
+```
+
+**New tests** (`tests/test_cellpy_file_format.py`):
+
+- `FORMAT_V8` field values match every `prms._cellpyfile_*` alias (parity contract).
+- `raw_limit_prefix == ""` on v8 format (limits-prefix trap).
+- `get_format(4)` returns legacy dirs; `get_format(8)` returns modern dirs.
+- `get_format(5/6/7/8)` all share modern layout paths.
+
+**Existing oracles (must stay green, no edits expected):**
+
+- `tests/test_cellpy_file_roundtrip.py` — round-trip, legacy matrix, selector, limits trap.
+- `tests/test_prms.py` — prms inventory/parity (#430).
+- `tests/test_cell_readers.py` — uses `prms._cellpyfile_fid` / `_cellpyfile_root`.
+
+**Manual grep check after implementation:**
+
+```bash
+rg '_cellpyfile_' cellpy/parameters/prms.py   # aliases only, no literals
+rg '"/CellpyData"' cellpy/ --glob '*.py'      # expect batch_helpers only
+```
+
+## Open questions
+
+1. **Template registry alias:** Move to `template_registry.py` with direct `cli.py`
+   import only (recommended), or also keep `prms._registered_templates` alias?
+2. **Issue branch:** Create `446-format-spec` (or `446-stage-1-1-format`) before
+   `/iflow-start`? Currently on `master` (clean except untracked `.issueflows/` files).
+3. **`CellpyFileFormat.version` field:** Include explicit `version: int` on each
+   frozen instance, or keep version mapping only in `get_format()`? (Recommend:
+   include `version` for clarity and test assertions.)
+
+---
+
+**Confirm:** Accept / Revise / Abort

--- a/.issueflows/03-solved-issues/issue446_status.md
+++ b/.issueflows/03-solved-issues/issue446_status.md
@@ -1,0 +1,25 @@
+# Issue #446 — status
+
+- [x] Done
+
+## What's done
+
+- Branch `446-format-spec` created from `master`.
+- `cellpy/readers/cellpy_file/format.py` — `CellpyFileFormat`, `FORMAT_V4`–`FORMAT_V8`, `get_format()`.
+- `prms._cellpyfile_*` rewired as aliases onto `FORMAT_V8`.
+- Template registry → `cellpy/utils/template_registry.py`; `cli.py` updated.
+- Example-data URL constants → `cellpy/utils/example_data.py`.
+- Dead `_globals_*` removed from `prms.py`.
+- `tests/test_cellpy_file_format.py` added (parity + limits-prefix + version dispatch).
+- Tests: 14/14 cellpy-file format+roundtrip green; 78/79 essential (1 pre-existing `loader_pec_csv` datetime dtype flake, unrelated).
+- Grep: `prms._cellpyfile_*` are aliases only; `"/CellpyData"` literal only in `batch_helpers` comment (Stage 1.4).
+
+## Remaining work
+
+- [ ] `/iflow-close` when ready (PR + push).
+
+## Judgment calls (plan open questions)
+
+- Template registry: direct `cli.py` import only (no `prms` alias).
+- `CellpyFileFormat.version` field included on each frozen instance.
+- Version ints duplicated in `format.py` (not imported from `internal_settings`) to avoid `prms` import cycle.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Stage 1.1: extract cellpy-file format spec into `cellpy/readers/cellpy_file/format.py`; `prms._cellpyfile_*` aliases preserved; template registry and example-data URL constants moved to owning modules (#446)
 * Stage 0 foundations complete — all linked characterization, oracle, baseline, convention, and decision-register issues closed; ready for Stage 1 (#439)
 * Docs: Stage 0.11 decision register recorded in architecture-plan (timezone, curve-schema, v9 container, IR semantics, easyplot, v1.x maintenance) (#438)
 * Conventions: `cellpy._deprecation.warn_once` helper, `DEPRECATIONS.md` registry, exception-tree stubs (`CellpyError` re-export plus `CorruptCellpyFile`, `ConfigurationError`, `UnitsError`, `LoaderError`), and `make_new_cell` wired as first consumer (#437, closes #456)

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -21,6 +21,7 @@ from cellpy.exceptions import ConfigFileNotWritten
 from cellpy.parameters import prmreader
 from cellpy.parameters.internal_settings import OTHERPATHS
 from cellpy.internals.connections import OtherPath
+from cellpy.utils.template_registry import REGISTERED_TEMPLATES
 
 DIFFICULT_MISSING_MODULES = {}
 
@@ -1669,7 +1670,7 @@ def _new(
         default_template = _get_default_template()
         local_templates = _read_local_templates()
         local_templates_path = prmreader.prms.Paths.templatedir
-        registered_templates = prms._registered_templates
+        registered_templates = REGISTERED_TEMPLATES
         click.echo(f"[cellpy] - default: {default_template}")
         click.echo("[cellpy] - registered templates (on github):")
         for label, link in registered_templates.items():
@@ -1706,7 +1707,7 @@ def _new(
             )
             return
     else:
-        templates = prms._registered_templates
+        templates = REGISTERED_TEMPLATES
         if local_templates := _read_local_templates():
             templates.update(local_templates)
 

--- a/cellpy/parameters/prms.py
+++ b/cellpy/parameters/prms.py
@@ -366,11 +366,6 @@ Instruments = InstrumentsClass(
 
 _github_repo_parent = "jepegit"
 _github_repo = "cellpy"
-_github_templates_repo = "cellpy_cookies.git"
-
-_url_example_data = f"https://raw.githubusercontent.com/{_github_repo_parent}/{_github_repo}/master/examples/data/"
-_url_example_data_download_with_progressbar = True
-_example_data_in_example_folder_if_available = True
 
 _use_local_fastnda = True
 
@@ -388,42 +383,26 @@ _sub_process_path = Path(__file__) / "../../../bin/mdbtools-win/mdb-export"
 _sub_process_path = _sub_process_path.resolve()
 _sort_if_subprocess = True
 
-_cellpyfile_root = "CellpyData"
-_cellpyfile_raw = "/raw"
-_cellpyfile_step = "/steps"
-_cellpyfile_summary = "/summary"
-_cellpyfile_fid = "/fid"
-_cellpyfile_common_meta = "/info"
-_cellpyfile_test_dependent_meta = "/info_test_dependent"
+from cellpy.readers.cellpy_file.format import FORMAT_V8 as _cellpyfile_format
 
-_cellpyfile_raw_unit_pre_id = "raw_unit_"
-_cellpyfile_raw_limit_pre_id = ""
-
-_cellpyfile_complevel = 1
-_cellpyfile_complib = None  # currently, defaults to "zlib"
-_cellpyfile_raw_format = "table"
-_cellpyfile_summary_format = "table"
-_cellpyfile_stepdata_format = "table"
-_cellpyfile_infotable_format = "fixed"
-_cellpyfile_fidtable_format = "fixed"
+_cellpyfile_root = _cellpyfile_format.root
+_cellpyfile_raw = _cellpyfile_format.raw_dir
+_cellpyfile_step = _cellpyfile_format.step_dir
+_cellpyfile_summary = _cellpyfile_format.summary_dir
+_cellpyfile_fid = _cellpyfile_format.fid_dir
+_cellpyfile_common_meta = _cellpyfile_format.common_meta_dir
+_cellpyfile_test_dependent_meta = _cellpyfile_format.test_dependent_meta_dir
+_cellpyfile_raw_unit_pre_id = _cellpyfile_format.raw_unit_prefix
+_cellpyfile_raw_limit_pre_id = _cellpyfile_format.raw_limit_prefix
+_cellpyfile_complevel = _cellpyfile_format.complevel
+_cellpyfile_complib = _cellpyfile_format.complib
+_cellpyfile_raw_format = _cellpyfile_format.raw_format
+_cellpyfile_summary_format = _cellpyfile_format.summary_format
+_cellpyfile_stepdata_format = _cellpyfile_format.stepdata_format
+_cellpyfile_infotable_format = _cellpyfile_format.infotable_format
+_cellpyfile_fidtable_format = _cellpyfile_format.fidtable_format
 
 _date_time_format = "%Y-%m-%d %H:%M:%S:%f"
-
-# templates
-_standard_template_uri = (
-    f"https://github.com/{_github_repo_parent}/{_github_templates_repo}"
-)
-
-_registered_templates = {
-    "standard": (_standard_template_uri, "standard"),  # (repository, name-of-folder)
-    "ife": (_standard_template_uri, "ife"),
-    "single": (_standard_template_uri, "single"),
-}
-
-# used as global variables
-_globals_status = ""
-_globals_errors = []
-_globals_message = []
 
 
 # general settings for loaders

--- a/cellpy/readers/cellpy_file/__init__.py
+++ b/cellpy/readers/cellpy_file/__init__.py
@@ -1,0 +1,25 @@
+"""Cellpy-file (HDF5) I/O package (Stage 1.1: format spec only)."""
+
+from cellpy.readers.cellpy_file.format import (
+    CELLPY_FILE_VERSION,
+    MINIMUM_CELLPY_FILE_VERSION,
+    FORMAT_V4,
+    FORMAT_V5,
+    FORMAT_V6,
+    FORMAT_V7,
+    FORMAT_V8,
+    CellpyFileFormat,
+    get_format,
+)
+
+__all__ = [
+    "CELLPY_FILE_VERSION",
+    "MINIMUM_CELLPY_FILE_VERSION",
+    "CellpyFileFormat",
+    "FORMAT_V4",
+    "FORMAT_V5",
+    "FORMAT_V6",
+    "FORMAT_V7",
+    "FORMAT_V8",
+    "get_format",
+]

--- a/cellpy/readers/cellpy_file/format.py
+++ b/cellpy/readers/cellpy_file/format.py
@@ -1,0 +1,111 @@
+"""Cellpy-file (HDF5) layout specification.
+
+Single source of truth for table keys, meta dirs, compression, and pandas
+store formats. Version-specific layouts for historical file versions v4–v8.
+
+Canonical file-version integers remain in ``internal_settings``; the values
+below are duplicated here to avoid an import cycle (``internal_settings`` imports
+``prms``, and ``prms`` aliases onto this module).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Must match cellpy.parameters.internal_settings (canonical site).
+CELLPY_FILE_VERSION = 8
+MINIMUM_CELLPY_FILE_VERSION = 4
+
+
+@dataclass(frozen=True)
+class CellpyFileFormat:
+    """Frozen layout spec for one cellpy-file format version."""
+
+    version: int
+    root: str
+    raw_dir: str
+    step_dir: str
+    summary_dir: str
+    fid_dir: str
+    common_meta_dir: str
+    test_dependent_meta_dir: str
+    raw_unit_prefix: str
+    raw_limit_prefix: str
+    complevel: int
+    complib: str | None
+    raw_format: str
+    summary_format: str
+    stepdata_format: str
+    infotable_format: str
+    fidtable_format: str
+
+
+def _modern_format(version: int) -> CellpyFileFormat:
+    return CellpyFileFormat(
+        version=version,
+        root="CellpyData",
+        raw_dir="/raw",
+        step_dir="/steps",
+        summary_dir="/summary",
+        fid_dir="/fid",
+        common_meta_dir="/info",
+        test_dependent_meta_dir="/info_test_dependent",
+        raw_unit_prefix="raw_unit_",
+        raw_limit_prefix="",
+        complevel=1,
+        complib=None,
+        raw_format="table",
+        summary_format="table",
+        stepdata_format="table",
+        infotable_format="fixed",
+        fidtable_format="fixed",
+    )
+
+
+FORMAT_V8 = _modern_format(8)
+FORMAT_V7 = _modern_format(7)
+FORMAT_V6 = _modern_format(6)
+FORMAT_V5 = _modern_format(5)
+
+FORMAT_V4 = CellpyFileFormat(
+    version=4,
+    root="CellpyData",
+    raw_dir="/dfdata",
+    step_dir="/step_table",
+    summary_dir="/dfsummary",
+    fid_dir="/fidtable",
+    common_meta_dir="/info",
+    test_dependent_meta_dir="/info_test_dependent",
+    raw_unit_prefix="raw_unit_",
+    raw_limit_prefix="",
+    complevel=1,
+    complib=None,
+    raw_format="table",
+    summary_format="table",
+    stepdata_format="table",
+    infotable_format="fixed",
+    fidtable_format="fixed",
+)
+
+_FORMAT_BY_VERSION: dict[int, CellpyFileFormat] = {
+    4: FORMAT_V4,
+    5: FORMAT_V5,
+    6: FORMAT_V6,
+    7: FORMAT_V7,
+    8: FORMAT_V8,
+}
+
+
+def get_format(version: int) -> CellpyFileFormat:
+    """Return the layout spec for a cellpy-file version.
+
+    Args:
+        version: On-disk ``cellpy_file_version`` (4–8 supported here).
+
+    Returns:
+        The matching ``CellpyFileFormat`` instance.
+
+    Raises:
+        KeyError: If ``version`` has no registered layout.
+    """
+    return _FORMAT_BY_VERSION[version]

--- a/cellpy/utils/example_data.py
+++ b/cellpy/utils/example_data.py
@@ -18,6 +18,14 @@ _DATA_PATH = CURRENT_PATH / "data"
 DO_NOT_REMOVE_THESE_FILES = [".gitkeep"]
 CHUNK_SIZE = 8192
 
+_GITHUB_REPO_PARENT = "jepegit"
+_GITHUB_REPO = "cellpy"
+_URL_EXAMPLE_DATA = (
+    f"https://raw.githubusercontent.com/{_GITHUB_REPO_PARENT}/{_GITHUB_REPO}/master/examples/data/"
+)
+_URL_EXAMPLE_DATA_DOWNLOAD_WITH_PROGRESSBAR = True
+_EXAMPLE_DATA_IN_EXAMPLE_FOLDER_IF_AVAILABLE = True
+
 _example_data_download_help = """
 You don't have any accessible example directory set in your configurations so
 cellpy will try to download the example data to the folder where the cellpy
@@ -52,7 +60,7 @@ def _user_examples_dir():
     return examples_dir / "data"
 
 
-if prms._example_data_in_example_folder_if_available:
+if _EXAMPLE_DATA_IN_EXAMPLE_FOLDER_IF_AVAILABLE:
     DATA_PATH = _user_examples_dir() or _DATA_PATH
 
 
@@ -100,12 +108,12 @@ def download_file(url, local_filename):
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
         with open(local_filename, "wb") as f:
-            if prms._url_example_data_download_with_progressbar:
+            if _URL_EXAMPLE_DATA_DOWNLOAD_WITH_PROGRESSBAR:
                 pbar = tqdm(
                     total=int(r.headers["Content-Length"]), unit="B", unit_scale=True
                 )
             for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
-                if chunk and prms._url_example_data_download_with_progressbar:
+                if chunk and _URL_EXAMPLE_DATA_DOWNLOAD_WITH_PROGRESSBAR:
                     pbar.update(len(chunk))
                 f.write(chunk)
 
@@ -157,7 +165,7 @@ def _download_example_data(filename: str):
 
     """
     logging.info(f"{filename} not found. Trying to access it from GitHub...")
-    base_url = prms._url_example_data
+    base_url = _URL_EXAMPLE_DATA
     if not os.path.exists(DATA_PATH):
         try:
             os.makedirs(DATA_PATH)

--- a/cellpy/utils/template_registry.py
+++ b/cellpy/utils/template_registry.py
@@ -1,0 +1,12 @@
+"""Registered cookiecutter batch templates (GitHub-hosted)."""
+
+_GITHUB_REPO_PARENT = "jepegit"
+_GITHUB_TEMPLATES_REPO = "cellpy_cookies.git"
+
+STANDARD_TEMPLATE_URI = f"https://github.com/{_GITHUB_REPO_PARENT}/{_GITHUB_TEMPLATES_REPO}"
+
+REGISTERED_TEMPLATES = {
+    "standard": (STANDARD_TEMPLATE_URI, "standard"),
+    "ife": (STANDARD_TEMPLATE_URI, "ife"),
+    "single": (STANDARD_TEMPLATE_URI, "single"),
+}

--- a/tests/test_cellpy_file_format.py
+++ b/tests/test_cellpy_file_format.py
@@ -1,0 +1,62 @@
+"""Tests for cellpy-file format spec (Stage 1.1, issue #446)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy import prms
+from cellpy.parameters import internal_settings
+from cellpy.readers.cellpy_file.format import (
+    CELLPY_FILE_VERSION,
+    MINIMUM_CELLPY_FILE_VERSION,
+    FORMAT_V4,
+    FORMAT_V8,
+    get_format,
+)
+
+
+@pytest.mark.essential
+def test_format_v8_matches_prms_aliases():
+    fmt = FORMAT_V8
+    assert prms._cellpyfile_root == fmt.root
+    assert prms._cellpyfile_raw == fmt.raw_dir
+    assert prms._cellpyfile_step == fmt.step_dir
+    assert prms._cellpyfile_summary == fmt.summary_dir
+    assert prms._cellpyfile_fid == fmt.fid_dir
+    assert prms._cellpyfile_common_meta == fmt.common_meta_dir
+    assert prms._cellpyfile_test_dependent_meta == fmt.test_dependent_meta_dir
+    assert prms._cellpyfile_raw_unit_pre_id == fmt.raw_unit_prefix
+    assert prms._cellpyfile_raw_limit_pre_id == fmt.raw_limit_prefix
+    assert prms._cellpyfile_complevel == fmt.complevel
+    assert prms._cellpyfile_complib == fmt.complib
+    assert prms._cellpyfile_raw_format == fmt.raw_format
+    assert prms._cellpyfile_summary_format == fmt.summary_format
+    assert prms._cellpyfile_stepdata_format == fmt.stepdata_format
+    assert prms._cellpyfile_infotable_format == fmt.infotable_format
+    assert prms._cellpyfile_fidtable_format == fmt.fidtable_format
+
+
+@pytest.mark.essential
+def test_v8_raw_limit_prefix_empty():
+    assert FORMAT_V8.raw_limit_prefix == ""
+    assert prms._cellpyfile_raw_limit_pre_id == ""
+
+
+@pytest.mark.essential
+def test_get_format_version_dispatch():
+    v4 = get_format(4)
+    assert v4.raw_dir == "/dfdata"
+    assert v4.step_dir == "/step_table"
+    assert v4.summary_dir == "/dfsummary"
+    assert v4.fid_dir == "/fidtable"
+
+    for version in (5, 6, 7, 8):
+        fmt = get_format(version)
+        assert fmt.raw_dir == "/raw"
+        assert fmt.step_dir == "/steps"
+        assert fmt.version == version
+
+
+def test_version_constants_match_internal_settings():
+    assert CELLPY_FILE_VERSION == internal_settings.CELLPY_FILE_VERSION
+    assert MINIMUM_CELLPY_FILE_VERSION == internal_settings.MINIMUM_CELLPY_FILE_VERSION


### PR DESCRIPTION
## Summary

- Add `cellpy/readers/cellpy_file/format.py` with frozen `CellpyFileFormat` and version registry (`FORMAT_V4`–`FORMAT_V8`, `get_format()`).
- Rewire `prms._cellpyfile_*` as aliases onto `FORMAT_V8` — zero call-site / behavior change.
- Move batch template registry to `cellpy/utils/template_registry.py` and example-data URL constants into `example_data.py`.
- Remove unused `_globals_*` from `prms.py`.
- Add essential characterization tests in `tests/test_cellpy_file_format.py`.

Part of Stage 1 behavior-preserving construction (tracking: #459). Does **not** move `cellreader.py` I/O yet (file-loading plan Steps 2–6).

Closes #446

## Test plan

- [x] `pytest tests/test_cellpy_file_format.py tests/test_cellpy_file_roundtrip.py tests/test_prms.py` — all green
- [x] Essential markers on new format tests
- [ ] CI essential gate on Linux
- [ ] Full `pytest -m essential` locally: 78/79 pass; `loader_pec_csv` golden fails on Windows (`datetime64[ns]` vs `datetime64[us]`) — pre-existing, unrelated to this PR


Made with [Cursor](https://cursor.com)