### PR TITLE
Add D6 legacy-header attribute shim (native-headers flip, Stage 2)

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -8,4 +8,5 @@ uv run python -m cellpy._deprecation
 
 | Name | Replacement | Introduced | Removal |
 | --- | --- | --- | --- |
+| `legacy header attribute access (headers_normal / _summary / _step_table)` | `the native cellpycore schema column names` | 2.0 | 2.1 |
 | `make_new_cell` | `CellpyCell.vacant` | 2.0 | 2.1 |

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -94,6 +94,16 @@ def write_deprecations_md(path: str | Path) -> None:
 def _seed_known_deprecations() -> None:
     """Register deprecations that exist before any runtime call (for doc generation)."""
     _register("make_new_cell", "CellpyCell.vacant", removal="2.1")
+    # Legacy header attribute access (headers_normal.voltage_txt, hdr_steps.cycle,
+    # hdr_summary[...]) is shimmed to the native cellpycore schema names at the
+    # native-headers flip (D6). One summary row here; the shim warns per attribute
+    # at runtime (cellpy.parameters.legacy_header_shim).
+    _register(
+        "legacy header attribute access (headers_normal / _summary / _step_table)",
+        "the native cellpycore schema column names",
+        removal="2.1",
+        introduced="2.0",
+    )
     # cellpy.utils.easyplot was removed in 2.0 (#544); it is no longer a
     # pending deprecation, so it is dropped from the registry / DEPRECATIONS.md.
 

