### PR TITLE
Use cellpycore StepType vocabulary for step-type literals (#543)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+* Step-type string literals use the `cellpycore` vocabulary (#543, native-
+  headers Phase-0 prerequisite): `CellpyCell.list_of_step_types` is now
+  `list(config.STEP_TYPES)` (was a hand-maintained duplicate of the 13
+  step-type names), and the step-table `type` comparisons in `utils/ocv_rlx.py`
+  / `utils/helpers.py` use `StepType.CHARGE.value` / `.DISCHARGE.value` instead
+  of bare `"charge"` / `"discharge"` literals. Behavior-identical.
+
 * Header column literals in `utils/helpers.py` and `filters/summary.py` use
   header-object attributes (#538, native-headers Phase-0 prerequisite): the
   base-name string-keyed `hdr_summary["charge_capacity"]`-style lookups become

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -58,6 +58,7 @@ from cellpy.parameters.internal_settings import (
 # still expects. cellpy-core's __init__ is intentionally empty, so import submodules.
 from cellpycore import units as core_units
 from cellpycore.cell_core import OldCellpyCellCore
+from cellpycore.config import STEP_TYPES
 
 from cellpy.readers.cellpy_file import dtype as cellpy_file_dtype
 from cellpy.readers.cellpy_file import fids as cellpy_file_fids
@@ -297,21 +298,9 @@ class CellpyCell:
 
         self.capacity_modifiers = ["reset"]
 
-        self.list_of_step_types = [
-            "charge",
-            "discharge",
-            "cv_charge",
-            "cv_discharge",
-            "taper_charge",
-            "taper_discharge",
-            "charge_cv",
-            "discharge_cv",
-            "ocvrlx_up",
-            "ocvrlx_down",
-            "ir",
-            "rest",
-            "not_known",
-        ]
+        # single source of the step-type vocabulary (cellpycore #543);
+        # was a hand-maintained duplicate of config.STEP_TYPES.
+        self.list_of_step_types = list(STEP_TYPES)
         # - options
         self.force_step_table_creation = config.reader.force_step_table_creation
         self.force_all = config.reader.force_all

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from cellpycore.config import StepType
+
 import cellpy
 import cellpy.config as config
 from cellpy import prms
@@ -1456,7 +1458,7 @@ def select_summary_based_on_rate(
         filtered summary (Pandas.DataFrame).
     """
     if on is None:
-        on = ["charge"]
+        on = [StepType.CHARGE.value]
     else:
         if not isinstance(on, (list, tuple)):
             on = [on]

--- a/cellpy/utils/ocv_rlx.py
+++ b/cellpy/utils/ocv_rlx.py
@@ -18,6 +18,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from cellpycore.config import StepType
+
 from cellpy import cellreader
 from cellpy.parameters.internal_settings import get_headers_normal, get_headers_step_table
 
@@ -371,21 +373,21 @@ class MultiCycleOcvFit:
         if direction == "up":
             end_voltage = step_table[
                 (step_table[hdr_steps.cycle] == cycle)
-                & (step_table[hdr_steps.type].isin(["discharge"]))
+                & (step_table[hdr_steps.type].isin([StepType.DISCHARGE.value]))
             ][hdr.voltage + "_last"].values[0]
 
             end_current = step_table[
                 (step_table[hdr_steps.cycle] == cycle)
-                & (step_table[hdr_steps.type].isin(["discharge"]))
+                & (step_table[hdr_steps.type].isin([StepType.DISCHARGE.value]))
             ][hdr.current + "_last"].values[0]
 
         elif direction == "down":
             end_voltage = step_table[
-                (step_table[hdr_steps.cycle] == cycle) & (step_table[hdr_steps.type].isin(["charge"]))
+                (step_table[hdr_steps.cycle] == cycle) & (step_table[hdr_steps.type].isin([StepType.CHARGE.value]))
             ][hdr.voltage + "_last"].values[0]
 
             end_current = step_table[
-                (step_table[hdr_steps.cycle] == cycle) & (step_table[hdr_steps.type].isin(["charge"]))
+                (step_table[hdr_steps.cycle] == cycle) & (step_table[hdr_steps.type].isin([StepType.CHARGE.value]))
             ][hdr.current + "_last"].values[0]
 
         return end_current, end_voltage


### PR DESCRIPTION
## Summary

Native-headers Phase-0 prerequisite, split from #538 (where the header scan flagged step-type *values* as false positives — they're compared against the step-table `type` column, not header columns).

- **`cellreader.py`** — `list_of_step_types` was a hand-maintained duplicate of the 13 step-type names; now `list(config.STEP_TYPES)` (single source, exact match verified).
- **`utils/ocv_rlx.py`** — `step_table[hdr_steps.type].isin(["discharge"])` / `(["charge"])` (4 sites) → `StepType.DISCHARGE.value` / `.CHARGE.value`.
- **`utils/helpers.py`** — the `on = ["charge"]` step-type filter default → `[StepType.CHARGE.value]`.

Behavior-identical (`StepType.<X>.value` equals the former literal).

**Out of scope (deliberately):** `direction == "charge"` / `cap_type == "charge"` comparisons (those compare API arguments / local direction variables, not the step-table `type` column), and `easyplot` (deprecated, removal 2.0 — #544).

## Test plan

- [x] `list_of_step_types == list(STEP_TYPES)` verified
- [x] `test_ocv_relax.py` + `test_helpers.py` + `test_cell_readers.py`: 120 passed
- [x] No step-type `isin` literals remain in ocv_rlx
- [x] ruff: no new findings
- [x] `full (linux / uv)` is the authoritative gate

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)