### PR TITLE
Stage 1.8 M3: remove import-time config init (#453)

### DIFF
--- a/.issueflows/01-current-issues/issue453_status.md
+++ b/.issueflows/01-current-issues/issue453_status.md
@@ -6,19 +6,13 @@
 
 - Plan accepted (2026-07-14).
 - **Milestone 1 (shim + legacy load)** — merged via PR #494 on `master`.
-- **Milestone 2 (internal call-site migration)** — branch `453-prms-m2-migrate`:
-  - Mechanical `prms.<Section>` → `cellpy.config.<section>` in ~32 files under `cellpy/`
-  - `cellpy/parameters/internal_settings.py` — dataclass defaults use lazy `default_factory`
-  - `cellpy/readers/instruments/arbin_sql_config.py` — shared Arbin SQL credential resolution
-  - `arbin_sql.py` / `arbin_sql_7.py` — lazy SQL settings via `arbin_sql_value()`
-  - Instrument `default_model` — attribute access on pydantic models
-  - `easyplot.py` — `set_arbin_sql_value()` for SQL mutation
-  - Fixed broken multi-line imports from codemod (`prmreader`, `helpers`, batch tools)
-  - Fixed circular import: `connections.py` defers `cellpy.config` import
-  - Helper: `.issueflows/00-tools/migrate_prms_calls.py`
+- **Milestone 2 (internal call-site migration)** — PR #495 on `453-prms-m2-migrate`.
+- **Milestone 3 (kill import-time init)** — branch `453-prms-m3-no-import-init`:
+  - Removed `init()` call and `init` from `cellpy/__init__.py`
+  - Added `test_import_cellpy_no_file_io` (subprocess; no config file reads on import)
   - Essential gate green: `uv run pytest -m essential` (93 passed)
 
 ## Remaining work
 
-- **Milestone 3:** remove import-time `initialize()` from `cellpy/__init__.py` + import-io test
+- Merge M2 PR #495, then M3 PR (stacked)
 - `/iflow-close`

--- a/cellpy/__init__.py
+++ b/cellpy/__init__.py
@@ -32,10 +32,8 @@ from cellpy.readers import cellreader, dbreader, filefinder, do
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-# TODO: (v2.0) remove this and enforce using for example `import cellpy.session as clp` and then
-#  run `prmreader.initialize` in that `__init__` instead:
-init = parameters.prmreader.initialize
-init()
+# Config loads lazily on first ``cellpy.config`` / ``config.*`` access, or via
+# ``cellpy.parameters.prmreader.initialize()`` (issue #453).
 
 # TODO: (v2.0) remove this and enforce using `cellpy.get` (or `cellpy.cellreader.get`) instead:
 get = cellreader.get
@@ -49,7 +47,6 @@ __all__ = [
     "filefinder",
     "get",
     "do",
-    "init",
     # "ureg",
     # "Q",
 ]

--- a/tests/test_prms_shim.py
+++ b/tests/test_prms_shim.py
@@ -69,3 +69,48 @@ Reader:
     )
     assert result.config.reader.cycle_mode == "cathode"
     assert result.provenance.get("reader.cycle_mode") == SourceLayer.USER_FILE
+
+
+@pytest.mark.essential
+def test_import_cellpy_no_file_io():
+    """``import cellpy`` must not read config files (issue #453 acceptance)."""
+
+    import subprocess
+    import sys
+
+    script = """
+import builtins
+from pathlib import Path
+
+reads = []
+_real_open = builtins.open
+
+def _track_open(path, *args, **kwargs):
+    reads.append(str(path))
+    return _real_open(path, *args, **kwargs)
+
+builtins.open = _track_open
+_real_read_text = Path.read_text
+
+def _track_read_text(self, *args, **kwargs):
+    reads.append(str(self))
+    return _real_read_text(self, *args, **kwargs)
+
+Path.read_text = _track_read_text
+
+import cellpy  # noqa: F401
+
+config_reads = [
+    p
+    for p in reads
+    if ".cellpy_prms" in p or p.endswith("cellpy.toml") or p.endswith(".env_cellpy")
+]
+assert not config_reads, config_reads
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- Removes automatic `prmreader.initialize()` from `cellpy/__init__.py` (drops `init` from `__all__`).
- Config now loads lazily on first `cellpy.config` access, or explicitly via `prmreader.initialize()`.
- Adds `test_import_cellpy_no_file_io` — essential acceptance test that `import cellpy` performs no config file reads.

**Stacked on M2:** merge #495 first, then this PR (or merge this into M2 branch and re-target to `master` after M2 lands).

## Test plan

- [x] `uv run pytest tests/test_prms_shim.py::test_import_cellpy_no_file_io`
- [x] `uv run pytest -m essential` (93 passed, on M2+M3 branch)


Made with [Cursor](https://cursor.com)