### PR TITLE
Stage 1.8 M1: prms shim + legacy YAML load path (#453)

### DIFF
--- a/.issueflows/01-current-issues/issue453_original.md
+++ b/.issueflows/01-current-issues/issue453_original.md
@@ -1,0 +1,38 @@
+# Issue #453: Stage 1.8: Config — swap the engine under prms, migrate call sites, kill import-time init
+
+Source: https://github.com/jepegit/cellpy/issues/453
+
+## Original issue text
+
+> Part of **Stage 1 — behavior-preserving construction** (see the Stage-1 tracking issue). Stage 0: jepegit/cellpy#439. Plan documents live in the shared workspace: `cellpy-workspace/architecture-plan/` (the [architecture-plan repo](https://github.com/cellpy/architecture-plan); formerly `architecture-plan/`) (alongside the `cellpy` and `cellpy-core` repos). Everything in Stage 1 lands on master with the full suite green; nothing flips user-visible behavior.
+
+## Goal
+
+Config plan Steps 3 + 4:
+
+- Re-point `cellpy.parameters.prms` onto the new stack via a `__getattr__` shim
+  (attribute reads/writes forwarded, `DeprecationWarning` once per name via the
+  Stage-1.11 helper); delete `_update_prms`/`_pack_prms`/file-glob discovery.
+- Mechanically rewrite the 383 internal `prms.X.y` call sites to `cellpy.config.x.y`.
+- Remove `prmreader.initialize()` from `cellpy/__init__.py` (the marked v2.0 TODO);
+  lazy loading on first access takes over.
+
+## Why
+
+This is the config flag-day, kept safe by the Step-0 characterization (#430) and the
+Step-2 parity contract. Killing import-time I/O is a stated cellpy 2 requirement
+(no side effects on `import cellpy`) and the same principle the conventions plan applies
+to logging.
+
+## Links
+
+- `architecture-plan/cellpy2-configuration-and-parameters-plan.md` (Steps 3–4, §3.5 shim)
+- Depends on: Stage 1.7, Stage 1.11 (warn_once).
+
+## Acceptance
+
+- Full suite green with the shim in place; then green again after call-site migration.
+- `python -c "import cellpy"` performs zero file reads (assert via monkeypatched opener
+  in a test).
+- User-facing mutation patterns (`prms.Reader.cycle_mode = ...`) still work, warn once.
+

--- a/.issueflows/01-current-issues/issue453_plan.md
+++ b/.issueflows/01-current-issues/issue453_plan.md
@@ -1,0 +1,186 @@
+# Issue #453 — Plan
+
+## Goal
+
+Wire production code onto the #452 `cellpy/config/` stack: a deprecated `prms` shim for
+external/notebook callers, mechanical migration of internal `prms.*` sites to
+`cellpy.config.*`, and removal of import-time `prmreader.initialize()` so
+`import cellpy` performs zero file I/O.
+
+## Constraints
+
+- **Behavior-preserving Stage 1** — full suite green after each milestone; #430 inventory
+  parity and #452 config parity tests unchanged except documented divergences.
+- **Depends on #452 (merged) and #456 (`warn_once`)** — shim warnings use
+  [`cellpy/_deprecation.py`](../../cellpy/_deprecation.py).
+- **Out of scope (#454)** — `cellpy setup` UX rewrite, interactive migrate command,
+  `cellpy info --config` provenance CLI. Keep `cellpy setup` working via a thin YAML
+  export adapter, not a full CLI rewrite.
+- **Out of scope (issue Step 6 / later)** — rewiring `connections.py` / `otherpath.py` to
+  stop using raw `os.getenv`; secrets stay env-backed in the new model.
+- **Constants stay on `prms`** — `_cellpyfile_*`, `_github_*`, loader dev flags, etc. are
+  not config; shim must not intercept them.
+- **Fast PR gate** — new import-io + shim smoke tests marked `@pytest.mark.essential`.
+
+### Prior art
+
+| Hit | Module / file | Reuse |
+|-----|---------------|--------|
+| New config stack | [`cellpy/config/`](../../cellpy/config/) (#452) | **Engine** — `session.reload()`, `override()`, models, loader. |
+| YAML → dict | [`cellpy/config/migrate.py`](../../cellpy/config/migrate.py) | **Legacy ingest** — `convert_yaml_to_toml_dict` for `.cellpy_prms_*.conf`. |
+| Inventory / parity | [`tests/prms_support.py`](../../tests/prms_support.py), [`tests/test_config.py`](../../tests/test_config.py) | **Guardrails** — keep green; extend only if shim changes observable defaults. |
+| Deprecation helper | [`cellpy/_deprecation.py`](../../cellpy/_deprecation.py) | **Shim warnings** — `warn_once("prms.Reader", "cellpy.config.reader")` per access pattern. |
+| Architecture authority | [`architecture-plan/cellpy2-configuration-and-parameters-plan.md`](../../architecture-plan/cellpy2-configuration-and-parameters-plan.md) Steps 3–4, §3.5 | Section mapping, sequencing. |
+| #452 plan (solved) | [`issue452_plan.md`](../03-solved-issues/issue452_plan.md) | Deliberate divergences (SQL→secrets, `units`, `defaults` nesting). |
+| Toolbox | [`.issueflows/00-tools/`](../../.issueflows/00-tools/) | No migration helper yet — optional one-shot codemod script (see Approach). |
+| Graph | — | No `graphify-out/`; grep-only. |
+
+## Approach
+
+Deliver in **three suite-green milestones** (one issue, ordered commits).
+
+### Milestone 1 — Shim + legacy load path (Step 3)
+
+**1a. Legacy config layer** — new [`cellpy/config/legacy.py`](../../cellpy/config/legacy.py):
+
+- Port `_get_prm_file` discovery (user-dir glob for `.cellpy_prms*.conf`) from
+  [`prmreader.py`](../../cellpy/parameters/prmreader.py) — single home for legacy path lookup.
+- `load_legacy_yaml(path) -> dict` via `migrate.convert_yaml_to_toml_dict`.
+- Extend [`loader.py`](../../cellpy/config/loader.py): when `skip_files` is false and
+  **no** `cellpy.toml` exists at user or project layer, fall back to discovered legacy YAML
+  (record provenance layer `USER_FILE` / tag as legacy in tests). TOML still wins when present.
+
+**1b. `prmreader` slim-down** (keep public API for CLI/tests):
+
+- `initialize()` → `cellpy.config.reload()` (+ load `.env` via existing loader env path).
+- Delete `_update_prms` and inline glob discovery (delegate to `legacy.py` + loader).
+- Replace `_pack_prms` with `export_legacy_yaml_dict()` reading **from** `get_config()` —
+  inverse of migrate mapping (CLI `cellpy setup` write path stays YAML until #454).
+- `_read_prm_file` → legacy load + `reload(overrides=…)`.
+
+**1c. `prms` shim** — new [`cellpy/parameters/_shim.py`](../../cellpy/parameters/_shim.py):
+
+- `_SECTION_MAP`: legacy export name → config accessor
+  (`Paths`→`paths`, `FileNames`→`file_names`, `Reader`→`reader`, `Db`→`db`,
+  `DbCols`→`db_cols`, `Batch`→`batch`, `Instruments`→`instruments`,
+  `CellInfo`→`defaults.cell_info`, `Materials`→`defaults.materials`).
+- `_SectionProxy`: attribute get/set forwards to pydantic section;
+  `warn_once` on first touch per call site (reads **and** writes).
+- Module-level `prms.__getattr__` for mapped sections; unmapped names unchanged
+  (constants, `*Class` type aliases kept for typing until v2.1).
+- **Instrument compat:** proxy `__getitem__` for `Arbin["SQL_server"]` etc. reads/writes
+  `config.secrets` with deprecation (SQL fields removed from `ArbinConfig` in #452).
+- Remove eager singleton instances (`Paths = PathsClass()`, …) for mapped sections;
+  keep dataclass **classes** as deprecated type aliases.
+
+**1d. Tests (Milestone 1)**
+
+- `test_import_cellpy_no_file_io` — monkeypatch `builtins.open` / `Path.read_text`; import
+  `cellpy`; assert zero config-path reads.
+- `test_prms_shim_forwards_and_warns` — mutation + read via `prms.Reader` hits `config.reader`.
+- `test_legacy_yaml_fallback_loads` — temp `.cellpy_prms_<user>.conf` overrides default.
+- Existing `tests/test_prms.py` green (shim preserves user-facing behavior).
+
+Suite gate: `uv run pytest -m essential`.
+
+### Milestone 2 — Internal call-site migration (Step 4)
+
+Mechanical rewrite **`prms.<Section>.<field>` → `cellpy.config.<section>.<field>`** in
+production code under `cellpy/` (~35 files, ~350 occurrences). Suggested batch order:
+
+| Batch | Paths | Notes |
+|-------|-------|-------|
+| A | `parameters/internal_settings.py`, `parameters/prmreader.py` | Highest coupling; fix dataclass defaults that bind `prms.CellInfo.*` at class body — use `None` + lazy read from `config.defaults` in factories, or read at use site. |
+| B | `readers/**` (incl. `arbin_*.py`, `filefinder.py`, `cellreader.py`) | Fix **module-level** `SQL_* = prms.Instruments.Arbin[...]` — move to lazy functions or read inside methods; map to `config.secrets` where applicable. |
+| C | `utils/**`, `cli.py`, `log.py`, `internals/connections.py` | `cli.py` may keep `prms` re-exports temporarily for setup UX; prefer `config` for reads. |
+
+**Mapping table** (mechanical):
+
+| Legacy | New |
+|--------|-----|
+| `prms.Paths` | `cellpy.config.paths` |
+| `prms.FileNames` | `cellpy.config.file_names` |
+| `prms.Reader` | `cellpy.config.reader` |
+| `prms.Db` | `cellpy.config.db` |
+| `prms.DbCols` | `cellpy.config.db_cols` |
+| `prms.Batch` | `cellpy.config.batch` |
+| `prms.Instruments` | `cellpy.config.instruments` |
+| `prms.CellInfo` | `cellpy.config.defaults.cell_info` |
+| `prms.Materials` | `cellpy.config.defaults.materials` |
+
+Import style: `import cellpy.config as config` (or `from cellpy import config` if added to
+public API) — avoid `from cellpy.config import reader` churn across 350 sites unless a
+follow-up cleanup prefers it.
+
+Optional helper: `.issueflows/00-tools/migrate_prms_calls.py` (stdlib + regex) for
+bulk replace + manual review of instrument/SQL/module-level edge cases.
+
+Tests: full suite; spot-check `tests/test_prms.py` still exercises shim for external API.
+
+### Milestone 3 — Kill import-time init
+
+- [`cellpy/__init__.py`](../../cellpy/__init__.py): remove `init()` call and `init` from
+  `__all__`; keep `from cellpy.parameters import prms` for backward compat.
+- Document lazy init in module docstring / HISTORY stub (full entry at `/iflow-close`).
+- Update [`cellpy/config/__init__.py`](../../cellpy/config/__init__.py) module docstring
+  (no longer “nothing imports this”).
+- Ensure first config touch in tests that relied on import-time load still passes
+  (`test_prms.py` calls `prmreader.initialize()` explicitly where needed — keep that).
+
+Suite gate: `uv run pytest -m essential` then `uv run pytest`.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `cellpy/config/legacy.py` | **New** — legacy YAML discovery + load. |
+| `cellpy/config/loader.py` | Legacy YAML fallback layer. |
+| `cellpy/parameters/_shim.py` | **New** — section proxies + `__getitem__` compat. |
+| `cellpy/parameters/prms.py` | Drop eager section singletons; wire shim; keep constants/classes. |
+| `cellpy/parameters/prmreader.py` | Delegate to config; delete `_update_prms`; YAML export adapter. |
+| `cellpy/__init__.py` | Remove import-time `initialize()`. |
+| `cellpy/config/__init__.py` | Docstring only. |
+| `cellpy/readers/**`, `cellpy/utils/**`, `cellpy/cli.py`, … | Mechanical `prms` → `config` (~35 files). |
+| `tests/test_prms_shim.py` or extend `tests/test_config.py` | Import-io, shim, legacy fallback tests. |
+| `tests/conftest.py` | If needed: autouse `reset_session()` ordering with legacy tests. |
+| `.issueflows/00-tools/migrate_prms_calls.py` | **Optional** codemod + README index row. |
+
+**Not in scope:** `cellpy/cli.py` setup rewrite (#454), TOML-first UX, secrets consumer cleanup.
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_config.py tests/test_prms.py -m essential  # parity + legacy
+uv run pytest -m essential                                          # Tier-1 gate
+uv run pytest                                                       # full suite before close
+```
+
+New essential tests:
+
+1. **`test_import_cellpy_no_file_io`** — acceptance criterion from issue body.
+2. **`test_prms_shim_warns_once`** — DeprecationWarning per call site, not per attribute.
+3. **`test_legacy_yaml_fallback_loads`** — user YAML without `cellpy.toml` applies overrides.
+
+Regression focus: `test_prms.py` round-trip, CLI setup tests (`test_cellpy_cmd.py`),
+instrument readers (Arbin SQL module-level constants), batch tools.
+
+## Open questions
+
+1. **Legacy YAML fallback until #454** — Recommend **yes** (Milestone 1): users with only
+   `.cellpy_prms_*.conf` keep working; TOML takes precedence when present. Confirm?
+
+2. **SQL credentials on instrument dict access** — Recommend shim + migrated call sites route
+   `Instruments.Arbin["SQL_*"]` to `config.secrets` with deprecation (matches #452 divergence).
+   `easyplot` mutation of SQL fields becomes secrets/env mutation. Confirm?
+
+3. **`internal_settings` dataclass defaults** — Recommend replace import-time
+   `prms.CellInfo.*` field defaults with lazy resolution (factory or `@property` on parent
+   config object) so lazy init does not freeze wrong values. Acceptable behavior change if
+   defaults now reflect first config load, not import-time file read?
+
+4. **Codemod script in `00-tools/`** — Recommend add small helper for bulk replace; still
+   manual pass on `arbin_*` / `easyplot` / module-level bindings. Want it, or pure manual?
+
+---
+
+**Next step after Accept:** `/iflow-start` on branch `453-prms-shim-swap`.

--- a/.issueflows/01-current-issues/issue453_status.md
+++ b/.issueflows/01-current-issues/issue453_status.md
@@ -1,0 +1,22 @@
+# Issue #453 — status
+
+- [ ] Done
+
+## What's done
+
+- Plan accepted (2026-07-14).
+- Branch `453-prms-shim-swap`.
+- **Milestone 1 (shim + legacy load):**
+  - `cellpy/config/legacy.py` — YAML discovery, ingest, export
+  - `cellpy/config/loader.py` — legacy YAML fallback, None stripping
+  - `cellpy/parameters/_shim.py` — deprecated section proxies (+ Arbin SQL compat)
+  - `cellpy/parameters/prms.py` — section singletons removed; module `__getattr__` shim
+  - `cellpy/parameters/prmreader.py` — delegates to config stack; YAML export adapter
+  - Tests: `tests/test_prms_shim.py`; `test_deprecation_conventions` adjusted for shim noise
+  - Essential gate green: `uv run pytest -m essential` (92 passed)
+
+## Remaining work
+
+- **Milestone 2:** mechanical `prms.*` → `cellpy.config.*` migration (~35 files)
+- **Milestone 3:** remove import-time `initialize()` from `cellpy/__init__.py` + import-io test
+- `/iflow-close`

--- a/cellpy/config/__init__.py
+++ b/cellpy/config/__init__.py
@@ -1,7 +1,7 @@
-"""Parallel pydantic-settings configuration stack (issue #452).
+"""Parallel pydantic-settings configuration stack (issues #452, #453).
 
-Nothing in legacy ``prms`` imports this package yet — it is built alongside the old
-system for parity testing and will replace it in #453.
+Production code should use ``cellpy.config`` directly. Legacy ``cellpy.parameters.prms``
+forwards here via a deprecated shim.
 """
 
 from __future__ import annotations

--- a/cellpy/config/legacy.py
+++ b/cellpy/config/legacy.py
@@ -1,0 +1,149 @@
+"""Legacy ``.cellpy_prms_*.conf`` discovery and YAML ingest (issue #453)."""
+
+from __future__ import annotations
+
+import getpass
+import glob
+import os
+import sys
+from collections import OrderedDict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from cellpy.config.migrate import convert_yaml_to_toml_dict
+from cellpy.config.models import CellpyConfig
+from cellpy.internals.connections import OtherPath
+
+DEFAULT_FILENAME_START = ".cellpy_prms_"
+DEFAULT_FILENAME_END = ".conf"
+DEFAULT_FILENAME = DEFAULT_FILENAME_START + "default" + DEFAULT_FILENAME_END
+PRM_GLOB = ".cellpy_prms*.conf"
+USE_MY_DOCUMENTS = False
+
+
+def get_user_name() -> str:
+    """Return the current username (cross-platform)."""
+
+    return getpass.getuser()
+
+
+def get_user_dir() -> Path:
+    """Return the user home directory (optionally Documents on Windows)."""
+
+    user_dir = Path.home().resolve()
+    if os.name == "nt" and USE_MY_DOCUMENTS:
+        documents = user_dir / "documents"
+        if documents.is_dir():
+            return documents
+    return user_dir
+
+
+def find_legacy_yaml_file(
+    file_name: str | Path | None = None,
+    search_order: Sequence[str] | None = None,
+) -> Path | None:
+    """Locate a legacy YAML prm file using the historical search order."""
+
+    if file_name is not None:
+        candidate = Path(file_name)
+        if candidate.is_file():
+            return candidate
+        return None
+
+    script_dir = Path(__file__).resolve().parents[1] / "parameters"
+    search_path = {
+        "curdir": Path(os.path.abspath(os.path.dirname(sys.argv[0]))),
+        "filedir": script_dir,
+        "user_dir": get_user_dir(),
+    }
+    order = list(search_order or ["user_dir"])
+
+    search_dict: OrderedDict[str, list[str | None]] = OrderedDict()
+    for key in order:
+        search_dict[key] = [None, None]
+        prm_directory = search_path[key]
+        default_file = prm_directory / DEFAULT_FILENAME
+
+        if default_file.is_file():
+            search_dict[key][0] = str(default_file)
+
+        for match in sorted(glob.glob(str(prm_directory / PRM_GLOB))):
+            if Path(match).name != DEFAULT_FILENAME:
+                search_dict[key][1] = match
+                break
+
+    prm_file: str | None = None
+    for file_list in search_dict.values():
+        if file_list[1]:
+            prm_file = file_list[1]
+            break
+        if not prm_file and file_list[0]:
+            prm_file = file_list[0]
+
+    if prm_file:
+        return Path(prm_file)
+
+    fallback = script_dir / DEFAULT_FILENAME
+    if fallback.is_file():
+        return fallback
+    return None
+
+
+def load_legacy_yaml_dict(path: Path) -> dict:
+    """Read a legacy YAML prm file into new-stack-shaped dict."""
+
+    return convert_yaml_to_toml_dict(path.read_text(encoding="utf-8"))
+
+
+def load_legacy_yaml_overrides(path: Path) -> dict:
+    """Alias for :func:`load_legacy_yaml_dict` (explicit reload overrides)."""
+
+    return load_legacy_yaml_dict(path)
+
+
+def _model_to_legacy_dict(model) -> dict[str, Any]:
+    """Export a config section without triggering pydantic serializers."""
+
+    result: dict[str, Any] = {}
+    for key in type(model).model_fields:
+        value = getattr(model, key)
+        if isinstance(value, (Path, OtherPath)):
+            result[key] = str(value)
+        elif hasattr(value, "model_dump"):
+            result[key] = value.model_dump(mode="python")
+        else:
+            result[key] = value
+    return result
+
+
+def _paths_to_legacy(paths) -> dict:
+    return _model_to_legacy_dict(paths)
+
+
+def export_legacy_yaml_dict(config: CellpyConfig | None = None) -> dict:
+    """Build a legacy YAML-shaped dict from the active config stack."""
+
+    from cellpy.config.session import get_config
+
+    cfg = config or get_config()
+
+    instruments = {}
+    for key in type(cfg.instruments).model_fields:
+        value = getattr(cfg.instruments, key)
+        if hasattr(value, "model_dump"):
+            instruments[key] = value.model_dump(mode="python")
+        else:
+            instruments[key] = value
+
+    return {
+        "Paths": _paths_to_legacy(cfg.paths),
+        "FileNames": _model_to_legacy_dict(cfg.file_names),
+        "Db": _model_to_legacy_dict(cfg.db),
+        "DbCols": _model_to_legacy_dict(cfg.db_cols),
+        "CellInfo": _model_to_legacy_dict(cfg.defaults.cell_info),
+        "Reader": _model_to_legacy_dict(cfg.reader),
+        "Materials": _model_to_legacy_dict(cfg.defaults.materials),
+        "Instruments": instruments,
+        "Batch": _model_to_legacy_dict(cfg.batch),
+    }

--- a/cellpy/config/loader.py
+++ b/cellpy/config/loader.py
@@ -34,6 +34,7 @@ class LoadOptions:
     cwd: Path | None = None
     skip_files: bool = False
     skip_env: bool = False
+    legacy_yaml_file: Path | None = None
 
 
 @dataclass
@@ -68,11 +69,29 @@ def _read_toml(path: Path) -> dict[str, Any]:
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
     merged = dict(base)
     for key, value in overlay.items():
+        if value is None:
+            continue
         if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
             merged[key] = _deep_merge(merged[key], value)
         else:
             merged[key] = value
     return merged
+
+
+def _strip_none_values(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop ``None`` entries (legacy YAML often omits or nulls optional fields)."""
+
+    cleaned: dict[str, Any] = {}
+    for key, value in payload.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            nested = _strip_none_values(value)
+            if nested:
+                cleaned[key] = nested
+        else:
+            cleaned[key] = value
+    return cleaned
 
 
 def _collect_env_overrides(env_file: Path | None) -> dict[str, Any]:
@@ -132,12 +151,23 @@ def load_config(
 
     user_file_path: Path | None = None
     if not opts.skip_files:
+        from cellpy.config.legacy import find_legacy_yaml_file, load_legacy_yaml_dict
+
         user_file = opts.user_config_file or user_config_path()
+        user_toml_loaded = False
         if user_file.is_file():
             user_file_path = user_file
+            user_toml_loaded = True
             user_data = _read_toml(user_file)
             merged = _deep_merge(merged, user_data)
             _record_layer(registry, SourceLayer.USER_FILE, user_data)
+
+        if not user_toml_loaded:
+            legacy_path = opts.legacy_yaml_file or find_legacy_yaml_file()
+            if legacy_path is not None and legacy_path.is_file():
+                legacy_data = load_legacy_yaml_dict(legacy_path)
+                merged = _deep_merge(merged, legacy_data)
+                _record_layer(registry, SourceLayer.USER_FILE, legacy_data)
 
         project_file = opts.project_config_file
         if project_file is None and not opts.skip_files:
@@ -161,10 +191,10 @@ def load_config(
             _record_layer(registry, SourceLayer.ENV, env_data)
 
     if overrides:
-        merged = _deep_merge(merged, overrides)
+        merged = _deep_merge(merged, _strip_none_values(overrides))
         _record_layer(registry, SourceLayer.RUNTIME, overrides)
 
-    config = CellpyConfig.model_validate(merged)
+    config = CellpyConfig.model_validate(_strip_none_values(merged))
     return LoadResult(config=config, provenance=registry)
 
 

--- a/cellpy/parameters/_shim.py
+++ b/cellpy/parameters/_shim.py
@@ -1,0 +1,173 @@
+"""Deprecated ``prms`` → ``cellpy.config`` forwarding (issue #453)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from cellpy._deprecation import warn_once
+from cellpy.config.session import get_config
+
+_SECTION_TO_CONFIG: dict[str, tuple[str, str]] = {
+    "Paths": ("paths", "cellpy.config.paths"),
+    "FileNames": ("file_names", "cellpy.config.file_names"),
+    "Reader": ("reader", "cellpy.config.reader"),
+    "Db": ("db", "cellpy.config.db"),
+    "DbCols": ("db_cols", "cellpy.config.db_cols"),
+    "Batch": ("batch", "cellpy.config.batch"),
+    "Instruments": ("instruments", "cellpy.config.instruments"),
+    "CellInfo": ("defaults.cell_info", "cellpy.config.defaults.cell_info"),
+    "Materials": ("defaults.materials", "cellpy.config.defaults.materials"),
+}
+
+_SHIM_SECTIONS = frozenset(_SECTION_TO_CONFIG)
+
+_LEGACY_ARBIN_SQL_KEYS = {
+    "SQL_server": ("host", "cellpy.config.secrets.host"),
+    "SQL_UID": ("user", "cellpy.config.secrets.user"),
+    "SQL_PWD": ("password", "cellpy.config.secrets.password"),
+    "SQL_Driver": (None, None),
+}
+
+
+def _resolve_config_path(path: str) -> Any:
+    obj: Any = get_config()
+    for part in path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _warn_section(legacy_name: str, replacement: str) -> None:
+    warn_once(f"prms.{legacy_name}", replacement)
+
+
+class _SectionProxy:
+    """Forward attribute access to a pydantic config section."""
+
+    def __init__(self, legacy_name: str, config_path: str, replacement: str) -> None:
+        object.__setattr__(self, "_legacy_name", legacy_name)
+        object.__setattr__(self, "_config_path", config_path)
+        object.__setattr__(self, "_replacement", replacement)
+
+    def _target(self) -> Any:
+        return _resolve_config_path(self._config_path)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        _warn_section(self._legacy_name, self._replacement)
+        value = getattr(self._target(), name)
+        if self._legacy_name == "Instruments" and isinstance(value, BaseModel):
+            return _InstrumentConfigProxy(self._legacy_name, name, value)
+        return value
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        _warn_section(self._legacy_name, self._replacement)
+        setattr(self._target(), name, value)
+
+    def __repr__(self) -> str:
+        return f"<deprecated prms.{self._legacy_name} shim → {self._replacement}>"
+
+
+class _InstrumentConfigProxy:
+    """Instrument subsection with legacy ``__getitem__`` SQL compat."""
+
+    def __init__(self, section_name: str, instrument_name: str, model: BaseModel) -> None:
+        object.__setattr__(self, "_section_name", section_name)
+        object.__setattr__(self, "_instrument_name", instrument_name)
+        object.__setattr__(self, "_model", model)
+
+    def _warn(self) -> None:
+        _warn_section(
+            self._section_name,
+            _SECTION_TO_CONFIG[self._section_name][1],
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        self._warn()
+        return getattr(self._model, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        self._warn()
+        setattr(self._model, name, value)
+
+    def __getitem__(self, key: str) -> Any:
+        self._warn()
+        if self._instrument_name == "Arbin" and key in _LEGACY_ARBIN_SQL_KEYS:
+            secret_field, replacement = _LEGACY_ARBIN_SQL_KEYS[key]
+            if secret_field is not None and replacement is not None:
+                warn_once(f"prms.Instruments.Arbin[{key!r}]", replacement)
+                return getattr(get_config().secrets, secret_field)
+        if hasattr(self._model, key):
+            return getattr(self._model, key)
+        extras = getattr(self._model, "model_extra", None) or {}
+        if key in extras:
+            return extras[key]
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._warn()
+        if self._instrument_name == "Arbin" and key in _LEGACY_ARBIN_SQL_KEYS:
+            secret_field, replacement = _LEGACY_ARBIN_SQL_KEYS[key]
+            if secret_field is not None and replacement is not None:
+                warn_once(f"prms.Instruments.Arbin[{key!r}]", replacement)
+                setattr(get_config().secrets, secret_field, value)
+                return
+        if hasattr(self._model, key):
+            setattr(self._model, key, value)
+            return
+        setattr(self._model, key, value)
+
+    def keys(self) -> list[str]:
+        self._warn()
+        data = self._model.model_dump()
+        return list(data.keys())
+
+    def __iter__(self):
+        self._warn()
+        return iter(self.keys())
+
+    def __contains__(self, key: object) -> bool:
+        self._warn()
+        try:
+            self[key]
+        except KeyError:
+            return False
+        return True
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def to_dict(self) -> dict[str, Any]:
+        self._warn()
+        return self._model.model_dump()
+
+
+class _InstrumentsProxy(_SectionProxy):
+    """``prms.Instruments`` with instrument-level proxies."""
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        _warn_section(self._legacy_name, self._replacement)
+        value = getattr(self._target(), name)
+        if isinstance(value, BaseModel):
+            return _InstrumentConfigProxy(self._legacy_name, name, value)
+        return value
+
+
+def _get_shim_section(name: str) -> Any:
+    config_path, replacement = _SECTION_TO_CONFIG[name]
+    if name == "Instruments":
+        return _InstrumentsProxy(name, config_path, replacement)
+    return _SectionProxy(name, config_path, replacement)

--- a/cellpy/parameters/prmreader.py
+++ b/cellpy/parameters/prmreader.py
@@ -1,33 +1,33 @@
 # -*- coding: utf-8 -*-
 import getpass
-import glob
 import logging
 import os
 import pathlib
-import sys
 import warnings
-from collections import OrderedDict
-from dataclasses import asdict, dataclass
+from pathlib import Path
 from pprint import pprint
-
-# import box
-import dotenv
 from rich import print
-import ruamel
+import dotenv
+from dataclasses import asdict
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from . import externals as externals
+from cellpy.config.legacy import (
+    DEFAULT_FILENAME,
+    DEFAULT_FILENAME_END,
+    DEFAULT_FILENAME_START,
+    export_legacy_yaml_dict,
+    find_legacy_yaml_file,
+    get_user_dir as _legacy_get_user_dir,
+    load_legacy_yaml_dict,
+)
+from cellpy.config.loader import LoadOptions
+from cellpy.config.session import get_config, reload
 from cellpy.exceptions import ConfigFileNotRead, ConfigFileNotWritten
 from cellpy.parameters import prms
+from cellpy.parameters._shim import _SHIM_SECTIONS
 from cellpy.parameters.internal_settings import OTHERPATHS
 from cellpy.internals.connections import OtherPath
-
-DEFAULT_FILENAME_START = ".cellpy_prms_"
-DEFAULT_FILENAME_END = ".conf"
-USE_MY_DOCUMENTS = False
-
-DEFAULT_FILENAME = DEFAULT_FILENAME_START + "default" + DEFAULT_FILENAME_END
 
 ENVIRONMENT_EXAMPLE = """
 # This is an example of an environment file for cellpy.
@@ -44,32 +44,42 @@ ENVIRONMENT_EXAMPLE = """
 # CELLPY_USER=<user>
 """
 
-# logger = logging.getLogger(__name__)
-
 yaml = YAML()
 
 
 def initialize():
-    """Initializes cellpy by reading the config file and the environment file"""
+    """Initializes cellpy by reading the config file and the environment file."""
+
     try:
-        _read_prm_file(_get_prm_file())
+        legacy_path = find_legacy_yaml_file()
+        options = LoadOptions()
+        if legacy_path is not None:
+            options = LoadOptions(legacy_yaml_file=legacy_path)
+        reload(options=options)
         _load_env_file()
     except FileNotFoundError:
         warnings.warn("Could not find the config-file")
-    except UserWarning:
+    except OSError:
         warnings.warn("Could not read the config-file")
 
 
 def _load_env_file():
-    """Loads the environment file"""
+    """Loads the environment file into ``os.environ`` (legacy OtherPath consumers)."""
+
     env_file = pathlib.Path(prms.Paths.env_file)
-    env_file_in_user_dir = pathlib.Path.home() / prms.Paths.env_file
+    env_file_in_user_dir = pathlib.Path.home() / env_file.name
     if env_file.is_file():
         dotenv.load_dotenv(env_file)
     elif env_file_in_user_dir.is_file():
         dotenv.load_dotenv(env_file_in_user_dir)
     else:
         logging.debug("No .env file found")
+
+
+def _pack_prms():
+    """Pack current config into legacy YAML section dict."""
+
+    return export_legacy_yaml_dict(get_config())
 
 
 def get_user_name():
@@ -81,8 +91,7 @@ def create_custom_init_filename(user_name=None):
     """Creates a custom prms filename"""
     if user_name is None:
         return DEFAULT_FILENAME_START + get_user_name() + DEFAULT_FILENAME_END
-    else:
-        return DEFAULT_FILENAME_START + user_name + DEFAULT_FILENAME_END
+    return DEFAULT_FILENAME_START + user_name + DEFAULT_FILENAME_END
 
 
 def get_user_dir_and_dst(init_filename=None):
@@ -96,13 +105,7 @@ def get_user_dir_and_dst(init_filename=None):
 
 def get_user_dir():
     """Gets the name of the user directory"""
-    # user_dir = pathlib.Path(os.path.abspath(os.path.expanduser("~")))
-    user_dir = pathlib.Path().home().resolve()
-    if os.name == "nt" and USE_MY_DOCUMENTS:
-        _user_dir = user_dir / "documents"
-        if _user_dir.is_dir():
-            user_dir = _user_dir
-    return user_dir
+    return _legacy_get_user_dir()
 
 
 def _write_prm_file(file_name=None):
@@ -120,7 +123,6 @@ def _write_prm_file(file_name=None):
         raise ConfigFileNotWritten
 
 
-# TODO: make this alive by setting it to not dev:
 def _write_env_file(env_file_name=None):
     """writes example environment file"""
     dev = False
@@ -143,68 +145,13 @@ def _write_env_file(env_file_name=None):
         print(e)
 
 
-def _update_prms(config_dict, resolve_paths=True):
-    """updates the prms with the values in the config_dict"""
-    # config_dict is your current config
-    # _config_attr is the attribute in the prms module (i.e. the defaults)
-
-    logging.debug("updating parameters")
-    logging.debug(f"new prms: {config_dict}")
-    for key in config_dict:
-        if config_dict[key] is None:
-            logging.debug(f"{config_dict[key]} is None")
-            continue
-        if key == "Paths":
-            _config_attr = getattr(prms, key)
-            for k in config_dict[key]:
-                z = config_dict[key][k]
-
-                _txt = f"{k}: {z}"
-                if k.lower() == "db_filename":
-                    # special hack because it is a filename and not a path
-                    pass
-                elif k.lower() in OTHERPATHS:
-                    logging.debug("converting to OtherPath")
-                    # special hack because it is possibly an external location
-                    z = OtherPath(str(z))
-                    if resolve_paths:
-                        z = z.resolve()  # v1.0.0: this is only resolving local paths
-                else:
-                    logging.debug("converting to pathlib.Path")
-                    z = pathlib.Path(z)
-                    if resolve_paths:
-                        z = z.resolve()
-                _txt += f" -> {z}"
-
-                logging.debug(_txt)
-                setattr(_config_attr, k, z)
-
-        elif hasattr(prms, key):
-            _config_attr = getattr(prms, key)
-            if _config_attr is None:
-                logging.debug(f"{_config_attr} is None")
-                continue
-            for k in config_dict[key]:
-                z = config_dict[key][k]
-                if isinstance(z, dict):
-                    y = getattr(_config_attr, k)
-                    z = externals.box.Box({**y, **z})
-                if isinstance(z, ruamel.yaml.comments.CommentedMap):
-                    z = externals.box.Box(z)
-                setattr(_config_attr, k, z)
-        else:
-            logging.info("\n  not-supported prm: %s" % key)
-
-
 def _convert_instruments_to_dict(x):
-    # Converting instruments to dictionary (since it contains box.Box objects)
     d = asdict(x)
     for k, v in d.items():
         try:
             d[k] = v.to_dict()
         except AttributeError:
             pass
-
     return d
 
 
@@ -217,9 +164,25 @@ def _convert_to_dict(x):
 
 
 def _convert_paths_to_dict(x):
+    from cellpy.config.models import PathsConfig
+    from cellpy.parameters._shim import _SectionProxy
+
+    if isinstance(x, _SectionProxy):
+        x = x._target()
+    if isinstance(x, PathsConfig):
+        dictionary = {}
+        for key in PathsConfig.model_fields:
+            value = getattr(x, key)
+            if key in {"rawdatadir", "cellpydatadir"}:
+                dictionary[key] = value.full_path if hasattr(value, "full_path") else str(value)
+            elif key == "db_filename":
+                dictionary[key] = value
+            else:
+                dictionary[key] = str(value)
+        return dictionary
+
     dictionary = {}
     for k in x.keys():
-        # hack to get around the leading underscore (since they are properties):
         if len(k) > 1 and k[0] == "_" and k.lower()[1:] in OTHERPATHS:
             t = getattr(x, k).full_path
             k = k[1:]
@@ -229,55 +192,35 @@ def _convert_paths_to_dict(x):
     return dictionary
 
 
-def _update_and_convert_to_dict(parameter_name):
-    """check that all the parameters are correct in the prm-file"""
-    # update from old prm-file (before v1.0.0):
-    if parameter_name == "DbCols":
-        if hasattr(prms, "DbCols"):
-            db_cols = _convert_to_dict(prms.DbCols)
-            if db_cols is None:
-                return prms.DbColsClass()
+def _resolve_loaded_paths(resolve_paths: bool = True) -> None:
+    """Resolve local path fields after loading a prm file (legacy behavior)."""
 
-            for k in db_cols:
-                if isinstance(db_cols[k], (list, tuple)):
-                    db_cols[k] = db_cols[k][0]
-            return db_cols
-        else:
-            return prms.DbColsClass()
+    if not resolve_paths:
+        return
+    from cellpy.config.models import PathsConfig
 
-
-def _pack_prms():
-    """if you introduce new 'save-able' parameter dictionaries, then you have
-    to include them here"""
-
-    config_dict = {
-        "Paths": _convert_paths_to_dict(prms.Paths),
-        "FileNames": _convert_to_dict(prms.FileNames),
-        "Db": _convert_to_dict(prms.Db),
-        "DbCols": _update_and_convert_to_dict("DbCols"),
-        "CellInfo": _convert_to_dict(prms.CellInfo),
-        "Reader": _convert_to_dict(prms.Reader),
-        "Materials": _convert_to_dict(prms.Materials),
-        "Instruments": _convert_instruments_to_dict(prms.Instruments),
-        "Batch": _convert_to_dict(prms.Batch),
-    }
-    return config_dict
+    paths: PathsConfig = get_config().paths
+    for key in PathsConfig.model_fields:
+        if key == "db_filename":
+            continue
+        value = getattr(paths, key)
+        if key in {"rawdatadir", "cellpydatadir"} and isinstance(value, OtherPath):
+            setattr(paths, key, value.resolve())
+        elif isinstance(value, Path):
+            setattr(paths, key, value.resolve())
 
 
 def _read_prm_file(prm_filename, resolve_paths=True):
     """read the prm file"""
+
     logging.debug("Reading config-file: %s" % prm_filename)
     try:
-        with open(prm_filename, "r") as config_file:
-            prm_dict = yaml.load(config_file)
-
+        overrides = load_legacy_yaml_dict(pathlib.Path(prm_filename))
     except YAMLError as e:
         raise ConfigFileNotRead from e
-    else:
-        if isinstance(prm_dict, dict):
-            _update_prms(prm_dict, resolve_paths=resolve_paths)
-        else:
-            print(type(prm_dict))
+    reload(overrides=overrides, options=LoadOptions(skip_files=True, skip_env=True))
+    _resolve_loaded_paths(resolve_paths=resolve_paths)
+    _load_env_file()
 
 
 def _read_prm_file_without_updating(prm_filename):
@@ -303,68 +246,17 @@ def _get_prm_file(file_name=None, search_order=None):
     if file_name is not None:
         if os.path.isfile(file_name):
             return file_name
-        else:
-            logging.info("Could not find the prm-file")
+        logging.info("Could not find the prm-file")
 
-    default_name = prms._prm_default_name  # NOQA
-    prm_globtxt = prms._prm_globtxt  # NOQA
+    legacy = find_legacy_yaml_file(search_order=search_order)
+    if legacy is not None:
+        return str(legacy)
 
-    script_dir = os.path.abspath(os.path.dirname(__file__))
-
-    search_path = dict()
-    search_path["curdir"] = os.path.abspath(os.path.dirname(sys.argv[0]))
-    search_path["filedir"] = script_dir
-    search_path["user_dir"] = get_user_dir()
-
-    if search_order is None:
-        search_order = ["user_dir"]  # ["curdir","filedir", "user_dir",]
-    else:
-        search_order = search_order
-
-    # The default name for the prm file is at the moment in the script-dir,@
-    # while default searching is in the user_dir (yes, I know):
-    prm_default = os.path.join(script_dir, default_name)
-
-    # -searching-----------------------
-    search_dict: OrderedDict = OrderedDict()
-
-    for key in search_order:
-        search_dict[key] = [None, None]
-        prm_directory = search_path[key]
-        default_file = os.path.join(prm_directory, default_name)
-
-        if os.path.isfile(default_file):
-            # noinspection PyTypeChecker
-            search_dict[key][0] = default_file
-
-        prm_globtxt_full = os.path.join(prm_directory, prm_globtxt)
-
-        user_files = glob.glob(prm_globtxt_full)
-
-        for f in user_files:
-            if os.path.basename(f) != os.path.basename(default_file):
-                search_dict[key][1] = f
-                break
-
-    # -selecting----------------------
-    prm_file = None
-    for key, file_list in search_dict.items():
-        if file_list[-1]:
-            prm_file = file_list[-1]
-            break
-        else:
-            if not prm_file:
-                prm_file = file_list[0]
-
-    if prm_file:
-        prm_filename = prm_file
-    else:
-        prm_filename = prm_default
-    return prm_filename
+    script_dir = pathlib.Path(__file__).resolve().parent
+    return str(script_dir / DEFAULT_FILENAME)
 
 
 def _save_current_prms_to_user_dir():
-    # This should be put into the cellpy setup script
     file_name = os.path.join(prms.user_dir, prms._prm_default_name)  # NOQA
     _write_prm_file(file_name)
 
@@ -372,31 +264,13 @@ def _save_current_prms_to_user_dir():
 def get_env_file_name():
     """Returns the location of the env-file"""
 
-    # TODO: make this more robust - especially on posix systems strange
-    #  things seem to happen
-
-    # from prms.py (default values):
-    # user_dir = Path.home()
-    # env_file: Union[Path, str] = user_dir / ".env_cellpy"
-
-    # from running setup on CI:
-    #
-    # location of env-file:
-    # /Users/runner/work/cellpy/cellpy/.env_cellpy
-    #
-    # location of config-file:
-    # /Users/runner/.cellpy_prms_runner.conf
-    #
-    # WHY ARE THEY NOT IN THE SAME DIRECTORY?
-    # (could it be that Path.home() behaves different than I expect?)
-
     env_file = pathlib.Path(prms.Paths.env_file)
     return env_file
 
 
 def info():
-    """This function will show only the 'box'-type
-    attributes and their content in the cellpy.prms module"""
+    """Show resolved config sections (legacy ``prms`` names)."""
+
     print(80 * "=")
     print(f"Listing the content of the prms module ({prms.__name__})")
     print(80 * "-")
@@ -409,35 +283,23 @@ def info():
     print(f" - exists: {os.path.isfile(env_file)}")
 
     print()
-
-    for key, current_object in prms.__dict__.items():
-        if key.startswith("_") and not key.startswith("__") and prms._debug:  # NOQA
-            print(f"Internal: {key} (type={type(current_object)}): {current_object}")
-
-        elif isinstance(current_object, externals.box.Box):
-            print()
-            print(f" {key} [OLD-TYPE PRM] ".center(80, "-"))
-            for subkey in current_object:
-                print(f"prms.{key}.{subkey} = {current_object[subkey]}")
-            print()
-
-        elif key == "Paths":
-            print(" Paths ".center(80, "-"))
-            attributes = {
-                k: v for k, v in vars(current_object).items() if not k.startswith("_")
-            }
-            for attr in OTHERPATHS:
-                attributes[attr] = getattr(current_object, attr)
-            print(attributes)
-
-        elif isinstance(current_object, (prms.CellPyConfig, prms.CellPyDataConfig)):
-            # print(" NEW-TYPE PRM ".center(80, "="))
-            attributes = {
-                k: v for k, v in vars(current_object).items() if not k.startswith("_")
-            }
-            print(f" {key} ".center(80, "-"))
-            print(attributes)
-            print()
+    cfg = get_config()
+    section_getters = {
+        "Paths": lambda: cfg.paths,
+        "FileNames": lambda: cfg.file_names,
+        "Reader": lambda: cfg.reader,
+        "Db": lambda: cfg.db,
+        "DbCols": lambda: cfg.db_cols,
+        "Batch": lambda: cfg.batch,
+        "Instruments": lambda: cfg.instruments,
+        "CellInfo": lambda: cfg.defaults.cell_info,
+        "Materials": lambda: cfg.defaults.materials,
+    }
+    for legacy_name in sorted(_SHIM_SECTIONS):
+        section = section_getters[legacy_name]()
+        print(f" {legacy_name} ".center(80, "-"))
+        print(section.model_dump(mode="json"))
+        print()
 
 
 def _main():
@@ -452,8 +314,7 @@ def _main():
     print("INFO:")
     info()
     print(prms)
-    pprint(str(prms.Batch), width=1)
-    print(prms.Batch.summary_plot_height_fractions)
+    pprint(str(prms.Batch.summary_plot_height_fractions), width=1)
 
 
 if __name__ == "__main__":

--- a/cellpy/parameters/prms.py
+++ b/cellpy/parameters/prms.py
@@ -290,14 +290,9 @@ class MaterialsClass(CellPyDataConfig):
     default_nom_cap_specifics: str = "gravimetric"
 
 
-Paths = PathsClass()
-FileNames = FileNamesClass()
-Reader = ReaderClass()
-Db = DbClass()
-DbCols = DbColsClass()
-CellInfo = CellInfoClass()
-Materials = MaterialsClass()
-Batch = BatchClass(backend="plotly")
+
+
+# Section singletons removed — access via deprecated shim (``__getattr__`` → config).
 
 
 # ------------------------------------------------------------------------------
@@ -349,16 +344,6 @@ Neware = externals.box.Box(_Neware)
 
 _Batmo = {"default_model": "bdf"}
 Batmo = externals.box.Box(_Batmo)
-
-Instruments = InstrumentsClass(
-    tester=None,  # TODO: moving this to DataSetClass (deprecate)
-    custom_instrument_definitions_file=None,
-    Arbin=Arbin,
-    Maccor=Maccor,
-    Neware=Neware,
-    Batmo=Batmo,
-)
-
 
 # ------------------------------------------------------------------------------
 # Other secret- or non-config (only for developers and super-users)
@@ -438,3 +423,12 @@ def _set_arbin_res_subprocess_exporter(sub_process_path: str):
     Instruments.Arbin.use_subprocess = True
     Instruments.Arbin.detect_subprocess_need = False
     Instruments.Arbin.sub_process_path = sub_process_path
+
+
+from cellpy.parameters._shim import _SHIM_SECTIONS, _get_shim_section
+
+
+def __getattr__(name: str):
+    if name in _SHIM_SECTIONS:
+        return _get_shim_section(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_deprecation_conventions.py
+++ b/tests/test_deprecation_conventions.py
@@ -60,9 +60,9 @@ def test_make_new_cell_uses_warn_once():
         make_new_cell()
         make_new_cell()
 
-    assert len(caught) == 1
-    assert "make_new_cell is deprecated" in str(caught[0].message)
-    assert "CellpyCell.vacant" in str(caught[0].message)
+    make_new_cell_warnings = [w for w in caught if "make_new_cell" in str(w.message)]
+    assert len(make_new_cell_warnings) == 1
+    assert "CellpyCell.vacant" in str(make_new_cell_warnings[0].message)
 
 
 @pytest.mark.essential

--- a/tests/test_prms_shim.py
+++ b/tests/test_prms_shim.py
@@ -1,0 +1,71 @@
+"""Tests for the deprecated prms shim and legacy YAML fallback (issue #453)."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from cellpy.config import LoadOptions, reset_session
+from cellpy.config.loader import load_config
+from cellpy.config.sources import SourceLayer
+from cellpy import _deprecation
+from cellpy.parameters import prms
+from cellpy.parameters import prmreader
+from tests.prms_support import write_minimal_prm_file
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_session():
+    reset_session()
+    yield
+    reset_session()
+
+
+@pytest.mark.essential
+def test_prms_shim_forwards_and_warns():
+    _deprecation._WARNED_SITES.clear()
+    prmreader.initialize()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        prms.Reader.cycle_mode = "cathode"
+        assert prms.Reader.cycle_mode == "cathode"
+
+    assert any("prms.Reader" in str(item.message) for item in caught)
+
+
+@pytest.mark.essential
+def test_legacy_yaml_fallback_loads(tmp_path):
+    root = str(tmp_path).replace("\\", "/")
+    yaml_content = f"""---
+Paths:
+  outdatadir: {root}/out
+  rawdatadir: {root}/raw
+  cellpydatadir: {root}/cellpy
+  db_path: {root}/db
+  filelogdir: {root}/logs
+  examplesdir: {root}/examples
+  notebookdir: {root}/notebooks
+  templatedir: {root}/templates
+  batchfiledir: {root}/batchfiles
+  instrumentdir: {root}/instruments
+  db_filename: cellpy_db.xlsx
+  env_file: .env_cellpy
+Reader:
+  cycle_mode: cathode
+...
+"""
+    legacy_file = tmp_path / ".cellpy_prms_testuser.conf"
+    write_minimal_prm_file(legacy_file, yaml_content)
+
+    result = load_config(
+        options=LoadOptions(
+            legacy_yaml_file=legacy_file,
+            user_config_file=tmp_path / "missing.toml",
+            cwd=tmp_path,
+            skip_env=True,
+        )
+    )
+    assert result.config.reader.cycle_mode == "cathode"
+    assert result.provenance.get("reader.cycle_mode") == SourceLayer.USER_FILE


### PR DESCRIPTION
## Summary

Milestone 1 of #453 — wire the #452 `cellpy/config/` stack behind production without migrating internal call sites yet.

- Add `cellpy/config/legacy.py` for `.cellpy_prms_*.conf` discovery, YAML ingest, and export (CLI round-trip)
- Extend `loader.py` with legacy YAML fallback when no `cellpy.toml` exists
- Replace eager `prms` section singletons with deprecated `_shim.py` proxies (`warn_once` per access)
- Slim `prmreader.py` to delegate reads/writes through `config.reload()` / export adapter
- **Out of scope for M1:** internal `prms.*` → `config.*` migration (M2) and removing import-time `initialize()` (M3)

## Test plan

- [x] `uv run pytest tests/test_config.py tests/test_prms.py` — 24 passed
- [x] `uv run pytest tests/test_prms_shim.py` — shim + legacy fallback
- [x] `uv run pytest -m essential` — 92 passed


Made with [Cursor](https://cursor.com)