### PR TITLE
Flip Stage 4 (#539): pin loader header contract + clean up demo literals

### DIFF
--- a/cellpy/readers/instruments/arbin_sql.py
+++ b/cellpy/readers/instruments/arbin_sql.py
@@ -518,7 +518,11 @@ def _check_loader_from_outside():
 
     cycle = c.get_cap(1, method="forth")
     print(cycle.head())
-    cycle.plot(x="capacity", y="voltage")
+    # get_cap returns a native CurveCols frame (capacity / potential).
+    from cellpycore.config import CurveCols
+
+    curve_cols = CurveCols()
+    cycle.plot(x=curve_cols.capacity, y=curve_cols.potential)
     plt.show()
 
 

--- a/cellpy/readers/instruments/arbin_sql_7.py
+++ b/cellpy/readers/instruments/arbin_sql_7.py
@@ -551,7 +551,11 @@ def _check_loader_from_outside():
 
     cycle = c.get_cap(1, method="forth")
     print(cycle.head())
-    cycle.plot(x="capacity", y="voltage")
+    # get_cap returns a native CurveCols frame (capacity / potential).
+    from cellpycore.config import CurveCols
+
+    curve_cols = CurveCols()
+    cycle.plot(x=curve_cols.capacity, y=curve_cols.potential)
     plt.show()
 
 

--- a/cellpy/readers/instruments/custom.py
+++ b/cellpy/readers/instruments/custom.py
@@ -271,6 +271,7 @@ def _process_cellpy_object(name, c, out):
 
     print(f"loaded the file - now lets see what we got")
     raw = c.data.raw
+    hdr = c.headers_normal
     print(raw.head())
     c.make_step_table()
 
@@ -288,10 +289,14 @@ def _process_cellpy_object(name, c, out):
         constrained_layout=True,
         sharex=True,
     )
-    raw.plot(x="test_time", y="voltage", ax=ax1)
-    raw.plot(x="test_time", y="current", ax=ax2)
-    raw.plot(x="test_time", y=["charge_capacity", "discharge_capacity"], ax=ax3)
-    raw.plot(x="test_time", y="cycle_index", ax=ax4)
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax1)
+    raw.plot(x=hdr.test_time_txt, y=hdr.current_txt, ax=ax2)
+    raw.plot(
+        x=hdr.test_time_txt,
+        y=[hdr.charge_capacity_txt, hdr.discharge_capacity_txt],
+        ax=ax3,
+    )
+    raw.plot(x=hdr.test_time_txt, y=hdr.cycle_index_txt, ax=ax4)
     fig_1.suptitle(f"{name.name}", fontsize=16)
 
     n = c.get_number_of_cycles()

--- a/cellpy/readers/instruments/maccor_txt.py
+++ b/cellpy/readers/instruments/maccor_txt.py
@@ -160,20 +160,25 @@ def c_heck_loader(name=None, number=1, model="one"):
     loader = DataLoader(sep="\t", model=model)
     dd = loader.loader(name)
     raw = dd[0].raw
-    raw.plot(x="data_point", y="current", title="current vs data-point")
+    caps = [headers_normal.charge_capacity_txt, headers_normal.discharge_capacity_txt]
     raw.plot(
-        x="data_point",
-        y=["charge_capacity", "discharge_capacity"],
+        x=headers_normal.data_point_txt,
+        y=headers_normal.current_txt,
+        title="current vs data-point",
+    )
+    raw.plot(
+        x=headers_normal.data_point_txt,
+        y=caps,
         title="capacity vs data-point",
     )
     raw.plot(
-        x="test_time",
-        y=["charge_capacity", "discharge_capacity"],
+        x=headers_normal.test_time_txt,
+        y=caps,
         title="capacity vs test-time",
     )
     raw.plot(
-        x="step_time",
-        y=["charge_capacity", "discharge_capacity"],
+        x=headers_normal.step_time_txt,
+        y=caps,
         title="capacity vs step-time",
     )
     print(raw.head())
