### PR TITLE
Per-cell cellpy_units: stop sharing the module-level singleton (#427)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+* Units are per-cell now (#427): `get_cellpy_units` returns a fresh
+  `CellpyUnits` per call (optionally seeded from its argument, which used to
+  be silently ignored), so changing units on one `CellpyCell` — directly, via
+  the constructor, or via `cellpy.get(units=...)` — no longer changes them
+  for every other cell in the session.
+
 * Campaign merge supports `renumber_cycles=False` (#529, unblocked by
   cellpycore 0.2.2): sources keep their original cycle numbers — the
   identifying key becomes `(test_id, cycle)` and cycle-keyed consumers see

--- a/cellpy/parameters/internal_settings.py
+++ b/cellpy/parameters/internal_settings.py
@@ -613,6 +613,9 @@ headers_step_table = HeadersStepTable()
 headers_journal = HeadersJournal()
 headers_summary = HeadersSummary()
 headers_normal = HeadersNormal()
+# Legacy module-level instance. NOT handed out anymore: ``get_cellpy_units``
+# returns a fresh object per call so units are per-cell (issue #427). Kept
+# only so external code importing it directly does not break.
 cellpy_units = CellpyUnits()
 
 base_columns_float = [
@@ -633,9 +636,21 @@ base_columns_int = [
 ]
 
 
-def get_cellpy_units(*args, **kwargs) -> CellpyUnits:
-    """Returns an augmented global dictionary with units"""
-    return cellpy_units
+def get_cellpy_units(units=None, *args, **kwargs) -> CellpyUnits:
+    """Return a fresh ``CellpyUnits`` instance, optionally seeded from ``units``.
+
+    Every call returns a **new** instance: mutating one cell's units must
+    never leak into other cells in the same session (issue #427 — this used
+    to hand out a shared module-level singleton and ignore ``units``).
+
+    Args:
+        units: optional mapping (or ``CellpyUnits``) whose entries override
+            the defaults on the returned instance.
+    """
+    fresh = CellpyUnits()
+    if units:
+        fresh.update(dict(units))
+    return fresh
 
 
 def get_default_output_units(*args, **kwargs) -> CellpyUnits:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -201,3 +201,45 @@ def test_pint_nom_cap_conversion(nom_cap_tuple, expected):
     print(f"{nom_cap_areal=}")
     print(80 * "-")
     assert nom_cap_abs.m == pytest.approx(expected, 0.0001)
+
+
+# --- per-cell units isolation (#427) ----------------------------------------
+def test_cellpy_units_are_per_cell():
+    """Mutating one cell's units must not leak into another (issue #427)."""
+    from cellpy import cellreader
+
+    c1 = cellreader.CellpyCell()
+    c2 = cellreader.CellpyCell()
+    assert c1.cellpy_units is not c2.cellpy_units
+
+    before = c2.cellpy_units["charge"]
+    c1.cellpy_units["charge"] = "kAh"
+    assert c2.cellpy_units["charge"] == before
+
+    # a later cell still starts from the defaults
+    c3 = cellreader.CellpyCell()
+    assert c3.cellpy_units["charge"] == before
+
+
+def test_cellpy_units_constructor_seed():
+    """The cellpy_units constructor argument seeds the per-cell units
+    (it used to be silently ignored)."""
+    from cellpy import cellreader
+
+    c = cellreader.CellpyCell(cellpy_units={"charge": "Ah", "mass": "g"})
+    assert c.cellpy_units["charge"] == "Ah"
+    assert c.cellpy_units["mass"] == "g"
+    # untouched entries keep their defaults; other cells are unaffected
+    plain = cellreader.CellpyCell()
+    assert plain.cellpy_units["charge"] == "mAh"
+    assert plain.cellpy_units["mass"] == "mg"
+
+
+def test_get_units_kwarg_does_not_leak(dataset):
+    """cellpy.get(units=...) updates only that instance (issue #427)."""
+    from cellpy import cellreader
+    from cellpy.readers.cellreader import _update_meta
+
+    _update_meta(dataset, units={"charge": "kAh"})
+    assert dataset.cellpy_units["charge"] == "kAh"
+    assert cellreader.CellpyCell().cellpy_units["charge"] == "mAh"


### PR DESCRIPTION
## Summary

Closes #427 ("changing cellpy unit in one object changes global cellpy unit"). Confirmed the report — and it was worse than described:

- `get_cellpy_units` returned one **shared module-level `CellpyUnits`** to every `CellpyCell`, so `c.cellpy_units[...] = ...` mutated units for every cell in the session.
- It also **ignored its argument**, so the documented `CellpyCell(cellpy_units={...})` constructor parameter was silently a no-op.
- The top API leaked too: `cellpy.get(units=...)` goes through `_update_meta`'s `cellpy_units.update(...)` — mutating the shared global.

The fix: `get_cellpy_units(units=None)` returns a **fresh instance per call**, seeded from the argument. That fixes all three paths at once (cellpycore's own `get_cellpy_units` already had these semantics — cellpy's copy was the outlier). The module-level global stays defined for any external code importing it directly, but is no longer handed out; nothing in-repo reads it.

## Test plan

- [x] Three regression tests in `tests/test_units.py`: per-cell isolation (mutation doesn't leak, later cells start from defaults), constructor seeding works, and the `cellpy.get(units=...)` / `_update_meta` path updates only that instance
- [x] Full suite: 664 passed, 0 failed
- [x] ruff: no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)