### PR TITLE
Stage 1.8 M2: migrate internal prms call sites to config (#453)

### DIFF
--- a/.issueflows/00-tools/README.md
+++ b/.issueflows/00-tools/README.md
@@ -28,3 +28,4 @@ to grow over time.
 | --- | --- | --- |
 | `scan_member_usage.py` | AST scan for `Data` / `CellpyCell` `.member` access in given package paths | Stage-0/1 consumer inventory reports (e.g. issue #435) |
 | `scan_hardcoded_headers.py` | AST scan for canonical header string literals in column-access contexts | Stage-0 header inventory / migration planning |
+| `migrate_prms_calls.py` | Bulk replace `prms.<Section>` → `config.<section>` and add imports | Issue #453 M2 mechanical migration (review arbin/SQL/module-level edge cases manually) |

--- a/.issueflows/00-tools/migrate_prms_calls.py
+++ b/.issueflows/00-tools/migrate_prms_calls.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Mechanical prms section → cellpy.config migration (issue #453 M2)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "cellpy"
+
+SKIP = {
+    ROOT / "parameters" / "_shim.py",
+    ROOT / "parameters" / "prms.py",
+}
+
+REPLACEMENTS = [
+    ("prmreader.prms.Paths", "config.paths"),
+    ("prmreader.prms.Batch", "config.batch"),
+    ("prms.CellInfo", "config.defaults.cell_info"),
+    ("prms.Materials", "config.defaults.materials"),
+    ("prms.FileNames", "config.file_names"),
+    ("prms.DbCols", "config.db_cols"),
+    ("prms.Instruments", "config.instruments"),
+    ("prms.Reader", "config.reader"),
+    ("prms.Paths", "config.paths"),
+    ("prms.Batch", "config.batch"),
+    ("prms.Db", "config.db"),
+]
+
+CONFIG_IMPORT = "import cellpy.config as config\n"
+
+
+def needs_config(text: str) -> bool:
+    return "config." in text and "import cellpy.config as config" not in text
+
+
+def migrate_file(path: Path) -> bool:
+    if path in SKIP or not path.suffix == ".py":
+        return False
+    original = path.read_text(encoding="utf-8")
+    text = original
+    for old, new in REPLACEMENTS:
+        text = text.replace(old, new)
+    if text == original:
+        return False
+    if needs_config(text):
+        lines = text.splitlines(keepends=True)
+        insert_at = 0
+        for idx, line in enumerate(lines):
+            if line.startswith("import ") or line.startswith("from "):
+                insert_at = idx + 1
+            elif line.strip() and not line.startswith("#"):
+                break
+        lines.insert(insert_at, CONFIG_IMPORT)
+        text = "".join(lines)
+    path.write_text(text, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    changed = []
+    for path in sorted(ROOT.rglob("*.py")):
+        if migrate_file(path):
+            changed.append(path.relative_to(ROOT.parent))
+    print(f"Updated {len(changed)} files")
+    for item in changed:
+        print(f"  {item}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.issueflows/01-current-issues/issue453_status.md
+++ b/.issueflows/01-current-issues/issue453_status.md
@@ -5,18 +5,20 @@
 ## What's done
 
 - Plan accepted (2026-07-14).
-- Branch `453-prms-shim-swap`.
-- **Milestone 1 (shim + legacy load):**
-  - `cellpy/config/legacy.py` — YAML discovery, ingest, export
-  - `cellpy/config/loader.py` — legacy YAML fallback, None stripping
-  - `cellpy/parameters/_shim.py` — deprecated section proxies (+ Arbin SQL compat)
-  - `cellpy/parameters/prms.py` — section singletons removed; module `__getattr__` shim
-  - `cellpy/parameters/prmreader.py` — delegates to config stack; YAML export adapter
-  - Tests: `tests/test_prms_shim.py`; `test_deprecation_conventions` adjusted for shim noise
-  - Essential gate green: `uv run pytest -m essential` (92 passed)
+- **Milestone 1 (shim + legacy load)** — merged via PR #494 on `master`.
+- **Milestone 2 (internal call-site migration)** — branch `453-prms-m2-migrate`:
+  - Mechanical `prms.<Section>` → `cellpy.config.<section>` in ~32 files under `cellpy/`
+  - `cellpy/parameters/internal_settings.py` — dataclass defaults use lazy `default_factory`
+  - `cellpy/readers/instruments/arbin_sql_config.py` — shared Arbin SQL credential resolution
+  - `arbin_sql.py` / `arbin_sql_7.py` — lazy SQL settings via `arbin_sql_value()`
+  - Instrument `default_model` — attribute access on pydantic models
+  - `easyplot.py` — `set_arbin_sql_value()` for SQL mutation
+  - Fixed broken multi-line imports from codemod (`prmreader`, `helpers`, batch tools)
+  - Fixed circular import: `connections.py` defers `cellpy.config` import
+  - Helper: `.issueflows/00-tools/migrate_prms_calls.py`
+  - Essential gate green: `uv run pytest -m essential` (93 passed)
 
 ## Remaining work
 
-- **Milestone 2:** mechanical `prms.*` → `cellpy.config.*` migration (~35 files)
 - **Milestone 3:** remove import-time `initialize()` from `cellpy/__init__.py` + import-io test
 - `/iflow-close`

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -22,6 +22,7 @@ from cellpy.parameters import prmreader
 from cellpy.parameters.internal_settings import OTHERPATHS
 from cellpy.internals.connections import OtherPath
 from cellpy.utils.template_registry import REGISTERED_TEMPLATES
+import cellpy.config as config
 
 DIFFICULT_MISSING_MODULES = {}
 
@@ -336,17 +337,17 @@ def _update_paths(
             h = h / default_dir
 
     if not reset:
-        outdatadir = pathlib.Path(prmreader.prms.Paths.outdatadir)
-        rawdatadir = OtherPath(prmreader.prms.Paths.rawdatadir)
-        cellpydatadir = OtherPath(prmreader.prms.Paths.cellpydatadir)
-        filelogdir = pathlib.Path(prmreader.prms.Paths.filelogdir)
-        examplesdir = pathlib.Path(prmreader.prms.Paths.examplesdir)
-        db_path = pathlib.Path(prmreader.prms.Paths.db_path)
-        db_filename = prmreader.prms.Paths.db_filename
-        notebookdir = pathlib.Path(prmreader.prms.Paths.notebookdir)
-        batchfiledir = pathlib.Path(prmreader.prms.Paths.batchfiledir)
-        templatedir = pathlib.Path(prmreader.prms.Paths.templatedir)
-        instrumentdir = pathlib.Path(prmreader.prms.Paths.instrumentsdir)
+        outdatadir = pathlib.Path(config.paths.outdatadir)
+        rawdatadir = OtherPath(config.paths.rawdatadir)
+        cellpydatadir = OtherPath(config.paths.cellpydatadir)
+        filelogdir = pathlib.Path(config.paths.filelogdir)
+        examplesdir = pathlib.Path(config.paths.examplesdir)
+        db_path = pathlib.Path(config.paths.db_path)
+        db_filename = config.paths.db_filename
+        notebookdir = pathlib.Path(config.paths.notebookdir)
+        batchfiledir = pathlib.Path(config.paths.batchfiledir)
+        templatedir = pathlib.Path(config.paths.templatedir)
+        instrumentdir = pathlib.Path(config.paths.instrumentsdir)
     else:
         outdatadir = "out"
         rawdatadir = "raw"
@@ -412,17 +413,17 @@ def _update_paths(
             click.echo(f"dry run (so I did not create {d})")
 
     # update config-file based on suggestions
-    prmreader.prms.Paths.outdatadir = str(outdatadir)
-    prmreader.prms.Paths.rawdatadir = str(rawdatadir)
-    prmreader.prms.Paths.cellpydatadir = str(cellpydatadir)
-    prmreader.prms.Paths.filelogdir = str(filelogdir)
-    prmreader.prms.Paths.examplesdir = str(examplesdir)
-    prmreader.prms.Paths.db_path = str(db_path)
-    prmreader.prms.Paths.db_filename = str(db_filename)
-    prmreader.prms.Paths.notebookdir = str(notebookdir)
-    prmreader.prms.Paths.batchfiledir = str(batchfiledir)
-    prmreader.prms.Paths.templatedir = str(templatedir)
-    prmreader.prms.Paths.instrumentdir = str(instrumentdir)
+    config.paths.outdatadir = str(outdatadir)
+    config.paths.rawdatadir = str(rawdatadir)
+    config.paths.cellpydatadir = str(cellpydatadir)
+    config.paths.filelogdir = str(filelogdir)
+    config.paths.examplesdir = str(examplesdir)
+    config.paths.db_path = str(db_path)
+    config.paths.db_filename = str(db_filename)
+    config.paths.notebookdir = str(notebookdir)
+    config.paths.batchfiledir = str(batchfiledir)
+    config.paths.templatedir = str(templatedir)
+    config.paths.instrumentdir = str(instrumentdir)
 
 
 def _ask_about_path(q, p):
@@ -510,8 +511,8 @@ def _check_import_pyodbc():
     ODBC = prms._odbc
     SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver
 
-    use_subprocess = prms.Instruments.Arbin.use_subprocess
-    detect_subprocess_need = prms.Instruments.Arbin.detect_subprocess_need
+    use_subprocess = config.instruments.Arbin.use_subprocess
+    detect_subprocess_need = config.instruments.Arbin.detect_subprocess_need
     click.echo(f" This is needed for loading Arbin .res files")
     click.echo(f" parsing prms")
     click.echo(
@@ -521,7 +522,7 @@ def _check_import_pyodbc():
     click.echo(f" - SEARCH_FOR_ODBC_DRIVERS: {SEARCH_FOR_ODBC_DRIVERS}")
     click.echo(f" - use_subprocess: {use_subprocess}")
     click.echo(f" - detect_subprocess_need: {detect_subprocess_need}")
-    click.echo(f" - stated office version: {prms.Instruments.Arbin.office_version}")
+    click.echo(f" - stated office version: {config.instruments.Arbin.office_version}")
 
     click.echo(" checking system")
     is_posix = False
@@ -539,10 +540,10 @@ def _check_import_pyodbc():
     click.echo(f" - os version: {os_version}")
 
     if not is_posix:
-        if not prms.Instruments.Arbin.sub_process_path:
+        if not config.instruments.Arbin.sub_process_path:
             sub_process_path = str(prms._sub_process_path)
         else:
-            sub_process_path = str(prms.Instruments.Arbin.sub_process_path)
+            sub_process_path = str(config.instruments.Arbin.sub_process_path)
         click.echo(f" stated path to sub-process: {sub_process_path}")
         if not os.path.isfile(sub_process_path):
             click.echo(f" - OBS! missing")
@@ -596,7 +597,7 @@ def _check_import_pyodbc():
     # not posix - checking for odbc drivers
     # 1) checking if you have defined one
     try:
-        driver = prms.Instruments.Arbin.odbc_driver
+        driver = config.instruments.Arbin.odbc_driver
         if not driver:
             raise AttributeError
         click.echo(" You have defined an odbc driver in your config file")
@@ -1193,7 +1194,7 @@ def _run_journal(file_name, debug, silent, raw, cellpyfile, minimal, nom_cap):
     from cellpy import prms
     from cellpy.utils import batch
 
-    batchfiledir = pathlib.Path(prms.Paths.batchfiledir)
+    batchfiledir = pathlib.Path(config.paths.batchfiledir)
     file = pathlib.Path(file_name)
     if not file.is_file():
         click.echo(f"file_name={file_name} not found - looking into batchfiledir")
@@ -1223,7 +1224,7 @@ def _run_list(batchfiledir):
     from cellpy import prms
 
     if batchfiledir == "NONE" or batchfiledir is None:
-        batchfiledir = pathlib.Path(prms.Paths.batchfiledir)
+        batchfiledir = pathlib.Path(config.paths.batchfiledir)
     else:
         batchfiledir = pathlib.Path(batchfiledir).resolve()
 
@@ -1305,7 +1306,7 @@ def _run_db(debug, silent):
     if debug:
         click.echo("running in debug-mode, but nothing to tell")
 
-    db_path = Path(prms.Paths.db_path) / prms.Paths.db_filename
+    db_path = Path(config.paths.db_path) / config.paths.db_filename
 
     if platform.system() == "Windows":
         try:
@@ -1346,7 +1347,7 @@ def pull(tests, examples, clone, directory, password):
     if directory is not None:
         click.echo(f"[cellpy] (pull) custom directory: {directory}")
     else:
-        directory = pathlib.Path(prmreader.prms.Paths.examplesdir)
+        directory = pathlib.Path(config.paths.examplesdir)
 
     if password is not None:
         click.echo("DEV MODE: password provided")
@@ -1469,7 +1470,7 @@ def _get_pw(method):
 
 def _pull(gdirpath="examples", rootpath=None, u=None, pw=None):
     if rootpath is None:
-        rootpath = prmreader.prms.Paths.examplesdir
+        rootpath = config.paths.examplesdir
 
     rootpath = pathlib.Path(rootpath)
 
@@ -1526,7 +1527,7 @@ def _pull(gdirpath="examples", rootpath=None, u=None, pw=None):
 def _get_default_template():
     template = "standard"
     try:
-        template = prmreader.prms.Batch.template
+        template = config.batch.template
     except:
         logging.debug("You dont have any default template defined in you .conf file")
     return template
@@ -1534,7 +1535,7 @@ def _get_default_template():
 
 def _read_local_templates(local_templates_path=None):
     if local_templates_path is None:
-        local_templates_path = pathlib.Path(prmreader.prms.Paths.templatedir)
+        local_templates_path = pathlib.Path(config.paths.templatedir)
     templates = {}
     for p in list(local_templates_path.rglob("cellpy_cookie*.zip")):
         label = p.stem.strip()[len("cellpy_cookie_") :]
@@ -1669,7 +1670,7 @@ def _new(
 
         default_template = _get_default_template()
         local_templates = _read_local_templates()
-        local_templates_path = prmreader.prms.Paths.templatedir
+        local_templates_path = config.paths.templatedir
         registered_templates = REGISTERED_TEMPLATES
         click.echo(f"[cellpy] - default: {default_template}")
         click.echo("[cellpy] - registered templates (on github):")
@@ -1717,7 +1718,7 @@ def _new(
 
     if directory is None:
         logging.debug("no dir given")
-        directory = prms.Paths.notebookdir
+        directory = config.paths.notebookdir
 
     if not os.path.isdir(directory):
         click.echo("Sorry. This did not work as expected!")
@@ -1875,7 +1876,7 @@ def serve(lab, directory, executable):
     from cellpy.parameters import prms
 
     if directory is None:
-        directory = prms.Paths.notebookdir
+        directory = config.paths.notebookdir
     elif directory == "home":
         directory = Path().home()
     elif directory == "here":
@@ -1989,7 +1990,7 @@ def _cli_setup_interactive():
     click.echo(result.output)
     from pprint import pprint
 
-    pprint(prmreader.prms.Paths)
+    pprint(config.paths)
     click.echo(" conf-file ".center(80, "."))
     click.echo(init_file)
     click.echo()

--- a/cellpy/internals/connections.py
+++ b/cellpy/internals/connections.py
@@ -49,7 +49,7 @@ def check_connection(
     the OtherPath class has been updated to work with python >= 3.12.
 
     Args:
-        p (str, pathlib.Path or OtherPath, optional): The path to check. Defaults to prms.Paths.rawdatadir.
+        p (str, pathlib.Path or OtherPath, optional): The path to check. Defaults to config.paths.rawdatadir.
 
     """
     # Note: users run this function from helpers.py
@@ -61,8 +61,9 @@ def check_connection(
 
         # need to import prms here to avoid circular imports:
         from cellpy import prms
+        import cellpy.config as config
 
-        p = prms.Paths.rawdatadir
+        p = config.paths.rawdatadir
 
     # recreating the OtherPath object to OtherPath since core is imported in the top __init__.py
     # file resulting in isinstance(p, OtherPath) to be False

--- a/cellpy/log.py
+++ b/cellpy/log.py
@@ -1,4 +1,5 @@
 """Set up logger instance"""
+import cellpy.config as config
 
 import datetime
 import json
@@ -58,7 +59,7 @@ def setup_logging(
         elif custom_log_dir:
             log_dir = custom_log_dir
         else:
-            log_dir = os.path.abspath(prms.Paths.filelogdir)
+            log_dir = os.path.abspath(config.paths.filelogdir)
 
         if not os.path.isdir(log_dir):
             warning_txt = (

--- a/cellpy/parameters/internal_settings.py
+++ b/cellpy/parameters/internal_settings.py
@@ -1,9 +1,10 @@
 """Internal settings and definitions and functions for getting them."""
+import cellpy.config as config
 
 import logging
 import warnings
 from collections import UserDict
-from dataclasses import dataclass, fields, asdict
+from dataclasses import dataclass, field, fields, asdict
 from typing import List, Optional
 
 from . import externals as externals
@@ -142,7 +143,9 @@ class CellpyMetaCommon(CellpyMeta):
     cell_name: Optional[str] = None  # used as property
     start_datetime: Optional[str] = None
     time_zone: Optional[str] = None
-    comment: Optional[prms.CellPyDataConfig] = prms.CellInfo.comment
+    comment: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.comment
+    )
     file_errors: Optional[str] = None  # not in use at the moment
     raw_id: Optional[str] = None  # used as property
     cellpy_file_version: int = CELLPY_FILE_VERSION
@@ -154,53 +157,63 @@ class CellpyMetaCommon(CellpyMeta):
     tester_calibration_date: Optional[prms.CellPyDataConfig] = None
 
     # about cell
-    material: Optional[prms.CellPyDataConfig] = prms.Materials.default_material
+    material: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.materials.default_material
+    )
     # TODO @jepe: Maybe we should use values with units here instead (pint)?
-    mass: Optional[prms.CellPyDataConfig] = (
-        prms.Materials.default_mass
+    mass: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.materials.default_mass
     )  # active material
-    tot_mass: Optional[prms.CellPyDataConfig] = (
-        prms.Materials.default_mass
+    tot_mass: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.materials.default_mass
     )  # total material
-    nom_cap: Optional[prms.CellPyDataConfig] = (
-        prms.Materials.default_nom_cap
+    nom_cap: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.materials.default_nom_cap
     )  # nominal capacity   # used as property
-    nom_cap_specifics: Optional[prms.CellPyDataConfig] = (
-        prms.Materials.default_nom_cap_specifics
+    nom_cap_specifics: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.materials.default_nom_cap_specifics
     )  # nominal capacity type  # used as property
 
-    active_electrode_area: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.active_electrode_area
+    active_electrode_area: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.active_electrode_area
     )
-    active_electrode_thickness: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.active_electrode_thickness
+    active_electrode_thickness: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.active_electrode_thickness
     )
-    active_electrode_loading: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.active_electrode_loading
+    active_electrode_loading: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.active_electrode_loading
     )  # mAh/cm2
-    # volume: Optional[prms.CellPyDataConfig] = prms.CellInfo.volume  # cm3
+    # volume: Optional[prms.CellPyDataConfig] = config.defaults.cell_info.volume  # cm3
 
-    electrolyte_volume: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.electrolyte_volume
+    electrolyte_volume: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.electrolyte_volume
     )
-    electrolyte_type: Optional[prms.CellPyDataConfig] = prms.CellInfo.electrolyte_type
-    active_electrode_type: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.active_electrode_type
+    electrolyte_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.electrolyte_type
     )
-    counter_electrode_type: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.counter_electrode_type
+    active_electrode_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.active_electrode_type
     )
-    reference_electrode_type: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.reference_electrode_type
+    counter_electrode_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.counter_electrode_type
     )
-    experiment_type: Optional[prms.CellPyDataConfig] = prms.CellInfo.experiment_type
-    cell_type: Optional[prms.CellPyDataConfig] = prms.CellInfo.cell_type
-    separator_type: Optional[prms.CellPyDataConfig] = prms.CellInfo.separator_type
-    active_electrode_current_collector: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.active_electrode_current_collector
+    reference_electrode_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.reference_electrode_type
     )
-    reference_electrode_current_collector: Optional[prms.CellPyDataConfig] = (
-        prms.CellInfo.reference_electrode_current_collector
+    experiment_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.experiment_type
+    )
+    cell_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.cell_type
+    )
+    separator_type: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.separator_type
+    )
+    active_electrode_current_collector: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.active_electrode_current_collector
+    )
+    reference_electrode_current_collector: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.reference_electrode_current_collector
     )
 
 
@@ -215,9 +228,15 @@ class CellpyMetaIndividualTest(CellpyMeta):
     test_type: Optional[prms.CellPyDataConfig] = (
         None  # Not used (and might be put inside test_ID)
     )
-    voltage_lim_low: Optional[prms.CellPyDataConfig] = prms.CellInfo.voltage_lim_low
-    voltage_lim_high: Optional[prms.CellPyDataConfig] = prms.CellInfo.voltage_lim_high
-    cycle_mode: Optional[prms.CellPyDataConfig] = prms.Reader.cycle_mode
+    voltage_lim_low: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.voltage_lim_low
+    )
+    voltage_lim_high: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.defaults.cell_info.voltage_lim_high
+    )
+    cycle_mode: Optional[prms.CellPyDataConfig] = field(
+        default_factory=lambda: config.reader.cycle_mode
+    )
     test_ID: Optional[prms.CellPyDataConfig] = (
         None  # id for the test - currently just a number; could become a list or more in the future
     )

--- a/cellpy/parameters/prmreader.py
+++ b/cellpy/parameters/prmreader.py
@@ -12,6 +12,7 @@ from dataclasses import asdict
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+import cellpy.config as config
 from cellpy.config.legacy import (
     DEFAULT_FILENAME,
     DEFAULT_FILENAME_END,
@@ -66,7 +67,7 @@ def initialize():
 def _load_env_file():
     """Loads the environment file into ``os.environ`` (legacy OtherPath consumers)."""
 
-    env_file = pathlib.Path(prms.Paths.env_file)
+    env_file = pathlib.Path(config.paths.env_file)
     env_file_in_user_dir = pathlib.Path.home() / env_file.name
     if env_file.is_file():
         dotenv.load_dotenv(env_file)
@@ -264,7 +265,7 @@ def _save_current_prms_to_user_dir():
 def get_env_file_name():
     """Returns the location of the env-file"""
 
-    env_file = pathlib.Path(prms.Paths.env_file)
+    env_file = pathlib.Path(config.paths.env_file)
     return env_file
 
 
@@ -314,7 +315,7 @@ def _main():
     print("INFO:")
     info()
     print(prms)
-    pprint(str(prms.Batch.summary_plot_height_fractions), width=1)
+    pprint(str(config.batch.summary_plot_height_fractions), width=1)
 
 
 if __name__ == "__main__":

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -10,6 +10,8 @@ Examples:
     >>> c.save("super_battery_run.h5")
 """
 
+import cellpy.config as config
+
 import collections
 import copy
 import csv
@@ -238,8 +240,8 @@ class CellpyCell:
         """
         # TODO v 1.1: move to data (allow for multiple testers for same cell)
         if tester is None:
-            self.tester = prms.Instruments.tester
-            logging.debug(f"reading instrument from prms: {prms.Instruments}")
+            self.tester = config.instruments.tester
+            logging.debug(f"reading instrument from prms: {config.instruments}")
         else:
             self.tester = tester
 
@@ -264,7 +266,7 @@ class CellpyCell:
         self.profile = profile
 
         self.minimum_selection = {}
-        self.filestatuschecker = filestatuschecker or prms.Reader.filestatuschecker
+        self.filestatuschecker = filestatuschecker or config.reader.filestatuschecker
         self.forced_errors = 0
 
         self.file_names = filenames or []
@@ -295,18 +297,18 @@ class CellpyCell:
             "not_known",
         ]
         # - options
-        self.force_step_table_creation = prms.Reader.force_step_table_creation
-        self.force_all = prms.Reader.force_all
-        self.sep = prms.Reader.sep
+        self.force_step_table_creation = config.reader.force_step_table_creation
+        self.force_all = config.reader.force_all
+        self.sep = config.reader.sep
         self._cycle_mode = None
-        self.select_minimal = prms.Reader.select_minimal
-        self.limit_loaded_cycles = prms.Reader.limit_loaded_cycles
+        self.select_minimal = config.reader.select_minimal
+        self.limit_loaded_cycles = config.reader.limit_loaded_cycles
         self.limit_data_points = None
-        self.ensure_step_table = prms.Reader.ensure_step_table
-        self.ensure_summary_table = prms.Reader.ensure_summary_table
-        self.raw_datadir = internals.OtherPath(prms.Paths.rawdatadir)
-        self.cellpy_datadir = internals.OtherPath(prms.Paths.cellpydatadir)
-        self.auto_dirs = prms.Reader.auto_dirs  # v2.0
+        self.ensure_step_table = config.reader.ensure_step_table
+        self.ensure_summary_table = config.reader.ensure_summary_table
+        self.raw_datadir = internals.OtherPath(config.paths.rawdatadir)
+        self.cellpy_datadir = internals.OtherPath(config.paths.cellpydatadir)
+        self.auto_dirs = config.reader.auto_dirs  # v2.0
 
         # - headers and instruments
         self.headers_normal = headers_normal
@@ -842,11 +844,11 @@ class CellpyCell:
         if instrument and instrument.endswith(".yml"):
             instrument_file = instrument
             instrument = "local_instrument"
-            prms.Instruments.custom_instrument_definitions_file = instrument_file
+            config.instruments.custom_instrument_definitions_file = instrument_file
             if _override_local_instrument_path:
                 instrument_file = Path(instrument_file)
             else:
-                instrument_file = Path(prms.Paths.instrumentdir) / instrument_file
+                instrument_file = Path(config.paths.instrumentdir) / instrument_file
 
             if not instrument_file.is_file():
                 raise FileNotFoundError(f"Could not locate {instrument_file}")
@@ -1330,7 +1332,7 @@ class CellpyCell:
         except AttributeError:
             logging.debug("could not set instrument name")
 
-        max_raw_files_to_merge = prms.Reader.max_raw_files_to_merge
+        max_raw_files_to_merge = config.reader.max_raw_files_to_merge
         if len(self.file_names) > max_raw_files_to_merge:
             logging.debug("ERROR? Too many files to merge")
             raise ValueError(
@@ -1390,7 +1392,7 @@ class CellpyCell:
 
         logging.debug("finished loading the raw-files")
 
-        if not prms.Reader.sorted_data:
+        if not config.reader.sorted_data:
             logging.debug("sorting data")
             data = self._sort_data(data)
 
@@ -1995,7 +1997,7 @@ class CellpyCell:
         #     # for arbin at least).
         #     raise NotImplementedError
 
-        step_specs = externals.pandas.read_csv(file_name, sep=prms.Reader.sep)
+        step_specs = externals.pandas.read_csv(file_name, sep=config.reader.sep)
         if "step" not in step_specs.columns:
             logging.info("Missing column: step")
             raise IOError
@@ -3756,7 +3758,7 @@ class CellpyCell:
 
         if interpolated:
             if dx is None and number_of_points is None:
-                dx = prms.Reader.time_interpolation_step
+                dx = config.reader.time_interpolation_step
             new_dfs = list()
             groupby_list = [cycle_label, step_label]
 
@@ -4736,7 +4738,7 @@ class CellpyCell:
             ensure_step_table = self.ensure_step_table
 
         if use_cellpy_stat_file is None:
-            use_cellpy_stat_file = prms.Reader.use_cellpy_stat_file
+            use_cellpy_stat_file = config.reader.use_cellpy_stat_file
             logging.debug("using use_cellpy_stat_file from prms")
             logging.debug(f"use_cellpy_stat_file: {use_cellpy_stat_file}")
 

--- a/cellpy/readers/dbreader.py
+++ b/cellpy/readers/dbreader.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from . import externals as externals
 from cellpy.parameters import prms
 from cellpy.readers import data_structures as core
+import cellpy.config as config
 
 # logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ class DbSheetCols:
     # Note to developers: this should only be used for this Excell reader
     # (it works, and that is its only reason to still exist)
     def __init__(self):
-        db_cols_from_prms = asdict(prms.DbCols)
+        db_cols_from_prms = asdict(config.db_cols)
         self.keys = []
         self.headers = []
         for table_key, value in db_cols_from_prms.items():
@@ -52,29 +53,29 @@ class Reader(core.BaseSimpleDbReader):
             batch_col_name (str): name of the column in the db-file that contains the batch name.
         """
 
-        self.db_sheet_table = prms.Db.db_table_name
-        self.db_header_row = prms.Db.db_header_row
-        self.db_unit_row = prms.Db.db_unit_row
-        self.db_data_start_row = prms.Db.db_data_start_row
-        self.db_search_start_row = prms.Db.db_search_start_row
-        self.db_search_end_row = prms.Db.db_search_end_row
+        self.db_sheet_table = config.db.db_table_name
+        self.db_header_row = config.db.db_header_row
+        self.db_unit_row = config.db.db_unit_row
+        self.db_data_start_row = config.db.db_data_start_row
+        self.db_search_start_row = config.db.db_search_start_row
+        self.db_search_end_row = config.db.db_search_end_row
 
         self.db_sheet_cols = DbSheetCols()
         self.selected_batch = None
 
         if not db_datadir:
-            self.db_datadir = prms.Paths.rawdatadir
+            self.db_datadir = config.paths.rawdatadir
         else:
             self.db_datadir = db_datadir
 
         if not db_datadir_processed:
-            self.db_datadir_processed = prms.Paths.cellpydatadir
+            self.db_datadir_processed = config.paths.cellpydatadir
         else:
             self.db_datadir_processed = db_datadir_processed
 
         if not db_file:
-            self.db_path = prms.Paths.db_path
-            self.db_filename = prms.Paths.db_filename
+            self.db_path = config.paths.db_path
+            self.db_filename = config.paths.db_filename
             self.db_file = os.path.join(self.db_path, self.db_filename)
         else:
             self.db_path = os.path.dirname(db_file)
@@ -483,8 +484,8 @@ class Reader(core.BaseSimpleDbReader):
             logging.warning(
                 "Could not read the cycle mode (using value from prms instead)"
             )
-            logging.debug(f"cycle mode: {prms.Reader.cycle_mode}")
-            return prms.Reader.cycle_mode
+            logging.debug(f"cycle mode: {config.reader.cycle_mode}")
+            return config.reader.cycle_mode
 
     def get_loading(self, serial_number):
         column_name = self.db_sheet_cols.loading

--- a/cellpy/readers/filefinder.py
+++ b/cellpy/readers/filefinder.py
@@ -14,6 +14,7 @@ from . import externals as externals
 import cellpy.exceptions
 from cellpy.parameters import prms
 from cellpy.internals.connections import OtherPath
+import cellpy.config as config
 
 
 # TODO: @jepe - add function for dumping the raw-file directory to a file,
@@ -76,7 +77,7 @@ def find_in_raw_file_directory(
     file_list = []
 
     if raw_file_dir is None:
-        raw_file_dir = prms.Paths.rawdatadir
+        raw_file_dir = config.paths.rawdatadir
 
     # 'dressing' the raw_file_dir in a list in case we want to
     # search in several folders (not implemented yet):
@@ -182,7 +183,7 @@ def list_raw_file_directory(
     file_list = []
 
     if raw_file_dir is None:
-        raw_file_dir = prms.Paths.rawdatadir
+        raw_file_dir = config.paths.rawdatadir
 
     # 'dressing' the raw_file_dir in a list in case we want to
     # search in several folders (not implemented yet):
@@ -274,16 +275,16 @@ def search_for_files(
     t0 = time.time()
 
     if reg_exp is None:
-        reg_exp = prms.FileNames.reg_exp
+        reg_exp = config.file_names.reg_exp
 
     if raw_extension is None:
-        raw_extension = prms.FileNames.raw_extension
+        raw_extension = config.file_names.raw_extension
 
     if raw_extension is None:
-        raw_extension = prms.FileNames.raw_extension
+        raw_extension = config.file_names.raw_extension
 
     if cellpy_file_extension is None:
-        cellpy_file_extension = prms.FileNames.cellpy_file_extension
+        cellpy_file_extension = config.file_names.cellpy_file_extension
 
     # backward compatibility check:
     if cellpy_file_extension.startswith("."):
@@ -293,10 +294,10 @@ def search_for_files(
         cellpy_file_extension = cellpy_file_extension[1:]
 
     if raw_file_dir is None:
-        raw_file_dir = prms.Paths.rawdatadir
+        raw_file_dir = config.paths.rawdatadir
 
     if file_name_format is None:
-        file_name_format = prms.FileNames.file_name_format
+        file_name_format = config.file_names.file_name_format
 
     # 'dressing' the raw_file_dir in a list in case we want to
     # search in several folders (not implemented yet):
@@ -316,14 +317,14 @@ def search_for_files(
         logging.debug("Sorry, reading prm file is not implemented yet.")
 
     if cellpy_file_dir is None:
-        cellpy_file_dir = OtherPath(prms.Paths.cellpydatadir)
+        cellpy_file_dir = OtherPath(config.paths.cellpydatadir)
     else:
         cellpy_file_dir = OtherPath(cellpy_file_dir)
 
     if file_name_format is None and reg_exp is None:
         try:
             # To be implemented in version 0.5:
-            file_name_format = prms.FileNames.file_name_format
+            file_name_format = config.file_names.file_name_format
         except AttributeError:
             file_name_format = "YYYYMMDD_[name]EEE_CC_TT_RR"
 
@@ -471,7 +472,7 @@ def _check_03():
     from cellpy import prms
     from pprint import pprint
 
-    prms.Paths.rawdatadir = r"C:\scripting\processing_cellpy\raw"
+    config.paths.rawdatadir = r"C:\scripting\processing_cellpy\raw"
     file_list = list_raw_file_directory(
         raw_file_dir=None,
         project_dir=None,

--- a/cellpy/readers/instruments/arbin_res.py
+++ b/cellpy/readers/instruments/arbin_res.py
@@ -1,4 +1,5 @@
 """arbin res-type data files"""
+import cellpy.config as config
 
 import logging
 import os
@@ -28,7 +29,7 @@ from cellpy.readers.instruments.base import MINIMUM_SELECTION, BaseLoader
 
 # TODO: use InstrumentSettings (dataclass) from internal_settings instead of HeaderDict.
 
-DEBUG_MODE = prms.Reader.diagnostics
+DEBUG_MODE = config.reader.diagnostics
 ALLOW_MULTI_TEST_FILE = False
 USE_SQLALCHEMY_ACCESS_ENGINE = True
 
@@ -36,8 +37,8 @@ USE_SQLALCHEMY_ACCESS_ENGINE = True
 ODBC = prms._odbc
 SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver
 
-_use_subprocess = prms.Instruments.Arbin.use_subprocess
-_detect_subprocess_need = prms.Instruments.Arbin.detect_subprocess_need
+_use_subprocess = config.instruments.Arbin.use_subprocess
+_detect_subprocess_need = config.instruments.Arbin.detect_subprocess_need
 
 _is_posix = False
 _is_macos = False
@@ -58,7 +59,7 @@ if DEBUG_MODE:
 if _detect_subprocess_need:
     logging.debug("detect_subprocess_need is True: checking versions")
     python_version, os_version = platform.architecture()
-    if python_version == "64bit" and prms.Instruments.Arbin.office_version == "32bit":
+    if python_version == "64bit" and config.instruments.Arbin.office_version == "32bit":
         logging.debug("python 64bit and office 32bit -> setting use_subprocess to True")
         _use_subprocess = True
 
@@ -67,16 +68,16 @@ if _use_subprocess and not _is_posix:
     logging.debug(
         "using subprocess (most likely mdbtools) on non-posix (most likely windows)"
     )
-    if not prms.Instruments.Arbin.sub_process_path:
+    if not config.instruments.Arbin.sub_process_path:
         _sub_process_path = str(prms.sub_process_path)
     else:
-        _sub_process_path = str(prms.Instruments.Arbin.sub_process_path)
+        _sub_process_path = str(config.instruments.Arbin.sub_process_path)
 
 if _is_posix:
     _sub_process_path = "mdb-export"
 
 try:
-    driver_dll = prms.Instruments.Arbin.odbc_driver
+    driver_dll = config.instruments.Arbin.odbc_driver
 except AttributeError:
     driver_dll = None
 
@@ -147,7 +148,7 @@ NORMAL_HEADERS_RENAMING_DICT = {
 class DataLoader(BaseLoader):
     """Class for loading arbin-data from res-files.
 
-    Parameters from configuration (`prms.Instruments.Arbin`)::
+    Parameters from configuration (`config.instruments.Arbin`)::
 
         - max_res_filesize: break if file size exceeds this limit.
         - chunk_size: size of chunks to load.
@@ -171,7 +172,7 @@ class DataLoader(BaseLoader):
         self.logger = logging.getLogger(__name__)
         # use the following prm to limit to loading only
         # one cycle or from cycle>x to cycle<x+n
-        # prms.Reader.limit_loaded_cycles = [cycle from, cycle to]
+        # config.reader.limit_loaded_cycles = [cycle from, cycle to]
 
         self.arbin_headers_normal = (
             self.get_headers_normal()
@@ -565,7 +566,7 @@ class DataLoader(BaseLoader):
             )
             # TODO 216: add order by on test_time as well in sql query
             summary_df = self._load_res_summary_table(conn, test_id)
-            if summary_df.empty and prms.Reader.use_cellpy_stat_file:
+            if summary_df.empty and config.reader.use_cellpy_stat_file:
                 txt = "\nCould not find any summary (stats-file)!"
                 txt += "\n -> issue make_summary(use_cellpy_stat_file=False)"
                 logging.debug(txt)
@@ -750,7 +751,7 @@ class DataLoader(BaseLoader):
             aux_global_data_df, aux_df, normal_df
         )
 
-        if summary_df.empty and prms.Reader.use_cellpy_stat_file:
+        if summary_df.empty and config.reader.use_cellpy_stat_file:
             txt = "\nCould not find any summary (stats-file)!"
             txt += "\n -> issue make_summary(use_cellpy_stat_file=False)"
             logging.debug(txt)
@@ -775,13 +776,13 @@ class DataLoader(BaseLoader):
         hfilesize = humanize_bytes(file_size)
         txt = f"File size: {file_size} ({hfilesize})"
         self.logger.debug(txt)
-        if file_size > prms.Instruments.Arbin.max_res_filesize:
+        if file_size > config.instruments.Arbin.max_res_filesize:
             error_message = "\nERROR (loader):\n"
             error_message += (
-                f"{hfilesize} > {humanize_bytes(prms.Instruments.Arbin.max_res_filesize)} "
+                f"{hfilesize} > {humanize_bytes(config.instruments.Arbin.max_res_filesize)} "
                 f"- File is too big!\n"
             )
-            error_message += "(edit prms.Instruments.Arbin ['max_res_filesize'])\n"
+            error_message += "(edit config.instruments.Arbin ['max_res_filesize'])\n"
             logging.critical(error_message)
             return False
         return True
@@ -996,16 +997,16 @@ class DataLoader(BaseLoader):
 
                 normal_df = normal_df.loc[~selector, :]
 
-        if prms.Reader.limit_loaded_cycles:
+        if config.reader.limit_loaded_cycles:
             logging.debug("Not yet tested for aux data")
-            if len(prms.Reader.limit_loaded_cycles) > 1:
-                c1, c2 = prms.Reader.limit_loaded_cycles
+            if len(config.reader.limit_loaded_cycles) > 1:
+                c1, c2 = config.reader.limit_loaded_cycles
                 selector = (
                     normal_df[self.arbin_headers_normal.cycle_index_txt] > c1
                 ) & (normal_df[self.arbin_headers_normal.cycle_index_txt] < c2)
 
             else:
-                c1 = prms.Reader.limit_loaded_cycles[0]
+                c1 = config.reader.limit_loaded_cycles[0]
                 selector = normal_df[self.arbin_headers_normal.cycle_index_txt] == c1
 
             normal_df = normal_df.loc[selector, :]
@@ -1113,7 +1114,7 @@ class DataLoader(BaseLoader):
 
         table_name_normal = TABLE_NAMES["normal"]
 
-        if prms.Reader.select_minimal:  # SETTING
+        if config.reader.select_minimal:  # SETTING
             columns = MINIMUM_SELECTION
             columns_txt = ", ".join(["%s"] * len(columns)) % tuple(columns)
         else:
@@ -1137,20 +1138,20 @@ class DataLoader(BaseLoader):
                 )
                 sql_4 += f"AND {self.arbin_headers_normal.step_index_txt}={bad_step}) "
 
-        if prms.Reader.limit_loaded_cycles:
-            if len(prms.Reader.limit_loaded_cycles) > 1:
+        if config.reader.limit_loaded_cycles:
+            if len(config.reader.limit_loaded_cycles) > 1:
                 sql_4 += "AND %s>%i " % (
                     self.arbin_headers_normal.cycle_index_txt,
-                    prms.Reader.limit_loaded_cycles[0],
+                    config.reader.limit_loaded_cycles[0],
                 )
                 sql_4 += "AND %s<%i " % (
                     self.arbin_headers_normal.cycle_index_txt,
-                    prms.Reader.limit_loaded_cycles[-1],
+                    config.reader.limit_loaded_cycles[-1],
                 )
             else:
                 sql_4 = "AND %s=%i " % (
                     self.arbin_headers_normal.cycle_index_txt,
-                    prms.Reader.limit_loaded_cycles[0],
+                    config.reader.limit_loaded_cycles[0],
                 )
 
         if data_points is not None:
@@ -1170,20 +1171,20 @@ class DataLoader(BaseLoader):
             current_memory_usage = sys.getsizeof(self)
             self.logger.debug(f"current memory usage: {current_memory_usage}")
 
-        if not prms.Instruments.Arbin.chunk_size:
+        if not config.instruments.Arbin.chunk_size:
             self.logger.debug("no chunk-size given")
             # memory here
             normal_df = pd.read_sql_query(sql=sa.text(sql), con=conn.connect())
             # memory here
             length_of_test = normal_df.shape[0]
         else:
-            self.logger.debug(f"chunk-size: {prms.Instruments.Arbin.chunk_size}")
+            self.logger.debug(f"chunk-size: {config.instruments.Arbin.chunk_size}")
             self.logger.debug("creating a pd.read_sql_query generator")
 
             normal_df_reader = pd.read_sql_query(
                 sql=sa.text(sql),
                 con=conn.connect(),
-                chunksize=prms.Instruments.Arbin.chunk_size,
+                chunksize=config.instruments.Arbin.chunk_size,
             )
             normal_df = None
             chunk_number = 0
@@ -1191,15 +1192,15 @@ class DataLoader(BaseLoader):
             self.logger.debug("iterating chunk-wise")
             for i, chunk in enumerate(normal_df_reader):
                 self.logger.debug(f"iteration number {i}")
-                if prms.Instruments.Arbin.max_chunks:
+                if config.instruments.Arbin.max_chunks:
                     self.logger.debug(
                         f"max number of chunks mode "
-                        f"({prms.Instruments.Arbin.max_chunks})"
+                        f"({config.instruments.Arbin.max_chunks})"
                     )
-                    if chunk_number < prms.Instruments.Arbin.max_chunks:
+                    if chunk_number < config.instruments.Arbin.max_chunks:
                         normal_df = pd.concat([normal_df, chunk], ignore_index=True)
                         self.logger.debug(
-                            f"chunk {i} of {prms.Instruments.Arbin.max_chunks}"
+                            f"chunk {i} of {config.instruments.Arbin.max_chunks}"
                         )
                     else:
                         break
@@ -1215,7 +1216,7 @@ class DataLoader(BaseLoader):
                             f"Last successfully loaded chunk number: {chunk_number}"
                         )
                         self.logger.error(
-                            f"Chunk size: {prms.Instruments.Arbin.chunk_size}"
+                            f"Chunk size: {config.instruments.Arbin.chunk_size}"
                         )
                         break
                 chunk_number += 1

--- a/cellpy/readers/instruments/arbin_sql.py
+++ b/cellpy/readers/instruments/arbin_sql.py
@@ -1,4 +1,5 @@
 """arbin MS SQL Server data"""
+import cellpy.config as config
 
 import datetime
 import logging
@@ -25,19 +26,16 @@ from cellpy.readers.data_structures import (
     xldate_as_datetime,
 )
 from cellpy.readers.instruments.base import BaseLoader
+from cellpy.readers.instruments.arbin_sql_config import arbin_sql_value
 
 # TODO: @muhammad - get more meta data from the SQL db
 # TODO: @jepe - update the batch functionality (including filefinder)
 # TODO: @muhammad - make routine for "setting up the SQL Server" so that it is accessible and document it
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 ODBC = prms._odbc
 SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver  # not used
-SQL_SERVER = prms.Instruments.Arbin["SQL_server"]
-SQL_UID = prms.Instruments.Arbin["SQL_UID"]
-SQL_PWD = prms.Instruments.Arbin["SQL_PWD"]
-SQL_DRIVER = prms.Instruments.Arbin["SQL_Driver"]
 DATE_TIME_FORMAT = prms._date_time_format
 
 # Names of the tables in the SQL Server db that is used by cellpy
@@ -143,7 +141,7 @@ class DataLoader(BaseLoader):
         self.arbin_headers_aux_global = self.get_headers_aux_global()
         self.arbin_headers_aux = self.get_headers_aux()
         self.current_chunk = 0  # use this to set chunks to load
-        self.server = SQL_SERVER
+        self.server = arbin_sql_value("SQL_server")
 
     @staticmethod
     def get_headers_normal():
@@ -259,7 +257,7 @@ class DataLoader(BaseLoader):
 
         # selecting only one value (might implement multi-channel/id use later)
         test_id = data_df["Test_ID"].iloc[0]
-        id_name = f"{SQL_SERVER}:{name}:{test_id}"
+        id_name = f"{arbin_sql_value('SQL_server')}:{name}:{test_id}"
 
         channel_id = data_df["Channel_ID"].iloc[0]
 
@@ -365,7 +363,8 @@ class DataLoader(BaseLoader):
         # TODO: refactor and include optional SQL arguments
         name_str = f"('{name}', '')"
         con_str = (
-            f"Driver={{{SQL_DRIVER}}};" + f"Server={SQL_SERVER};Trusted_Connection=yes;"
+            f"Driver={{{arbin_sql_value('SQL_Driver')}}};"
+            + f"Server={arbin_sql_value('SQL_server')};Trusted_Connection=yes;"
         )
 
         # TODO: use variable for the name of the main db (ArbinPro8....)
@@ -478,7 +477,7 @@ def _check_query():
     import pathlib
 
     name = ["20201106_HC03B1W_1_cc_01"]
-    dd, ds = check_sql_loader(SQL_SERVER, name)
+    dd, ds = check_sql_loader(arbin_sql_value("SQL_server"), name)
     out = pathlib.Path(r"C:\scripts\notebooks\Div")
     input("x")
 

--- a/cellpy/readers/instruments/arbin_sql_7.py
+++ b/cellpy/readers/instruments/arbin_sql_7.py
@@ -1,4 +1,5 @@
 """arbin MS SQL Server data for MITS 7.0"""
+import cellpy.config as config
 
 import datetime
 import logging
@@ -27,19 +28,16 @@ from cellpy.readers.data_structures import (
     xldate_as_datetime,
 )
 from cellpy.readers.instruments.base import BaseLoader
+from cellpy.readers.instruments.arbin_sql_config import arbin_sql_value
 
 # TODO: @muhammad - get more meta data from the SQL db
 # TODO: @jepe - update the batch functionality (including filefinder)
 # TODO: @muhammad - make routine for "setting up the SQL Server" so that it is accessible and document it
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 ODBC = prms._odbc
 SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver  # not used
-SQL_SERVER = prms.Instruments.Arbin["SQL_server"]
-SQL_UID = prms.Instruments.Arbin["SQL_UID"]
-SQL_PWD = prms.Instruments.Arbin["SQL_PWD"]
-SQL_DRIVER = prms.Instruments.Arbin["SQL_Driver"]
 
 # Names of the tables in the SQL Server db that is used by cellpy
 
@@ -144,7 +142,7 @@ class DataLoader(BaseLoader):
         self.arbin_headers_aux_global = self.get_headers_aux_global()
         self.arbin_headers_aux = self.get_headers_aux()
         self.current_chunk = 0  # use this to set chunks to load
-        self.server = SQL_SERVER
+        self.server = arbin_sql_value("SQL_server")
 
     @staticmethod
     def get_headers_normal():
@@ -265,7 +263,7 @@ class DataLoader(BaseLoader):
         # init data
         # selecting only one value (might implement id selection later)
         test_id = meta_data["Test_ID"].iloc[0]
-        id_name = f"{SQL_SERVER}:{self.name}:{test_id}"
+        id_name = f"{arbin_sql_value('SQL_server')}:{self.name}:{test_id}"
 
         channel_id = meta_data["IV_Ch_ID"][0]
 
@@ -368,11 +366,11 @@ class DataLoader(BaseLoader):
 
         # prepare engine
         params = urllib.parse.quote_plus(
-            f"DRIVER={SQL_DRIVER};"
-            f"SERVER={SQL_SERVER};"
+            f"DRIVER={arbin_sql_value('SQL_Driver')};"
+            f"SERVER={arbin_sql_value('SQL_server')};"
             f"DATABASE=ArbinMasterData;"
-            f"UID={SQL_UID};"
-            f"PWD={SQL_PWD}"
+            f"UID={arbin_sql_value('SQL_UID')};"
+            f"PWD={arbin_sql_value('SQL_PWD')}"
         )
 
         # Create engine to SQL server using SQLAlchemy (mssql+pyodbc)
@@ -512,7 +510,7 @@ def _check_query():
     import pathlib
 
     name = ["20201106_HC03B1W_1_cc_01"]
-    dd, ds = check_sql_loader(SQL_SERVER, name)
+    dd, ds = check_sql_loader(arbin_sql_value("SQL_server"), name)
     out = pathlib.Path(r"C:\scripts\notebooks\Div")
     input("x")
 

--- a/cellpy/readers/instruments/arbin_sql_config.py
+++ b/cellpy/readers/instruments/arbin_sql_config.py
@@ -1,0 +1,58 @@
+"""Shared Arbin SQL credential resolution for instrument loaders."""
+
+from __future__ import annotations
+
+import os
+
+import cellpy.config as config
+
+_DEFAULTS = {
+    "SQL_server": r"localhost\SQLEXPRESS",
+    "SQL_UID": "sa",
+    "SQL_PWD": "ChangeMe123",
+    "SQL_Driver": "SQL Server",
+}
+
+_SECRET_MAP = {
+    "SQL_server": "host",
+    "SQL_UID": "user",
+    "SQL_PWD": "password",
+}
+
+
+def arbin_sql_value(key: str) -> str:
+    """Resolve a legacy Arbin SQL setting from secrets, extras, or defaults."""
+
+    secret_field = _SECRET_MAP.get(key)
+    if secret_field is not None:
+        secret_val = getattr(config.secrets, secret_field, None)
+        if secret_val:
+            return secret_val
+        env_key = {
+            "host": "CELLPY_HOST",
+            "user": "CELLPY_USER",
+            "password": "CELLPY_PASSWORD",
+        }[secret_field]
+        env_val = os.getenv(env_key)
+        if env_val:
+            return env_val
+
+    arbin = config.instruments.Arbin
+    if hasattr(arbin, key):
+        value = getattr(arbin, key)
+        if value is not None:
+            return value
+    extras = arbin.model_extra or {}
+    if key in extras and extras[key] is not None:
+        return extras[key]
+    return _DEFAULTS[key]
+
+
+def set_arbin_sql_value(key: str, value: str) -> None:
+    """Write a legacy Arbin SQL setting (secrets for auth fields)."""
+
+    secret_field = _SECRET_MAP.get(key)
+    if secret_field is not None:
+        setattr(config.secrets, secret_field, value)
+        return
+    setattr(config.instruments.Arbin, key, value)

--- a/cellpy/readers/instruments/arbin_sql_csv.py
+++ b/cellpy/readers/instruments/arbin_sql_csv.py
@@ -1,4 +1,5 @@
 """arbin MS SQL Server csv data"""
+import cellpy.config as config
 
 import pandas as pd
 from dateutil.parser import parse
@@ -10,7 +11,7 @@ from cellpy.readers.instruments.base import BaseLoader
 
 headers_normal = get_headers_normal()
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 
 # Not used yet - only supporting loading raw data (normal)
@@ -213,8 +214,8 @@ class DataLoader(BaseLoader):
         return data
 
     def _query_csv(self, name):
-        # NOTE! I am using the prms.Reader.sep prm as the delimiter.
-        data_df = pd.read_csv(name, sep=prms.Reader.sep)
+        # NOTE! I am using the config.reader.sep prm as the delimiter.
+        data_df = pd.read_csv(name, sep=config.reader.sep)
         return data_df
 
 
@@ -306,7 +307,7 @@ def _check_seamless_files():
     c = cellreader.CellpyCell()
     c.set_instrument("arbin_sql_csv")
 
-    prms.Reader.sep = ";"
+    config.reader.sep = ";"
 
     c.from_raw(name1)
     c.set_mass(0.016569)

--- a/cellpy/readers/instruments/arbin_sql_h5.py
+++ b/cellpy/readers/instruments/arbin_sql_h5.py
@@ -1,4 +1,5 @@
 """arbin MS SQL Server exported h5 data"""
+import cellpy.config as config
 
 import datetime
 import logging
@@ -16,7 +17,7 @@ from cellpy.readers.data_structures import Data, FileID
 from cellpy.readers.instruments.base import BaseLoader
 from pathlib import Path
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 DATE_TIME_FORMAT = prms._date_time_format  # not used
 

--- a/cellpy/readers/instruments/arbin_sql_xlsx.py
+++ b/cellpy/readers/instruments/arbin_sql_xlsx.py
@@ -1,4 +1,5 @@
 """arbin MS SQL Server csv data"""
+import cellpy.config as config
 
 import logging
 import pathlib
@@ -16,7 +17,7 @@ from cellpy.readers.instruments.base import BaseLoader
 
 headers_normal = get_headers_normal()
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 
 SHEET_NAME_KEYWORD = "Channel"

--- a/cellpy/readers/instruments/batmo_bdf.py
+++ b/cellpy/readers/instruments/batmo_bdf.py
@@ -1,4 +1,5 @@
 """ batmo outputs in BDF format. """
+import cellpy.config as config
 
 import pandas as pd
 
@@ -32,7 +33,7 @@ class DataLoader(TxtLoader):
     instrument_name = "batmo"
     raw_ext = "csv"
 
-    default_model = prms.Instruments.Batmo["default_model"]  # Required
+    default_model = config.instruments.Batmo.default_model  # Required
     supported_models = SUPPORTED_MODELS  # Required
 
     def _post_rename_headers(self, data):

--- a/cellpy/readers/instruments/custom.py
+++ b/cellpy/readers/instruments/custom.py
@@ -2,6 +2,7 @@
 If no ``instrument_file`` is given (either directly or through the use
 of the ``::`` separator), the default instrument file (yaml) will be used.
 """
+import cellpy.config as config
 
 # This module works, but is by no means finished. The module is meant to
 # be developed further allowing for example
@@ -36,7 +37,7 @@ class DataLoader(AutoLoader, ABC):
             # currently using the name custom_instrument_definitions_file for this also
             # consider adding a separate config parameter for the default instrument file
             # e.g. local_instrument_default_file
-            instrument_file = prms.Instruments.custom_instrument_definitions_file
+            instrument_file = config.instruments.custom_instrument_definitions_file
         if not instrument_file:
             raise FileExistsError(
                 "Missing instrument definition file "
@@ -44,7 +45,7 @@ class DataLoader(AutoLoader, ABC):
             )
         if not Path(instrument_file).is_file():
             # searching in the Instruments folder:
-            instrument_dir = Path(prms.Paths.instrumentdir)
+            instrument_dir = Path(config.paths.instrumentdir)
             logging.debug(f"Looking for file in {instrument_dir}")
             instrument_file_in_instrument_dir = instrument_dir / instrument_file
             if not instrument_file_in_instrument_dir.is_file():

--- a/cellpy/readers/instruments/local_instrument.py
+++ b/cellpy/readers/instruments/local_instrument.py
@@ -5,7 +5,8 @@ As a "short-cut", this loader will be used if you set the ``instrument``
 to the name of the instrument file (with the ``.yml`` extension) e.g.
 ``c = cellpy.get(rawfile, instrument="instrumentfile.yml")``.
 The default instrument file is defined in the cellpy configuration file
-(available through ``prms.Instruments.custom_instrument_definitions_file``)."""
+(available through ``config.instruments.custom_instrument_definitions_file``)."""
+import cellpy.config as config
 
 from cellpy.readers.instruments.base import TxtLoader
 from cellpy.readers.instruments.configurations import (

--- a/cellpy/readers/instruments/maccor_txt.py
+++ b/cellpy/readers/instruments/maccor_txt.py
@@ -1,4 +1,5 @@
 """Maccor txt data"""
+import cellpy.config as config
 
 import pandas as pd
 
@@ -42,7 +43,7 @@ class DataLoader(TxtLoader):
     instrument_name = "maccor_txt"
     raw_ext = "txt"
 
-    default_model = prms.Instruments.Maccor["default_model"]  # Required
+    default_model = config.instruments.Maccor.default_model  # Required
     supported_models = SUPPORTED_MODELS  # Required
 
     @staticmethod
@@ -92,7 +93,7 @@ def _check_retrieve_file(n=1):
     import pathlib
 
     pd.options.display.max_columns = 100
-    # prms.Reader.sep = "\t"
+    # config.reader.sep = "\t"
     data_root = pathlib.Path(r"C:\scripting\cellpy_dev_resources")
     data_dir = data_root / r"2021_leafs_data\Charge-Discharge\Maccor series 4000"
     if n == 2:
@@ -112,7 +113,7 @@ def _check_dev_loader(name=None, model=None):
         name = check_retrieve_file()
 
     pd.options.display.max_columns = 100
-    # prms.Reader.sep = "\t"
+    # config.reader.sep = "\t"
 
     sep = "\t"
     loader1 = DataLoader(sep=sep, model=model)
@@ -154,7 +155,7 @@ def c_heck_loader(name=None, number=1, model="one"):
         name = check_retrieve_file(number)
     print(name)
     pd.options.display.max_columns = 100
-    # prms.Reader.sep = "\t"
+    # config.reader.sep = "\t"
 
     loader = DataLoader(sep="\t", model=model)
     dd = loader.loader(name)

--- a/cellpy/readers/instruments/neware_nda.py
+++ b/cellpy/readers/instruments/neware_nda.py
@@ -7,13 +7,14 @@ from cellpy.readers.instruments.base import BaseLoader
 from cellpy import prms
 from cellpy.parameters.internal_settings import HeaderDict, get_headers_normal
 from cellpy.readers.data_structures import Data
+import cellpy.config as config
 
 headers_normal = get_headers_normal()
 
 """Neware NDA (or NDAX) data"""
 
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 DATE_TIME_FORMAT = prms._date_time_format  # not used
 USE_LOCAL_FASTNDA = prms._use_local_fastnda

--- a/cellpy/readers/instruments/neware_txt.py
+++ b/cellpy/readers/instruments/neware_txt.py
@@ -37,6 +37,7 @@
 
 5. Put a file in test_data and create at least one test.
 """
+import cellpy.config as config
 
 import pandas as pd
 
@@ -77,7 +78,7 @@ class DataLoader(TxtLoader):
     instrument_name = "neware_txt"
     raw_ext = "csv"
 
-    default_model = prms.Instruments.Neware["default_model"]  # Required
+    default_model = config.instruments.Neware.default_model  # Required
     supported_models = SUPPORTED_MODELS  # Required
 
     @staticmethod

--- a/cellpy/readers/instruments/neware_xlsx.py
+++ b/cellpy/readers/instruments/neware_xlsx.py
@@ -1,4 +1,5 @@
 """neware xlsx exported data"""
+import cellpy.config as config
 
 from dataclasses import dataclass
 import datetime
@@ -20,7 +21,7 @@ from cellpy.readers.instruments.base import BaseLoader
 from cellpy.readers.instruments.processors import post_processors as pp
 from pathlib import Path
 
-DEBUG_MODE = prms.Reader.diagnostics  # not used
+DEBUG_MODE = config.reader.diagnostics  # not used
 ALLOW_MULTI_TEST_FILE = prms._allow_multi_test_file  # not used
 DATE_TIME_FORMAT = prms._date_time_format  # not used
 

--- a/cellpy/readers/sql_dbreader.py
+++ b/cellpy/readers/sql_dbreader.py
@@ -1,4 +1,5 @@
 """This module is an example of how to implement a custom database reader for the batch utility in cellpy."""
+import cellpy.config as config
 
 import logging
 import pathlib
@@ -27,11 +28,11 @@ from cellpy.parameters.internal_settings import (
 from cellpy.readers.data_structures import BaseSimpleDbReader
 
 # ----------------- USED WHEN CONVERTING FROM EXCEL -----------------
-DB_FILE_EXCEL = prms.Paths.db_filename
-DB_FILE_SQLITE = prms.Db.db_file_sqlite
-TABLE_NAME_EXCEL = prms.Db.db_table_name
-HEADER_ROW = prms.Db.db_header_row
-UNIT_ROW = prms.Db.db_unit_row
+DB_FILE_EXCEL = config.paths.db_filename
+DB_FILE_SQLITE = config.db.db_file_sqlite
+TABLE_NAME_EXCEL = config.db.db_table_name
+HEADER_ROW = config.db.db_header_row
+UNIT_ROW = config.db.db_unit_row
 
 # ------------------- USED BY NEW CELLPY DB --------------------------
 DB_URI = f"sqlite:///cellpy.db"

--- a/cellpy/utils/batch.py
+++ b/cellpy/utils/batch.py
@@ -1,4 +1,5 @@
 """Routines for batch processing of cells (v2)."""
+import cellpy.config as config
 
 import logging
 import os
@@ -876,7 +877,7 @@ class Batch:
         logging.info(f"project: {self.experiment.journal.project}")
 
         if auto_use_file_list is None:
-            auto_use_file_list = prms.Batch.auto_use_file_list
+            auto_use_file_list = config.batch.auto_use_file_list
 
         to_project_folder = kwargs.pop("to_project_folder", False)
         # Backward compatibility: accept both old and new parameter names
@@ -970,11 +971,11 @@ class Batch:
                 duplicate_to_project_folder=duplicate_to_project_folder,
             )
 
-            if to_project_folder and pathlib.Path(prms.Paths.batchfiledir).is_dir():
+            if to_project_folder and pathlib.Path(config.paths.batchfiledir).is_dir():
                 logging.debug(
                     "duplicating journal to batch directory (will be a deprecated feature in the future)"
                 )
-                self.duplicate_journal(prms.Paths.batchfiledir)
+                self.duplicate_journal(config.paths.batchfiledir)
 
         else:
             is_str = isinstance(description, str)
@@ -1078,8 +1079,8 @@ class Batch:
             )
             self.experiment.journal.generate_folder_names(use_outdatadir=False)
             self.experiment.journal.paginate()
-            if to_project_folder and pathlib.Path(prms.Paths.batchfiledir).is_dir():
-                self.duplicate_journal(prms.Paths.batchfiledir)
+            if to_project_folder and pathlib.Path(config.paths.batchfiledir).is_dir():
+                self.duplicate_journal(config.paths.batchfiledir)
 
     def _create_folder_structure(self) -> None:
         warnings.warn("Deprecated - use paginate instead.", DeprecationWarning)
@@ -1096,7 +1097,7 @@ class Batch:
         """Save journal and cellpy files.
 
         The journal file will be saved in the project directory and in the
-        batch-file-directory (``prms.Paths.batchfiledir``). The latter is useful
+        batch-file-directory (``config.paths.batchfiledir``). The latter is useful
         for processing several batches using the ``iterate_batches`` functionality.
 
         The name and location of the cellpy files is determined by the journal pages.
@@ -1109,13 +1110,13 @@ class Batch:
         """Save the journal (json-format).
 
         The journal file will be saved to the current directory by default. Optionally,
-        it can be copied to the project directory in prms.Paths.outdatadir and/or
-        the batch-file-directory (``prms.Paths.batchfiledir``).
+        it can be copied to the project directory in config.paths.outdatadir and/or
+        the batch-file-directory (``config.paths.batchfiledir``).
 
         Args:
             paginate (bool): paginate the journal pages, i.e. create a project folder structure inside your
                 'out' folder (default False).
-            duplicate_to_project_folder (bool): if True, copy the journal to prms.Paths.outdatadir/project/
+            duplicate_to_project_folder (bool): if True, copy the journal to config.paths.outdatadir/project/
                 (default False).
         """
 
@@ -1132,10 +1133,10 @@ class Batch:
             logging.info("copied journal pages to project folder")
 
         if (
-            pathlib.Path(prms.Paths.batchfiledir).is_dir()
+            pathlib.Path(config.paths.batchfiledir).is_dir()
             and duplicate_to_project_folder
         ):
-            self.duplicate_journal(prms.Paths.batchfiledir)
+            self.duplicate_journal(config.paths.batchfiledir)
             logging.info("duplicated journal pages to batch dir")
 
     def export_journal(self, filename=None) -> None:
@@ -1179,7 +1180,7 @@ class Batch:
         """
 
         pages = self.experiment.journal.pages
-        cellpy_file_dir = OtherPath(prms.Paths.cellpydatadir)
+        cellpy_file_dir = OtherPath(config.paths.cellpydatadir)
 
         if location == "standard":
             batch_data_dir = pathlib.Path("data") / "interim"
@@ -1406,7 +1407,7 @@ class Batch:
             self.summary_collector.do(reset=True)
 
         if backend is None:
-            backend = prms.Batch.backend
+            backend = config.batch.backend
             if backend in ["bokeh", "matplotlib"]:
                 logging.debug(
                     f"over-riding default backend ('{backend}' will soon be deprecated)"
@@ -1414,7 +1415,7 @@ class Batch:
                 backend = "plotly"
 
         if backend in ["bokeh", "matplotlib", "plotly", "seaborn"]:
-            prms.Batch.backend = backend
+            config.batch.backend = backend
 
         if backend == "bokeh":
             print("...Using old plotter - this will change soon")
@@ -1467,25 +1468,25 @@ class Batch:
             self.summary_collector.do(reset=True)
 
         if backend is None:
-            backend = prms.Batch.backend
+            backend = config.batch.backend
 
         if backend in ["bokeh", "matplotlib"]:
-            prms.Batch.backend = backend
+            config.batch.backend = backend
 
         if backend == "bokeh":
             try:
                 import bokeh.plotting  # pyright: ignore[reportMissingImports]
 
-                prms.Batch.backend = "bokeh"
+                config.batch.backend = "bokeh"
 
                 if output_filename is not None:
                     bokeh.plotting.output_file(output_filename)
                 else:
-                    if prms.Batch.notebook:
+                    if config.batch.notebook:
                         bokeh.plotting.output_notebook()
 
             except ModuleNotFoundError:
-                prms.Batch.backend = "matplotlib"
+                config.batch.backend = "matplotlib"
                 logging.warning(
                     "could not find the bokeh module -> using matplotlib instead"
                 )
@@ -1984,9 +1985,9 @@ def process_batch(*args, **kwargs) -> Batch:
     backend = kwargs.pop("backend", None)
 
     if backend is not None:
-        prms.Batch.backend = backend
+        config.batch.backend = backend
     else:
-        prms.Batch.backend = "matplotlib"
+        config.batch.backend = "matplotlib"
 
     dpi = kwargs.pop("dpi", 300)
 
@@ -2137,12 +2138,12 @@ def _check_standard():
     out_data_path = Path(out_data_path)
 
     logging.info("---SETTING SOME PRMS---")
-    prms.Paths.db_filename = "cellpy_db.xlsx"
-    prms.Paths.cellpydatadir = test_data_path / "hdf5"
-    prms.Paths.outdatadir = out_data_path
-    prms.Paths.rawdatadir = test_data_path / "data"
-    prms.Paths.db_path = test_data_path / "db"
-    prms.Paths.filelogdir = test_data_path / "log"
+    config.paths.db_filename = "cellpy_db.xlsx"
+    config.paths.cellpydatadir = test_data_path / "hdf5"
+    config.paths.outdatadir = out_data_path
+    config.paths.rawdatadir = test_data_path / "data"
+    config.paths.db_path = test_data_path / "db"
+    config.paths.filelogdir = test_data_path / "log"
 
     project = "prebens_experiment"
     name = "test"

--- a/cellpy/utils/batch_tools/batch_experiments.py
+++ b/cellpy/utils/batch_tools/batch_experiments.py
@@ -16,6 +16,7 @@ from cellpy.internals.connections import OtherPath
 from cellpy.utils.batch_tools import batch_helpers as helper
 from cellpy.utils.batch_tools.batch_core import BaseExperiment
 from cellpy.utils.batch_tools.batch_journals import LabJournal
+import cellpy.config as config
 
 hdr_journal = get_headers_journal()
 hdr_summary = get_headers_summary()
@@ -403,14 +404,14 @@ class CyclingExperiment(BaseExperiment):
             if hdr_journal.nom_cap_specifics in row:
                 nom_cap_specifics = row[hdr_journal.nom_cap_specifics]
             else:
-                nom_cap_specifics = prms.Materials.default_nom_cap_specifics
+                nom_cap_specifics = config.defaults.materials.default_nom_cap_specifics
             if hdr_journal.loading in row:
                 loading = row[hdr_journal.loading]
             if hdr_journal.area in row:
                 area = row[hdr_journal.area]
 
             summary_kwargs = {
-                "use_cellpy_stat_file": prms.Reader.use_cellpy_stat_file,
+                "use_cellpy_stat_file": config.reader.use_cellpy_stat_file,
                 "find_ir": find_ir,
             }
 
@@ -556,7 +557,7 @@ class CyclingExperiment(BaseExperiment):
                 pbar.set_description(n_txt, refresh=True)
                 cell_data.to_csv(
                     self.journal.raw_dir,
-                    sep=prms.Reader.sep,
+                    sep=config.reader.sep,
                     cycles=self.export_cycles,
                     shifted=self.shifted_cycles,
                     raw=self.export_raw,
@@ -569,7 +570,7 @@ class CyclingExperiment(BaseExperiment):
                     helper.export_dqdv(
                         cell_data,
                         savedir=self.journal.raw_dir,
-                        sep=prms.Reader.sep,
+                        sep=config.reader.sep,
                         last_cycle=self.last_cycle,
                     )
                 except Exception as e:
@@ -752,7 +753,7 @@ class CyclingExperiment(BaseExperiment):
                     area = row[hdr_journal.area]
 
                 summary_kwargs = {
-                    "use_cellpy_stat_file": prms.Reader.use_cellpy_stat_file,
+                    "use_cellpy_stat_file": config.reader.use_cellpy_stat_file,
                     "find_ir": find_ir,
                     "find_end_voltage": find_end_voltage,
                 }
@@ -878,7 +879,7 @@ class CyclingExperiment(BaseExperiment):
                     pbar.set_description(n_txt, refresh=True)
                     cell_data.to_csv(
                         self.journal.raw_dir,
-                        sep=prms.Reader.sep,
+                        sep=config.reader.sep,
                         cycles=self.export_cycles,
                         shifted=self.shifted_cycles,
                         raw=self.export_raw,
@@ -891,7 +892,7 @@ class CyclingExperiment(BaseExperiment):
                         helper.export_dqdv(
                             cell_data,
                             savedir=self.journal.raw_dir,
-                            sep=prms.Reader.sep,
+                            sep=config.reader.sep,
                             last_cycle=self.last_cycle,
                         )
                     except Exception as e:

--- a/cellpy/utils/batch_tools/batch_helpers.py
+++ b/cellpy/utils/batch_tools/batch_helpers.py
@@ -9,6 +9,7 @@ import pandas as pd
 import cellpy.parameters.internal_settings
 from cellpy import filefinder, prms
 from cellpy.readers import data_structures as core
+import cellpy.config as config
 
 hdr_summary = cellpy.parameters.internal_settings.get_headers_summary()
 hdr_journal = cellpy.parameters.internal_settings.get_headers_journal()
@@ -47,7 +48,7 @@ def create_folder_structure(project_name, batch_name):
     Returns: (info_file, (project_dir, batch_dir, raw_dir))
 
     """
-    out_data_dir = prms.Paths.outdatadir
+    out_data_dir = config.paths.outdatadir
     project_dir = os.path.join(out_data_dir, project_name)
     batch_dir = os.path.join(project_dir, batch_name)
     raw_dir = os.path.join(batch_dir, "raw_data")
@@ -120,7 +121,7 @@ def find_files(
     if skip_file_search:
         return info_dict
 
-    sub_folders = sub_folders or prms.FileNames.sub_folders
+    sub_folders = sub_folders or config.file_names.sub_folders
     instrument_factory = create_factory()
     file_name_indicators = info_dict.get(
         hdr_journal["file_name_indicator"], hdr_journal["filename"]
@@ -141,7 +142,7 @@ def find_files(
             instrument = info_dict[hdr_journal["instrument"]][i]
             raw_ext = instrument_factory.query(instrument, "raw_ext")
             if raw_ext:
-                prms.FileNames.raw_extension = raw_ext
+                config.file_names.raw_extension = raw_ext
         except IndexError:
             warnings.warn(f"no instrument given for {run_name}")
 
@@ -356,7 +357,7 @@ def join_summaries(
 def generate_folder_names(name, project):
     """Creates sensible folder names."""
 
-    out_data_dir = prms.Paths.outdatadir
+    out_data_dir = config.paths.outdatadir
     project_dir = os.path.join(out_data_dir, project)
     batch_dir = os.path.join(project_dir, name)
     raw_dir = os.path.join(batch_dir, "raw_data")

--- a/cellpy/utils/batch_tools/batch_journals.py
+++ b/cellpy/utils/batch_tools/batch_journals.py
@@ -11,6 +11,7 @@ from abc import ABC
 import pandas as pd
 
 from cellpy.exceptions import UnderDefined
+import cellpy.config as config
 from cellpy.parameters import prms
 from cellpy.parameters.internal_settings import (
     get_headers_journal,
@@ -73,7 +74,7 @@ class LabJournal(BaseJournal, ABC):
                 self.db_reader = None
                 return
             if db_reader == "default":
-                db_reader = prms.Db.db_type
+                db_reader = config.db.db_type
 
             if db_reader == "simple_excel_reader":
                 self.db_reader = dbreader.Reader()
@@ -174,9 +175,9 @@ class LabJournal(BaseJournal, ABC):
         else:
             file_name = pathlib.Path(file_name)
         if to_project_folder:
-            # When saving to project folder, use prms.Paths.outdatadir
+            # When saving to project folder, use config.paths.outdatadir
             file_name = file_name.with_suffix(".json").name
-            out_data_dir = prms.Paths.outdatadir
+            out_data_dir = config.paths.outdatadir
             project_dir = pathlib.Path(out_data_dir) / self.project
             file_name = project_dir / file_name
         self.file_name = file_name  # updates object (maybe not smart)
@@ -667,9 +668,9 @@ class LabJournal(BaseJournal, ABC):
         Args:
             file_name (str or pathlib.Path): journal file name (.json or .xlsx)
             paginate (bool): make project folders
-            to_project_folder (bool): if True, save journal file to prms.Paths.outdatadir/project/
+            to_project_folder (bool): if True, save journal file to config.paths.outdatadir/project/
                 (default False, saves to current directory)
-            duplicate_to_project_folder (bool): if True, copy journal file to prms.Paths.outdatadir/project/
+            duplicate_to_project_folder (bool): if True, copy journal file to config.paths.outdatadir/project/
                 after saving to current directory (default False)
             duplicate_to_local_folder (bool): Deprecated. For backward compatibility only.
                 If provided, it is ignored since the default behavior now saves to current directory.
@@ -750,9 +751,9 @@ class LabJournal(BaseJournal, ABC):
             self.paginate()
 
         if duplicate_to_project_folder:
-            # Copy to prms.Paths.outdatadir/project/ if requested
+            # Copy to config.paths.outdatadir/project/ if requested
             if self.project:
-                out_data_dir = prms.Paths.outdatadir
+                out_data_dir = config.paths.outdatadir
                 project_dir = pathlib.Path(out_data_dir) / self.project
                 project_dir.mkdir(parents=True, exist_ok=True)
                 target_file = project_dir / file_name.name
@@ -810,7 +811,7 @@ class LabJournal(BaseJournal, ABC):
         """Set appropriate folder names.
 
         Args:
-            use_outdatadir (bool): if True, use prms.Paths.outdatadir as base for all directories,
+            use_outdatadir (bool): if True, use config.paths.outdatadir as base for all directories,
                 otherwise use current_directory as base.
         """
         logging.debug("creating folder names")
@@ -819,7 +820,7 @@ class LabJournal(BaseJournal, ABC):
             if self.project and isinstance(self.project, (pathlib.Path, str)):
                 logging.debug("got project name")
                 logging.debug(self.project)
-                self.project_dir = os.path.join(prms.Paths.outdatadir, self.project)
+                self.project_dir = os.path.join(config.paths.outdatadir, self.project)
             else:
                 logging.critical(
                     "Could not create project dir (missing project definition)"
@@ -835,7 +836,7 @@ class LabJournal(BaseJournal, ABC):
             self.project_dir = pathlib.Path.cwd()
             if self.project and isinstance(self.project, (pathlib.Path, str)):
                 self.legacy_project_dir = os.path.join(
-                    prms.Paths.outdatadir, self.project
+                    config.paths.outdatadir, self.project
                 )
             else:
                 logging.critical(
@@ -970,7 +971,7 @@ class LabJournal(BaseJournal, ABC):
         self, cellpy_directory: pathlib.Path = None
     ) -> None:
         if cellpy_directory is None:
-            cellpy_directory = prms.Paths.cellpydatadir
+            cellpy_directory = config.paths.cellpydatadir
         try:
             pages = self.pages.copy()
             pages[hdr_journal.cellpy_file_name] = self.pages[
@@ -1034,7 +1035,7 @@ class LabJournal(BaseJournal, ABC):
         """generate a suitable file name for the experiment
 
         Args:
-            to_project_folder (bool): if True, save to prms.Paths.outdatadir/project/,
+            to_project_folder (bool): if True, save to config.paths.outdatadir/project/,
                 otherwise save to current directory (default False)
         """
         if not self.name:
@@ -1045,7 +1046,7 @@ class LabJournal(BaseJournal, ABC):
         if to_project_folder:
             if not self.project:
                 raise UnderDefined("project name not given")
-            out_data_dir = prms.Paths.outdatadir
+            out_data_dir = config.paths.outdatadir
             project_dir = pathlib.Path(out_data_dir) / self.project
             self.file_name = project_dir / file_name
         else:

--- a/cellpy/utils/batch_tools/batch_plotters.py
+++ b/cellpy/utils/batch_tools/batch_plotters.py
@@ -15,6 +15,7 @@ from cellpy.exceptions import UnderDefined
 from cellpy.parameters.internal_settings import get_headers_journal, get_headers_summary
 from cellpy.utils.batch_tools.batch_core import BasePlotter
 from cellpy.utils.batch_tools.batch_experiments import CyclingExperiment
+import cellpy.config as config
 
 
 plotly_available = importlib.util.find_spec("plotly") is not None
@@ -92,7 +93,7 @@ def create_plot_option_dicts(
         try:
             # palette = bokeh.palettes.brewer['YlGnBu']
             palette = bokeh.palettes.d3["Category20"]
-            # palette = bokeh.palettes.brewer[prms.Batch.bokeh_palette']
+            # palette = bokeh.palettes.brewer[config.batch.bokeh_palette']
         except (NameError, AttributeError) as e:
             logging.info(f"could not create the palette {e}")
             palette = {
@@ -341,7 +342,7 @@ def plot_cycle_life_summary_bokeh(
     if height_fractions is None:
         height_fractions = [0.3, 0.4, 0.3]
     logging.debug(f"   * stacking and plotting")
-    logging.debug(f"      backend: {prms.Batch.backend}")
+    logging.debug(f"      backend: {config.batch.backend}")
     logging.debug(f"      received kwargs: {kwargs}")
 
     idx = pd.IndexSlice
@@ -587,7 +588,7 @@ def plot_cycle_life_summary_matplotlib(
     )
 
     logging.debug(f"   * stacking and plotting")
-    logging.debug(f"      backend: {prms.Batch.backend}")
+    logging.debug(f"      backend: {config.batch.backend}")
     logging.debug(f"      received kwargs: {kwargs}")
 
     # Not used (yet?) - requires a more advanced generation of sub-plots
@@ -726,8 +727,8 @@ def summary_plotting_engine(**kwargs):
     experiments = kwargs.pop("experiments")
     farms = kwargs.pop("farms")
     barn = None
-    backend = prms.Batch.backend
-    logging.debug(f"Using {prms.Batch.backend} for plotting summaries")
+    backend = config.batch.backend
+    logging.debug(f"Using {config.batch.backend} for plotting summaries")
     if backend not in available_plotting_backends:
         warnings.warn(f"The back-end {backend} is not available.")
         warnings.warn(f"Available back-ends are: {available_plotting_backends}")
@@ -760,7 +761,7 @@ def summary_plotting_engine(**kwargs):
 
 def generate_summary_plots(experiment, **kwargs):
     pages = experiment.journal.pages
-    backend = prms.Batch.backend
+    backend = config.batch.backend
     plotters = {
         "plotly": plot_cycle_life_summary_plotly,
         "seaborn": plot_cycle_life_summary_seaborn,
@@ -1353,20 +1354,20 @@ def _get_ranges(summaries, plotted_summaries, defaults=None):
 def _plotting_data_legacy(pages, summaries, width, height, height_fractions, **kwargs):
     # sub-sub-engine
     canvas = None
-    if prms.Batch.backend == "bokeh":
+    if config.batch.backend == "bokeh":
         canvas = plot_cycle_life_summary_bokeh(
             pages, summaries, width, height, height_fractions, **kwargs
         )
-    elif prms.Batch.backend == "plotly":
+    elif config.batch.backend == "plotly":
         print("plotly not implemented yet")
 
-    elif prms.Batch.backend == "matplotlib":
+    elif config.batch.backend == "matplotlib":
         logging.info("[obs! experimental]")
         canvas = plot_cycle_life_summary_matplotlib(
             pages, summaries, width, height, height_fractions, **kwargs
         )
     else:
-        logging.info(f"the {prms.Batch.backend} back-end is not implemented yet.")
+        logging.info(f"the {config.batch.backend} back-end is not implemented yet.")
 
     return canvas
 
@@ -1376,11 +1377,11 @@ def _preparing_data_and_plotting_legacy(**kwargs):
     logging.debug("    - _preparing_data_and_plotting_legacy")
     experiments = kwargs.pop("experiments")
     farms = kwargs.pop("farms")
-    width = kwargs.pop("width", prms.Batch.summary_plot_width)
-    height = kwargs.pop("height", prms.Batch.summary_plot_height)
+    width = kwargs.pop("width", config.batch.summary_plot_width)
+    height = kwargs.pop("height", config.batch.summary_plot_height)
 
     height_fractions = kwargs.pop(
-        "height_fractions", prms.Batch.summary_plot_height_fractions
+        "height_fractions", config.batch.summary_plot_height_fractions
     )
 
     for experiment in experiments:

--- a/cellpy/utils/batch_tools/dumpers.py
+++ b/cellpy/utils/batch_tools/dumpers.py
@@ -2,6 +2,7 @@
 Keyword Args: experiments, farms, barn, engine
 Returns nothing.
 """
+import cellpy.config as config
 
 import logging
 import os
@@ -39,7 +40,7 @@ def csv_dumper(**kwargs):
             file_name = os.path.join(out_dir, "summary_%s_%s.csv" % (animal.name, name))
             logging.debug(f"processing {name}::{animal.name}")
             logging.info(f"-> {file_name}")
-            animal.to_csv(file_name, sep=prms.Reader.sep)
+            animal.to_csv(file_name, sep=config.reader.sep)
 
 
 def excel_dumper(**kwargs):

--- a/cellpy/utils/batch_tools/sqlite_from_excel_db.py
+++ b/cellpy/utils/batch_tools/sqlite_from_excel_db.py
@@ -7,17 +7,18 @@ import sqlalchemy as sa
 import pandas as pd
 
 import cellpy
+import cellpy.config as config
 from cellpy import prms
 from cellpy.parameters.internal_settings import (
     TABLE_NAME_SQLITE,
     COLUMNS_RENAMER,
 )
 
-DB_FILE_EXCEL = prms.Paths.db_filename
-DB_FILE_SQLITE = prms.Db.db_file_sqlite
-TABLE_NAME_EXCEL = prms.Db.db_table_name
-HEADER_ROW = prms.Db.db_header_row
-UNIT_ROW = prms.Db.db_unit_row
+DB_FILE_EXCEL = config.paths.db_filename
+DB_FILE_SQLITE = config.db.db_file_sqlite
+TABLE_NAME_EXCEL = config.db.db_table_name
+HEADER_ROW = config.db.db_header_row
+UNIT_ROW = config.db.db_unit_row
 
 
 @dataclass
@@ -29,10 +30,10 @@ class DbColsRenamer:
 
 
 def create_column_names_from_prms():
-    """Create a list of DbColsRenamer objects from the cellpy.prms.DbCols object."""
-    logging.debug(cellpy.prms.DbCols.keys())
+    """Create a list of DbColsRenamer objects from the cellpy.config.db_cols object."""
+    logging.debug(cellpy.config.db_cols.keys())
     logging.debug("----")
-    attrs = cellpy.prms.DbCols.keys()
+    attrs = cellpy.config.db_cols.keys()
     dtypes = cellpy.prms._db_cols_unit
     columns = []
     for attr in attrs:
@@ -43,7 +44,7 @@ def create_column_names_from_prms():
         col = DbColsRenamer(
             cellpy_col=attr,
             dtype=getattr(dtypes, attr),
-            excel_col=getattr(cellpy.prms.DbCols, attr),
+            excel_col=getattr(cellpy.config.db_cols, attr),
             db_col=db_col,
         )
         columns.append(col)
@@ -126,9 +127,9 @@ def clean_up(df, columns):
 
 def run():
     db_exel_file = (
-        pathlib.Path(cellpy.prms.Paths.db_path) / cellpy.prms.Paths.db_filename
+        pathlib.Path(cellpy.config.paths.db_path) / cellpy.config.paths.db_filename
     )
-    db_sqlite_file = pathlib.Path(cellpy.prms.Paths.db_path) / DB_FILE_SQLITE
+    db_sqlite_file = pathlib.Path(cellpy.config.paths.db_path) / DB_FILE_SQLITE
     columns = create_column_names_from_prms()
     df = load_xlsx(db_file=db_exel_file)
     df = clean_up(df, columns=columns)
@@ -140,7 +141,7 @@ def main():
     if not db_exel_file.exists():
         print(f"File not found: {db_exel_file}")
         sys.exit(1)
-    db_sqlite_file = pathlib.Path(cellpy.prms.Paths.db_path) / DB_FILE_SQLITE
+    db_sqlite_file = pathlib.Path(cellpy.config.paths.db_path) / DB_FILE_SQLITE
     columns = create_column_names_from_prms()
     df = load_xlsx(db_file=db_exel_file)
     df = clean_up(df, columns=columns)
@@ -149,8 +150,8 @@ def main():
 
 def _check():
     print("Settings:")
-    print(f"{cellpy.prms.Paths.db_path=}")
-    print(f"{cellpy.prms.Paths.db_filename=}")
+    print(f"{cellpy.config.paths.db_path=}")
+    print(f"{cellpy.config.paths.db_filename=}")
 
     print("But choosing:")
     db_exel_file = pathlib.Path("2022_Cell_Analysis_db_001.xlsx").resolve()

--- a/cellpy/utils/easyplot.py
+++ b/cellpy/utils/easyplot.py
@@ -4,6 +4,8 @@ Author: Amund M. Raniseth
 Date: 01.07.2021
 """
 
+import cellpy.config as config
+
 import logging
 import os
 import warnings
@@ -466,13 +468,15 @@ class EasyPlot:
         pwd="Changeme123",
         driver="ODBC Driver 17 for SQL Server",
     ):
-        """Sets cellpy.prms.Instruments.Arbin details to fit what is inserted.
+        """Sets cellpy.config.instruments.Arbin details to fit what is inserted.
         Parameters: Server = 'IP of server', uid = 'username', pwd = 'password', driver = 'ODBC Driver 17 for SQL Server'
         """
-        cellpy.prms.Instruments.Arbin["SQL_server"] = server
-        cellpy.prms.Instruments.Arbin["SQL_UID"] = uid
-        cellpy.prms.Instruments.Arbin["SQL_PWD"] = pwd
-        cellpy.prms.Instruments.Arbin["SQL_Driver"] = driver
+        from cellpy.readers.instruments.arbin_sql_config import set_arbin_sql_value
+
+        set_arbin_sql_value("SQL_server", server)
+        set_arbin_sql_value("SQL_UID", uid)
+        set_arbin_sql_value("SQL_PWD", pwd)
+        set_arbin_sql_value("SQL_Driver", driver)
         self.use_arbin_sql = True
 
     def give_color(self):

--- a/cellpy/utils/example_data.py
+++ b/cellpy/utils/example_data.py
@@ -1,4 +1,5 @@
 """Tools for getting some data to play with"""
+import cellpy.config as config
 
 from enum import Enum
 import logging
@@ -45,14 +46,14 @@ You can set up cellpy through the command line interface:
 or you can set the path to the example data directory manually in your script:
 
     >>> from cellpy import prms
-    >>> prms.Paths.examplesdir = "/path/to/your/example/data"
+    >>> config.paths.examplesdir = "/path/to/your/example/data"
 
 """
 
 
 def _user_examples_dir():
     """Get the path to the user's examples directory"""
-    examples_dir = Path(prms.Paths.examplesdir)
+    examples_dir = Path(config.paths.examplesdir)
     if not examples_dir.is_dir():
         warnings.warn(f"Could not find {examples_dir}")
         print(_example_data_download_help)

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -10,6 +10,7 @@ import pandas as pd
 from scipy import stats
 
 import cellpy
+import cellpy.config as config
 from cellpy import prms
 from cellpy.parameters.internal_settings import (
     get_headers_journal,
@@ -175,7 +176,7 @@ def update_journal_cellpy_data_dir(
 
     Args:
         pages: the (batch.experiment.)journal.pages object (pandas.DataFrame)
-        new_path: the base path (uses prms.Paths.cellpydatadir if not given)
+        new_path: the base path (uses config.paths.cellpydatadir if not given)
         from_path: type of path to convert from.
         to_path: type of path to convert to.
 
@@ -186,7 +187,7 @@ def update_journal_cellpy_data_dir(
     # TODO: move this to batch?
 
     if new_path is None:
-        new_path = prms.Paths.cellpydatadir
+        new_path = config.paths.cellpydatadir
 
     from_path = getattr(pathlib, from_path)
     to_path = getattr(pathlib, to_path)
@@ -1589,7 +1590,7 @@ def load_and_save_resfile(filename, outfile=None, outdir=None, mass=1.00):
     d = CellpyCell()
 
     if not outdir:
-        outdir = prms.Paths.cellpydatadir
+        outdir = config.paths.cellpydatadir
 
     if not outfile:
         outfile = os.path.basename(filename).split(".")[0] + ".h5"


### PR DESCRIPTION
## Summary

- Mechanical migration of internal `prms.<Section>` access to `cellpy.config.<section>` across ~32 production files (readers, utils, CLI).
- Adds `arbin_sql_config.py` for shared Arbin SQL credential resolution (secrets, extras, env, defaults).
- Replaces import-time Arbin SQL module constants with lazy `arbin_sql_value()`; fixes instrument `default_model` and `easyplot` SQL mutation paths.
- Fixes codemod-damaged multi-line imports and defers `cellpy.config` import in `connections.py` to avoid circular import.
- Adds `.issueflows/00-tools/migrate_prms_calls.py` codemod helper.

Depends on M1 (merged #494). M3 (import-time init removal) follows in a stacked PR.

## Test plan

- [x] `uv run pytest tests/test_config.py tests/test_prms.py tests/test_prms_shim.py`
- [x] `uv run pytest -m essential` (93 passed)


Made with [Cursor](https://cursor.com)