@@ -212,10 +217,15 @@ def _check_loader_from_outside():
     steps.to_csv(r"C:\scripts\notebooks\Div\trash\steps.csv", sep=";")
     summary.to_csv(r"C:\scripts\notebooks\Div\trash\summary.csv", sep=";")
 
+    hdr = c.headers_normal
     fig_1, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))
-    raw.plot(x="test_time", y="voltage", ax=ax1)
-    raw.plot(x="test_time", y=["charge_capacity", "discharge_capacity"], ax=ax3)
-    raw.plot(x="test_time", y="current", ax=ax2)
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax1)
+    raw.plot(
+        x=hdr.test_time_txt,
+        y=[hdr.charge_capacity_txt, hdr.discharge_capacity_txt],
+        ax=ax3,
+    )
+    raw.plot(x=hdr.test_time_txt, y=hdr.current_txt, ax=ax2)
 
     n = c.get_number_of_cycles()
     print(f"number of cycles: {n}")
@@ -223,8 +233,12 @@ def _check_loader_from_outside():
     cycle = c.get_cap(1, method="forth-and-forth")
     print(cycle.head())
 
+    # get_cap returns a native CurveCols frame (capacity / potential).
+    from cellpycore.config import CurveCols
+
+    curve_cols = CurveCols()
     fig_2, (ax4, ax5, ax6) = plt.subplots(1, 3)
-    cycle.plot(x="capacity", y="voltage", ax=ax4)
+    cycle.plot(x=curve_cols.capacity, y=curve_cols.potential, ax=ax4)
     s = c.get_step_numbers()
     t = c.sget_timestamp(1, s[1])
     v = c.sget_voltage(1, s[1])
@@ -243,8 +257,8 @@ def _check_loader_from_outside():
     ax6.plot(t, steps, label="steps")
 
     fig_3, (ax7, ax8) = plt.subplots(2, sharex=True)
-    raw.plot(x="test_time", y="voltage", ax=ax7)
-    raw.plot(x="test_time", y="step_index", ax=ax8)
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax7)
+    raw.plot(x=hdr.test_time_txt, y=hdr.step_index_txt, ax=ax8)
 
     plt.legend()
     plt.show()
@@ -281,12 +295,16 @@ def _check_loader_from_outside_with_get():
     steps.to_csv(r"C:\scripting\trash\steps.csv", sep=";")
     summary.to_csv(r"C:\scripting\trash\summary.csv", sep=";")
 
+    hdr = c.headers_normal
     fig_1, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))
-    raw.plot(x="test_time", y="voltage", ax=ax1, title="voltage")
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax1, title="voltage")
     raw.plot(
-        x="test_time", y=["charge_capacity", "discharge_capacity"], ax=ax3, title="caps"
+        x=hdr.test_time_txt,
+        y=[hdr.charge_capacity_txt, hdr.discharge_capacity_txt],
+        ax=ax3,
+        title="caps",
     )
-    raw.plot(x="test_time", y="current", ax=ax2, title="current")
+    raw.plot(x=hdr.test_time_txt, y=hdr.current_txt, ax=ax2, title="current")
 
     n = c.get_number_of_cycles()
     print(f"number of cycles: {n}")
@@ -313,8 +331,8 @@ def _check_loader_from_outside_with_get():
     ax6.plot(t, steps, label="steps")
 
     fig_3, (ax7, ax8) = plt.subplots(2, sharex=True)
-    raw.plot(x="test_time", y="voltage", ax=ax7, title="voltage")
-    raw.plot(x="test_time", y="step_index", ax=ax8, title="step index")
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax7, title="voltage")
+    raw.plot(x=hdr.test_time_txt, y=hdr.step_index_txt, ax=ax8, title="step index")
 
     plt.legend()
     plt.show()
@@ -384,6 +402,7 @@ def _check_loader_from_outside_with_get2():
     )
     print(f"loaded the file - now lets see what we got")
     raw = c.data.raw
+    hdr = c.headers_normal
     print(raw.head())
     c.make_step_table()
 
