### PR TITLE
Per-test metadata: TestMetaCollection on Data (#506)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+* Per-test metadata API (#506, v2 Phase 1, themes V2-01/02/04): `Data.tests`
+  exposes a `cellpycore.metadata.TestMetaCollection` keyed by `test_id`
+  (active record derived from the legacy meta boxes, which stay authoritative;
+  extra records stored in memory), with `Data.set_test_meta`,
+  `Data.get_cycle_mode(test_id)` / `set_cycle_mode(mode, test_id)` and
+  `Data.active_test_id`. v1-v8 cellpy files load as a single-test collection
+  (`test_id=0`). Engine compute on objects mixing different `cycle_mode`s now
+  raises `MixedCycleModesError` instead of silently applying one convention
+  (per-test engine polarity: #507/#510). On-disk format v8 unchanged; only the
+  active test's metadata is persisted (full collection persistence: #510).
+  Adds the legacy<->core metadata mapping contract tests that
+  `cellpycore.legacy.meta_mapping` assigns to cellpy. Future vocabulary/export
+  alignment target: BattINFO (BIG-MAP).
+
 * Header single source (#505, v2 Phase 0 gate): drop the redundant module-level
   `HEADERS_NORMAL` / `HEADERS_SUMMARY` / `HEADERS_STEP_TABLE` constants in
   `cellreader.py` and `data_structures.py`; use the instance attributes /

--- a/cellpy/exceptions.py
+++ b/cellpy/exceptions.py
@@ -63,6 +63,14 @@ class LoaderError(CellpyError):
     pass
 
 
+class MixedCycleModesError(CellpyError):
+    """Raised when engine compute is requested on a multi-test object whose
+    tests carry different ``cycle_mode`` values (per-test engine polarity is
+    not implemented yet; see issues #506/#507)."""
+
+    pass
+
+
 class DeprecatedFeature(Error):
     """Raised when the feature is recently deprecated"""
 
@@ -107,6 +115,7 @@ __all__ = [
     "ConfigurationError",
     "UnitsError",
     "LoaderError",
+    "MixedCycleModesError",
     "DeprecatedFeature",
     "ExportFailed",
     "IOError",

--- a/cellpy/readers/cellpy_file/write.py
+++ b/cellpy/readers/cellpy_file/write.py
@@ -56,6 +56,12 @@ def create_infotable(data, fmt: CellpyFileFormat = FORMAT_V8):
 def save(data, path, *, format_spec: CellpyFileFormat = FORMAT_V8) -> None:
     """Write ``Data`` to a cellpy-file (HDF5) with a single owned store lifecycle."""
     fmt = format_spec
+    if getattr(data, "_extra_tests", None):
+        logging.warning(
+            f"this object holds TestMeta records for non-active test_ids "
+            f"{sorted(data._extra_tests)}; cellpy-file format v8 only persists "
+            "the active test's metadata (full collection persistence: #510)"
+        )
     common_meta_table, test_dependent_meta_table, fid_table = create_infotable(
         data, fmt=fmt
     )

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -33,10 +33,12 @@ import numpy as np
 
 from . import externals as externals
 from cellpy.readers import data_structures as ds
+from cellpy.readers import test_meta
 import cellpy.internals.connections as internals
 
 from cellpy.exceptions import (
     DeprecatedFeature,
+    MixedCycleModesError,
     NullData,
     WrongFileVersion,
     NoDataFound,
@@ -515,6 +517,8 @@ class CellpyCell:
         if cell is not None:
             new_cell.data.meta_common = cell.data.meta_common
             new_cell.data.meta_test_dependent = cell.data.meta_test_dependent
+            new_cell.data._extra_tests = dict(cell.data._extra_tests)
+            new_cell.data._active_test_id = cell.data._active_test_id
 
             new_cell.data.raw_data_files = cell.data.raw_data_files
             new_cell.data.raw_data_files_length = cell.data.raw_data_files_length
@@ -880,7 +884,12 @@ class CellpyCell:
 
     @property
     def cycle_mode(self):
-        # TODO: v2.0 edit this from scalar to list
+        """The active test's ``cycle_mode`` (scalar).
+
+        For per-test access on multi-test objects, use
+        ``self.data.get_cycle_mode(test_id)`` / ``set_cycle_mode`` and the
+        ``self.data.tests`` collection (issue #506).
+        """
         try:
             data = self.data
             m = data.meta_test_dependent.cycle_mode
@@ -903,6 +912,26 @@ class CellpyCell:
             self._cycle_mode = cycle_mode
         except NoDataFound:
             self._cycle_mode = cycle_mode
+
+    def _guard_mixed_cycle_modes(self):
+        """Refuse engine compute when tests present carry different cycle_modes.
+
+        The engine applies one global charge/discharge convention; running it
+        on a merged object mixing e.g. anode and cathode tests would silently
+        apply the wrong convention to some tests (issue #506; per-test engine
+        polarity is future work, #507).
+        """
+        try:
+            modes = test_meta.cycle_modes_in_data(self.data)
+        except NoDataFound:
+            return
+        if len(modes) > 1:
+            raise MixedCycleModesError(
+                f"tests in this object carry different cycle_modes {sorted(modes)} "
+                f"(test_ids: {self.data.tests.test_ids}); the engine applies one "
+                "global convention, so computing steps/summary would be wrong for "
+                "some tests. Per-test engine polarity is tracked in #507/#510."
+            )
 
     # TODO: this probably does not need to be here
     def set_raw_datadir(self, directory=None):
@@ -2089,6 +2118,8 @@ class CellpyCell:
                 "all_steps will be deprecated, use usteps instead", FutureWarning
             )
             usteps = True
+
+        self._guard_mixed_cycle_modes()
 
         time_00 = time.time()
 
@@ -4618,6 +4649,8 @@ class CellpyCell:
         except NoDataFound:
             logging.info("Empty test (no data found)")
             return
+
+        self._guard_mixed_cycle_modes()
 
         if isinstance(test.loaded_from, (list, tuple)):
             for f in test.loaded_from:

--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -20,6 +20,9 @@ from typing import Any, Tuple, Dict, List, Union, Optional
 from typing import TypedDict
 
 from . import externals as externals
+from . import test_meta as test_meta_helpers
+
+from cellpycore.metadata.models import TestMeta, TestMetaCollection
 
 from cellpy.exceptions import NullData
 from cellpy.internals.connections import OtherPath
@@ -345,8 +348,18 @@ class Data:
         raw (pandas.DataFrame): raw data.
         summary (pandas.DataFrame): summary data.
         steps (pandas.DataFrame): step data.
-        meta_common (CellpyMetaCommon): common meta-data.
-        meta_test_dependent (CellpyMetaIndividualTest): test-dependent meta-data.
+        meta_common (CellpyMetaCommon): common meta-data (authoritative for the
+            active test; see ``tests``).
+        meta_test_dependent (CellpyMetaIndividualTest): test-dependent meta-data
+            (authoritative for the active test; see ``tests``).
+        tests (TestMetaCollection): per-test metadata keyed by ``test_id``. The
+            active test's record is *derived on access* from the legacy meta
+            boxes above (mutating it does not persist — use ``set_test_meta`` /
+            ``set_cycle_mode`` or the legacy attributes); records for other
+            ``test_id`` values are stored and survive in memory, but are not
+            written to cellpy files in format v8 (full persistence: #510).
+        active_test_id (int): compact grouping key of the active test (0 for a
+            single, unmerged test; matches the engine's ``test_id`` column).
         custom_info (Any): custom meta-data.
         raw_units (dict): dictionary with units for the raw data.
         raw_limits (dict): dictionary with limits for the raw data.
@@ -374,6 +387,10 @@ class Data:
                     "populate_defaults",
                 ]:
                     value = self.__getattribute__(p)
+                    # a bound method's repr embeds repr(self) -> infinite
+                    # recursion; skip callables
+                    if callable(value):
+                        continue
                     txt += f"{p}: {value}\n"
             if p == "raw_data_files":
                 fid_txt = "raw data files: ["
@@ -436,6 +453,10 @@ class Data:
                     "populate_defaults",
                 ]:
                     value = self.__getattribute__(p)
+                    # a bound method's repr embeds repr(self) -> infinite
+                    # recursion; skip callables
+                    if callable(value):
+                        continue
                     txt += f"<b>{p}</b>: {value}<br>"
             if p == "raw_data_files":
                 fid_txt = "<b>raw data files</b>:"
@@ -502,8 +523,16 @@ class Data:
         self.steps = externals.pandas.DataFrame()
 
         self.meta_common = CellpyMetaCommon()
-        # TODO: v2.0 consider making this a list of several CellpyMetaIndividualTest
+        # Authoritative box for the *active* test; per-test records for other
+        # test_ids live in _extra_tests and surface through the ``tests``
+        # property (issue #506).
         self.meta_test_dependent = CellpyMetaIndividualTest()
+        self._extra_tests: Dict[int, TestMeta] = {}
+        # Compact per-test grouping key of the active test (0 = single,
+        # unmerged; matches the engine's test_id convention). Note: the legacy
+        # ``meta_test_dependent.test_ID`` is the *tester-assigned* id (e.g.
+        # Arbin's Test_ID) — provenance, not this key.
+        self._active_test_id: int = 0
 
         self.custom_info = None  # Placeholder for custom meta-data
 
@@ -605,6 +634,88 @@ class Data:
                 stacklevel=2,
             )
         self.meta_common.nom_cap = value  # nominal capacity
+
+    # ---------------- per-test metadata (issue #506, v2 Phase 1) -----------------
+
+    @property
+    def active_test_id(self) -> int:
+        """Compact grouping key of the active test (0 = single, unmerged).
+
+        Matches the engine's ``test_id`` convention (raw/steps/summary are
+        stamped 0 for a single test). Distinct from the legacy
+        ``meta_test_dependent.test_ID``, which is the tester-assigned id and
+        stays available as provenance.
+        """
+        return self._active_test_id
+
+    @property
+    def tests(self) -> TestMetaCollection:
+        """Per-test metadata keyed by ``test_id`` (a fresh collection each access).
+
+        The active test's record is derived from ``meta_common`` /
+        ``meta_test_dependent`` (which stay authoritative — the core engine
+        reads them live), so mutating the returned record is a snapshot edit
+        and does not persist. Use :meth:`set_test_meta` /
+        :meth:`set_cycle_mode` (or the legacy attributes) to write.
+        """
+        collection = TestMetaCollection()
+        active_id = self.active_test_id
+        collection.add(test_meta_helpers.build_active_test_meta(self))
+        for test_id, record in self._extra_tests.items():
+            if test_id == active_id:
+                logging.warning(
+                    f"dropping stale extra TestMeta record for test_id={test_id} "
+                    f"(collides with the active test)"
+                )
+                continue
+            collection.add(record)
+        return collection
+
+    def set_test_meta(self, meta: TestMeta, *, replace: bool = True) -> None:
+        """Store a ``TestMeta`` record, routed by its ``test_id``.
+
+        The active test's record is written back onto the legacy meta boxes
+        (fields without a legacy home, e.g. ``uuid`` / ``source_*``, are
+        skipped); records for other ``test_id`` values are kept in memory but
+        are not persisted in cellpy-file format v8 (see #510).
+        """
+        if meta.test_id == self.active_test_id:
+            test_meta_helpers.apply_test_meta_to_legacy(
+                meta, self.meta_common, self.meta_test_dependent
+            )
+            return
+        if not replace and meta.test_id in self._extra_tests:
+            raise KeyError(f"test_id {meta.test_id} already present")
+        self._extra_tests[meta.test_id] = meta
+
+    def get_cycle_mode(self, test_id: Optional[int] = None) -> Optional[str]:
+        """``cycle_mode`` for the given test (``None`` = the active test)."""
+        if test_id is None or test_id == self.active_test_id:
+            return test_meta_helpers._unwrap(self.meta_test_dependent.cycle_mode)
+        try:
+            return self._extra_tests[test_id].cycle_mode
+        except KeyError:
+            raise KeyError(
+                f"no TestMeta record for test_id={test_id} "
+                f"(known: {sorted([self.active_test_id, *self._extra_tests])})"
+            ) from None
+
+    def set_cycle_mode(self, cycle_mode: str, test_id: Optional[int] = None) -> None:
+        """Set ``cycle_mode`` for the given test (``None`` = the active test).
+
+        The active test writes through to ``meta_test_dependent.cycle_mode``
+        — the attribute the processing engine reads.
+        """
+        if test_id is None or test_id == self.active_test_id:
+            self.meta_test_dependent.cycle_mode = cycle_mode
+            return
+        try:
+            self._extra_tests[test_id].cycle_mode = cycle_mode
+        except KeyError:
+            raise KeyError(
+                f"no TestMeta record for test_id={test_id} "
+                f"(known: {sorted([self.active_test_id, *self._extra_tests])})"
+            ) from None
 
     @staticmethod
     def _header_str(hdr):

--- a/cellpy/readers/test_meta.py
+++ b/cellpy/readers/test_meta.py
@@ -1,0 +1,153 @@
+"""Per-test metadata helpers: legacy meta boxes <-> cellpycore TestMeta.
+
+Pure translation helpers behind ``Data.tests`` (issue #506, epic #402 themes
+V2-01/02/04). The legacy boxes (``Data.meta_common`` /
+``Data.meta_test_dependent``) stay authoritative for the *active* test — the
+core engine reads ``data.meta_test_dependent.cycle_mode`` live at compute time
+— so the active ``TestMeta`` record is derived on access, and writes are
+routed back onto the legacy boxes through the same importable pair tables.
+
+Future direction: the metadata vocabulary and its export formats should align
+with the BattINFO ontology (BIG-MAP initiative,
+https://github.com/BIG-MAP/BattINFO) — prefer BattINFO-mappable terms when
+extending fields or vocabularies here.
+"""
+
+import dataclasses
+import logging
+from typing import Any, Optional, Set, Tuple
+
+from cellpycore.legacy import meta_mapping
+from cellpycore.metadata.models import TestMeta
+
+from . import externals as externals
+
+logger = logging.getLogger(__name__)
+
+# Core-model fields legacy has no home for; ``apply_test_meta_to_legacy`` must
+# skip them instead of guessing a destination.
+_CORE_ONLY_TEST_FIELDS = frozenset(meta_mapping.CORE_ONLY_TEST)
+_CORE_ONLY_CELL_FIELDS = frozenset(meta_mapping.CORE_ONLY_CELL)
+
+
+def _unwrap(value: Any) -> Any:
+    """Normalize a legacy meta value to a plain scalar (or ``None``).
+
+    Cellpy-file loads leave 1-element lists in ``meta_test_dependent`` (the
+    ``update(as_list=True)`` path in ``cellpy_file.read``); HDF round-trips
+    also produce numpy scalar types and ``NaN`` for absent values. ``TestMeta``
+    fields are plain scalars with ``None`` meaning absent.
+    """
+    if isinstance(value, (list, tuple)):
+        if len(value) == 1:
+            return _unwrap(value[0])
+        return value
+    if isinstance(value, externals.numpy.generic):
+        value = value.item()
+    if isinstance(value, float) and value != value:  # NaN -> absent
+        return None
+    return value
+
+
+def legacy_boxes_to_mappings(meta_common, meta_test_dependent) -> Tuple[dict, dict]:
+    """Field mappings for the two legacy boxes, unwrapped to plain scalars.
+
+    ``schedule_file_name`` is an un-annotated class attribute on
+    ``CellpyMetaIndividualTest`` (``asdict`` drops it) but participates in the
+    mapping — re-add it via ``getattr``.
+    """
+    common = {k: _unwrap(v) for k, v in dataclasses.asdict(meta_common).items()}
+    individual = {
+        k: _unwrap(v) for k, v in dataclasses.asdict(meta_test_dependent).items()
+    }
+    individual["schedule_file_name"] = _unwrap(
+        getattr(meta_test_dependent, "schedule_file_name", None)
+    )
+    # A test_ID that cannot coerce to an int would make the core translation
+    # raise on every access; degrade to None (-> test_id 0) with a warning.
+    try:
+        meta_mapping.coerce_test_id(individual.get("test_ID"))
+    except ValueError:
+        logger.warning(
+            f"cannot interpret legacy test_ID {individual.get('test_ID')!r} "
+            f"as an int; treating it as unset (test_id=0)"
+        )
+        individual["test_ID"] = None
+    return common, individual
+
+
+def build_active_test_meta(data) -> TestMeta:
+    """Derive the active test's ``TestMeta`` (with linked ``CellMeta``) from
+    the legacy meta boxes.
+
+    ``test_id`` is set to ``data.active_test_id`` (the compact grouping key,
+    0 for a single unmerged test) — the legacy ``test_ID`` is the
+    tester-assigned id and remains in the legacy box as provenance.
+    """
+    common, individual = legacy_boxes_to_mappings(
+        data.meta_common, data.meta_test_dependent
+    )
+    cell, test = meta_mapping.legacy_meta_to_core(common, individual)
+    test.cell = cell
+    test.test_id = data.active_test_id
+    return test
+
+
+def apply_test_meta_to_legacy(test_meta: TestMeta, meta_common, meta_test_dependent):
+    """Write a ``TestMeta`` (and its linked ``CellMeta``) back onto the legacy
+    boxes, inverting the mapping pair tables.
+
+    ``None`` values and core-only fields (``uuid``, ``source_*``, ...) are
+    skipped — this only routes fields that have a legacy home, so the legacy
+    boxes (which the core engine reads live) never diverge from what was set.
+    """
+    for legacy_field, core_field in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS:
+        value = getattr(test_meta, core_field, None)
+        if value is not None:
+            setattr(meta_test_dependent, legacy_field, value)
+    for legacy_field, core_field in meta_mapping.COMMON_TO_TEST_PAIRS:
+        value = getattr(test_meta, core_field, None)
+        if value is not None:
+            setattr(meta_common, legacy_field, value)
+    if test_meta.cell is not None:
+        for legacy_field, core_field in meta_mapping.COMMON_TO_CELL_PAIRS:
+            value = getattr(test_meta.cell, core_field, None)
+            if value is not None:
+                setattr(meta_common, legacy_field, value)
+
+
+def cycle_modes_in_data(data) -> Set[str]:
+    """Distinct non-None ``cycle_mode`` values among tests present in the data.
+
+    When the raw frame carries a ``test_id`` column, only records for the ids
+    actually present are considered; otherwise only the active test counts.
+    Single-record collections short-circuit to the active mode.
+    """
+    tests = data.tests
+    if len(tests) <= 1:
+        mode = _unwrap(getattr(data.meta_test_dependent, "cycle_mode", None))
+        return {mode} if mode is not None else set()
+
+    # Extras without raw rows are dormant metadata: only the tests whose
+    # ``test_id`` actually appears in the raw frame take part in compute. A raw
+    # frame without the column carries the active test only.
+    present_ids = {data.active_test_id}
+    try:
+        raw = data.raw
+    except Exception:
+        raw = None
+    if raw is not None:
+        from cellpy.parameters.internal_settings import get_headers_normal
+
+        test_id_col = get_headers_normal().test_id_txt
+        if hasattr(raw, "columns") and test_id_col in raw.columns:
+            present_ids = {int(v) for v in raw[test_id_col].unique()}
+
+    modes = set()
+    for record in tests:
+        if record.test_id not in present_ids:
+            continue
+        mode = _unwrap(record.cycle_mode)
+        if mode is not None:
+            modes.add(mode)
+    return modes

--- a/dev/conda-recipes/cellpycore/meta.yaml
+++ b/dev/conda-recipes/cellpycore/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "cellpycore" %}
 {% set version = "0.2.1" %}
+{% set python_min = "3.13" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.13
+    - python {{ python_min }}
     - pip
     - hatchling >=1.27
   run:
-    - python >=3.13
+    - python >={{ python_min }}
     - pandas >=2.2.3
     - polars >=1.29.0
     - pyarrow >=20.0.0
@@ -28,6 +29,8 @@ requirements:
 test:
   imports:
     - cellpycore
+  requires:
+    - python {{ python_min }}
 
 about:
   home: https://github.com/cellpy/cellpy-core

--- a/tests/test_core_meta_mapping_contract.py
+++ b/tests/test_core_meta_mapping_contract.py
@@ -1,0 +1,88 @@
+"""Contract tests for the legacy <-> core metadata field mapping.
+
+``cellpycore.legacy.meta_mapping`` pins cellpy's legacy metadata field
+inventories as frozensets (core cannot import cellpy). Its docstring assigns
+cellpy the job of guarding that those pinned lists match the real legacy
+dataclasses — these are those guards (issue #506; same arrangement as the
+header-mapping contract tests).
+"""
+
+import dataclasses
+
+import pytest
+
+from cellpycore.legacy import meta_mapping
+from cellpycore.metadata.models import CellMeta, TestMeta
+
+from cellpy.parameters.internal_settings import (
+    CellpyMetaCommon,
+    CellpyMetaIndividualTest,
+)
+
+
+def _field_names(cls) -> set:
+    return {f.name for f in dataclasses.fields(cls)}
+
+
+@pytest.mark.essential
+def test_pinned_common_fields_match_dataclass():
+    assert meta_mapping.LEGACY_COMMON_FIELDS == _field_names(CellpyMetaCommon)
+
+
+@pytest.mark.essential
+def test_pinned_individual_fields_match_dataclass():
+    # ``schedule_file_name`` is deliberately an un-annotated class attribute in
+    # the legacy dataclass (so ``asdict`` drops it) but still carries data and
+    # participates in the mapping — compare fields plus that documented attr.
+    assert (
+        _field_names(CellpyMetaIndividualTest)
+        == meta_mapping.LEGACY_INDIVIDUAL_FIELDS - {"schedule_file_name"}
+    )
+    assert hasattr(CellpyMetaIndividualTest, "schedule_file_name")
+    assert "schedule_file_name" not in _field_names(CellpyMetaIndividualTest)
+
+
+@pytest.mark.essential
+def test_mapping_totality_legacy_side():
+    """Every legacy field appears exactly once across pair tables + LEGACY_ONLY."""
+    mapped_common = [lf for lf, _ in meta_mapping.COMMON_TO_CELL_PAIRS] + [
+        lf for lf, _ in meta_mapping.COMMON_TO_TEST_PAIRS
+    ]
+    mapped_individual = [lf for lf, _ in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS]
+    legacy_only = set(meta_mapping.LEGACY_ONLY)
+
+    assert len(mapped_common) == len(set(mapped_common)), "duplicate common mapping"
+    assert len(mapped_individual) == len(set(mapped_individual)), (
+        "duplicate individual mapping"
+    )
+    assert set(mapped_common) & legacy_only == set()
+    assert (
+        set(mapped_common) | legacy_only == meta_mapping.LEGACY_COMMON_FIELDS
+    ), "common fields not fully covered"
+    assert set(mapped_individual) == meta_mapping.LEGACY_INDIVIDUAL_FIELDS, (
+        "individual fields not fully covered"
+    )
+
+
+@pytest.mark.essential
+def test_mapping_totality_core_side():
+    """Every CellMeta / TestMeta field is a pair target or documented core-only."""
+    cell_targets = {cf for _, cf in meta_mapping.COMMON_TO_CELL_PAIRS}
+    test_targets = {cf for _, cf in meta_mapping.COMMON_TO_TEST_PAIRS} | {
+        cf for _, cf in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS
+    }
+    assert cell_targets | meta_mapping.CORE_ONLY_CELL == _field_names(CellMeta)
+    assert test_targets | meta_mapping.CORE_ONLY_TEST == _field_names(TestMeta)
+
+
+@pytest.mark.essential
+def test_translation_smoke_defaults():
+    """Default legacy boxes translate to a single-test (test_id=0) TestMeta."""
+    cell, test = meta_mapping.legacy_meta_to_core(
+        CellpyMetaCommon(), CellpyMetaIndividualTest()
+    )
+    assert isinstance(cell, CellMeta)
+    assert isinstance(test, TestMeta)
+    assert test.test_id == 0
+    # cycle_mode default flows from cellpy config through the mapping
+    assert test.cycle_mode == CellpyMetaIndividualTest().cycle_mode

--- a/tests/test_test_meta_collection.py
+++ b/tests/test_test_meta_collection.py
@@ -1,0 +1,235 @@
+"""Tests for the per-test metadata API (``Data.tests``, issue #506).
+
+Covers: the legacy->core translation helpers, the derived-collection semantics
+(legacy boxes stay authoritative for the active test), v1-file backward compat
+(single record, ``test_id=0``), the mixed-cycle-mode compute guard, and the v8
+save/load round-trip of the collection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cellpycore.metadata import io as core_meta_io
+from cellpycore.metadata.models import TestMeta
+
+from cellpy import cellreader
+from cellpy.exceptions import MixedCycleModesError
+from cellpy.parameters.internal_settings import (
+    CellpyMetaCommon,
+    CellpyMetaIndividualTest,
+    get_headers_normal,
+)
+from cellpy.readers import test_meta
+from cellpy.readers.data_structures import Data
+from tests.cellpy_file_support import load_cellpy_file
+
+HDF5_DIR = Path(__file__).resolve().parents[1] / "testdata" / "hdf5"
+V8_WITH_FIDS = HDF5_DIR / "20160805_test001_45_cc_v8_with_fids.h5"
+
+LEGACY_FILES = [
+    ("v4", "20160805_test001_45_cc_v4.h5"),
+    ("v5", "20160805_test001_45_cc_v5.h5"),
+    ("v6", "20160805_test001_45_cc_v6.h5"),
+    ("v7", "20160805_test001_45_cc_v7.h5"),
+    ("v8", "20160805_test001_45_cc_v8_with_fids.h5"),
+]
+
+
+def _require(path: Path) -> Path:
+    if not path.is_file():
+        pytest.skip(f"missing fixture: {path}")
+    return path
+
+
+# ---------------------------------------------------------------- helpers ----
+
+
+def test_unwrap_variants():
+    assert test_meta._unwrap(["anode"]) == "anode"
+    assert test_meta._unwrap(("anode",)) == "anode"
+    assert test_meta._unwrap("anode") == "anode"
+    assert test_meta._unwrap(np.float64(1.5)) == 1.5
+    assert test_meta._unwrap([np.int64(3)]) == 3
+    assert test_meta._unwrap(None) is None
+    # multi-element sequences are left alone (nothing sensible to unwrap)
+    assert test_meta._unwrap([1, 2]) == [1, 2]
+
+
+def test_schedule_file_name_survives_mapping():
+    individual = CellpyMetaIndividualTest()
+    individual.schedule_file_name = "myschedule.sdu"
+    _, mapped = test_meta.legacy_boxes_to_mappings(CellpyMetaCommon(), individual)
+    assert mapped["schedule_file_name"] == "myschedule.sdu"
+
+
+def test_build_apply_build_fixed_point():
+    """build -> apply -> build is a fixed point on the mapped fields."""
+    data = Data()
+    data.meta_common.mass = 1.234
+    data.meta_common.cell_name = "cell_x"
+    data.meta_test_dependent.cycle_mode = "cathode"
+    data.meta_test_dependent.channel_index = 7
+
+    first = test_meta.build_active_test_meta(data)
+
+    other = Data()
+    test_meta.apply_test_meta_to_legacy(
+        first, other.meta_common, other.meta_test_dependent
+    )
+    second = test_meta.build_active_test_meta(other)
+
+    assert core_meta_io.to_dict(second) == core_meta_io.to_dict(first)
+    assert other.meta_common.mass == 1.234
+    assert other.meta_test_dependent.cycle_mode == "cathode"
+
+
+# ------------------------------------------------------- collection on Data ----
+
+
+def test_fresh_data_has_single_test_zero():
+    data = Data()
+    assert data.active_test_id == 0
+    assert data.tests.test_ids == [0]
+    record = data.tests.get(0)
+    assert record.cycle_mode == data.meta_test_dependent.cycle_mode
+    assert record.cell is not None
+    assert record.cell.mass == data.meta_common.mass
+
+
+def test_set_cycle_mode_active_writes_through():
+    """Active-test writes land on the attribute the core engine reads."""
+    data = Data()
+    data.set_cycle_mode("cathode")
+    assert data.meta_test_dependent.cycle_mode == "cathode"
+    assert data.get_cycle_mode() == "cathode"
+    assert data.tests.get(0).cycle_mode == "cathode"
+
+
+def test_set_test_meta_active_writes_through():
+    data = Data()
+    record = data.tests.get(0)
+    record.cycle_mode = "cathode"
+    record.cell.mass = 9.9
+    data.set_test_meta(record)
+    assert data.meta_test_dependent.cycle_mode == "cathode"
+    assert data.meta_common.mass == 9.9
+
+
+def test_extra_test_record_is_isolated():
+    data = Data()
+    data.set_test_meta(TestMeta(test_id=1, cycle_mode="full"))
+    assert data.tests.test_ids == [0, 1]
+    assert data.get_cycle_mode(1) == "full"
+    # active untouched
+    assert data.get_cycle_mode() == data.meta_test_dependent.cycle_mode
+    data.set_cycle_mode("cathode", test_id=1)
+    assert data.get_cycle_mode(1) == "cathode"
+    with pytest.raises(KeyError, match="no TestMeta record"):
+        data.get_cycle_mode(42)
+
+
+def test_mutating_derived_record_does_not_persist():
+    """The active record is a snapshot: edits do not write back (documented)."""
+    data = Data()
+    before = data.meta_test_dependent.cycle_mode
+    data.tests.get(0).cycle_mode = "something_else"
+    assert data.meta_test_dependent.cycle_mode == before
+    assert data.tests.get(0).cycle_mode == before
+
+
+def test_vacant_copies_extra_tests():
+    cell = cellreader.CellpyCell(initialize=True)
+    cell.data.set_test_meta(TestMeta(test_id=1, cycle_mode="full"))
+    other = cellreader.CellpyCell.vacant(cell=cell)
+    assert other.data.tests.test_ids == [0, 1]
+    assert other.data.get_cycle_mode(1) == "full"
+
+
+# ------------------------------------------------------------ mixed modes ----
+
+
+def _mixed_mode_cell():
+    cell = cellreader.CellpyCell(initialize=True)
+    cell.data.set_cycle_mode("anode")
+    cell.data.set_test_meta(TestMeta(test_id=1, cycle_mode="cathode"))
+    return cell
+
+
+def test_mixed_modes_raise_when_both_tests_in_raw():
+    import pandas as pd
+
+    cell = _mixed_mode_cell()
+    hdr = get_headers_normal().test_id_txt
+    cell.data.raw = pd.DataFrame({hdr: [0, 0, 1, 1], "current": [1.0, -1, 1, -1]})
+    assert test_meta.cycle_modes_in_data(cell.data) == {"anode", "cathode"}
+    with pytest.raises(MixedCycleModesError, match="different cycle_modes"):
+        cell.make_step_table()
+    with pytest.raises(MixedCycleModesError, match="different cycle_modes"):
+        cell.make_summary()
+
+
+def test_mixed_modes_dormant_without_test_id_column():
+    """Extras without raw rows are dormant: no test_id column -> active only."""
+    import pandas as pd
+
+    cell = _mixed_mode_cell()
+    cell.data.raw = pd.DataFrame({"current": [1.0, -1.0]})
+    assert test_meta.cycle_modes_in_data(cell.data) == {"anode"}
+
+
+# ------------------------------------------------- file compat / round-trip ----
+
+
+@pytest.mark.parametrize("label,filename", LEGACY_FILES)
+def test_files_load_as_single_test_zero(label, filename):
+    """V2-04: v4-v8 files surface as a single-test collection (test_id=0)."""
+    path = _require(HDF5_DIR / filename)
+    cell = load_cellpy_file(path, accept_old=True)
+
+    tests = cell.data.tests
+    assert tests.test_ids == [0]
+    assert len(tests) == 1
+    record = tests.get(0)
+    # scalar (not a 1-element list), matching the public property
+    assert not isinstance(record.cycle_mode, (list, tuple))
+    assert record.cycle_mode == cell.cycle_mode
+    assert record.cell.mass == cell.data.meta_common.mass
+
+
+@pytest.mark.essential
+def test_v8_roundtrip_preserves_collection(tmp_path):
+    """V2-01: save -> reload keeps the (single-record) collection identical."""
+    source = _require(V8_WITH_FIDS)
+    original = load_cellpy_file(source)
+    snapshot = {
+        tid: core_meta_io.to_dict(original.data.tests.get(tid))
+        for tid in original.data.tests.test_ids
+    }
+
+    outfile = tmp_path / source.name
+    original.save(outfile)
+    reloaded = load_cellpy_file(outfile)
+
+    result = {
+        tid: core_meta_io.to_dict(reloaded.data.tests.get(tid))
+        for tid in reloaded.data.tests.test_ids
+    }
+    assert result == snapshot
+
+
+def test_save_warns_about_unpersisted_extras(tmp_path, caplog):
+    source = _require(V8_WITH_FIDS)
+    cell = load_cellpy_file(source)
+    cell.data.set_test_meta(TestMeta(test_id=1, cycle_mode="full"))
+
+    outfile = tmp_path / "extras.h5"
+    with caplog.at_level("WARNING"):
+        cell.save(outfile)
+    assert any("not persist" in r.message or "persists" in r.message for r in caplog.records)
+
+    reloaded = load_cellpy_file(outfile)
+    assert reloaded.data.tests.test_ids == [0]


### PR DESCRIPTION
Closes #506 — v2 Phase 1 (epic #402, themes V2-01/02/04). Implements the
approved plan (derived active record, stored extras).

## Design

`Data.tests` exposes a `cellpycore.metadata.TestMetaCollection` keyed by
`test_id`. The legacy meta boxes stay **authoritative for the active test** —
the core engine reads `data.meta_test_dependent.cycle_mode` live at compute
time, and many call sites write the legacy boxes directly — so the active
record is **derived on access** via `cellpycore.legacy.meta_mapping` and writes
route back through the same pair tables (`set_test_meta`, `set_cycle_mode`,
`get_cycle_mode`). Divergence is structurally impossible; the trade-off
(mutating the returned record is a snapshot edit) is documented and pinned by a
test.

Key modeling point surfaced by the legacy fixtures: `Data.active_test_id` is
the **compact grouping key** (0 = single unmerged, matching the engine's
`test_id` column), distinct from legacy `test_ID`, which is the
*tester-assigned* id (v4–v7 files carry `test_ID=1`) and remains provenance.

## What's included

- **V2-01**: the collection + write-through API on `Data`; v8 round-trip
  preserves it (single-record case; extras warn on save — full persistence is
  #510, on-disk format v8 unchanged).
- **V2-02**: per-test `cycle_mode` get/set; engine compute on objects whose
  present tests mix modes now raises `MixedCycleModesError` instead of silently
  applying one convention (per-test engine polarity: #507/#510).
- **V2-04**: v4–v8 files load as a single-record collection (`test_id=0`), with
  normalization of HDF artifacts (1-element lists, numpy scalars, NaN → None).
- The legacy↔core **meta-mapping contract tests** that `cellpycore.legacy.
  meta_mapping` assigns to cellpy (pinned field lists vs real dataclasses,
  totality both ways).
- Drive-by fix: `Data.__str__`/`_repr_html_` recursed via bound-method reprs
  (which embed `repr(self)`) once `Data` gained public methods; callables are
  now skipped.
- Future vocabulary/export alignment target noted: **BattINFO** (BIG-MAP).

## Verification

- New tests: 23 passed (`test_core_meta_mapping_contract.py`,
  `test_test_meta_collection.py`)
- `uv run pytest -m essential`: 99 passed
- Full `uv run pytest`: **615 passed**, 62 skipped, 14 xfailed — **no golden
  regeneration**
- Spot-check: `cellpy.get(..., cycle_mode="cathode")` →
  `c.data.tests.get(0).cycle_mode == "cathode"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