--- a/cellpy/parameters/legacy_header_shim.py
+++ b/cellpy/parameters/legacy_header_shim.py
@@ -1,0 +1,143 @@
+"""Legacy-header attribute shim (native-headers flip, D6 / Stage 2).
+
+After the flip renames the on-frame columns to the native ``cellpycore``
+schema, code that still references headers **by legacy attribute** —
+``headers_normal.voltage_txt``, ``hdr_steps.cycle``,
+``hdr_summary["charge_capacity"]`` — must keep resolving to the (now native)
+column name. This shim does that: it wraps a native ``config.Cols`` object for
+one frame and, on a legacy attribute/key, returns the native column name and
+emits a one-time ``DeprecationWarning``. Native-name access passes straight
+through without warning.
+
+All legacy→native knowledge lives in ``cellpycore.legacy.mapping`` — this
+module only adapts it to attribute/subscript access and owns the warning. The
+mapping already handles the ``discharge_capacity`` / ``discharge_capacity_raw``
+shared-value pair and lists legacy-only attributes (raised here as a clear
+error).
+
+**Not wired into ``CellpyCell`` yet.** The flip (Stage 5) substitutes these
+shims for the legacy ``Headers*`` objects; until then this module is inert,
+tested infrastructure and changes no runtime behavior.
+
+Scope note: statistic step columns composed by callers as ``f"{hdr.voltage}_avr"``
+are *not* interceptable here (they are built strings, not attribute access) —
+those callers migrate in Stage 3. Summary specific columns accessed by key
+(``hdr_summary["charge_capacity_gravimetric"]``) *are* handled, via postfix
+decomposition.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cellpycore.legacy import mapping
+
+from cellpy._deprecation import warn_once
+
+if TYPE_CHECKING:
+    from cellpycore import config
+
+# HeadersSummary specific-column postfixes (native and legacy names match).
+_SPECIFIC_MODES = ("gravimetric", "areal", "absolute")
+
+# Frame label -> the attribute name a warning should mention.
+_FRAME_LABEL = {
+    "raw": "headers_normal",
+    "step": "headers_step_table",
+    "cycle": "headers_summary",
+}
+
+
+class LegacyHeaderShim:
+    """Resolve legacy header attributes/keys to native column names, with a warning.
+
+    Args:
+        frame: The Schema frame this shim covers — ``"raw"``, ``"step"`` or
+            ``"cycle"``.
+        native_cols: The native ``config.Cols`` object for that frame; native
+            attribute access passes through to it unchanged (no warning).
+    """
+
+    def __init__(self, frame: str, native_cols: "config.Cols") -> None:
+        if frame not in mapping.LEGACY_ATTR_TO_SCHEMA:
+            raise ValueError(
+                f"unknown frame {frame!r}; expected one of "
+                f"{sorted(mapping.LEGACY_ATTR_TO_SCHEMA)}"
+            )
+        # Set via __dict__ so __getattr__ never sees these.
+        object.__setattr__(self, "_frame", frame)
+        object.__setattr__(self, "_native", native_cols)
+
+    # -- resolution -----------------------------------------------------------
+    def _resolve(self, name: str) -> str:
+        frame = self._frame
+        native = self._native
+
+        # Native attribute -> pass through, no warning.
+        if not name.startswith("_") and hasattr(native, name):
+            return getattr(native, name)
+
+        # Direct legacy attribute -> native name (+ warning).
+        try:
+            native_name = mapping.legacy_attr_to_native(frame, name)
+        except KeyError:
+            native_name = None
+
+        if native_name is not None:
+            self._warn(name)
+            return native_name
+
+        # Summary specific column by key: strip the postfix, resolve the base,
+        # re-attach the (identical) native postfix.
+        if frame == "cycle":
+            for mode in _SPECIFIC_MODES:
+                suffix = f"_{mode}"
+                if name.endswith(suffix):
+                    base = name[: -len(suffix)]
+                    try:
+                        native_base = mapping.legacy_attr_to_native("cycle", base)
+                    except KeyError:
+                        break
+                    self._warn(name)
+                    return f"{native_base}{suffix}"
+
+        raise KeyError(
+            f"{_FRAME_LABEL[frame]}: {name!r} is not a native column and has no "
+            f"legacy mapping (legacy-only or unknown attribute)."
+        )
+
+    def _warn(self, name: str) -> None:
+        label = _FRAME_LABEL[self._frame]
+        warn_once(
+            f"{label}.{name}",
+            "the native cellpycore schema column names",
+            removal="2.1",
+            introduced="2.0",
+            stacklevel=4,
+        )
+
+    # -- access protocols -----------------------------------------------------
+    def __getattr__(self, name: str) -> str:
+        # __getattr__ only fires when normal attribute lookup fails, so the
+        # real instance attributes (_frame/_native) never reach here.
+        try:
+            return self._resolve(name)
+        except KeyError as exc:
+            raise AttributeError(str(exc)) from None
+
+    def __getitem__(self, key: str) -> str:
+        return self._resolve(key)
+
+
+def build_legacy_shims(schema: "config.Schema") -> dict[str, LegacyHeaderShim]:
+    """Return the three legacy-header shims for a native ``config.Schema``.
+
+    Keys are the ``CellpyCell`` header attribute names the flip (Stage 5) will
+    point at these shims: ``headers_normal`` / ``headers_step_table`` /
+    ``headers_summary``.
+    """
+    return {
+        "headers_normal": LegacyHeaderShim("raw", schema.raw),
+        "headers_step_table": LegacyHeaderShim("step", schema.step),
+        "headers_summary": LegacyHeaderShim("cycle", schema.cycle),
+    }

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -316,6 +316,11 @@ class CellpyCell:
         self.auto_dirs = config.reader.auto_dirs  # v2.0
 
         # - headers and instruments
+        # Stage 5 (native-headers flip): when the runtime goes native, replace
+        # these legacy Headers* objects with the D6 shims from
+        # cellpy.parameters.legacy_header_shim.build_legacy_shims(self.core.schema)
+        # so legacy attribute access (headers_normal.voltage_txt, ...) resolves
+        # to native column names with a DeprecationWarning.
         self.headers_normal = headers_normal
         self.headers_summary = headers_summary
         self.headers_step_table = headers_step_table

--- a/tests/test_legacy_header_shim.py
+++ b/tests/test_legacy_header_shim.py
@@ -1,0 +1,123 @@
+"""Tests for the D6 legacy-header attribute shim (native-headers flip, Stage 2).
+
+The shim is not wired into ``CellpyCell`` yet (Stage 5), so these test it
+directly against a native ``config.default_schema()``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from cellpycore.config import default_schema
+
+from cellpy import _deprecation
+from cellpy.parameters.legacy_header_shim import (
+    LegacyHeaderShim,
+    build_legacy_shims,
+)
+
+
+@pytest.fixture
+def shims():
+    return build_legacy_shims(default_schema())
+
+
+def _count_dep_warnings(fn):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        value = fn()
+    n = sum(1 for w in caught if issubclass(w.category, DeprecationWarning))
+    return value, n
+
+
+def test_build_legacy_shims_frames(shims):
+    assert set(shims) == {"headers_normal", "headers_step_table", "headers_summary"}
+    assert all(isinstance(s, LegacyHeaderShim) for s in shims.values())
+
+
+def test_raw_renamed_attributes_resolve_and_warn(shims):
+    hn = shims["headers_normal"]
+    assert _count_dep_warnings(lambda: hn.voltage_txt) == ("potential", 1)
+    assert _count_dep_warnings(lambda: hn.cycle_index_txt) == ("cycle_num", 1)
+    assert _count_dep_warnings(lambda: hn.data_point_txt) == ("datapoint_num", 1)
+
+
+def test_step_and_summary_renamed_attributes_resolve(shims):
+    hst = shims["headers_step_table"]
+    hs = shims["headers_summary"]
+    assert _count_dep_warnings(lambda: hst.cycle) == ("cycle_num", 1)
+    assert _count_dep_warnings(lambda: hst.voltage) == ("potential", 1)
+    assert _count_dep_warnings(lambda: hs.cycle_index) == ("cycle_num", 1)
+
+
+def test_unchanged_names_pass_through_without_warning(shims):
+    # native names (and legacy names that equal the native name) do not warn.
+    hn = shims["headers_normal"]
+    hs = shims["headers_summary"]
+    assert _count_dep_warnings(lambda: hn.potential) == ("potential", 0)
+    assert _count_dep_warnings(lambda: hn.current) == ("current", 0)
+    assert _count_dep_warnings(lambda: hs.charge_capacity) == ("charge_capacity", 0)
+
+
+def test_summary_specific_column_by_key_composes(shims):
+    hs = shims["headers_summary"]
+    value, _ = _count_dep_warnings(lambda: hs["charge_capacity_gravimetric"])
+    assert value == "charge_capacity_gravimetric"
+    value2, _ = _count_dep_warnings(lambda: hs["discharge_capacity_areal"])
+    assert value2 == "discharge_capacity_areal"
+
+
+def test_duplicate_value_pair_resolves_and_warns(shims):
+    hs = shims["headers_summary"]
+    # charge_capacity_raw shares the "charge_capacity" column value.
+    assert _count_dep_warnings(lambda: hs.discharge_capacity_raw) == (
+        "discharge_capacity",
+        1,
+    )
+    assert _count_dep_warnings(lambda: hs.charge_capacity_raw) == (
+        "charge_capacity",
+        1,
+    )
+
+
+def test_getitem_matches_getattr(shims):
+    hn = shims["headers_normal"]
+    assert hn["voltage_txt"] == "potential"
+    assert hn["voltage_txt"] == hn.voltage_txt
+
+
+def test_legacy_only_attribute_raises(shims):
+    hn = shims["headers_normal"]
+    hst = shims["headers_step_table"]
+    hs = shims["headers_summary"]
+    with pytest.raises(AttributeError, match="power_txt"):
+        _ = hn.power_txt
+    with pytest.raises(AttributeError, match="info"):
+        _ = hst.info
+    with pytest.raises(AttributeError, match="shifted_charge_capacity"):
+        _ = hs.shifted_charge_capacity
+
+
+def test_unknown_attribute_raises(shims):
+    with pytest.raises(AttributeError):
+        _ = shims["headers_normal"].not_a_real_attr
+
+
+def test_warns_once_per_attribute(shims):
+    _deprecation._WARNED_SITES.clear()
+    hn = shims["headers_normal"]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        hn.voltage_txt
+        hn.voltage_txt
+        hn.voltage_txt
+    voltage_warnings = [
+        w for w in caught if "headers_normal.voltage_txt" in str(w.message)
+    ]
+    assert len(voltage_warnings) == 1
+
+
+def test_bad_frame_rejected():
+    with pytest.raises(ValueError, match="unknown frame"):
+        LegacyHeaderShim("nonsense", default_schema().raw)


