### PR TITLE
CI: add full (linux / uv) job as the intended required merge gate (#530)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
-# Fast merge gate (Tier 1): PRs and pushes to master only.
+# Merge gate (Tier 1): PRs and pushes to master only.
+# ``essential`` is the fast signal; ``full`` runs the whole linux suite and is
+# the intended required check (issue #530 — four non-essential test failures
+# once landed on master through the essential-only gate).
 # Full conda / pip matrix runs in ci-scheduled.yml (Tier 3).
 name: CI
 on:
@@ -50,3 +53,25 @@ jobs:
         run: uv run cellpy setup --silent
       - name: Run cellpy check
         run: uv run cellpy info --check
+
+  full:
+    name: full (linux / uv)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      UV_NO_SOURCES: 1
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y mdbtools
+      - run: uv python install 3.13
+      - name: Sync dependencies (PyPI cellpycore only)
+        run: uv sync
+      - name: Run the full test suite
+        # same ignore as the tier-3 linux job (plotutils summary plot needs a
+        # display); everything else runs — this is the gate that catches
+        # non-essential regressions (issue #530)
+        run: uv run pytest --ignore=tests/test_plotutils_summary_plot.py


### PR DESCRIPTION
## Summary

Implements the recommended option from #530 (option 1): a `full (linux / uv)` job in the tier-1 CI workflow that runs the whole suite on every PR and push to master, so non-essential regressions (like the four that landed on master and were fixed in #524) can't slip through the essential-only gate.

- Mirrors the essential job's setup (uv, Python 3.13, mdbtools) and the tier-3 linux invocation (`--ignore=tests/test_plotutils_summary_plot.py` — needs a display).
- `essential` stays as the fast signal; `full` has a 25-minute job timeout as a hang guard (the suite takes ~3 min).
- **After merging:** an admin must add `full (linux / uv)` to the required status checks in branch protection. I can run that via `gh api` on request, or it's Settings → Branches → master → required status checks.

This PR's own check run doubles as the proof that the job passes.

Closes #530.

## Test plan

- [x] Full suite green locally (661 passed) at master + this change (workflow-only)
- [x] The `full (linux / uv)` job runs and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)