@@ -401,12 +420,15 @@ def _check_loader_from_outside_with_get2():
         constrained_layout=True,
         sharex=True,
     )
-    raw.plot(x="test_time", y="voltage", ax=ax1, xlabel="")
-    raw.plot(x="test_time", y="current", ax=ax2, xlabel="")
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax1, xlabel="")
+    raw.plot(x=hdr.test_time_txt, y=hdr.current_txt, ax=ax2, xlabel="")
     raw.plot(
-        x="test_time", y=["charge_capacity", "discharge_capacity"], ax=ax3, xlabel=""
+        x=hdr.test_time_txt,
+        y=[hdr.charge_capacity_txt, hdr.discharge_capacity_txt],
+        ax=ax3,
+        xlabel="",
     )
-    raw.plot(x="test_time", y="cycle_index", ax=ax4)
+    raw.plot(x=hdr.test_time_txt, y=hdr.cycle_index_txt, ax=ax4)
     fig_1.suptitle(f"{name.name}", fontsize=16)
 
     n = c.get_number_of_cycles()
@@ -451,6 +473,7 @@ def _fix_bugs_now():
     )
     print(f"loaded the file - now lets see what we got")
     raw = c.data.raw
+    hdr = c.headers_normal
     print(raw.head())
     c.make_step_table()
     steps = c.data.steps
@@ -467,12 +490,15 @@ def _fix_bugs_now():
         constrained_layout=True,
         sharex=True,
     )
-    raw.plot(x="test_time", y="voltage", ax=ax1, xlabel="")
-    raw.plot(x="test_time", y="current", ax=ax2, xlabel="")
+    raw.plot(x=hdr.test_time_txt, y=hdr.voltage_txt, ax=ax1, xlabel="")
+    raw.plot(x=hdr.test_time_txt, y=hdr.current_txt, ax=ax2, xlabel="")
     raw.plot(
-        x="test_time", y=["charge_capacity", "discharge_capacity"], ax=ax3, xlabel=""
+        x=hdr.test_time_txt,
+        y=[hdr.charge_capacity_txt, hdr.discharge_capacity_txt],
+        ax=ax3,
+        xlabel="",
     )
-    raw.plot(x="test_time", y="cycle_index", ax=ax4)
+    raw.plot(x=hdr.test_time_txt, y=hdr.cycle_index_txt, ax=ax4)
     fig_1.suptitle(f"{name.name}", fontsize=16)
 
     n = c.get_number_of_cycles()