### PR DESCRIPTION
## Summary

Stage 2 of the native-headers flip. Builds the **D6 attribute shim** that will let code referencing headers by legacy attribute keep working after the flip renames the columns — without wiring it in yet.

After the flip, `headers_normal.voltage_txt` must still resolve to the (now native) column name `potential`. `LegacyHeaderShim` wraps a native `config.Cols` object for one frame and, on a legacy attribute/key:
- resolves it to the native column name via **cellpycore's existing** `legacy_attr_to_native` (no hand-built ~60-entry table),
- emits a **one-time** `DeprecationWarning` per attribute (`warn_once` with a per-attr name),
- passes native names / unchanged names through **without** warning,
- composes summary specific columns by postfix (`hdr_summary["charge_capacity_gravimetric"]`),
- raises a clear error for legacy-only attributes (`power_txt`, `info`, `shifted_*`).

The `discharge_capacity` / `discharge_capacity_raw` shared-value pair is handled by the cellpycore mapping.

## Not wired yet

The shim is **inert infrastructure** this PR — `CellpyCell` still uses the legacy `Headers*` objects. Stage 5 substitutes the shims (there's a wire-point comment at the header assignment). Proof it's inert: the base suite count is unchanged.

## Test plan

- [x] `tests/test_legacy_header_shim.py`: 11 passed (resolution, native pass-through, postfix composition, duplicate-value pair, warn-once-per-attr, legacy-only raise, `__getitem__`)
- [x] `DEPRECATIONS.md` regenerated (+1 row) and the renderer-sync test passes
- [x] Full suite: **672 passed** (661 base + 11 new), 0 failed — base count unchanged
- [x] ruff: All checks passed on the new files

Refs the flip program (Stages 0/1 = #547/#548).

🤖 Generated with [Claude Code](https://claude.com/claude-code)