### PR TITLE
Flip Stage 6: make value-parity oracle real (native vs legacy pipeline)

### DIFF
--- a/tests/parity_support.py
+++ b/tests/parity_support.py
@@ -28,6 +28,17 @@ def run_legacy_pipeline(cell) -> None:
     cell.make_summary(find_ir=True, find_end_voltage=True)
 
 
+def run_native_pipeline(cell) -> None:
+    """Full native pipeline on the canonical Arbin ``.res``.
+
+    Identical call sequence to :func:`run_legacy_pipeline` but on a native cell
+    (``CellpyCell(native_schema=True)``, the cellpy 2 default). Frames come out
+    with native cellpycore column names, so the real oracle can compare the two
+    independent pipelines end to end.
+    """
+    run_legacy_pipeline(cell)
+
+
 def _current_conversion_factor(cell) -> float:
     from cellpy.readers import data_structures as core
 

--- a/tests/test_value_parity.py
+++ b/tests/test_value_parity.py
@@ -1,43 +1,75 @@
-"""Trivial-pass value-parity tests for the legacy bridge (issue #434)."""
+"""Real value-parity oracle: native pipeline vs legacy pipeline (issue #434).
+
+Native-headers flip Stage 6. Runs the **full independent** native pipeline
+(``CellpyCell(native_schema=True)``, the cellpy 2 default) and the legacy bridge
+pipeline (``native_schema=False``) on the canonical Arbin ``.res``, then asserts
+their frames carry equal values on every **mapped** column
+(``tests.parity.assert_value_parity`` compares through
+``cellpycore.legacy.mapping``). Columns the native pipeline does not produce
+(e.g. shifted / RIC / cumulated-CE, tracked in #552) are skipped automatically;
+columns that deliberately differ are listed in the exception sets below.
+"""
 
 from __future__ import annotations
 
 import pytest
 
+from cellpy import cellreader
 from tests.parity import assert_value_parity
 from tests.parity_support import (
-    build_native_raw,
-    build_native_steps,
-    build_native_summary,
     res_file_available,
     run_legacy_pipeline,
+    run_native_pipeline,
 )
 
+# Documented intended divergences (native-headers plan §7 register): mapped
+# columns present on both frames whose values deliberately differ between the
+# corrected native pipeline and the legacy bridge. Keep this list tight — every
+# entry is a known, reviewed semantic difference, not a bug to hide.
+RAW_EXCEPTIONS: tuple[str, ...] = ()
+STEP_EXCEPTIONS: tuple[str, ...] = ()
+SUMMARY_EXCEPTIONS: tuple[str, ...] = ()
 
-@pytest.fixture
-def parity_cell(cellpy_data_instance):
+
+@pytest.fixture(scope="module")
+def pipelines():
     if not res_file_available():
         pytest.skip("canonical Arbin .res testdata not available")
-    run_legacy_pipeline(cellpy_data_instance)
-    return cellpy_data_instance
+    legacy = cellreader.CellpyCell(native_schema=False)
+    run_legacy_pipeline(legacy)
+    native = cellreader.CellpyCell(native_schema=True)
+    run_native_pipeline(native)
+    return legacy, native
 
 
 @pytest.mark.essential
-def test_value_parity_raw_bridge_trivial_pass(parity_cell):
-    legacy_raw = parity_cell.data.raw.reset_index(drop=True)
-    native_raw = build_native_raw(parity_cell)
-    assert_value_parity(legacy_raw, native_raw, "raw")
+def test_value_parity_raw(pipelines):
+    legacy, native = pipelines
+    assert_value_parity(
+        legacy.data.raw.reset_index(drop=True),
+        native.data.raw.reset_index(drop=True),
+        "raw",
+        exceptions=RAW_EXCEPTIONS,
+    )
 
 
 @pytest.mark.essential
-def test_value_parity_steps_bridge_trivial_pass(parity_cell):
-    legacy_steps = parity_cell.data.steps.reset_index(drop=True)
-    native_steps = build_native_steps(parity_cell)
-    assert_value_parity(legacy_steps, native_steps, "steps")
+def test_value_parity_steps(pipelines):
+    legacy, native = pipelines
+    assert_value_parity(
+        legacy.data.steps.reset_index(drop=True),
+        native.data.steps.reset_index(drop=True),
+        "steps",
+        exceptions=STEP_EXCEPTIONS,
+    )
 
 
 @pytest.mark.essential
-def test_value_parity_summary_bridge_trivial_pass(parity_cell):
-    legacy_summary = parity_cell.data.summary.reset_index(drop=True)
-    native_summary = build_native_summary(parity_cell)
-    assert_value_parity(legacy_summary, native_summary, "summary")
+def test_value_parity_summary(pipelines):
+    legacy, native = pipelines
+    assert_value_parity(
+        legacy.data.summary.reset_index(drop=True),
+        native.data.summary.reset_index(drop=True),
+        "summary",
+        exceptions=SUMMARY_EXCEPTIONS,
+    )


### PR DESCRIPTION
## Native-headers flip — Stage 6 (final stage)

Turns the value-parity oracle from trivial-pass into a real cross-pipeline check. `test_value_parity` now runs the **full independent native pipeline** (`CellpyCell(native_schema=True)`, the cellpy 2 default) and the **legacy bridge pipeline** (`native_schema=False`) on the canonical Arbin `.res`, then asserts value parity on every **mapped** column via `assert_value_parity` (comparing through `cellpycore.legacy.mapping`).

Previously the tests fed the native engine *legacy intermediates* (per-stage cross-checks) — now both pipelines run end to end and are compared independently.

### Result
- **125 mapped-column comparisons** across the two pipelines: raw 10/10, steps 63/63, summary 52/54 — **including IR and CE**.
- All agree with **zero exceptions** on the canonical dataset: the flip preserves value parity on every mapped column.
- The `RAW/STEP/SUMMARY_EXCEPTIONS` sets stay defined and documented (empty) for any future intended divergence (native-headers plan §7 register).
- Columns the native pipeline doesn't produce (shifted / RIC / cumulated-CE, #552) are skipped automatically.

Full suite: **677 passed, 0 failed, 18 xfailed**.

### This completes the native-headers flip
Stages 0–6 done: plotter net → get_cap CurveCols → D6 shim → consumer migration → loader contract → **default flip + shim wiring** → native merge → **real parity oracle**. cellpy 2's runtime now speaks native cellpycore column names end to end, with the legacy bridge available via `native_schema=False` and legacy header access carried by the deprecation-warned shim.

Remaining follow-ups (tracked, out of the flip's critical path): #552 (native summary feature columns), #554 (native step_specifications / exclude_step_types parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)