### PR TITLE
Campaign merge: support renumber_cycles=False (#529)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+* Campaign merge supports `renumber_cycles=False` (#529, unblocked by
+  cellpycore 0.2.2): sources keep their original cycle numbers — the
+  identifying key becomes `(test_id, cycle)` and cycle-keyed consumers see
+  the union of matching cycles; data points are still offset to stay
+  globally unique. Steps/summary group and window per test, and the merged
+  object round-trips through v9.
+
 * Dependency-injection tail of V2-09 (#520): `CellpyCell(core=...,
   instrument_factory=...)` — the core seam and the loader registry are now
   constructor-injectable (defaults unchanged);

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1602,7 +1602,8 @@ class CellpyCell:
           ``Test_ID`` — those remain as provenance in
           ``meta_test_dependent.test_ID``), and its metadata becomes a
           record in ``self.data.tests``. Cycle numbers are renumbered to be
-          globally unique; data points are offset; ``test_time`` /
+          globally unique by default (see ``renumber_cycles``); data points
+          are offset; ``test_time`` /
           ``date_time`` are *not* shifted (independent timelines). Sources
           are never mutated. Mixing different ``cycle_mode`` values is
           allowed here, but computing steps/summary on the merged object
@@ -1616,10 +1617,15 @@ class CellpyCell:
         Args:
             cells: a CellpyCell or Data instance, or a sequence of them.
             mode (str): "campaign" (default) or "continuation".
-            renumber_cycles (bool): campaign mode only. v1 supports only
-                ``True`` (the legacy summary format cannot represent
-                duplicate cycle numbers); ``False`` raises
-                ``NotImplementedError`` (tracked for the native-schema path).
+            renumber_cycles (bool): campaign mode only. If True (default),
+                cycle numbers are renumbered to be globally unique. If False
+                (#529, needs cellpycore >= 0.2.2), sources keep their original
+                cycle numbers: the identifying key becomes
+                ``(test_id, cycle)`` and cycle numbers repeat across tests —
+                cycle-keyed consumers (``get_cap(cycle=...)``, ``split`` /
+                ``with_cycles``, exporters) then operate on the union of the
+                matching cycles. Data points are always offset to stay
+                globally unique.
             **kwargs: forwarded to the continuation fold.
 
         Returns:
@@ -1656,16 +1662,12 @@ class CellpyCell:
 
         if mode != "campaign":
             raise ValueError(f"unknown merge mode: {mode!r}")
-        if not renumber_cycles:
-            raise NotImplementedError(
-                "campaign merge with original (overlapping) cycle numbers "
-                "requires per-test summary support through the core bridge; "
-                "tracked for the native-schema path (#511)"
-            )
 
         logging.info("Merging (campaign)")
         for other in datas:
-            merger.campaign_fold(self.data, other, **kwargs)
+            merger.campaign_fold(
+                self.data, other, renumber_cycles=renumber_cycles, **kwargs
+            )
         modes = test_meta.cycle_modes_in_data(self.data)
         if len(modes) > 1:
             logging.warning(

--- a/cellpy/readers/merger.py
+++ b/cellpy/readers/merger.py
@@ -4,9 +4,12 @@ Implements the v2 "campaign" merge (issue #507, epic #402 themes V2-03/V2-07):
 each source keeps its identity via a distinct compact ``test_id`` stamped on the
 raw frame, and its metadata becomes a record in the per-test collection
 (``Data.tests``, issue #506). Cycle numbers are renumbered to be globally
-unique (v1 — the legacy summary format cannot represent duplicate cycle
-numbers; keeping original per-test numbering is deferred to the native-schema
-path). ``test_time`` / ``date_time`` are *not* shifted — campaign sources have
+unique by default; with ``renumber_cycles=False`` (#529, unblocked by
+cellpycore 0.2.2 carrying ``test_id`` through the bridge) the sources keep
+their original cycle numbers and the identifying key becomes
+``(test_id, cycle)`` — cycle-keyed consumers then see the union of matching
+cycles. Data points are always offset to stay globally unique.
+``test_time`` / ``date_time`` are *not* shifted — campaign sources have
 independent timelines (mirrors ``cellpycore.merge.merge_data``).
 
 This intentionally mirrors the semantics of ``cellpycore.merge.merge_data`` +
@@ -80,12 +83,15 @@ def fold_test_metadata(left, right) -> Dict[int, int]:
     return id_map
 
 
-def campaign_fold(left, right, *, merge_steps=True, merge_summary=True) -> None:
+def campaign_fold(
+    left, right, *, merge_steps=True, merge_summary=True, renumber_cycles=True
+) -> None:
     """Fold ``right`` (a ``Data`` object) into ``left`` as a distinct test.
 
     Mutates ``left`` in place; never mutates ``right``. See the module
-    docstring for the semantics (compact test_id stamping, global cycle
-    renumbering, no time shifting, per-test metadata records).
+    docstring for the semantics (compact test_id stamping, cycle renumbering
+    by default / original per-test numbering with ``renumber_cycles=False``,
+    no time shifting, per-test metadata records).
     """
     hn = get_headers_normal()
     hs = get_headers_summary()
@@ -127,7 +133,10 @@ def campaign_fold(left, right, *, merge_steps=True, merge_summary=True) -> None:
     dp_hdr = hn.data_point_txt
     cyc_raw_hdr = hn.cycle_index_txt
     dp_offset = int(left.raw[dp_hdr].max())
-    cycle_offset = int(left.raw[cyc_raw_hdr].max())
+    # Data points must stay globally unique (fid / step lookups key on them).
+    # Cycles are renumbered only when requested — with renumber_cycles=False
+    # the key is (test_id, cycle) and cycle numbers repeat across tests (#529).
+    cycle_offset = int(left.raw[cyc_raw_hdr].max()) if renumber_cycles else 0
     right_raw[dp_hdr] = right_raw[dp_hdr] + dp_offset
     right_raw[cyc_raw_hdr] = right_raw[cyc_raw_hdr] + cycle_offset
 

--- a/tests/test_merge_campaign.py
+++ b/tests/test_merge_campaign.py
@@ -144,8 +144,17 @@ def test_campaign_guards():
     with pytest.raises(ValueError, match="raw_units differ"):
         left.merge(other)
 
-    with pytest.raises(NotImplementedError, match="original"):
-        left.merge(_mini_data(name="three"), renumber_cycles=False)
+    # renumber_cycles=False is supported since #529 (cellpycore 0.2.2 carries
+    # test_id through the bridge): original cycle numbers are kept.
+    three = _mini_data(name="three")
+    three_cycles = set(three.raw[HN.cycle_index_txt].unique())
+    left.merge(three, renumber_cycles=False)
+    merged = left.data.raw
+    new_tid = max(merged[HN.test_id_txt].unique())
+    assert set(
+        merged[merged[HN.test_id_txt] == new_tid][HN.cycle_index_txt].unique()
+    ) == three_cycles
+    assert merged[HN.data_point_txt].is_unique
 
     with pytest.raises(ValueError, match="unknown merge mode"):
         left.merge(_mini_data(name="four"), mode="bogus")
@@ -226,6 +235,83 @@ def test_campaign_recompute_stamps_steps_and_windows_summary(campaign_cell):
     assert first_row[cum_col] == pytest.approx(
         first_row["charge_capacity"], rel=1e-6
     )
+
+
+def test_campaign_merge_original_cycle_numbers(parameters):
+    """renumber_cycles=False (#529): sources keep their own cycle numbers;
+    the key becomes (test_id, cycle); data points stay globally unique."""
+    left = cellreader.CellpyCell()
+    left.from_raw(parameters.res_file_path)
+    right = cellreader.CellpyCell()
+    right.from_raw(parameters.res_file_path2)
+    left_cycles = set(left.data.raw[HN.cycle_index_txt].unique())
+    right_cycles = set(right.data.raw[HN.cycle_index_txt].unique())
+    left_max_dp = int(left.data.raw[HN.data_point_txt].max())
+    assert left_cycles & right_cycles  # the fixture overlaps, so the flag matters
+
+    left.merge(right, renumber_cycles=False)
+
+    raw = left.data.raw
+    assert set(raw[HN.test_id_txt].unique()) == {0, 1}
+    t0 = raw[raw[HN.test_id_txt] == 0]
+    t1 = raw[raw[HN.test_id_txt] == 1]
+    assert set(t0[HN.cycle_index_txt].unique()) == left_cycles
+    assert set(t1[HN.cycle_index_txt].unique()) == right_cycles
+    assert raw[HN.data_point_txt].is_unique
+    assert int(t1[HN.data_point_txt].min()) > left_max_dp
+
+
+def test_campaign_original_cycles_pipeline_and_v9_roundtrip(parameters, tmp_path):
+    """renumber_cycles=False (#529): steps/summary group on (test_id, cycle),
+    cumulatives reset per test, and everything round-trips through v9."""
+    left = cellreader.CellpyCell()
+    left.from_raw(parameters.res_file_path)
+    right = cellreader.CellpyCell()
+    right.from_raw(parameters.res_file_path2)
+    left.merge(right, renumber_cycles=False)
+
+    left.make_step_table()
+    steps = left.data.steps
+    assert set(steps[HN.test_id_txt].unique()) == {0, 1}
+    # duplicate cycle numbers overall, unique per (test_id, cycle, step)
+    assert steps.duplicated(subset=[HN.test_id_txt, "cycle", "step"]).sum() == 0
+    assert steps["cycle"].min() == 1
+    assert set(steps[steps[HN.test_id_txt] == 1]["cycle"].unique()) == set(
+        right.data.raw[HN.cycle_index_txt].unique()
+    )
+
+    left.make_summary(find_ir=False, find_end_voltage=False)
+    summary = left.data.summary
+    assert set(summary[HS.test_id].astype(int).unique()) == {0, 1}
+    # (test_id, cycle_index) is the key: unique pairs, repeated cycle numbers
+    assert summary.duplicated(subset=[HS.test_id, HS.cycle_index]).sum() == 0
+    assert summary[HS.cycle_index].duplicated().any()
+    # per-test windowing: the cumulation restarts at the test boundary
+    cum_col = "cumulated_charge_capacity"
+    block1 = summary[summary[HS.test_id] == 1]
+    first_row = block1.sort_values(HS.cycle_index).iloc[0]
+    assert first_row[cum_col] == pytest.approx(first_row["charge_capacity"], rel=1e-6)
+
+    outfile = tmp_path / "campaign_original_cycles.cellpy"
+    left.save(outfile)
+    reloaded = cellreader.CellpyCell()
+    reloaded.load(outfile)
+    r_raw = reloaded.data.raw
+    assert set(r_raw[HN.test_id_txt].unique()) == {0, 1}
+    for tid in (0, 1):
+        assert set(
+            r_raw[r_raw[HN.test_id_txt] == tid][HN.cycle_index_txt].unique()
+        ) == set(raw_cycles_per_test(left.data)[tid])
+    assert sorted(reloaded.data.tests.test_ids) == [0, 1]
+
+
+def raw_cycles_per_test(data):
+    """The set of raw cycle numbers per test_id (test helper)."""
+    raw = data.raw
+    return {
+        int(tid): set(raw[raw[HN.test_id_txt] == tid][HN.cycle_index_txt].unique())
+        for tid in raw[HN.test_id_txt].unique()
+    }
 
 
 def test_campaign_merge_remaps_summary_test_id(parameters):


### PR DESCRIPTION
## Summary

Closes #529: campaign merge can now keep the sources' original per-test cycle numbers. cellpycore 0.2.2 (core #136) removed the blocker the old `NotImplementedError` cited — `test_id` is carried through the bridge on steps and summary, and summary cumulatives window per test. (Rebased onto master now that the #524–#528 stack has merged.)

- `merger.campaign_fold` gains `renumber_cycles=True`: with `False` the cycle offset is 0 for raw/steps/summary, while **data-point offsets stay unconditional** (fid/step lookups key on globally unique `data_point`).
- `CellpyCell.merge` forwards the flag instead of raising; docstrings document the new semantics: the identifying key becomes `(test_id, cycle)`, cycle numbers repeat across tests, and cycle-keyed consumers (`get_cap(cycle=...)`, `split`/`with_cycles`, exporters) operate on the union of matching cycles.
- Defaults unchanged — `renumber_cycles=True` behaves exactly as before.

## Test plan

- [x] New: original-cycle merge invariants (per-test cycle sets preserved, overlap proven in the fixture, `data_point` unique)
- [x] New: full pipeline on an original-cycles campaign — steps unique per `(test_id, cycle, step)`, summary unique per `(test_id, cycle_index)` with repeated cycle numbers, cumulatives reset at the test boundary, v9 round-trip preserves ids and cycle sets
- [x] Updated: the guards pin flipped from raises-`NotImplementedError` to keeps-original-cycles
- [x] Full suite green at the pre-rebase tip (661 passed); campaign tests re-run green post-rebase; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)