### PR TITLE
CI: run plotting extras; add collector/plotter smoke tests (flip Stage 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y mdbtools
       - run: uv python install 3.13
-      - name: Sync dependencies (PyPI cellpycore only)
-        run: uv sync
+      - name: Sync dependencies (PyPI cellpycore only, with plotting extras)
+        # --extra batch pulls in plotly/seaborn so the collector/plotter code
+        # paths actually execute under test (they were never exercised in CI
+        # before — the flip's curve-consumer migration needs this net).
+        run: uv sync --extra batch
       - name: Run the full test suite
         # same ignore as the tier-3 linux job (plotutils summary plot needs a
         # display); everything else runs — this is the gate that catches

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,65 @@
+"""Smoke/characterization tests for the batch collectors + plotters.
+
+Before this file nothing in the suite exercised `cellpy.utils.collectors`'
+collect→plot paths, and CI did not even install the plotting extras
+(`plotly`/`seaborn` live in the `batch` optional-dependency group). That left
+the collector/plotter code — including the curve-frame consumers that the
+native-headers flip must migrate (#540) — with **no** test net.
+
+These tests drive each public collector end to end (construction autoruns the
+data collection and the plot) so a broken column-name migration or a plotter
+regression fails loudly. They require the plotting extras; the `full` CI job
+installs them (`uv sync --extra batch`), and they skip cleanly when the extras
+or the batch testdata are absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Reuse the batch fixtures (clean_dir → batch_instance → populated_batch).
+from tests.test_batch import (  # noqa: F401  (imported for fixture resolution)
+    batch_instance,
+    clean_dir,
+    populated_batch,
+)
+
+plotly = pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+
+from cellpy.utils.collectors import (  # noqa: E402
+    BatchCyclesCollector,
+    BatchICACollector,
+    BatchSummaryCollector,
+)
+
+
+def _assert_ran(collector):
+    """A collector that autoran must have collected data and built a figure."""
+    assert collector.data is not None, "collector produced no data"
+    assert not collector.data.empty, "collector data is empty"
+    assert collector.figure is not None, "collector did not build a figure"
+
+
+def test_batch_summary_collector_runs(populated_batch):
+    """Summary collector collects + plots (guards the summary-frame path that
+    #540 must NOT touch)."""
+    _assert_ran(BatchSummaryCollector(populated_batch))
+
+
+def test_batch_cycles_collector_runs(populated_batch):
+    """Capacity-curve collector collects `get_cap` frames + plots (the curve
+    consumer path the flip migrates — #540)."""
+    collector = BatchCyclesCollector(populated_batch)
+    _assert_ran(collector)
+    # the collected curve frame carries capacity + a cycle-key + a voltage-axis
+    # column; tolerate the legacy/native name for the two that the flip renames.
+    cols = set(collector.data.columns)
+    assert "capacity" in cols
+    assert cols & {"cycle", "cycle_num"}, f"no cycle column in {cols}"
+    assert cols & {"voltage", "potential"}, f"no voltage column in {cols}"
+
+
+def test_batch_ica_collector_runs(populated_batch):
+    """ICA (dQ/dV) collector collects + plots."""
+    collector = BatchICACollector(populated_batch)
+    _assert_ran(collector)


### PR DESCRIPTION
## Summary

Stage 0 of the native-headers flip (see #540): establish the test net the consumer-migration stages need.

**Problem found while starting #540:** `cellpy.utils.collectors` (the batch collectors + their plotters) was **never exercised** by the suite. `plotly`/`seaborn` are in the `batch` optional-dependency group, and CI's `full` job ran plain `uv sync`, so the plotting code paths — including the `get_cap` curve-frame consumers the flip must migrate — had **zero** coverage, locally and in CI. Migrating them blind (a wrong `voltage`/`cycle` rename silently produces broken plots) was unsafe.

**This PR:**
- `ci.yml` `full` job → `uv sync --extra batch`, so plotly/seaborn are installed and the collector/plotter code actually runs under test.
- New `tests/test_collectors.py`: smoke/characterization tests driving `BatchSummaryCollector` / `BatchCyclesCollector` / `BatchICACollector` end to end (construction autoruns collect + plot). They `importorskip` the plotting extras and reuse the batch fixtures.

Now a broken `get_cap → CurveCols` rename (#540) fails `test_batch_cycles_collector_runs` instead of shipping silently. This de-risks every consumer-migration stage of the flip, and closes the standing gap where CI never ran the plotting code at all.

## Test plan

- [x] `tests/test_collectors.py`: 3 passed (summary/cycles/ica collectors run collect+plot end to end)
- [x] Full suite with `--extra batch` installed (mirrors the new CI): **661 passed, 0 failed** — the extras activate ~44 previously-skipped tests with nothing turning red (skips 62 → 18)
- [x] Change is scoped to CI config + a new test file; no product code touched

Refs #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)