### PR TITLE
fix: resolve full-suite test failures (#491)

### DIFF
--- a/.issueflows/03-solved-issues/issue491_original.md
+++ b/.issueflows/03-solved-issues/issue491_original.md
@@ -1,0 +1,13 @@
+# Issue #491: Iterative fixes: full-suite test failures
+
+Source: https://github.com/jepegit/cellpy/issues/491
+
+## Original issue text
+
+Interactive `/iflow-fix` session addressing failures from `uv run pytest`:
+
+- `test_extract_fids_from_cellpy_file` â€” AttributeError: `_extract_fids_from_cellpy_file` moved to module function
+- `test_check_file_ids_external_not_accessible` â€” TimeoutError from live SCP connection attempt
+- `test_curve_extraction_matches_golden[curve_get_dcap_null_cycle]` â€” ODBC/Access error in full suite (passes in isolation)
+
+Individual fixes are recorded in the status markdown; landed together via `/iflow-close`.

--- a/.issueflows/03-solved-issues/issue491_status.md
+++ b/.issueflows/03-solved-issues/issue491_status.md
@@ -1,0 +1,11 @@
+# Issue #491 — Iterative fixes: full-suite test failures
+
+Interactive `/iflow-fix` session.
+
+- [x] Done
+
+## Iterative fixes log
+
+- **2026-07-14** — `test_extract_fids_from_cellpy_file`: call module-level `extract_fids_from_cellpy_file` from `cellpy.readers.cellpy_file.read` instead of removed `CellpyCell._extract_fids_from_cellpy_file`.
+- **2026-07-14** — `test_check_file_ids_external_not_accessible`: monkeypatch external `OtherPath.is_file` → `False` so test exercises inaccessible-file path without live SCP (avoids ~22s timeout).
+- **2026-07-14** — `curve_get_dcap_null_cycle` / ODBC flake: close Access ODBC connections in `arbin_res._query_table` and dispose SQLAlchemy engine in `_loader_win` finally block (prevents connection exhaustion in long test runs).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix: full-suite test failures — `extract_fids` test uses module helper; external `check_file_ids` test avoids live SCP; Arbin `.res` loader closes ODBC connections (#491)
 * Stage 1.10: replace hard-coded column-header literals with canonical `headers_*` lookups in journal pages, ocv_rlx/plotutils, and instrument loaders (priorities 1–3); delete dead easyplot block (#455)
 * Stage 1.4: redirect out-of-band HDF5 readers to `cellpy_file.read_table` / `read_fid_table`; `CorruptCellpyFile` for missing keys; `cellpy convert` CLI for v<8 upgrades (#449)
 * Units Phase 1: re-export ``CellpyUnits`` and ``Q`` from cellpycore; remove cellpy-local pint registry; rename ``cellreader`` ``data_structures`` alias to ``ds`` (#450)

--- a/cellpy/readers/instruments/arbin_res.py
+++ b/cellpy/readers/instruments/arbin_res.py
@@ -481,7 +481,8 @@ class DataLoader(BaseLoader):
         if sql is None:
             sql = f"select * from {table_name}"
         self.logger.debug(f"sql statement: {sql}")
-        df = pd.read_sql_query(sql=sa.text(sql), con=conn.connect())
+        with conn.connect() as connection:
+            df = pd.read_sql_query(sql=sa.text(sql), con=connection)
         return df
 
     def _make_name_from_frame(self, df, aux_index, data_type, dx_dt=False):
@@ -522,68 +523,71 @@ class DataLoader(BaseLoader):
             time_0 = time.time()
 
         conn = self._get_connection_or_engine(temp_filename)
+        try:
+            self.logger.debug("reading global data table")
 
-        self.logger.debug("reading global data table")
+            global_data_df = self._query_table(table_name=table_name_global, conn=conn)
+            tests = global_data_df[self.arbin_headers_normal.test_id_txt]
+            number_of_sets = len(tests)
+            self.logger.debug(f"number of datasets: {number_of_sets}")
 
-        global_data_df = self._query_table(table_name=table_name_global, conn=conn)
-        tests = global_data_df[self.arbin_headers_normal.test_id_txt]
-        number_of_sets = len(tests)
-        self.logger.debug(f"number of datasets: {number_of_sets}")
+            if dataset_number is not None:
+                self.logger.info(f"Dataset number given: {dataset_number}")
+                self.logger.info(f"Available dataset numbers: {tests}")
+                # check if dataset_number is valid
+                #
 
-        if dataset_number is not None:
-            self.logger.info(f"Dataset number given: {dataset_number}")
-            self.logger.info(f"Available dataset numbers: {tests}")
-            # check if dataset_number is valid
-            #
+            else:
+                dataset_number = None
 
-        else:
-            dataset_number = None
+            data = self._init_data(file_name, global_data_df, dataset_number)
+            self.logger.debug("reading raw-data")
+            test_id = data._internal_test_number
 
-        data = self._init_data(file_name, global_data_df, dataset_number)
-        self.logger.debug("reading raw-data")
-        test_id = data._internal_test_number
+            # --------- read stats-data (summary-data) ---------------------
 
-        # --------- read stats-data (summary-data) ---------------------
-
-        # --------- read raw-data (normal-data) ------------------------
-        length_of_test, normal_df = self._load_res_normal_table(
-            conn, test_id, bad_steps, data_points
-        )
-        # --------- read auxiliary data (aux-data) ---------------------
-        normal_df = self._load_win_res_auxiliary_table(
-            conn, normal_df, table_name_aux, table_name_aux_global, test_id
-        )
-        # FIX: error in order by since datetime is not accurate enough (also need sorting on test-time)
-        #   sorting dataframe:
-        normal_df = normal_df.sort_values(
-            by=[
-                self.arbin_headers_normal.datetime_txt,
-                self.arbin_headers_normal.test_time_txt,
-            ],
-            ascending=True,
-        )
-        # TODO 216: add order by on test_time as well in sql query
-        summary_df = self._load_res_summary_table(conn, test_id)
-        if summary_df.empty and prms.Reader.use_cellpy_stat_file:
-            txt = "\nCould not find any summary (stats-file)!"
-            txt += "\n -> issue make_summary(use_cellpy_stat_file=False)"
-            logging.debug(txt)
-            # TODO: Enforce creating a summary df or modify renaming summary df (post process part)
-        # normal_df = normal_df.set_index("Data_Point")
-
-        data.summary = summary_df
-        if DEBUG_MODE:
-            mem_usage = normal_df.memory_usage()
-            logging.debug(
-                f"memory usage for "
-                f"loaded data: \n{mem_usage}"
-                f"\ntotal: {humanize_bytes(mem_usage.sum())}"
+            # --------- read raw-data (normal-data) ------------------------
+            length_of_test, normal_df = self._load_res_normal_table(
+                conn, test_id, bad_steps, data_points
             )
-            logging.debug(f"time used: {(time.time() - time_0):2.4f} s")
+            # --------- read auxiliary data (aux-data) ---------------------
+            normal_df = self._load_win_res_auxiliary_table(
+                conn, normal_df, table_name_aux, table_name_aux_global, test_id
+            )
+            # FIX: error in order by since datetime is not accurate enough (also need sorting on test-time)
+            #   sorting dataframe:
+            normal_df = normal_df.sort_values(
+                by=[
+                    self.arbin_headers_normal.datetime_txt,
+                    self.arbin_headers_normal.test_time_txt,
+                ],
+                ascending=True,
+            )
+            # TODO 216: add order by on test_time as well in sql query
+            summary_df = self._load_res_summary_table(conn, test_id)
+            if summary_df.empty and prms.Reader.use_cellpy_stat_file:
+                txt = "\nCould not find any summary (stats-file)!"
+                txt += "\n -> issue make_summary(use_cellpy_stat_file=False)"
+                logging.debug(txt)
+                # TODO: Enforce creating a summary df or modify renaming summary df (post process part)
+            # normal_df = normal_df.set_index("Data_Point")
 
-        data.raw = normal_df
-        data.raw_data_files_length.append(length_of_test)
-        return data
+            data.summary = summary_df
+            if DEBUG_MODE:
+                mem_usage = normal_df.memory_usage()
+                logging.debug(
+                    f"memory usage for "
+                    f"loaded data: \n{mem_usage}"
+                    f"\ntotal: {humanize_bytes(mem_usage.sum())}"
+                )
+                logging.debug(f"time used: {(time.time() - time_0):2.4f} s")
+
+            data.raw = normal_df
+            data.raw_data_files_length.append(length_of_test)
+            return data
+        finally:
+            if conn is not None:
+                conn.dispose()
 
     def _load_win_res_auxiliary_table(
         self, conn, normal_df, table_name_aux, table_name_aux_global, test_id

--- a/tests/test_cell_readers.py
+++ b/tests/test_cell_readers.py
@@ -500,12 +500,16 @@ def test_check_file_ids(parameters):
     assert check
 
 
-def test_check_file_ids_external_not_accessible(parameters):
+def test_check_file_ids_external_not_accessible(parameters, monkeypatch):
     from cellpy import cellreader
 
     c = cellreader.CellpyCell()
     cellpy_file = OtherPath(parameters.cellpy_file_path_external)
     raw_file = OtherPath(parameters.res_file_path)
+
+    # External OtherPath assumes remote files exist; simulate inaccessible file
+    # without opening a live SCP connection (read_fid_table would hang/time out).
+    monkeypatch.setattr(cellpy_file, "is_file", lambda *args, **kwargs: False)
 
     print(f"{cellpy_file=} :: {type(cellpy_file)=}")
     print(f"{raw_file=} :: {type(raw_file)=}")
@@ -562,8 +566,8 @@ def test_pack_meta_convert2fid_table(parameters):
 
 
 def test_extract_fids_from_cellpy_file(parameters, tmp_path):
-    from cellpy import cellreader
     from cellpy import prms
+    from cellpy.readers.cellpy_file.read import extract_fids_from_cellpy_file
 
     import pandas as pd
 
@@ -572,9 +576,8 @@ def test_extract_fids_from_cellpy_file(parameters, tmp_path):
 
     cellpy_file = OtherPath(parameters.cellpy_file_path)
 
-    c = cellreader.CellpyCell()
     with pd.HDFStore(cellpy_file) as store:
-        fid_table, fid_table_selected = c._extract_fids_from_cellpy_file(
+        fid_table, fid_table_selected = extract_fids_from_cellpy_file(
             fid_dir, parent_level, store
         )
 
@@ -586,7 +589,7 @@ def test_extract_fids_from_cellpy_file(parameters, tmp_path):
     fids0 = c0.data.raw_data_files
 
     with pd.HDFStore(new_cellpy_file_path) as store:
-        fid_table2, fid_table_selected2 = c._extract_fids_from_cellpy_file(
+        fid_table2, fid_table_selected2 = extract_fids_from_cellpy_file(
             fid_dir, parent_level, store
         )
     assert fid_table["raw_data_name"][0] == fid_table2["raw_data_name"][0]


### PR DESCRIPTION
## Summary

- Update `test_extract_fids_from_cellpy_file` to call module-level `extract_fids_from_cellpy_file` after the cellpy-file refactor removed the `CellpyCell` private method.
- Mock external `OtherPath.is_file` in `test_check_file_ids_external_not_accessible` so the test verifies inaccessible-file behavior without a live SCP connection (~22s timeout on Windows).
- Close Access ODBC connections in `arbin_res._query_table` and dispose the SQLAlchemy engine in `_loader_win` to prevent flaky `08004` errors when running the full suite.

## Test plan

- [x] `uv run pytest tests/test_cell_readers.py::test_extract_fids_from_cellpy_file`
- [x] `uv run pytest tests/test_cell_readers.py::test_check_file_ids_external_not_accessible`
- [x] `uv run pytest "tests/test_curve_goldens.py::test_curve_extraction_matches_golden[curve_get_dcap_null_cycle]"`
- [x] `uv run pytest -m essential`
- [x] `uv run pytest` (567 passed)

Closes #491

Made with [Cursor](https://cursor.com)