### PR TITLE
docs: warn that cellpy 1.x is maintained until July 2027

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,15 @@
 
 **version:** {{ ProjectVersion }}
 
+:::{warning}
+**cellpy 1.x maintenance window**
+
+This documentation covers **cellpy version 1**. The 1.x line will be maintained
+until approximately **July 2027** (one year from this notice). After that,
+**cellpy version 2** will take over as the actively developed release line.
+Plan migrations accordingly; new features and long-term support will focus on v2.
+:::
+
 ```{include} adapted_readme.md
 ```
 


### PR DESCRIPTION
## Summary
- Add a front-page docs warning that cellpy 1.x will be maintained until approximately July 2027
- After that window, cellpy version 2 becomes the actively developed release line

## Test plan
- [ ] Confirm the warning renders on the docs landing page (`docs/index.md`) after Sphinx/MyST build
- [ ] Spot-check wording and date (July 2027) look correct on RTD once merged


Made with [Cursor](https://cursor.com)