### PR TITLE
Header-object attributes for column lookups in helpers and filters (#538)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* Header column literals in `utils/helpers.py` and `filters/summary.py` use
+  header-object attributes (#538, native-headers Phase-0 prerequisite): the
+  base-name string-keyed `hdr_summary["charge_capacity"]`-style lookups become
+  attribute access, and `filter_summary`'s `rate_columns` default is resolved
+  from `HeadersSummary` (was a hard-coded `("charge_c_rate", "discharge_c_rate")`
+  tuple). Postfix/specific columns (`*_gravimetric`, `areal_*`) keep string-key
+  composition. Behavior-identical.
+
 * Journal-page column literals use `HeadersJournal` attributes (#537, native-
   headers Phase-0 prerequisite): the string-keyed `hdr_journal["mass"]`-style
   lookups in `batch_plotters.py` and `helpers.py` become attribute access

--- a/cellpy/filters/summary.py
+++ b/cellpy/filters/summary.py
@@ -29,6 +29,8 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable, Optional, Union
 
+from cellpy.parameters.internal_settings import get_headers_summary
+
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -145,7 +147,7 @@ def filter_summary(
     df: pd.DataFrame,
     *,
     rate: RangeArg = None,
-    rate_columns: ColumnsArg = ("charge_c_rate", "discharge_c_rate"),
+    rate_columns: ColumnsArg = None,
     **extra_filters: Any,
 ) -> pd.DataFrame:
     """Filter rows of a cellpy summary DataFrame.
@@ -159,6 +161,8 @@ def filter_summary(
             mapping ``{"value": v, "delta": d}`` (keep rows with
             ``v - d < value <= v + d``).
         rate_columns: Which column(s) the ``rate`` filter applies to.
+            ``None`` (default) resolves to the summary C-rate columns
+            (``HeadersSummary.charge_c_rate`` / ``.discharge_c_rate``).
             A single string is coerced to a one-element tuple. With more
             than one column the predicate is AND-ed across columns - a
             row is kept only if *every* listed column lies in range.
@@ -176,6 +180,10 @@ def filter_summary(
             argument is malformed.
         TypeError: A range argument has an unsupported type.
     """
+    if rate_columns is None:
+        hdr_summary = get_headers_summary()
+        rate_columns = (hdr_summary.charge_c_rate, hdr_summary.discharge_c_rate)
+
     range_kwargs = {k: v for k, v in extra_filters.items() if not k.endswith("_columns")}
     column_kwargs = {k: v for k, v in extra_filters.items() if k.endswith("_columns")}
 

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -37,8 +37,8 @@ def _make_average_legacy(
 ):
     if key_index_bounds is None:
         key_index_bounds = [1, -2]
-    hdr_norm_cycle = hdr_summary["normalized_cycle_index"]
-    hdr_cum_charge = hdr_summary["cumulated_charge_capacity"]
+    hdr_norm_cycle = hdr_summary.normalized_cycle_index
+    hdr_cum_charge = hdr_summary.cumulated_charge_capacity
     cell_id = ""
     not_a_number = np.nan
     new_frames = []
@@ -103,7 +103,7 @@ def _make_average(
     skip_st_dev_for_equivalent_cycle_index=True,
     average_method="mean",
 ):
-    hdr_norm_cycle = hdr_summary["normalized_cycle_index"]
+    hdr_norm_cycle = hdr_summary.normalized_cycle_index
     not_a_number = np.nan
     new_frames = []
 
@@ -225,7 +225,7 @@ def add_normalized_cycle_index(summary, nom_cap, column_name=None):
     Returns:
         data object now with normalized cycle index in its summary.
     """
-    hdr_norm_cycle = hdr_summary["normalized_cycle_index"]
+    hdr_norm_cycle = hdr_summary.normalized_cycle_index
     hdr_cum_charge = hdr_summary["cumulated_charge_capacity_gravimetric"]
 
     if column_name is None:
@@ -260,7 +260,7 @@ def add_c_rate(cell, nom_cap=None, column_name=None):
     # now also included in step_table
     # TODO: remove this function
     if column_name is None:
-        column_name = hdr_steps["rate_avr"]
+        column_name = hdr_steps.rate_avr
     if nom_cap is None:
         nom_cap = cell.data.nom_cap
 
@@ -278,10 +278,10 @@ def add_areal_capacity(cell, cell_id, journal):
     loading = journal.pages.loc[cell_id, hdr_journal.loading]
 
     cell.data.summary[hdr_summary["areal_charge_capacity"]] = (
-        cell.data.summary[hdr_summary["charge_capacity"]] * loading / 1000
+        cell.data.summary[hdr_summary.charge_capacity] * loading / 1000
     )
     cell.data.summary[hdr_summary["areal_discharge_capacity"]] = (
-        cell.data.summary[hdr_summary["discharge_capacity"]] * loading / 1000
+        cell.data.summary[hdr_summary.discharge_capacity] * loading / 1000
     )
     return cell
 
@@ -303,7 +303,7 @@ def remove_outliers_from_summary_on_window(
 ):
     """Removes outliers based on neighbours"""
     if col_name is None:
-        col = hdr_summary["charge_capacity"]
+        col = hdr_summary.charge_capacity
 
     else:
         col = hdr_summary[col_name]
@@ -344,8 +344,8 @@ def remove_outliers_from_summary_on_nn_distance(
     """
     if filter_cols is None:
         filter_cols = [
-            hdr_summary["charge_capacity"],
-            hdr_summary["discharge_capacity"],
+            hdr_summary.charge_capacity,
+            hdr_summary.discharge_capacity,
         ]
 
     def neighbour_window(y):
@@ -391,8 +391,8 @@ def remove_outliers_from_summary_on_zscore(
 
     if filter_cols is None:
         filter_cols = [
-            hdr_summary["charge_capacity"],
-            hdr_summary["discharge_capacity"],
+            hdr_summary.charge_capacity,
+            hdr_summary.discharge_capacity,
         ]
 
     s2 = s[filter_cols].copy()
@@ -424,8 +424,8 @@ def remove_outliers_from_summary_on_value(
     """
     if filter_cols is None:
         filter_cols = [
-            hdr_summary["charge_capacity"],
-            hdr_summary["discharge_capacity"],
+            hdr_summary.charge_capacity,
+            hdr_summary.discharge_capacity,
         ]
 
     s2 = s[filter_cols].copy()
@@ -756,7 +756,7 @@ def concatenate_summaries(
         group_nest.append(b.pages.group.to_list())
 
     default_columns = [hdr_summary["charge_capacity_gravimetric"]]
-    hdr_norm_cycle = hdr_summary["normalized_cycle_index"]
+    hdr_norm_cycle = hdr_summary.normalized_cycle_index
 
     if columns is None:
         columns = []
@@ -786,16 +786,16 @@ def concatenate_summaries(
 
     if normalize_capacity_on is not None:
         normalize_capacity_headers = [
-            hdr_summary["normalized_charge_capacity"],
-            hdr_summary["normalized_discharge_capacity"],
+            hdr_summary.normalized_charge_capacity,
+            hdr_summary.normalized_discharge_capacity,
         ]
         output_columns = [
             col
             for col in output_columns
             if col
             not in [
-                hdr_summary["charge_capacity"],
-                hdr_summary["discharge_capacity"],
+                hdr_summary.charge_capacity,
+                hdr_summary.discharge_capacity,
             ]
         ]
         output_columns.extend(normalize_capacity_headers)
@@ -917,7 +917,7 @@ def _partition_summary_based_on_cv_steps(
     import pandas as pd
 
     if not x:
-        x = hdr_summary["cycle_index"]
+        x = hdr_summary.cycle_index
 
     summary = c.data.summary.copy()
 
@@ -1081,7 +1081,7 @@ def concat_summaries(
         group_nest.append(pages.group.to_list())
 
     default_columns = [hdr_summary["charge_capacity_gravimetric"]]
-    hdr_norm_cycle = hdr_summary["normalized_cycle_index"]
+    hdr_norm_cycle = hdr_summary.normalized_cycle_index
 
     if columns is None:
         columns = []
@@ -1111,16 +1111,16 @@ def concat_summaries(
 
     if normalize_capacity_on is not None:
         normalize_capacity_headers = [
-            hdr_summary["normalized_charge_capacity"],
-            hdr_summary["normalized_discharge_capacity"],
+            hdr_summary.normalized_charge_capacity,
+            hdr_summary.normalized_discharge_capacity,
         ]
         output_columns = [
             col
             for col in output_columns
             if col
             not in [
-                hdr_summary["charge_capacity"],
-                hdr_summary["discharge_capacity"],
+                hdr_summary.charge_capacity,
+                hdr_summary.discharge_capacity,
             ]
         ]
         output_columns.extend(normalize_capacity_headers)
@@ -1462,10 +1462,10 @@ def select_summary_based_on_rate(
             on = [on]
 
     if rate_column is None:
-        rate_column = hdr_steps["rate_avr"]
+        rate_column = hdr_steps.rate_avr
 
     if on:
-        on_column = hdr_steps["type"]
+        on_column = hdr_steps.type
 
     if rate is None:
         rate = 0.05
@@ -1473,7 +1473,7 @@ def select_summary_based_on_rate(
     if rate_std is None:
         rate_std = 0.1 * rate
 
-    cycle_number_header = hdr_summary["cycle_index"]
+    cycle_number_header = hdr_summary.cycle_index
 
     step_table = cell.data.steps
 
@@ -1545,10 +1545,10 @@ def add_normalized_capacity(
     if norm_cycles is None:
         norm_cycles = [1, 2, 3, 4, 5]
 
-    col_name_charge = hdr_summary["charge_capacity"]
-    col_name_discharge = hdr_summary["discharge_capacity"]
-    col_name_norm_charge = hdr_summary["normalized_charge_capacity"]
-    col_name_norm_discharge = hdr_summary["normalized_discharge_capacity"]
+    col_name_charge = hdr_summary.charge_capacity
+    col_name_discharge = hdr_summary.discharge_capacity
+    col_name_norm_charge = hdr_summary.normalized_charge_capacity
+    col_name_norm_discharge = hdr_summary.normalized_discharge_capacity
 
     try:
         norm_val_charge = cell.data.summary.loc[norm_cycles, col_name_charge].mean()


### PR DESCRIPTION
## Summary

Native-headers Phase-0 prerequisite (#538). Two behavior-identical changes:

- **`utils/helpers.py`** — 32 base-name string-keyed lookups (`hdr_summary["charge_capacity"]`, `hdr_steps["rate_avr"]`, …) → attribute access. The **postfix/specific** columns (`*_gravimetric`, `areal_*`) are deliberately left as string-key lookups: those names are composed, not direct attributes (report §8-5), and converting them would `AttributeError` / trip the specific-column deprecation path.
- **`filters/summary.py`** — `filter_summary`'s `rate_columns` default was a hard-coded `("charge_c_rate", "discharge_c_rate")` tuple; now defaults to `None` and resolves from `HeadersSummary` in the body, mirroring `filters/cycles.py` (report §9.2).

## Scope correction (important)

Implementing this surfaced that #538's original file list was **over-broad** — the scan tool matches strings, and most of its hits outside helpers/filters are **not** raw/steps/summary header literals:

- **`plotutils.py`** — the `"cycle"` / `"voltage"` / `"direction"` hits are `get_cap` **curve-frame** columns (e.g. `df.sort_values(by=["cycle", "direction"])`). These belong to the **CurveCols adoption, #540** — fixing them here (mapping to `HeadersNormal`) would be a latent bug after the flip.
- **`ocv_rlx.py`** — the `"charge"` / `"discharge"` / `"ir"` hits are **step-type values** (`.isin(["discharge"])`) and dict keys (`result_dict["ir"]`), not header columns. These belong to a separate **StepType-constants migration** (report §8 step-type note).

I'll re-scope #538 and file the StepType issue after merge.

## Test plan

- [x] Scan: helpers + filters in-scope findings ~40 → 1 (the lone remaining is `on = ["charge"]`, a step-type literal, correctly left)
- [x] `test_helpers.py` + `test_filters_summary.py` + `test_batch.py`: 72 passed
- [x] `filter_summary` default and explicit-override paths verified equivalent
- [x] ruff: no new findings vs master
- [x] `full (linux / uv)` is the authoritative post-edit gate

Refs #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)