### PR TITLE
Drop redundant module-level header constants (#505)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Header single source (#505, v2 Phase 0 gate): drop the redundant module-level
+  `HEADERS_NORMAL` / `HEADERS_SUMMARY` / `HEADERS_STEP_TABLE` constants in
+  `cellreader.py` and `data_structures.py`; use the instance attributes /
+  `get_headers_*()` accessors from `internal_settings` instead.
 * Decommission the in-repo legacy summary engine (#385, v2 Phase 0 gate):
   remove `_make_summar_legacy`, `_generate_absolute_summary_columns`,
   `_ir_to_summary`, `_end_voltage_to_summary` and the `make_summary(old=True)`

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -51,9 +51,6 @@ from cellpy.parameters.legacy.update_headers import (
 )
 from cellpy.parameters.internal_settings import (
     get_cellpy_units,
-    get_headers_normal,
-    get_headers_step_table,
-    get_headers_summary,
     headers_normal,
     headers_step_table,
     headers_summary,
@@ -81,9 +78,6 @@ from cellpy.readers.cellpy_file import write as cellpy_file_write
 
 DIGITS_C_RATE = 5
 
-HEADERS_NORMAL = get_headers_normal()  # TODO @jepe refactor this (not needed)
-HEADERS_SUMMARY = get_headers_summary()  # TODO @jepe refactor this (not needed)
-HEADERS_STEP_TABLE = get_headers_step_table()  # TODO @jepe refactor this (not needed)
 
 # TODO: @jepe - new feature - method for assigning new cycle numbers and step numbers
 #   - Sometimes the user forgets to increment the cycle number and it would be good
@@ -630,9 +624,9 @@ class CellpyCell:
             List of CellpyCell objects
 
         """
-        h_summary_index = HEADERS_SUMMARY.cycle_index
-        h_raw_index = HEADERS_NORMAL.cycle_index_txt
-        h_step_cycle = HEADERS_STEP_TABLE.cycle
+        h_summary_index = self.headers_summary.cycle_index
+        h_raw_index = self.headers_normal.cycle_index_txt
+        h_step_cycle = self.headers_step_table.cycle
 
         if base_cycles is None:
             all_cycles = self.get_cycle_numbers()
@@ -698,9 +692,9 @@ class CellpyCell:
             A new CellpyCell object containing only the selected cycles.
 
         """
-        h_summary_index = HEADERS_SUMMARY.cycle_index
-        h_raw_index = HEADERS_NORMAL.cycle_index_txt
-        h_step_cycle = HEADERS_STEP_TABLE.cycle
+        h_summary_index = self.headers_summary.cycle_index
+        h_raw_index = self.headers_normal.cycle_index_txt
+        h_step_cycle = self.headers_step_table.cycle
 
         if isinstance(cycles, int):
             cycles = [cycles]

--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -25,17 +25,12 @@ from cellpy.exceptions import NullData
 from cellpy.internals.connections import OtherPath
 from cellpy.parameters.internal_settings import (
     get_headers_normal,
-    get_headers_step_table,
-    get_headers_summary,
     get_default_raw_units,
     get_default_raw_limits,
     CellpyMetaCommon,
     CellpyMetaIndividualTest,
 )
 
-HEADERS_NORMAL = get_headers_normal()  # TODO @jepe refactor this (not needed)
-HEADERS_SUMMARY = get_headers_summary()  # TODO @jepe refactor this (not needed)
-HEADERS_STEP_TABLE = get_headers_step_table()  # TODO @jepe refactor this (not needed)
 
 LOADERS_NOT_READY_FOR_PROD = [
     "ext_nda_reader"
@@ -940,7 +935,7 @@ def identify_last_data_point(data):
     """Find the last data point and store it in the fid instance"""
 
     logging.debug("searching for last data point")
-    hdr_data_point = HEADERS_NORMAL.data_point_txt
+    hdr_data_point = get_headers_normal().data_point_txt
     try:
         if hdr_data_point in data.raw.columns:
             last_data_point = data.raw[hdr_data_point].max()
@@ -1364,12 +1359,13 @@ def group_by_interpolate(
     """
     # TODO: @jepe - create more tests
     time_00 = time.time()
+    headers_normal = get_headers_normal()
     if x is None:
-        x = HEADERS_NORMAL.step_time_txt
+        x = headers_normal.step_time_txt
     if y is None:
-        y = HEADERS_NORMAL.voltage_txt
+        y = headers_normal.voltage_txt
     if group_by is None:
-        group_by = [HEADERS_NORMAL.cycle_index_txt]
+        group_by = [headers_normal.cycle_index_txt]
 
     if not isinstance(group_by, (list, tuple)):
         group_by = [group_by]


### PR DESCRIPTION
Closes #505 — final item of the v2 Phase 0 gate (epic #402).

## What

Removes the redundant module-level `HEADERS_NORMAL` / `HEADERS_SUMMARY` /
`HEADERS_STEP_TABLE` constants (all carrying `# TODO refactor this (not needed)`)
from `cellreader.py` and `data_structures.py`:

- `CellpyCell.split_many` / `with_cycles` use the existing `self.headers_*`
  instance attributes.
- Module-level functions in `data_structures.py` call the `get_headers_*()`
  accessors from `internal_settings` directly.
- Now-unused imports dropped.

No third copy of header definitions remains; `internal_settings` (backed by the
core parity contract, #378) is the single source. No external code imported these
constants (verified by grep).

## Verification

- `uv run pytest -m essential`: 93 passed
- Full `uv run pytest`: 592 passed, 62 skipped, 14 xfailed, 0 failures

With #385 (merged today) and #504 (closed — already done by #451), this
completes **Phase 0**; v2 feature work (#506) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