--- a/tests/test_loader_header_contract.py
+++ b/tests/test_loader_header_contract.py
@@ -1,0 +1,75 @@
+"""Contract test: instrument-config renaming dicts stay in sync with HeadersNormal.
+
+Native-headers flip, Stage 4 (#539). The instrument loaders are already
+flip-safe: every cellpy-side raw column name is sourced from ``HeadersNormal``
+(the config ``normal_headers_renaming_dict`` is keyed by header **attribute
+names**, and ``post_processors.rename_headers`` resolves the final column via
+``headers_normal[key]``). So a header rename at the flip touches the header
+class only -- *provided* every renaming-dict key is a real ``HeadersNormal``
+field.
+
+The one fragility this guards: ``rename_headers`` applies a key only
+``if key in headers_normal`` (post_processors.py), so a key that no longer
+matches a ``HeadersNormal`` field is **silently skipped** -- the vendor column
+would just not be renamed. This test turns that silent skip into a loud
+failure: if someone renames a ``HeadersNormal`` field without updating the
+configs, the desynced config keys are reported here.
+
+Intentional exceptions are keys for signals cellpy maps from the instrument but
+does not (yet) carry as first-class ``HeadersNormal`` columns.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import pathlib
+
+import pytest
+
+from cellpy.parameters.internal_settings import HeadersNormal
+
+# Keys that are deliberately not HeadersNormal fields: signals some instruments
+# expose that cellpy maps but does not carry as a first-class raw column. If a
+# new such key is added to a config, list it here (with the reason in review).
+KNOWN_NON_HEADER_KEYS = frozenset({"dq_dv_txt", "dv_dq_txt", "acr_txt"})
+
+_HEADER_FIELDS = frozenset(f.name for f in dataclasses.fields(HeadersNormal))
+
+
+def _config_modules():
+    import cellpy.readers.instruments.configurations as configurations
+
+    cfg_dir = pathlib.Path(configurations.__file__).parent
+    for path in sorted(cfg_dir.glob("*.py")):
+        if path.stem.startswith("__"):
+            continue
+        module = importlib.import_module(
+            f"cellpy.readers.instruments.configurations.{path.stem}"
+        )
+        if getattr(module, "normal_headers_renaming_dict", None) is not None:
+            yield pytest.param(module, id=path.stem)
+
+
+@pytest.mark.parametrize("module", list(_config_modules()))
+def test_config_renaming_keys_are_header_fields(module):
+    """Every renaming-dict key is a HeadersNormal field or a known exception."""
+    keys = set(module.normal_headers_renaming_dict)
+    desynced = keys - _HEADER_FIELDS - KNOWN_NON_HEADER_KEYS
+    assert not desynced, (
+        f"{module.__name__}: renaming-dict keys are not HeadersNormal fields: "
+        f"{sorted(desynced)}. Either the header field was renamed (update the "
+        f"config) or add the key to KNOWN_NON_HEADER_KEYS with a reason."
+    )
+
+
+def test_known_non_header_keys_are_all_used():
+    """The allowlist stays minimal: every exempted key is actually in some config."""
+    used = set()
+    for param in _config_modules():
+        module = param.values[0]
+        used |= set(module.normal_headers_renaming_dict)
+    stale = KNOWN_NON_HEADER_KEYS - used
+    assert not stale, (
+        f"KNOWN_NON_HEADER_KEYS has unused entries {sorted(stale)}; remove them."
+    )


### PR DESCRIPTION
## Native-headers flip — Stage 4

### Investigation finding: the loaders are already flip-safe
Every cellpy-side raw column name is sourced from `HeadersNormal` — the config `normal_headers_renaming_dict` is keyed by header **attribute names**, and `post_processors.rename_headers` resolves the final column via `headers_normal[key]`. The boundary `to_native()` (cellreader `from_raw`/`load`) converts legacy→native under the flag. So **loaders need no change to emit native raw post-flip.**

The ~155 raw-column-name "findings" in #539 are dominated by false positives: unit-kind keys, semantic-vocabulary keys, `*_txt` attribute-name strings, metadata keys, vendor names, and dev-only `__main__` demo plots. Rewriting those already-safe indirection layers just to zero a literal scan would be a large, risky churn of working instrument loaders for **no benefit to this flip** — so it is deliberately not done.

This PR lands the two pieces of genuine value.

### 1. Contract guard — `tests/test_loader_header_contract.py`
Asserts every config renaming-dict key is a real `HeadersNormal` field (allowlisting the intentional not-yet-in-cellpy keys `dq_dv_txt` / `dv_dq_txt` / `acr_txt`).

The one real fragility: `rename_headers` applies a key only `if key in headers_normal`, so a `HeadersNormal` field rename that desyncs a config would be **silently skipped** (vendor column left unrenamed). This test turns that silent skip into a **loud CI failure** — making "a header rename touches header classes only" actually enforced.

### 2. Demo cleanup
Routes the dev-only `__main__` / `_check_*` plot literals (`maccor_txt`, `custom`, `arbin_sql`, `arbin_sql_7`) through the header objects:
- `c.headers_normal.*` for raw-frame plots (flip-correct via the Stage-2 shim, since `c` is in scope),
- `CurveCols` for the `get_cap` curve-frame plots (the stale `y="voltage"` is now the native `potential`).

Matplotlib labels/titles/comments left as display strings.

### Safety
Loader goldens **byte-identical**; full suite **681 passed** (672 base + 9 contract tests). No runtime code paths changed.

Closes #539. Part of the staged native-headers flip: Stage 0 (#547), 1 (#548), 2 (#549), 3 (#550), **Stage 4 (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)