### PR TITLE
feat(units): delegate duplicated converters to cellpycore.units (Stage 1.6, #451)

### DIFF
--- a/.issueflows/03-solved-issues/issue451_original.md
+++ b/.issueflows/03-solved-issues/issue451_original.md
@@ -1,0 +1,18 @@
+# Issue #451 — Stage 1.6: Units Phase 2 — delegate the duplicated converters to cellpycore.units
+
+GitHub: https://github.com/jepegit/cellpy/issues/451
+Labels: cellpy2-stage1, yolo
+
+## Goal
+
+Delete cellpy's duplicated converter bodies and wrap the cellpycore.units
+originals (unit plan Phase 2): `get_converter_to_specific`,
+`nominal_capacity_as_absolute`, `to_cellpy_unit` (→ `convert_value`),
+`unit_scaler_from_raw` (→ `calculate_scaler`), and the inline current-factor
+pint math in `_make_summary` (→ `calculate_current_conversion_factor`).
+Blocked on core#115 (released as cellpycore 0.2.0) + re-pin.
+
+## Acceptance
+
+- Converter parity fixtures green (tests/test_unit_handling_stage0.py).
+- Full suite green; duplicated bodies deleted, wrappers ≤ a few lines each.

--- a/.issueflows/03-solved-issues/issue451_plan.md
+++ b/.issueflows/03-solved-issues/issue451_plan.md
@@ -1,0 +1,26 @@
+# Plan — issue #451 (Stage 1.6)
+
+1. **Re-pin** `cellpycore==0.2.0` (the Stage-1 additive release carrying
+   core#115 `convert_value` / `calculate_scaler` / `validate_units`) +
+   `uv lock` / `uv sync`. Rides in this PR per the core-first merge order.
+2. **Delegate, delete the bodies** in `cellpy/readers/cellreader.py`:
+   - `get_converter_to_specific` → `core_units.get_converter_to_specific`
+     (wrapper keeps the `mode is None → 1.0` early-out and the
+     `to_units or self.cellpy_units` default).
+   - `nominal_capacity_as_absolute` → core original (wrapper pins the legacy
+     `nom_cap_specifics or "gravimetric"` default and passes
+     `cellpy_units=self.cellpy_units`); the old PerformanceWarning help text
+     is condensed into the docstring.
+   - `to_cellpy_unit` → `core_units.convert_value` (pint `Quantity` inputs
+     handled in the wrapper — core's public API takes plain values; the
+     NoDataFound message for cell-less conversion preserved).
+   - `unit_scaler_from_raw` → `core_units.calculate_scaler(raw_units[prop],
+     unit)`.
+   - `_make_summary` current factor →
+     `core_units.calculate_current_conversion_factor`.
+3. **Known benign deltas:** `value=0` no longer falls back to `data.mass`
+   (`is not None` instead of truthiness); unitless strings raise `ValueError`
+   with a clear message instead of pint `DimensionalityError`; volumetric mode
+   without a volume raises `ValueError` instead of `AttributeError`.
+4. **Guards:** converter-parity fixtures (Stage-0 #431) compare cellpy output
+   against cellpycore on both sides; full suite green.

--- a/.issueflows/03-solved-issues/issue451_status.md
+++ b/.issueflows/03-solved-issues/issue451_status.md
@@ -1,0 +1,26 @@
+# Status — issue #451 (Stage 1.6)
+
+- [x] Done
+
+## 2026-07-15
+
+- Re-pinned `cellpycore==0.2.0` (the Stage-1 additive release: core#115–#118)
+  and delegated the duplicated converter bodies to `cellpycore.units`:
+  `get_converter_to_specific`, `nominal_capacity_as_absolute`,
+  `to_cellpy_unit` → `convert_value`, `unit_scaler_from_raw` →
+  `calculate_scaler`, and `_make_summary`'s inline current-factor pint math →
+  `calculate_current_conversion_factor` (also renamed the summary call to the
+  non-deprecated `specific_conversion_factors` kwarg).
+- Fixed three Stage 1.8 M2 leftovers found by the full-suite run (all
+  pre-existing on master, not caused by the delegation):
+  1. `dbreader.DbSheetCols` called `dataclasses.asdict` on the pydantic
+     `config.db_cols` → `model_dump()`.
+  2. `log.setup_logging` shadowed the `config` module with the logging.json
+     dict, breaking `config.paths.filelogdir` — module aliased to
+     `cellpy_config`. This was also the test-pollution source behind the
+     order-dependent `total_time_at_low_voltage` failures.
+  3. `PathsConfig` now has `validate_assignment=True` (config plan §3.1) so
+     string assignments re-run Path/OtherPath coercion; the Path serializers
+     are additionally defensive. Fixes `cellpy info --params` crashing after
+     batch runs (PydanticSerializationError).
+- Full suite: **581 passed, 0 failed** (previously 9 failures on master).

--- a/cellpy/config/models.py
+++ b/cellpy/config/models.py
@@ -13,7 +13,11 @@ from cellpy.config.types import LimitLoadedCycles, OtherPathField, PathField
 class PathsConfig(BaseModel):
     """Paths used in cellpy."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    # validate_assignment keeps the mutable-session ergonomics *validated*
+    # (config plan §3.1): assigning a plain string re-runs the PathField /
+    # OtherPathField coercion instead of storing a raw str that breaks
+    # serialization later (seen via `cellpy info --params` after batch runs).
+    model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
     outdatadir: PathField = Path.cwd()
     rawdatadir: OtherPathField = Path.cwd()

--- a/cellpy/config/types.py
+++ b/cellpy/config/types.py
@@ -18,7 +18,8 @@ def _coerce_otherpath(value: Any) -> OtherPath:
     return OtherPath(value)
 
 
-def _serialize_otherpath(value: OtherPath) -> str:
+def _serialize_otherpath(value: Any) -> str:
+    # defensive: tolerate raw strings that bypassed assignment validation
     return str(value).replace("\\", "/")
 
 
@@ -35,8 +36,9 @@ def _coerce_path(value: Any) -> Path:
     return Path(value)
 
 
-def _serialize_path(value: Path) -> str:
-    return value.as_posix()
+def _serialize_path(value: Any) -> str:
+    # defensive: tolerate raw strings that bypassed assignment validation
+    return Path(value).as_posix()
 
 
 PathField = Annotated[

--- a/cellpy/log.py
+++ b/cellpy/log.py
@@ -1,5 +1,7 @@
 """Set up logger instance"""
-import cellpy.config as config
+# distinct alias: setup_logging shadows the name ``config`` with the
+# logging.json dict, which broke the M2 rewrite's config.paths lookup (#453)
+import cellpy.config as cellpy_config
 
 import datetime
 import json
@@ -59,7 +61,7 @@ def setup_logging(
         elif custom_log_dir:
             log_dir = custom_log_dir
         else:
-            log_dir = os.path.abspath(config.paths.filelogdir)
+            log_dir = os.path.abspath(cellpy_config.paths.filelogdir)
 
         if not os.path.isdir(log_dir):
             warning_txt = (

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -71,6 +71,7 @@ from cellpy.parameters.internal_settings import (
 # pipeline to cellpy-core. OldCellpyCellCore is the legacy bridge that restores the
 # old headers/units (identical to cellpy.parameters.internal_settings) that cellpy
 # still expects. cellpy-core's __init__ is intentionally empty, so import submodules.
+from cellpycore import units as core_units
 from cellpycore.cell_core import OldCellpyCellCore
 
 from cellpy.readers.cellpy_file import dtype as cellpy_file_dtype
@@ -4018,104 +4019,23 @@ class CellpyCell:
         nom_cap_specifics=None,
         convert_charge_units=False,
     ):
-        """Get the nominal capacity as absolute value."""
+        """Get the nominal capacity as absolute value.
 
-        # TODO: implement handling of edge-cases (i.e. the raw capacity is not in absolute values)
-        if self.debug:
-            print("nominal_capacity_as_absolute".center(80, "="))
-            print(f"{value=}")
-            print(f"{specific=}")
-            print(f"{nom_cap_specifics=}")
-            print(f"{convert_charge_units=}")
-            print(80 * "-")
-
-        if nom_cap_specifics is None:
-            nom_cap_specifics = "gravimetric"
-
-        if specific is None:
-            if nom_cap_specifics == "gravimetric":
-                specific = self.data.mass
-            elif nom_cap_specifics == "areal":
-                specific = self.data.active_electrode_area
-
-            # TODO: implement volumetric
-            elif nom_cap_specifics == "volumetric":
-                raise NotImplementedError("volumetric not implemented yet")
-
-        if value is None:
-            value = self.data.nom_cap
-
-        value = ds.Q(value, self.cellpy_units["nominal_capacity"])
-
-        if nom_cap_specifics == "gravimetric":
-            specific = ds.Q(specific, self.cellpy_units["mass"])
-        elif nom_cap_specifics == "areal":
-            specific = ds.Q(specific, self.cellpy_units["area"])
-        elif nom_cap_specifics == "absolute":
-            specific = 1
-
-        # TODO: implement volumetric
-        elif nom_cap_specifics == "volumetric":
-            raise NotImplementedError("volumetric not implemented yet")
-
-        if convert_charge_units:
-            conversion_factor_charge = ds.Q(1, self.cellpy_units["charge"]) / ds.Q(
-                1, self.data.raw_units["charge"]
-            )
-        else:
-            conversion_factor_charge = 1.0
-
-        try:
-            absolute_value = (
-                (value * conversion_factor_charge * specific)
-                .to_reduced_units()
-                .to("Ah")
-            )
-        except externals.pint.errors.PerformanceWarning as e:
-            print(" DimensionalityError ".center(80, "="))
-            print("Could not convert nominal capacity to absolute value!")
-            print(
-                "This is probably because the nominal capacity is given in "
-                "different unit than the given specifics."
-            )
-            print(
-                " - Maybe you have given nominal capacity in mAh/cm**2 and your "
-                "specifics is set to 'gravimetric'?"
-            )
-            print(
-                " - Maybe you have given nominal capacity in mAh/g and your "
-                "specifics is set to 'areal'?"
-            )
-            print("Please check your input parameters!")
-            print(
-                "\n[hint 1] try to set the parameter 'nom_cap_specifics' in the get function:\n"
-            )
-            print(
-                "    c = cellpy.get(filename, area=1.55, nom_cap='1.2 mAh/cm**2', nom_cap_specifics='areal')"
-            )
-            print(
-                "\n[hint 2] try to set it on the cellpy object directly after loading, "
-                "\n  but before processing (making the step-table etc):\n"
-            )
-            print("    c = cellpy.get(filename, auto_summary=False)")
-            print("    c.nom_cap_specifics = 'areal'")
-            print("    ... # set other stuff if needed")
-            print("    c.make_step_table()")
-            print("    c.make_summary()")
-            print("\nRe-raising the exception.")
-            print(80 * "=")
-            raise e
-
-        if self.debug:
-            print(f"{self.mass=}")
-            print(f"{self.active_electrode_area=}")
-            print(f"{self.nom_cap=}")
-            print(f"{self.cellpy_units=}")
-            print(
-                f"nominal capacity: {value} [{self.cellpy_units.nominal_capacity}] -> {absolute_value:.3f} [Ah]"
-            )
-            print(80 * "=")
-        return absolute_value.m
+        Delegated to ``cellpycore.units.nominal_capacity_as_absolute``
+        (#451, unit plan Phase 2). A ``DimensionalityError`` here usually
+        means the nominal capacity is given in a different unit than the
+        chosen ``nom_cap_specifics`` — e.g. ``nom_cap='1.2 mAh/cm**2'`` with
+        gravimetric specifics; pass ``nom_cap_specifics='areal'`` (or set it
+        on the cell before processing).
+        """
+        return core_units.nominal_capacity_as_absolute(
+            data=self.data,
+            value=value,
+            specific=specific,
+            nom_cap_specifics=nom_cap_specifics or "gravimetric",
+            convert_charge_units=convert_charge_units,
+            cellpy_units=self.cellpy_units,
+        )
 
     def with_cellpy_unit(self, parameter, as_str=False):
         """Return quantity as `pint.Quantity` object."""
@@ -4157,34 +4077,24 @@ class CellpyCell:
         Returns (numeric):
             the value in cellpy units
         """
-        logging.debug(f"value {value} is numeric? {isinstance(value, numbers.Number)}")
-        logging.debug(
-            f"value {value} is a pint quantity? {isinstance(value, externals.pint.Quantity)}"
+        # Delegated to cellpycore.units.convert_value (#451); pint Quantity
+        # inputs are handled here since core's public API takes plain values.
+        if isinstance(value, externals.pint.Quantity):
+            return value.to(self.cellpy_units[physical_property]).m
+        try:
+            raw_units = self.data.raw_units
+        except NoDataFound:
+            raise NoDataFound(
+                "If you dont have any cells you cannot convert"
+                " values to cellpy units without providing what"
+                " unit to convert from!"
+            )
+        return core_units.convert_value(
+            value,
+            physical_property,
+            from_units=raw_units,
+            to_units=self.cellpy_units,
         )
-
-        if not isinstance(value, externals.pint.Quantity):
-            if isinstance(value, numbers.Number):
-                try:
-                    value = ds.Q(value, self.data.raw_units[physical_property])
-                    logging.debug(f"With unit from raw-units: {value}")
-                except NoDataFound:
-                    raise NoDataFound(
-                        "If you dont have any cells you cannot convert"
-                        " values to cellpy units without providing what"
-                        " unit to convert from!"
-                    )
-                except KeyError as e:
-                    raise KeyError(
-                        "You have to provide a valid physical_property"
-                    ) from e
-            elif isinstance(value, tuple):
-                value = ds.Q(*value)
-            else:
-                value = ds.Q(value)
-
-        value = value.to(self.cellpy_units[physical_property])
-
-        return value.m
 
     def unit_scaler_from_raw(self, unit, physical_property):
         """Get the conversion factor going from raw to given unit.
@@ -4197,14 +4107,10 @@ class CellpyCell:
         Returns (numeric):
             conversion factor (scaler)
         """
-        logging.debug(
-            f"value {unit} is a pint quantity? {isinstance(unit, externals.pint.Quantity)}"
+        # Delegated to cellpycore.units.calculate_scaler (#451).
+        return core_units.calculate_scaler(
+            self.data.raw_units[physical_property], unit
         )
-
-        old_unit = self.data.raw_units[physical_property]
-        value = ds.Q(1, old_unit)
-        value = value.to(unit)
-        return value.m
 
     def get_converter_to_specific(
         self,
@@ -4232,49 +4138,20 @@ class CellpyCell:
         """
         # TODO @jepe: implement handling of edge-cases
         # TODO @jepe: fix all the instrument readers (replace floats in raw_units with strings)
+        # Delegated to cellpycore.units (#451, unit plan Phase 2); the core
+        # port is the extended verbatim copy, guarded by converter-parity
+        # fixtures on both sides.
+        if mode is None:
+            return 1.0
         if dataset is None:
             dataset = self.data
-
-        new_units = to_units or self.cellpy_units
-        old_units = from_units or dataset.raw_units
-
-        if mode == "gravimetric":
-            value = value or dataset.mass
-            value = ds.Q(value, new_units["mass"])
-            to_unit_specific = ds.Q(1.0, new_units["specific_gravimetric"])
-
-        elif mode == "areal":
-            value = value or dataset.active_electrode_area
-            value = ds.Q(value, new_units["area"])
-            to_unit_specific = ds.Q(1.0, new_units["specific_areal"])
-
-        elif mode == "volumetric":
-            value = value or dataset.volume
-            value = ds.Q(value, new_units["volume"])
-            to_unit_specific = ds.Q(1.0, new_units["specific_volumetric"])
-
-        elif mode == "absolute":
-            value = ds.Q(1.0, None)
-            to_unit_specific = ds.Q(1.0, None)
-
-        elif mode is None:
-            return 1.0
-
-        else:
-            logging.debug(f"mode={mode} not supported!")
-            return 1.0
-
-        from_unit_cap = ds.Q(1.0, old_units["charge"])
-        to_unit_cap = ds.Q(1.0, new_units["charge"])
-
-        # from unit is always in absolute values:
-        from_unit = from_unit_cap
-
-        to_unit = to_unit_cap / to_unit_specific
-
-        conversion_factor = (from_unit / to_unit / value).to_reduced_units()
-        logging.debug(f"conversion factor: {conversion_factor}")
-        return conversion_factor.m
+        return core_units.get_converter_to_specific(
+            data=dataset,
+            value=value,
+            from_units=from_units,
+            to_units=to_units or self.cellpy_units,
+            mode=mode,
+        )
 
     def _set_mass(self, value):
         # TODO: replace with setter
@@ -4931,15 +4808,10 @@ class CellpyCell:
         # cellpy-core takes unit conversions by value: cellpy (the consumer, which
         # owns cellpy_units and pint) computes the factors and passes them in, so
         # the core summary engine needs no pint.
-        current_conversion_factor = float(
-            (
-                ds.Q(1.0, data.raw_units["current"])
-                / ds.Q(1.0, self.cellpy_units["current"])
-            )
-            .to_reduced_units()
-            .magnitude
+        current_conversion_factor = core_units.calculate_current_conversion_factor(
+            data.raw_units["current"], to_units=self.cellpy_units
         )
-        specific_converters = {
+        specific_conversion_factors = {
             mode: self.get_converter_to_specific(
                 dataset=data, mode=mode, to_units=self.cellpy_units
             )
@@ -4957,7 +4829,7 @@ class CellpyCell:
             nom_cap_abs=nom_cap_abs,
             normalization_cycles=normalization_cycles,
             specifics=specifics,
-            specific_converters=specific_converters,
+            specific_conversion_factors=specific_conversion_factors,
         )
 
         if sort_my_columns:

--- a/cellpy/readers/dbreader.py
+++ b/cellpy/readers/dbreader.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import warnings
-from dataclasses import asdict
 from datetime import datetime
 from typing import List, Optional
 
@@ -18,7 +17,9 @@ class DbSheetCols:
     # Note to developers: this should only be used for this Excell reader
     # (it works, and that is its only reason to still exist)
     def __init__(self):
-        db_cols_from_prms = asdict(config.db_cols)
+        # config.db_cols is a pydantic model since Stage 1.8 M2 (#453);
+        # dataclasses.asdict() no longer applies.
+        db_cols_from_prms = config.db_cols.model_dump()
         self.keys = []
         self.headers = []
         for table_key, value in db_cols_from_prms.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # a known core revision. For dual-repo development, install the sibling
     # checkout editable after sync (see CONTRIBUTING.md); do not commit a
     # [tool.uv.sources] path override — it breaks Dependabot lock updates.
-    "cellpycore==0.1.5",
+    "cellpycore==0.2.0",
     "pydantic-settings>=2.14.2",
     "platformdirs>=4.10.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cellpycore", specifier = "==0.1.5" },
+    { name = "cellpycore", specifier = "==0.2.0" },
     { name = "charset-normalizer" },
     { name = "click" },
     { name = "cookiecutter" },
@@ -495,16 +495,16 @@ dev = [
 
 [[package]]
 name = "cellpycore"
-version = "0.1.5"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/cd/d5c16c36dbb63925af27f0f77c58ea3812e4dcd9ef25d8fbbf10dfcea80e/cellpycore-0.1.5.tar.gz", hash = "sha256:68f45fc6e510fa8ae8e0172b0061eab7e0b79b16ec2de23fe7d49327c8502f47", size = 680782, upload-time = "2026-07-07T10:21:41.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/4b/b239e59e51fbe883104fbe4f2a533a8f391f9699139c5597a411f424063b/cellpycore-0.2.0.tar.gz", hash = "sha256:e3948b8764a9e80fead93eee2476ed634686b70bb6686a4031ab0c1a57989981", size = 827692, upload-time = "2026-07-14T22:27:00.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/6f/be4dc8d576fa7b1922fe4ebc5c6c1ccf15b3b4566742657d977c76c2b227/cellpycore-0.1.5-py3-none-any.whl", hash = "sha256:f0febeb4391b1ddb8aacbdce576c5eed3ed3a5f619e60e8147e8b3de4995cc7c", size = 74199, upload-time = "2026-07-07T10:21:39.698Z" },
+    { url = "https://files.pythonhosted.org/packages/85/38/f9af8d174c97d94fd9ea970030ee71ce5fbb013417d428f670fc43ab3a57/cellpycore-0.2.0-py3-none-any.whl", hash = "sha256:3e53e13ca61aa6f693f3dc8758e34f152c15f796cfc52b6b2cb88383628f9176", size = 89415, upload-time = "2026-07-14T22:26:58.447Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #451 (Stage 1.6 / unit plan Phase 2). Also completes the **cellpycore 0.2.0 re-pin** (core-first merge order; the 0.2.0 release carries core#115–#118).

**Delegation (duplicated bodies deleted, thin wrappers remain):**
- `get_converter_to_specific` → `cellpycore.units.get_converter_to_specific` (mode-None early-out + `to_units` default preserved)
- `nominal_capacity_as_absolute` → core original (legacy gravimetric default pinned; the old console help text condensed into the docstring)
- `to_cellpy_unit` → `convert_value` (pint `Quantity` inputs handled in the wrapper; NoDataFound message preserved)
- `unit_scaler_from_raw` → `calculate_scaler`
- `_make_summary` inline current-factor pint math → `calculate_current_conversion_factor`; summary call renamed to the non-deprecated `specific_conversion_factors` kwarg (kills the DeprecationWarning spam)

**Plus three Stage 1.8 M2 leftovers** (separate commit; all pre-existing on master, surfaced by making the suite green):
1. `dbreader.DbSheetCols`: `dataclasses.asdict` on the pydantic `config.db_cols` → `model_dump()`
2. `log.setup_logging` shadowed the `config` module with the logging.json dict (`config.paths.filelogdir` → AttributeError) — module aliased; this was also the pollution source behind the order-dependent `total_time_at_low_voltage` failures
3. `PathsConfig` gains `validate_assignment=True` (config plan §3.1) + defensive Path serializers — fixes `cellpy info --params` crashing after batch runs

Benign deltas (documented in the issueflow plan file): `value=0` no longer falls back to `data.mass`; unitless strings raise a clear `ValueError`; volumetric without volume raises `ValueError` instead of `AttributeError`.

**Full suite: 581 passed, 0 failed** (master had 9 failures). Converter-parity fixtures (Stage-0 #431) green on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)