### PR TITLE
fix: PEC golden datetime + tiered benchmark gate (#476)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
       - run: uv python install 3.13
       - name: Sync dependencies
         run: uv sync
-      - name: Run benchmarks and compare against v1.x baseline (+20% slowdown max)
+      - name: Run benchmarks and compare against v1.x baseline (warn +20%%, fail +100%%)
         run: |
           uv run pytest benchmarks/ --benchmark-only --benchmark-json=/tmp/bench.json
           uv run python benchmarks/check_baseline.py /tmp/bench.json benchmarks/baselines/v1x_ubuntu_py313.json

--- a/.issueflows/03-solved-issues/issue476_original.md
+++ b/.issueflows/03-solved-issues/issue476_original.md
@@ -1,0 +1,71 @@
+# Issue #476: golden test fails
+
+Source: https://github.com/jepegit/cellpy/issues/476
+
+## Original issue text
+
+Part 1: loader_pec_csv golden fails on Windows (datetime64[ns] vs datetime64[us]. Fix it.
+
+Part 2: Benchmarks fail. Tests seem flaky. Either due to bad limits or floating benchmark values. Set to limits, warning + exception. Exception only with extreme slow-downs (> 100%). Error message:
+
+```
+Run uv run pytest benchmarks/ --benchmark-only --benchmark-json=/tmp/bench.json
+============================= test session starts ==============================
+platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0 -- /home/runner/work/cellpy/cellpy/.venv/bin/python
+cachedir: .pytest_cache
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /home/runner/work/cellpy/cellpy
+configfile: pyproject.toml
+plugins: benchmark-5.2.3, timeout-2.4.0
+collecting ... collected 5 items
+
+benchmarks/test_performance.py::test_benchmark_single_cell_pipeline PASSED [ 20%]
+benchmarks/test_performance.py::test_benchmark_batch_summary_collection PASSED [ 40%]
+benchmarks/test_performance.py::test_benchmark_v8_cellpy_file_load PASSED [ 60%]
+benchmarks/test_performance.py::test_benchmark_get_cap_all_cycles PASSED [ 80%]
+
+Wrote benchmark data in: <_io.BufferedWriter name='/tmp/bench.json'>
+benchmarks/test_performance.py::test_benchmark_peak_rss_kib PASSED       [100%]
+
+=============================== warnings summary ===============================
+benchmarks/test_performance.py::test_benchmark_single_cell_pipeline
+benchmarks/test_performance.py::test_benchmark_single_cell_pipeline
+benchmarks/test_performance.py::test_benchmark_get_cap_all_cycles
+benchmarks/test_performance.py::test_benchmark_peak_rss_kib
+  /home/runner/work/cellpy/cellpy/cellpy/readers/cellreader.py:5919: DeprecationWarning: `specific_converters` is deprecated; use `specific_conversion_factors` instead
+    data = self.core.add_scaled_summary_columns(
+
+benchmarks/test_performance.py::test_benchmark_v8_cellpy_file_load
+benchmarks/test_performance.py::test_benchmark_v8_cellpy_file_load
+  /home/runner/work/cellpy/cellpy/cellpy/readers/cellreader.py:2335: UserWarning: no fid_table - you should update your cellpy-file
+    warnings.warn("no fid_table - you should update your cellpy-file")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+
+---------------------------------------------------------------------------------------------- benchmark: 5 tests ---------------------------------------------------------------------------------------------
+Name (time in ms)                                Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_batch_summary_collection      61.7604 (1.0)       61.7604 (1.0)       61.7604 (1.0)      0.0000 (1.0)       61.7604 (1.0)      0.0000 (1.0)           0;0  16.1916 (1.0)           1           1
+test_benchmark_get_cap_all_cycles            72.3815 (1.17)      72.3815 (1.17)      72.3815 (1.17)     0.0000 (1.0)       72.3815 (1.17)     0.0000 (1.0)           0;0  13.8157 (0.85)          1           1
+test_benchmark_v8_cellpy_file_load           87.2147 (1.41)      87.2147 (1.41)      87.2147 (1.41)     0.0000 (1.0)       87.2147 (1.41)     0.0000 (1.0)           0;0  11.4660 (0.71)          1           1
+test_benchmark_single_cell_pipeline         149.1890 (2.42)     149.1890 (2.42)     149.1890 (2.42)     0.0000 (1.0)      149.1890 (2.42)     0.0000 (1.0)           0;0   6.7029 (0.41)          1           1
+test_benchmark_peak_rss_kib                 153.5246 (2.49)     153.5246 (2.49)     153.5246 (2.49)     0.0000 (1.0)      153.5246 (2.49)     0.0000 (1.0)           0;0   6.5136 (0.40)          1           1
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+============================== slowest durations ===============================
+5.80s setup    benchmarks/test_performance.py::test_benchmark_batch_summary_collection
+2.13s call     benchmarks/test_performance.py::test_benchmark_single_cell_pipeline
+0.17s call     benchmarks/test_performance.py::test_benchmark_v8_cellpy_file_load
+0.16s setup    benchmarks/test_performance.py::test_benchmark_get_cap_all_cycles
+0.15s call     benchmarks/test_performance.py::test_benchmark_peak_rss_kib
+0.07s call     benchmarks/test_performance.py::test_benchmark_get_cap_all_cycles
+0.07s call     benchmarks/test_performance.py::test_benchmark_batch_summary_collection
+
+(8 durations < 0.005s hidden.  Use -vv to show these durations.)
+======================== 5 passed, 6 warnings in 10.60s ========================
+Benchmark baseline regression:
+  - test_benchmark_batch_summary_collection: mean 0.061760s vs baseline 0.048794s (ratio 1.266, max slowdown +20%)
+```

--- a/.issueflows/03-solved-issues/issue476_plan.md
+++ b/.issueflows/03-solved-issues/issue476_plan.md
@@ -1,0 +1,135 @@
+# Issue #476 — plan
+
+## Goal
+
+Fix the Windows `loader_pec_csv` essential golden failure and make the benchmark
+baseline gate tolerant of normal CI noise: **warn** on moderate slowdowns, **fail**
+only on extreme regressions (>100%).
+
+## Constraints
+
+- **Behavior-preserving:** no loader or production code changes unless required for
+  the golden fix (Part 1 should be test-helper only).
+- **Essential gate:** `test_loader_raw_matches_golden_parquet[loader_pec_csv]` must
+  pass on Windows and Linux.
+- **Benchmark ruler unchanged:** do not rebaseline JSON in this PR unless a deliberate
+  speed change is documented — the CI failure in the issue (26.6% slowdown) should
+  become a warning, not a pass-by-rebaseline.
+- **Stage 0.9 contract:** keep the dedicated `benchmarks.yml` workflow; peak RSS stays
+  compare-exempt.
+
+### Prior art
+
+- [`tests/loader_golden_support.py`](../../tests/loader_golden_support.py) —
+  `assert_raw_matches_golden()` compares `date_time` / `step_time` / `test_time` via
+  epoch-ns tolerance; all other columns use strict `assert_frame_equal` (dtype-sensitive).
+- [`tests/golden_support.py`](../../tests/golden_support.py) — same pattern for summary
+  goldens (`date_time` only).
+- [`cellpy/readers/instruments/pec_csv.py`](../../cellpy/readers/instruments/pec_csv.py) —
+  adds `position_start_time` as `pd.to_datetime` (PEC-only datetime column).
+- [`benchmarks/check_baseline.py`](../../benchmarks/check_baseline.py) — single ±20%
+  fail threshold; used by [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml).
+- [`benchmarks/README.md`](../../benchmarks/README.md) — documents the 20% gate.
+- **Toolbox:** no existing helper; add small unit tests for `check_baseline.compare()`.
+
+## Approach
+
+### Part 1 — `loader_pec_csv` golden on Windows
+
+**Root cause:** `position_start_time` is datetime64 on both sides but not listed in
+`DATETIME_LIKE_COLUMNS` (only `date_time`). It lands in the strict `exact_cols`
+branch → pandas compares `datetime64[ns]` (Windows load) vs `datetime64[us]` (parquet
+golden from Linux CI).
+
+**Fix:** In `assert_raw_matches_golden()` (and the matching path in
+`prepare_raw_for_golden` if needed), **auto-detect temporal columns** from dtypes:
+
+```python
+def _temporal_columns(actual, expected):
+    cols = set(DATETIME_LIKE_COLUMNS) | set(TIMEDELTA_LIKE_COLUMNS)
+    for frame in (actual, expected):
+        for col in frame.columns:
+            if pd.api.types.is_datetime64_any_dtype(frame[col]):
+                cols.add(col)
+            elif pd.api.types.is_timedelta64_dtype(frame[col]):
+                cols.add(col)
+    return cols
+```
+
+Use `_temporal_columns()` for the temporal vs exact split and for
+`assert_temporal_series_equal()` (already normalizes to ns epoch int64).
+
+Explicitly add `position_start_time` to `DATETIME_LIKE_COLUMNS` only if we prefer
+minimal diff — **prefer auto-detect** so future loader datetime columns don't repeat
+this failure.
+
+No parquet regeneration expected (values match; dtype comparison was the bug).
+
+### Part 2 — Tiered benchmark baseline gate
+
+Replace the single hard-fail at +20% with two bands (issue spec):
+
+| Ratio vs baseline | Action |
+|-------------------|--------|
+| ≤ 1.20 (+20%) | Pass silently |
+| > 1.20 and ≤ 2.0 (+20% … +100%) | **`warnings.warn()`** with benchmark name, means, ratio — exit 0 |
+| > 2.0 (+100%) | **Fail** (exit 1), same message shape as today |
+
+Implementation in `benchmarks/check_baseline.py`:
+
+- Refactor `compare()` → return `(warnings: list[str], failures: list[str])` or a
+  small result dataclass.
+- `main()`: print warnings to stderr, return 1 only if `failures` non-empty.
+- CLI flags: `--warn-tolerance 0.20` (default), `--fail-tolerance 1.0` (default =
+  +100% slowdown → ratio 2.0). Keep backward-compatible `--tolerance` as alias for
+  `--warn-tolerance` if useful.
+
+Update docs:
+
+- `benchmarks/README.md` — describe warn vs fail bands.
+- `.github/workflows/benchmarks.yml` step comment (no workflow logic change beyond
+  what the script does).
+
+**Not in scope:** increasing `pytest-benchmark` rounds/min_time (noise reduction) —
+only revisit if warnings still flood CI after the tiered gate.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| [`tests/loader_golden_support.py`](../../tests/loader_golden_support.py) | Auto-detect datetime/timedelta columns in golden compare |
+| [`benchmarks/check_baseline.py`](../../benchmarks/check_baseline.py) | Tiered warn (+20%) / fail (+100%) logic |
+| [`benchmarks/README.md`](../../benchmarks/README.md) | Document new gate behavior |
+| [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml) | Update step description |
+| [`tests/test_check_baseline.py`](../../tests/test_check_baseline.py) | **New** — unit tests for compare bands with synthetic JSON |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_loader_goldens.py::test_loader_raw_matches_golden_parquet[loader_pec_csv] -v
+uv run pytest tests/test_check_baseline.py -v
+uv run pytest -m essential --ignore=tests/test_plotutils_summary_plot.py
+```
+
+**New tests (`tests/test_check_baseline.py`):**
+
+- ratio 1.10 → no warn, no fail
+- ratio 1.30 → warn, exit 0
+- ratio 2.50 → fail
+- peak RSS benchmark name still skipped
+
+**Manual verify (optional):** run `check_baseline.py` against the CI log means from
+the issue (batch_summary ratio 1.266) — should warn, not fail.
+
+**Branch:** create `476-golden-benchmark-fixes` from updated `master` (current
+`446-format-spec` is stale; run `/iflow-cleanup` or `git switch master && git pull`
+first).
+
+## Open questions
+
+1. **Warning channel:** `warnings.warn()` (pytest captures in logs) vs `print(..., file=sys.stderr)` — recommend stderr print so GHA logs show yellow-style visibility without pytest warning filters.
+2. **Rebaseline:** Confirm we do **not** refresh `v1x_ubuntu_py313.json` in this PR (issue slowdown becomes warn-only).
+
+---
+
+**Confirm:** Accept / Revise / Abort

--- a/.issueflows/03-solved-issues/issue476_status.md
+++ b/.issueflows/03-solved-issues/issue476_status.md
@@ -1,0 +1,16 @@
+# Issue #476 — status
+
+- [x] Done
+
+## What's done
+
+- Plan accepted (2026-07-11).
+- Branch `476-golden-benchmark-fixes` from updated `master`.
+- Part 1: `_temporal_columns()` auto-detect in `loader_golden_support.py`.
+- Part 2: tiered warn (+20%) / fail (+100%) in `check_baseline.py`.
+- `tests/test_check_baseline.py` added; `loader_pec_csv` golden passes on Windows.
+- Docs: `benchmarks/README.md`, `benchmarks.yml` step name.
+
+## Remaining work
+
+- [ ] `/iflow-close` (HISTORY, commit, PR).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix: loader PEC golden compares all datetime columns by epoch-ns (Windows `datetime64[us]` vs `ns`); benchmark baseline gate warns above +20% slowdown and fails only above +100% (#476)
 * Stage 1.1: extract cellpy-file format spec into `cellpy/readers/cellpy_file/format.py`; `prms._cellpyfile_*` aliases preserved; template registry and example-data URL constants moved to owning modules (#446)
 * Stage 0 foundations complete — all linked characterization, oracle, baseline, convention, and decision-register issues closed; ready for Stage 1 (#439)
 * Docs: Stage 0.11 decision register recorded in architecture-plan (timezone, curve-schema, v9 container, IR semantics, easyplot, v1.x maintenance) (#438)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,7 +34,7 @@ uv run pytest benchmarks/ --benchmark-only
 uv run pytest benchmarks/ --benchmark-only --benchmark-save=v1x \
   --benchmark-json=benchmarks/baselines/v1x_ubuntu_py313.json
 
-# Regression gate (fail only if slower than baseline by more than 20%) — CI uses this
+# Regression gate — warn +20%%, fail +100%% (CI uses this)
 uv run pytest benchmarks/ --benchmark-only --benchmark-json=/tmp/bench.json
 uv run python benchmarks/check_baseline.py /tmp/bench.json benchmarks/baselines/v1x_ubuntu_py313.json
 ```
@@ -45,8 +45,9 @@ Linux CI.
 ## CI
 
 See `.github/workflows/benchmarks.yml` — runs on `ubuntu-latest` only, separate from the
-Tier-1 `essential` merge gate. The compare job **fails only on slowdown** (>20% slower than
-baseline); faster runs pass. Rebaseline on GHA when a speedup should become the new ruler.
+Tier-1 `essential` merge gate. The compare job **warns** on slowdowns above +20% and
+**fails** only above +100%; faster runs pass. Rebaseline on GHA when a speedup should
+become the new ruler.
 
 To refresh the committed baseline on the real CI runner, trigger the workflow manually
 (*Actions → Benchmarks → Run workflow*). The `capture-baseline` job uploads

--- a/benchmarks/check_baseline.py
+++ b/benchmarks/check_baseline.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Compare a pytest-benchmark JSON run against the committed v1.x baseline.
 
-Fails only on slowdowns beyond the tolerance band. Faster runs pass — refresh the
-committed baseline when an intentional speedup should become the new ruler.
+Warns on moderate slowdowns; fails only on extreme regressions. Faster runs
+pass — refresh the committed baseline when an intentional speedup should become
+the new ruler.
 """
 
 from __future__ import annotations
@@ -10,7 +11,16 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CompareResult:
+    """Outcome of comparing current benchmark means to a baseline."""
+
+    warnings: tuple[str, ...]
+    failures: tuple[str, ...]
 
 
 def _means_by_name(payload: dict) -> dict[str, float]:
@@ -25,14 +35,34 @@ def _means_by_name(payload: dict) -> dict[str, float]:
 
 
 def compare(
-    current_path: Path, baseline_path: Path, tolerance: float = 0.20
-) -> list[str]:
+    current_path: Path,
+    baseline_path: Path,
+    *,
+    warn_tolerance: float = 0.20,
+    fail_tolerance: float = 1.0,
+) -> CompareResult:
+    """Compare benchmark means to baseline with tiered warn/fail bands.
+
+    Args:
+        current_path: pytest-benchmark JSON from the current run.
+        baseline_path: committed baseline JSON.
+        warn_tolerance: Emit a warning when slowdown exceeds this fraction
+            (default 0.20 = +20%%).
+        fail_tolerance: Fail when slowdown exceeds this fraction (default 1.0 =
+            +100%%, ratio 2.0).
+
+    Returns:
+        CompareResult with warning and failure messages.
+    """
     current = json.loads(current_path.read_text(encoding="utf-8"))
     baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
 
     cur = _means_by_name(current)
     ref = _means_by_name(baseline)
+    warnings: list[str] = []
     failures: list[str] = []
+    warn_ratio = 1 + warn_tolerance
+    fail_ratio = 1 + fail_tolerance
 
     for name, ref_mean in sorted(ref.items()):
         if name.startswith("test_benchmark_peak_rss"):
@@ -45,13 +75,20 @@ def compare(
             failures.append(f"{name}: invalid baseline mean {ref_mean}")
             continue
         ratio = cur_mean / ref_mean
-        if ratio > 1 + tolerance:
+        message = (
+            f"{name}: mean {cur_mean:.6f}s vs baseline {ref_mean:.6f}s "
+            f"(ratio {ratio:.3f})"
+        )
+        if ratio > fail_ratio:
             failures.append(
-                f"{name}: mean {cur_mean:.6f}s vs baseline {ref_mean:.6f}s "
-                f"(ratio {ratio:.3f}, max slowdown +{tolerance:.0%})"
+                f"{message}, exceeds max slowdown +{fail_tolerance:.0%}"
+            )
+        elif ratio > warn_ratio:
+            warnings.append(
+                f"{message}, above warn threshold +{warn_tolerance:.0%}"
             )
 
-    return failures
+    return CompareResult(tuple(warnings), tuple(failures))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -61,23 +98,54 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("baseline", type=Path, help="committed baseline JSON")
     parser.add_argument(
-        "--tolerance",
+        "--warn-tolerance",
         type=float,
         default=0.20,
-        help="maximum allowed slowdown vs baseline (default: 0.20 = +20%%)",
+        help="warn when slowdown exceeds this fraction (default: 0.20 = +20%%)",
+    )
+    parser.add_argument(
+        "--fail-tolerance",
+        type=float,
+        default=1.0,
+        help="fail when slowdown exceeds this fraction (default: 1.0 = +100%%)",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=None,
+        help="deprecated alias for --warn-tolerance",
     )
     args = parser.parse_args(argv)
 
-    failures = compare(args.current, args.baseline, tolerance=args.tolerance)
-    if failures:
+    warn_tolerance = args.warn_tolerance
+    if args.tolerance is not None:
+        warn_tolerance = args.tolerance
+
+    result = compare(
+        args.current,
+        args.baseline,
+        warn_tolerance=warn_tolerance,
+        fail_tolerance=args.fail_tolerance,
+    )
+    if result.warnings:
+        print("Benchmark baseline warnings:", file=sys.stderr)
+        for item in result.warnings:
+            print(f"  - {item}", file=sys.stderr)
+    if result.failures:
         print("Benchmark baseline regression:", file=sys.stderr)
-        for item in failures:
+        for item in result.failures:
             print(f"  - {item}", file=sys.stderr)
         return 1
-    print(
-        f"No benchmark slowdown beyond +{args.tolerance:.0%} vs {args.baseline} "
-        "(faster runs are OK — rebaseline when intentional)"
-    )
+    if result.warnings:
+        print(
+            f"Benchmarks within +{args.fail_tolerance:.0%} fail band vs {args.baseline} "
+            f"({len(result.warnings)} warn-only slowdown(s))"
+        )
+    else:
+        print(
+            f"No benchmark slowdown beyond +{warn_tolerance:.0%} vs {args.baseline} "
+            "(faster runs are OK — rebaseline when intentional)"
+        )
     return 0
 
 

--- a/tests/loader_golden_support.py
+++ b/tests/loader_golden_support.py
@@ -132,6 +132,18 @@ LOADER_GOLDEN_SPECS: tuple[LoaderGoldenSpec, ...] = (
 )
 
 
+def _temporal_columns(*frames: pd.DataFrame) -> set[str]:
+    """Return datetime/timedelta column names from frames (plus static sets)."""
+    cols = set(DATETIME_LIKE_COLUMNS) | set(TIMEDELTA_LIKE_COLUMNS)
+    for frame in frames:
+        for col in frame.columns:
+            if pd.api.types.is_datetime64_any_dtype(frame[col]):
+                cols.add(col)
+            elif pd.api.types.is_timedelta64_dtype(frame[col]):
+                cols.add(col)
+    return cols
+
+
 def prepare_raw_for_golden(raw: pd.DataFrame) -> pd.DataFrame:
     """Return a column-only raw frame with stable column order for goldens."""
     frame = raw.copy()
@@ -141,7 +153,7 @@ def prepare_raw_for_golden(raw: pd.DataFrame) -> pd.DataFrame:
         frame = frame.reset_index()
     if not isinstance(frame.index, pd.RangeIndex):
         frame = frame.reset_index(drop=True)
-    temporal_cols = DATETIME_LIKE_COLUMNS | TIMEDELTA_LIKE_COLUMNS
+    temporal_cols = _temporal_columns(frame)
     for col in frame.columns:
         if col in INTEGER_RAW_COLUMNS or col in temporal_cols:
             continue
@@ -248,7 +260,7 @@ def assert_raw_matches_golden(actual: pd.DataFrame, expected: pd.DataFrame) -> N
     expected = sort_summary_columns(prepare_raw_for_golden(expected))
     assert list(actual.columns) == list(expected.columns)
 
-    temporal_cols = DATETIME_LIKE_COLUMNS | TIMEDELTA_LIKE_COLUMNS
+    temporal_cols = _temporal_columns(actual, expected)
     exact_cols = [c for c in actual.columns if c not in temporal_cols]
     if exact_cols:
         assert_frame_equal(actual[exact_cols], expected[exact_cols])

--- a/tests/test_check_baseline.py
+++ b/tests/test_check_baseline.py
@@ -1,0 +1,67 @@
+"""Unit tests for benchmarks/check_baseline.py (issue #476)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.check_baseline import compare
+
+
+def _write_bench_json(path: Path, means: dict[str, float]) -> None:
+    payload = {
+        "benchmarks": [
+            {"name": name, "stats": {"mean": mean}} for name, mean in means.items()
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def baseline_file(tmp_path: Path) -> Path:
+    path = tmp_path / "baseline.json"
+    _write_bench_json(
+        path,
+        {
+            "test_benchmark_batch_summary_collection": 0.050,
+            "test_benchmark_peak_rss_kib": 100.0,
+        },
+    )
+    return path
+
+
+def test_compare_passes_within_warn_band(tmp_path: Path, baseline_file: Path) -> None:
+    current = tmp_path / "current.json"
+    _write_bench_json(current, {"test_benchmark_batch_summary_collection": 0.055})
+    result = compare(current, baseline_file)
+    assert result.warnings == ()
+    assert result.failures == ()
+
+
+def test_compare_warns_above_warn_threshold(tmp_path: Path, baseline_file: Path) -> None:
+    current = tmp_path / "current.json"
+    _write_bench_json(current, {"test_benchmark_batch_summary_collection": 0.065})
+    result = compare(current, baseline_file, warn_tolerance=0.20, fail_tolerance=1.0)
+    assert len(result.warnings) == 1
+    assert "test_benchmark_batch_summary_collection" in result.warnings[0]
+    assert result.failures == ()
+
+
+def test_compare_fails_above_fail_threshold(tmp_path: Path, baseline_file: Path) -> None:
+    current = tmp_path / "current.json"
+    _write_bench_json(current, {"test_benchmark_batch_summary_collection": 0.130})
+    result = compare(current, baseline_file, warn_tolerance=0.20, fail_tolerance=1.0)
+    assert result.failures
+    assert "exceeds max slowdown +100%" in result.failures[0]
+
+
+def test_compare_skips_peak_rss(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    _write_bench_json(baseline, {"test_benchmark_peak_rss_kib": 100.0})
+    current = tmp_path / "current.json"
+    _write_bench_json(current, {})
+    result = compare(current, baseline)
+    assert result.warnings == ()
+    assert result.failures == ()


### PR DESCRIPTION
## Summary

- Auto-detect datetime/timedelta columns in loader golden compares so `loader_pec_csv` passes on Windows (`datetime64[us]` vs `ns` on `position_start_time`).
- Tiered benchmark baseline gate: **warn** above +20% slowdown, **fail** only above +100% (CI noise from single-round benchmarks).

Closes #476

## Test plan

- [x] `pytest tests/test_loader_goldens.py::test_loader_raw_matches_golden_parquet[loader_pec_csv]`
- [x] `pytest tests/test_check_baseline.py`
- [x] `pytest -m essential` — 79/79 pass on Windows
- [ ] CI Benchmarks workflow green (batch_summary ~+26% should warn, not fail)


Made with [Cursor](https://cursor.com)