### PR TITLE
Flip Stage 3: route residual bare-literal frame indexers through header objects

### DIFF
--- a/cellpy/utils/batch_tools/batch_experiments.py
+++ b/cellpy/utils/batch_tools/batch_experiments.py
@@ -504,7 +504,7 @@ class CyclingExperiment(BaseExperiment):
                         columns={b"Cycle_Index": "Cycle_Index"}, inplace=True
                     )
                 try:
-                    summary_tmp.set_index("cycle_index", inplace=True)
+                    summary_tmp.set_index(hdr_summary.cycle_index, inplace=True)
                 except KeyError:
                     logging.debug("cycle_index already an index")
 
@@ -829,7 +829,7 @@ class CyclingExperiment(BaseExperiment):
                             columns={b"Cycle_Index": "Cycle_Index"}, inplace=True
                         )
                     try:
-                        summary_tmp.set_index("cycle_index", inplace=True)
+                        summary_tmp.set_index(hdr_summary.cycle_index, inplace=True)
                     except KeyError:
                         logging.debug("cycle_index already an index")
 

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -1162,7 +1162,7 @@ class SummaryPlotDataPreparer:
                 - max_val_normalized_col: max value for normalized columns
                 - formation_cycle_selector: boolean selector for formation cycles
         """
-        x = config.x if config.x is not None else "cycle_index"
+        x = config.x if config.x is not None else c.headers_summary.cycle_index
         y = config.y
 
         number_of_rows = 1
@@ -1604,7 +1604,7 @@ class PlotlyPlotBuilder:
         if title is None:
             title = f"Summary <b>{c.cell_name}</b>"
 
-        x = config.x if config.x is not None else "cycle_index"
+        x = config.x if config.x is not None else c.headers_summary.cycle_index
         y = config.y
         number_of_rows = prepared_data_info["number_of_rows"]
         x_label = prepared_data_info["x_label"]
@@ -2412,7 +2412,7 @@ class SeabornPlotBuilder:
         if title is None:
             title = f"Summary {c.cell_name}"
 
-        x = config.x if config.x is not None else "cycle_index"
+        x = config.x if config.x is not None else c.headers_summary.cycle_index
         y = config.y
         number_of_rows = prepared_data_info["number_of_rows"]
         x_label = prepared_data_info["x_label"]
@@ -3361,7 +3361,7 @@ def summary_plot_legacy(
             title = f"Summary {c.cell_name}"
 
     if x is None:
-        x = "cycle_index"
+        x = c.headers_summary.cycle_index
     xlim_formation = kwargs.pop("xlim_formation", (0.6, formation_cycles + 0.4))
 
     eff_lim = ce_range


### PR DESCRIPTION
## Native-headers flip — Stage 3

Migrates the remaining in-repo consumers that still indexed a cellpycore schema frame by a **bare legacy string literal** (bypassing the header objects) over to header-object access, so they resolve correctly once the flip renames the underlying columns at Stage 5 (via the D6 shim from #549).

### Context
Most consumers were already routed through the header objects by the prerequisite work (#537 / #538 / #540 / #543); those accesses are **shim-carried and flip-safe**. This stage closes the small residue of *direct-literal* frame indexers — the ones that would break (or silently misbehave) once `data.summary` / `data.raw` / `data.steps` carry native column names.

### Changes (6 sites, 2 files)
- **batch_experiments**: `summary_tmp.set_index("cycle_index")` (two sites) → `set_index(hdr_summary.cycle_index)`. The adjacent index-name check already used the header object; the bare literal would have silently failed to set the index post-flip (the `KeyError` is swallowed as *"already an index"*).
- **plotutils**: summary-plot default x-axis `"cycle_index"` (four sites) → `c.headers_summary.cycle_index`.

### Safety
Behavior is **identical on today's legacy default** (the header attribute returns the same `"cycle_index"` string), so the change is inert until the flip; the value it protects is verified at Stage 5. Full suite unchanged — **672 passed**, plus the collector/plotter test net (`tests/test_collectors.py`) green.

### Out of scope (verified, not targets)
- Header-object **subscripts** like `hdr_summary["cycle_index"]` — shim-carried; these migrate to native keys at Stage 5, when the object becomes schema-backed.
- **ica**'s own dQ/dV output schema (`voltage`/`dq`/`cycle`) and **collector** aggregation frames (`cycle`/`cell`/`variable`) — consumer-owned schemas, not cellpycore frames.
- The **bdf** `_COLUMN_MAP` — `cellpy_field` is resolved via `getattr` on the header object (shim-carried); `base_machine` is BDF output naming.
- Units-mapping keys (#539).

Part of the staged native-headers flip: Stage 0 (#547), Stage 1 (#548), Stage 2 (#549), **Stage 3 (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)