### PR TITLE
Flip Stage 5b: native merge() via legacy round-trip

### DIFF
--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1653,12 +1653,6 @@ class CellpyCell:
         """
         from cellpy.readers import merger
 
-        if self.native_schema:
-            raise NotImplementedError(
-                "merge() is not supported on a native-schema cell yet "
-                "(#511 opt-in scope); merge on the legacy path and load the "
-                "result into a native-schema cell instead"
-            )
         if cells is None:
             raise TypeError(
                 "merge() requires the cells/datasets to merge into this one "
@@ -1667,6 +1661,25 @@ class CellpyCell:
         if isinstance(cells, (CellpyCell, ds.Data)):
             cells = [cells]
         datas = [c.data if isinstance(c, CellpyCell) else c for c in cells]
+
+        # Native-headers flip Stage 5b: the merge machinery (_append /
+        # campaign_fold) is written against legacy column names, so on a native
+        # cell we round-trip through legacy — translate this object and copies of
+        # the participants to legacy (keeping test_id on every frame so the
+        # merge's id assignments survive), merge, then translate back to native.
+        # Copies keep the source cells' native frames intact.
+        if self.native_schema:
+            import copy as _copy
+
+            from cellpy.readers.cellpy_file import translate as _merge_translate
+
+            _merge_translate.to_legacy(self.data, injected_test_id=False)
+            legacy_datas = []
+            for other in datas:
+                other_copy = _copy.copy(other)
+                _merge_translate.to_legacy(other_copy, injected_test_id=False)
+                legacy_datas.append(other_copy)
+            datas = legacy_datas
 
         if mode == "continuation":
             logging.info("Merging (continuation)")
@@ -1678,6 +1691,8 @@ class CellpyCell:
                 ):
                     self.data.raw_data_files.append(raw_data_file)
                     self.data.raw_data_files_length.append(file_size)
+            if self.native_schema:
+                _merge_translate.to_native(self.data)
             return self
 
         if mode != "campaign":
@@ -1688,6 +1703,8 @@ class CellpyCell:
             merger.campaign_fold(
                 self.data, other, renumber_cycles=renumber_cycles, **kwargs
             )
+        if self.native_schema:
+            _merge_translate.to_native(self.data)
         modes = test_meta.cycle_modes_in_data(self.data)
         if len(modes) > 1:
             logging.warning(

--- a/tests/test_native_schema.py
+++ b/tests/test_native_schema.py
@@ -162,8 +162,40 @@ def test_native_hdf5_save_roundtrips_via_to_legacy(native_cell, tmp_path):
     assert "voltage" in reloaded.data.raw.columns
 
 
-def test_native_merge_raises(native_cell, parameters):
-    other = cellreader.CellpyCell()
+def test_native_campaign_merge_roundtrips_through_legacy(native_cell, parameters):
+    """Stage 5b: campaign merge on a native cell works via the legacy round-trip;
+    the result stays native and carries distinct per-source test_ids."""
+    other = cellreader.CellpyCell(native_schema=True)
     other.from_raw(parameters.res_file_path2)
-    with pytest.raises(NotImplementedError, match="native-schema"):
-        native_cell.merge(other)
+    other_native_raw_cols = set(other.data.raw.columns)
+
+    n_self = len(native_cell.data.raw)
+    n_other = len(other.data.raw)
+    native_cell.merge(other)
+
+    merged = native_cell.data.raw
+    # result is native (not legacy-named) and folds both sources
+    assert SCHEMA.raw.potential in merged.columns
+    assert "voltage" not in merged.columns
+    assert len(merged) == n_self + n_other
+    # distinct compact test_ids per source (campaign identity)
+    assert set(merged[SCHEMA.raw.test_id].unique()) == {0, 1}
+    # the source cell's frames are untouched by the merge (copies used)
+    assert set(other.data.raw.columns) == other_native_raw_cols
+
+    # the merged native cell still computes its pipeline
+    native_cell.make_step_table()
+    native_cell.make_summary(find_ir=False)
+    assert SCHEMA.cycle.cycle_num in native_cell.data.summary.columns
+
+
+def test_native_continuation_merge_roundtrips(native_cell, parameters):
+    """Stage 5b: continuation merge also works on a native cell."""
+    other = cellreader.CellpyCell(native_schema=True)
+    other.from_raw(parameters.res_file_path2)
+    n_self = len(native_cell.data.raw)
+    n_other = len(other.data.raw)
+    native_cell.merge(other, mode="continuation")
+    merged = native_cell.data.raw
+    assert SCHEMA.raw.potential in merged.columns
+    assert len(merged) == n_self + n_other


### PR DESCRIPTION
## Native-headers flip — Stage 5b

Makes `merge()` (campaign + continuation) work on a **native** cell, closing the last functional gap the flip deferred. On a native cell it round-trips through the legacy merge machinery:

1. `to_legacy(self.data)` and `to_legacy(copy(participant))` for each source — **keeping `test_id` on every frame** (`injected_test_id=False`) so the merge's per-source id assignments survive the round-trip. Copies keep the source cells' native frames intact.
2. Run the existing `_append` / `campaign_fold` (incl. the #524 test_id remap + `renumber_cycles`).
3. `to_native(self.data)` on the result.

### Changes
- `cellreader.merge`: drop the `NotImplementedError`; wrap the existing continuation/campaign logic in the legacy round-trip when `native_schema`.
- `test_native_schema`: replace `test_native_merge_raises` with `test_native_campaign_merge_roundtrips_through_legacy` (asserts native columns, folded length, distinct per-source `test_id`, untouched sources, and that the merged cell still computes its pipeline) + `test_native_continuation_merge_roundtrips`.

### Coverage note
The legacy `test_merge_campaign` suite stays pinned to `native_schema=False` — it directly validates the core `campaign_fold` machinery that the native path round-trips through. Native-path coverage is the two new tests.

Full suite: **677 passed, 0 failed, 18 xfailed**.

Part of the staged flip: Stages 0–4 merged, 5a merged, **5b (this PR)**. Remaining: Stage 6 (real parity oracle), #552 / #554 (native summary feature/behavior parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)