### PR TITLE
Fix Windows-only failure in the posix-coercion OtherPath test

### DIFF
--- a/tests/test_otherpaths.py
+++ b/tests/test_otherpaths.py
@@ -266,8 +266,12 @@ def test_posix_path_coercion_keeps_single_leading_slash():
     abs_path = pathlib.Path("/cellpy_inventory_root")
     op = cellpy.internals.connections.OtherPath(abs_path)
     assert op.original == "/cellpy_inventory_root"
-    assert str(op) == "/cellpy_inventory_root"
+    # str() uses the platform separator (Windows gives "\\cellpy_inventory_root");
+    # the guarded regression is slash-doubling, so compare against plain pathlib
+    assert str(op) == str(abs_path)
+    assert op.as_posix() == "/cellpy_inventory_root"
     assert not str(op).startswith("//")
+    assert not str(op).startswith("\\\\")
 
 
 def test_copy_local(parameters, tmp_path):


### PR DESCRIPTION
## Summary

Pre-`v2.0.0a2` blocker: the full suite on master fails on **Windows** in `test_posix_path_coercion_keeps_single_leading_slash` (from #535) because `str(pathlib.Path("/foo"))` is `\foo` on win32 and the test hard-codes the posix literal. The linux-only required checks couldn't catch it.

Test-only fix, intent preserved: compare `str(op)` against plain `pathlib` (identical to the old assertion on posix), pin the posix form via `op.as_posix()`, and guard slash-doubling for both separators.

## Test plan

- [x] `test_otherpaths.py` + `test_otherpaths_sftp.py`: 46 passed on Windows (was 1 failing)
- [x] On Linux the comparison is literal-identical to the previous assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)