### PR TITLE
#558: public c.schema header API; headers_* becomes the shim

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -8,5 +8,5 @@ uv run python -m cellpy._deprecation
 
 | Name | Replacement | Introduced | Removal |
 | --- | --- | --- | --- |
-| `legacy header attribute access (headers_normal / _summary / _step_table)` | `the native cellpycore schema column names` | 2.0 | 2.1 |
+| `legacy header attribute access (headers_normal / _summary / _step_table)` | `c.schema.raw / c.schema.steps / c.schema.summary` | 2.0 | 2.1 |
 | `make_new_cell` | `CellpyCell.vacant` | 2.0 | 2.1 |

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -100,7 +100,7 @@ def _seed_known_deprecations() -> None:
     # at runtime (cellpy.parameters.legacy_header_shim).
     _register(
         "legacy header attribute access (headers_normal / _summary / _step_table)",
-        "the native cellpycore schema column names",
+        "c.schema.raw / c.schema.steps / c.schema.summary",
         removal="2.1",
         introduced="2.0",
     )

--- a/cellpy/exporters/tabular.py
+++ b/cellpy/exporters/tabular.py
@@ -413,8 +413,8 @@ def cap_mod_summary(cell: "CellpyCell", summary, capacity_modifier="reset"):
     time_00 = time.time()
     # operates on the summary frame, so use the summary headers (native summary
     # discharge/charge differ from the raw names under the flip).
-    discharge_title = cell.headers_summary.discharge_capacity
-    charge_title = cell.headers_summary.charge_capacity
+    discharge_title = cell.schema.summary.discharge_capacity
+    charge_title = cell.schema.summary.charge_capacity
     chargecap = 0.0
     dischargecap = 0.0
 
@@ -443,11 +443,11 @@ def cap_mod_normal(cell: "CellpyCell", capacity_modifier="reset", allctypes=True
     time_00 = time.time()
     logging.debug("Not properly checked yet! Use with caution!")
 
-    cycle_index_header = cell.headers_normal.cycle_index_txt
-    step_index_header = cell.headers_normal.step_index_txt
-    discharge_index_header = cell.headers_normal.discharge_capacity_txt
+    cycle_index_header = cell.schema.raw.cycle_num
+    step_index_header = cell.schema.raw.step_num
+    discharge_index_header = cell.schema.raw.cumulative_discharge_capacity
     discharge_energy_index_header = cell.headers_normal.discharge_energy_txt
-    charge_index_header = cell.headers_normal.charge_capacity_txt
+    charge_index_header = cell.schema.raw.cumulative_charge_capacity
     charge_energy_index_header = cell.headers_normal.charge_energy_txt
 
     raw = cell.data.raw

--- a/cellpy/parameters/cell_schema.py
+++ b/cellpy/parameters/cell_schema.py
@@ -1,0 +1,146 @@
+"""The public column-name API for a cell (native-headers Phase 4, issue #558).
+
+``CellpyCell.schema`` answers one question: *what is this column called on the
+frames this cell is carrying?* It is the sanctioned replacement for the legacy
+``headers_normal`` / ``headers_step_table`` / ``headers_summary`` attributes,
+which are now a deprecation shim (``legacy_header_shim``, D6).
+
+    >>> c = cellpy.get(...)                                    # doctest: +SKIP
+    >>> c.data.raw[c.schema.raw.potential]                     # doctest: +SKIP
+    >>> c.data.summary[c.schema.summary.charge_capacity]       # doctest: +SKIP
+
+**Frame names follow the frames, not cellpy-core.** ``cellpycore.config.Schema``
+spells its three frames ``raw`` / ``step`` / ``cycle``; the frames a user holds
+are ``c.data.raw`` / ``c.data.steps`` / ``c.data.summary``. This wrapper closes
+that gap — ``c.schema.summary`` sits next to ``c.data.summary`` — so there is
+exactly one public spelling per frame. Internals that want the cellpy-core
+object keep using ``c.core.schema``.
+
+**You always spell the column the native way; the value tracks the runtime.**
+``c.schema.raw.potential`` is how you ask for the potential column on *any*
+cell. On the native runtime (the cellpy 2 default) it returns ``"potential"``.
+On the legacy runtime (``native_schema=False``, the retiring v8/bridge
+compatibility path) the frames still carry legacy column names, so the same
+attribute returns ``"voltage"`` — the name that actually indexes that frame.
+That uniformity is what lets cellpy's own internals, which must run on both
+runtimes, be written once against the native vocabulary.
+
+The contract in one line: whatever ``c.schema.<frame>.<column>`` returns is a
+valid key into ``c.data.<frame>``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cellpycore.legacy import mapping
+
+if TYPE_CHECKING:
+    from cellpycore import config
+
+# HeadersSummary specific-column postfixes (native and legacy names match).
+_SPECIFIC_MODES = ("gravimetric", "areal", "absolute")
+
+# native column name -> legacy attribute, per frame (the inverse of the D6
+# mapping). Built once: the mapping is a module-level constant in cellpy-core.
+_NATIVE_TO_LEGACY_ATTR = {
+    frame: {native: legacy for legacy, native in attrs.items()}
+    for frame, attrs in mapping.LEGACY_ATTR_TO_SCHEMA.items()
+}
+
+
+class _LegacySpellingAdapter:
+    """Serve native column *attributes* off a legacy ``BaseHeaders`` object.
+
+    Only used on the legacy runtime (``native_schema=False``). ``.potential``
+    resolves through the inverted D6 mapping to the legacy ``voltage_txt``
+    attribute and returns its value (``"voltage"``) — the name that actually
+    indexes the legacy frame. Legacy attribute names still work directly, so
+    code that has not migrated keeps resolving.
+    """
+
+    __slots__ = ("_legacy", "_frame")
+
+    def __init__(self, legacy_cols: object, frame: str) -> None:
+        object.__setattr__(self, "_legacy", legacy_cols)
+        object.__setattr__(self, "_frame", frame)
+
+    def _resolve(self, name: str) -> str:
+        legacy = self._legacy
+
+        # Native name -> legacy attribute -> the legacy column name.
+        legacy_attr = _NATIVE_TO_LEGACY_ATTR.get(self._frame, {}).get(name)
+        if legacy_attr is not None and hasattr(legacy, legacy_attr):
+            return getattr(legacy, legacy_attr)
+
+        # Summary specific columns: strip the postfix, resolve, re-attach.
+        if self._frame == "cycle":
+            for mode in _SPECIFIC_MODES:
+                suffix = f"_{mode}"
+                if name.endswith(suffix):
+                    base = name[: -len(suffix)]
+                    base_attr = _NATIVE_TO_LEGACY_ATTR["cycle"].get(base)
+                    if base_attr is not None and hasattr(legacy, base_attr):
+                        return f"{getattr(legacy, base_attr)}{suffix}"
+
+        # Legacy spelling, or a column the flip never renamed.
+        if not name.startswith("_") and hasattr(legacy, name):
+            return getattr(legacy, name)
+
+        raise AttributeError(
+            f"{name!r} is not a column of the {self._frame!r} frame on the "
+            f"legacy runtime (schema is native-spelled; see "
+            f"cellpy.parameters.cell_schema)"
+        )
+
+    def __getattr__(self, name: str) -> str:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return self._resolve(name)
+
+    def __getitem__(self, key: str) -> str:
+        return self._resolve(key)
+
+
+class CellSchema:
+    """Column names for one cell's three frames.
+
+    Args:
+        core_schema: the ``Schema``-like object owned by the cell's core
+            (``CellpyCell.core.schema``). Its ``raw`` / ``step`` / ``cycle``
+            frames are re-exposed here as ``raw`` / ``steps`` / ``summary``.
+        native: whether the cell's frames carry native column names. When
+            False the frames are wrapped so native attribute spelling still
+            resolves — to the legacy column names those frames actually use.
+    """
+
+    __slots__ = ("_raw", "_steps", "_summary")
+
+    def __init__(self, core_schema: "config.Schema", native: bool = True) -> None:
+        if native:
+            raw, steps, summary = core_schema.raw, core_schema.step, core_schema.cycle
+        else:
+            raw = _LegacySpellingAdapter(core_schema.raw, "raw")
+            steps = _LegacySpellingAdapter(core_schema.step, "step")
+            summary = _LegacySpellingAdapter(core_schema.cycle, "cycle")
+        object.__setattr__(self, "_raw", raw)
+        object.__setattr__(self, "_steps", steps)
+        object.__setattr__(self, "_summary", summary)
+
+    @property
+    def raw(self):
+        """Column names of ``c.data.raw``."""
+        return self._raw
+
+    @property
+    def steps(self):
+        """Column names of ``c.data.steps``."""
+        return self._steps
+
+    @property
+    def summary(self):
+        """Column names of ``c.data.summary``."""
+        return self._summary
+
+    def __repr__(self) -> str:
+        return "CellSchema(raw=…, steps=…, summary=…)"

--- a/cellpy/parameters/legacy_header_shim.py
+++ b/cellpy/parameters/legacy_header_shim.py
@@ -50,6 +50,15 @@ _FRAME_LABEL = {
     "cycle": "headers_summary",
 }
 
+# Frame label -> the public replacement frame on ``CellpyCell.schema`` (#558).
+# Note the frames are spelled as they are on ``c.data`` (raw/steps/summary),
+# not as cellpy-core spells them (raw/step/cycle).
+_SCHEMA_FRAME = {
+    "raw": "raw",
+    "step": "steps",
+    "cycle": "summary",
+}
+
 
 class LegacyHeaderShim:
     """Resolve legacy header attributes/keys to native column names, with a warning.
@@ -99,7 +108,7 @@ class LegacyHeaderShim:
             native_name = None
 
         if native_name is not None:
-            self._warn(name)
+            self._warn(name, native_name)
             return native_name
 
         # Summary specific column by key: strip the postfix, resolve the base,
@@ -113,7 +122,7 @@ class LegacyHeaderShim:
                         native_base = mapping.legacy_attr_to_native("cycle", base)
                     except KeyError:
                         break
-                    self._warn(name)
+                    self._warn(name, f"{native_base}{suffix}")
                     return f"{native_base}{suffix}"
 
         # Legacy-only attribute: the flip does not rename this column, so the
@@ -128,11 +137,14 @@ class LegacyHeaderShim:
             f"legacy mapping (unknown attribute)."
         )
 
-    def _warn(self, name: str) -> None:
+    def _warn(self, name: str, native_name: str) -> None:
         label = _FRAME_LABEL[self._frame]
+        # Name the exact replacement, not just the concept: the user needs the
+        # attribute they should type, and we know it here (conventions plan §3).
+        replacement = f"c.schema.{_SCHEMA_FRAME[self._frame]}.{native_name}"
         warn_once(
             f"{label}.{name}",
-            "the native cellpycore schema column names",
+            replacement,
             removal="2.1",
             introduced="2.0",
             stacklevel=4,

--- a/cellpy/readers/capacity_curves.py
+++ b/cellpy/readers/capacity_curves.py
@@ -536,9 +536,9 @@ def _get_cap(
         usteps=usteps,
     )
     if cap_type == "charge":
-        column_txt = cell.headers_normal.charge_capacity_txt
+        column_txt = cell.schema.raw.cumulative_charge_capacity
     else:
-        column_txt = cell.headers_normal.discharge_capacity_txt
+        column_txt = cell.schema.raw.cumulative_discharge_capacity
 
     if cycle:
         steps = cycles[cycle]
@@ -553,22 +553,22 @@ def _get_cap(
         if usteps:
             selected = cell._select_usteps(cycle, steps)
             if not cell._is_empty_array(selected):
-                _v.append(selected[cell.headers_normal.voltage_txt])
+                _v.append(selected[cell.schema.raw.potential])
                 _c.append(selected[column_txt] * converter)
                 if detailed:
-                    _t.append(selected[cell.headers_normal.test_time_txt])
-                    _p.append(selected[cell.headers_normal.data_point_txt])
+                    _t.append(selected[cell.schema.raw.test_time])
+                    _p.append(selected[cell.schema.raw.datapoint_num])
             else:
                 logging.debug(f"Steps {steps} is empty")
         else:
             for step in sorted(steps):
                 selected_step = cell._select_step(cycle, step)
                 if not cell._is_empty_array(selected_step):
-                    _v.append(selected_step[cell.headers_normal.voltage_txt])
+                    _v.append(selected_step[cell.schema.raw.potential])
                     _c.append(selected_step[column_txt] * converter)
                     if detailed:
-                        _t.append(selected_step[cell.headers_normal.test_time_txt])
-                        _p.append(selected_step[cell.headers_normal.data_point_txt])
+                        _t.append(selected_step[cell.schema.raw.test_time])
+                        _p.append(selected_step[cell.schema.raw.datapoint_num])
                 else:
                     logging.debug(f"Step {step} is empty")
         try:
@@ -654,10 +654,10 @@ def get_ocv(
     if remove_first:
         ocv_steps = ocv_steps.iloc[1:, :]
 
-    step_time_label = cell.headers_normal.step_time_txt
-    voltage_label = cell.headers_normal.voltage_txt
-    cycle_label = cell.headers_normal.cycle_index_txt
-    step_label = cell.headers_normal.step_index_txt
+    step_time_label = cell.schema.raw.step_time
+    voltage_label = cell.schema.raw.potential
+    cycle_label = cell.schema.raw.cycle_num
+    step_label = cell.schema.raw.step_num
 
     selected_df = raw.loc[
         (

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -41,6 +41,7 @@ from cellpy.exceptions import (
     NoDataFound,
 )
 from cellpy.parameters import prms
+from cellpy.parameters.cell_schema import CellSchema
 from cellpy.parameters.internal_settings import (
     get_cellpy_units,
     headers_normal,
@@ -276,6 +277,7 @@ class CellpyCell:
             self.core = OldCellpyCellCore(initialize=False, debug=debug)
 
         self._cell_name = None
+        self._schema = None  # lazily wrapped core schema (#558)
         self._initial_cells = None
         self.group = None
         self.last_uploaded_from = None
@@ -353,6 +355,30 @@ class CellpyCell:
         self.core._data = ds.Data()
 
     # the batch utility might be using session name
+    @property
+    def schema(self):
+        """The column names of this cell's frames (the public header API).
+
+        Use this instead of ``headers_normal`` / ``headers_step_table`` /
+        ``headers_summary``, which are a deprecation shim as of 2.0 (removed
+        in 2.1)::
+
+            c.data.raw[c.schema.raw.potential]
+            c.data.steps[c.schema.steps.cycle_num]
+            c.data.summary[c.schema.summary.charge_capacity]
+
+        The frames are named as they are on ``c.data``: ``raw``, ``steps``,
+        ``summary``. You always spell the column the native way; the value
+        tracks the runtime, so on the legacy runtime
+        (``native_schema=False``) ``schema.raw.potential`` returns
+        ``"voltage"`` — the name that actually indexes that frame. Whatever
+        this returns is a valid column key for the matching frame. See
+        :mod:`cellpy.parameters.cell_schema`.
+        """
+        if self._schema is None:
+            self._schema = CellSchema(self.core.schema, native=self.native_schema)
+        return self._schema
+
     # the cycle and ica collector are using session name
     # improvement suggestion: use data.cell_name instead
     @property
@@ -1841,8 +1867,8 @@ class CellpyCell:
             # on last_cycle when recalc=False)
             if t1.has_steps and t2.has_steps:
                 if recalc:
-                    t2.steps[self.headers_step_table.cycle] = (
-                        t2.steps[self.headers_step_table.cycle] + last_cycle
+                    t2.steps[self.schema.steps.cycle_num] = (
+                        t2.steps[self.schema.steps.cycle_num] + last_cycle
                     )
                 steps2 = externals.pandas.concat(
                     [t1.steps, t2.steps], ignore_index=True
@@ -1859,7 +1885,7 @@ class CellpyCell:
 
     # TODO: check if this can be moved to helpers
     def _validate_step_table(self, simple=False):
-        step_index_header = self.headers_normal.step_index_txt
+        step_index_header = self.schema.raw.step_num
         logging.debug(f"-validating step table ({step_index_header=!r})")
         d = self.data.raw
         s = self.data.steps
@@ -1867,9 +1893,8 @@ class CellpyCell:
         if not self.data.has_steps:
             return False
 
-        no_cycles_raw = externals.numpy.amax(d[self.headers_normal.cycle_index_txt])
-        headers_step_table = self.headers_step_table
-        no_cycles_step_table = externals.numpy.amax(s[headers_step_table.cycle])
+        no_cycles_raw = externals.numpy.amax(d[self.schema.raw.cycle_num])
+        no_cycles_step_table = externals.numpy.amax(s[self.schema.steps.cycle_num])
 
         if simple:
             logging.debug("  (simple)")
@@ -1889,15 +1914,15 @@ class CellpyCell:
                     no_steps_raw = len(
                         externals.numpy.unique(
                             d.loc[
-                                d[self.headers_normal.cycle_index_txt] == cycle_number,
-                                self.headers_normal.step_index_txt,
+                                d[self.schema.raw.cycle_num] == cycle_number,
+                                self.schema.raw.step_num,
                             ]
                         )
                     )
                     no_steps_step_table = len(
                         s.loc[
-                            s[headers_step_table.cycle] == cycle_number,
-                            headers_step_table.step,
+                            s[self.schema.steps.cycle_num] == cycle_number,
+                            self.schema.steps.step_num,
                         ]
                     )
                     if no_steps_raw != no_steps_step_table:
@@ -2013,7 +2038,7 @@ class CellpyCell:
             st = self.data.steps
         else:
             st = steptable
-        shdr = self.headers_step_table
+        shdr = self.schema.steps
 
         # Retrieving cycle numbers (if cycle_number is None, it selects all cycles)
         if cycle_number is None:
@@ -2035,15 +2060,21 @@ class CellpyCell:
                     "possible when returning externals.pandas.DataFrame. "
                     "Do it manually instead."
                 )
-            out = st[st[shdr.type].isin(steptypes) & st[shdr.cycle].isin(cycle_numbers)]
+            out = st[
+                st[shdr.step_type].isin(steptypes)
+                & st[shdr.cycle_num].isin(cycle_numbers)
+            ]
             return out
 
         out = dict()
-        step_hdr = shdr.ustep if usteps else shdr.step
+        # ustep is legacy-only (no native column) -> resolved via the D6 shim
+        step_hdr = self.headers_step_table.ustep if usteps else shdr.step_num
         for cycle in cycle_numbers:
             steplist = []
             for s in steptypes:
-                mask_type_and_cycle = (st[shdr.type] == s) & (st[shdr.cycle] == cycle)
+                mask_type_and_cycle = (st[shdr.step_type] == s) & (
+                    st[shdr.cycle_num] == cycle
+                )
                 if not any(mask_type_and_cycle):
                     logging.debug(f"Cycle {cycle} | StepType {s}: Not present!")
                 else:
@@ -2240,10 +2271,10 @@ class CellpyCell:
 
     def _select_usteps(self, cycle: int, steps: Union[list, np.ndarray]):
         # TODO: @jepe - insert sub_step here
-        s_hdr = self.headers_step_table.step
+        s_hdr = self.schema.steps.step_num
         us_hdr = self.headers_step_table.ustep
-        c_txt = self.headers_normal.cycle_index_txt
-        s_txt = self.headers_normal.step_index_txt
+        c_txt = self.schema.raw.cycle_num
+        s_txt = self.schema.raw.step_num
         steps = self.data.steps.loc[self.data.steps[us_hdr].isin(steps), s_hdr].unique()
         v = self.data.raw[
             (self.data.raw[c_txt] == cycle) & (self.data.raw[s_txt].isin(steps))
@@ -2257,8 +2288,8 @@ class CellpyCell:
 
     def _select_step(self, cycle, step):
         # TODO: @jepe - insert sub_step here
-        c_txt = self.headers_normal.cycle_index_txt
-        s_txt = self.headers_normal.step_index_txt
+        c_txt = self.schema.raw.cycle_num
+        s_txt = self.schema.raw.step_num
         v = self.data.raw[
             (self.data.raw[c_txt] == cycle) & (self.data.raw[s_txt] == step)
         ]
@@ -2488,7 +2519,7 @@ class CellpyCell:
         Returns:
             pandas.Series or None if empty
         """
-        header = self.headers_normal.voltage_txt
+        header = self.schema.raw.potential
         return self._sget(cycle, step, header)
 
     def sget_current(self, cycle, step):
@@ -2505,7 +2536,7 @@ class CellpyCell:
         Returns:
             pandas.Series or None if empty
         """
-        header = self.headers_normal.current_txt
+        header = self.schema.raw.current
         return self._sget(cycle, step, header)
 
     def get_raw(
@@ -2536,9 +2567,9 @@ class CellpyCell:
             pandas.DataFrame (or list of numpy arrays if as_frame=False)
         """
         y_header = header  # Consider including some lookup handling here
-        cycle_index_header = self.headers_normal.cycle_index_txt
-        time_header = self.headers_normal.test_time_txt
-        step_index_header = self.headers_normal.step_index_txt
+        cycle_index_header = self.schema.raw.cycle_num
+        time_header = self.schema.raw.test_time
+        step_index_header = self.schema.raw.step_num
 
         if not as_frame:
             with_time = False
@@ -2592,7 +2623,7 @@ class CellpyCell:
             pandas.DataFrame (or list of pandas.Series if cycle=None and as_frame=False)
         """
 
-        y_header = self.headers_normal.voltage_txt
+        y_header = self.schema.raw.potential
         return self.get_raw(
             y_header,
             cycle=cycle,
@@ -2618,7 +2649,7 @@ class CellpyCell:
             ``pandas.DataFrame`` (or list of ``pandas.Series`` if cycle=None and as_frame=False)
         """
 
-        y_header = self.headers_normal.current_txt
+        y_header = self.schema.raw.current
         return self.get_raw(
             y_header,
             cycle=cycle,
@@ -2674,7 +2705,7 @@ class CellpyCell:
             ``pandas.DataFrame`` (or list of ``pandas.Series`` if cycle=None and as_frame=False)
         """
 
-        y_header = self.headers_normal.test_time_txt
+        y_header = self.schema.raw.test_time
 
         if in_minutes:
             units = "minutes"
@@ -2710,14 +2741,14 @@ class CellpyCell:
             ``pandas.Series`` or None if empty
         """
 
-        header = self.headers_normal.step_time_txt
+        header = self.schema.raw.step_time
         return self._sget(cycle, step, header)
 
     def _sget(self, cycle, step, header):
         logging.debug(f"searching for {header}")
 
-        cycle_index_header = self.headers_normal.cycle_index_txt
-        step_index_header = self.headers_normal.step_index_txt
+        cycle_index_header = self.schema.raw.cycle_num
+        step_index_header = self.schema.raw.step_num
 
         test = self.data.raw
 
@@ -2745,7 +2776,7 @@ class CellpyCell:
             ``pandas.Series``
         """
 
-        header = self.headers_normal.test_time_txt
+        header = self.schema.raw.test_time
         return self._sget(cycle, step, header)
 
     def sget_step_numbers(self, cycle, step):
@@ -2764,7 +2795,7 @@ class CellpyCell:
             ``pandas.Series``
         """
 
-        header = self.headers_normal.step_index_txt
+        header = self.schema.raw.step_num
         return self._sget(cycle, step, header)
 
     def _using_usteps(self):
@@ -2918,11 +2949,11 @@ class CellpyCell:
         if steptable is None:
             d = self.data.raw
             number_of_cycles = externals.numpy.amax(
-                d[self.headers_normal.cycle_index_txt]
+                d[self.schema.raw.cycle_num]
             )
         else:
             number_of_cycles = externals.numpy.amax(
-                steptable[self.headers_step_table.cycle]
+                steptable[self.schema.steps.cycle_num]
             )
         return number_of_cycles
 
@@ -2945,16 +2976,16 @@ class CellpyCell:
             steptable = self.data.steps
         rates = steptable[
             [
-                self.headers_step_table.cycle,
-                self.headers_step_table.type,
-                self.headers_step_table.rate_avr,
+                self.schema.steps.cycle_num,
+                self.schema.steps.step_type,
+                self.schema.steps.c_rate,
             ]
         ].dropna()
 
         if agg:
             rates = (
                 rates.groupby(
-                    [self.headers_step_table.cycle, self.headers_step_table.type]
+                    [self.schema.steps.cycle_num, self.schema.steps.step_type]
                 )
                 .agg(agg)
                 .reset_index()
@@ -2963,7 +2994,7 @@ class CellpyCell:
         if direction is not None:
             if not isinstance(direction, (list, tuple)):
                 direction = [direction]
-            rates = rates.loc[rates[self.headers_step_table.type].isin(direction), :]
+            rates = rates.loc[rates[self.schema.steps.step_type].isin(direction), :]
 
         return rates
 
@@ -3003,11 +3034,11 @@ class CellpyCell:
 
         if steptable is None:
             d = self.data.raw
-            cycles = d[self.headers_normal.cycle_index_txt].dropna().unique()
+            cycles = d[self.schema.raw.cycle_num].dropna().unique()
             steptable = self.data.steps
         else:
             logging.debug("steptable is given as input parameter")
-            cycles = steptable[self.headers_step_table.cycle].dropna().unique()
+            cycles = steptable[self.schema.steps.cycle_num].dropna().unique()
 
         if rate is None:
             return cycles
@@ -3023,7 +3054,7 @@ class CellpyCell:
         if rate_on is None:
             rate_on = ["charge", "discharge"]
         rates = self.get_rates(steptable=steptable, agg=rate_agg, direction=rate_on)
-        rate_column = self.headers_step_table.rate_avr
+        rate_column = self.schema.steps.c_rate
         cycles_mask = (rates[rate_column] < (rate + rate_std)) & (
             rates[rate_column] > (rate - rate_std)
         )
@@ -3032,7 +3063,7 @@ class CellpyCell:
             cycles_mask = ~cycles_mask
 
         filtered_rates = rates[cycles_mask]
-        filtered_cycles = filtered_rates[self.headers_step_table["cycle"]].unique()
+        filtered_cycles = filtered_rates[self.schema.steps.cycle_num].unique()
 
         return filtered_cycles
 
@@ -3042,11 +3073,11 @@ class CellpyCell:
 
     def has_data_point_as_index(self):
         """Check if the raw data has data_point as index."""
-        return self.data.raw.index.name == self.headers_normal.data_point_txt
+        return self.data.raw.index.name == self.schema.raw.datapoint_num
 
     def has_data_point_as_column(self):
         """Check if the raw data has data_point as column."""
-        return self.headers_normal.data_point_txt in self.data.raw.columns
+        return self.schema.raw.datapoint_num in self.data.raw.columns
 
     def has_no_full_duplicates(self):
         """Check if the raw data has no full duplicates."""
@@ -3055,7 +3086,7 @@ class CellpyCell:
     def has_no_partial_duplicates(self, subset="data_point"):
         """Check if the raw data has no partial duplicates."""
         if subset == "data_point":
-            subset = self.headers_normal.data_point_txt
+            subset = self.schema.raw.datapoint_num
         return not self.data.raw.duplicated(subset=subset).any()
 
     def total_time_at_voltage_level(
@@ -3094,8 +3125,8 @@ class CellpyCell:
             )
 
         date_time_hdr = self.headers_normal.datetime_txt
-        cycle_index_hdr = self.headers_normal.cycle_index_txt
-        voltage_hdr = self.headers_normal.voltage_txt
+        cycle_index_hdr = self.schema.raw.cycle_num
+        voltage_hdr = self.schema.raw.potential
         date_time_format = prms._date_time_format
 
         if cycles is not None:
@@ -3506,8 +3537,8 @@ class CellpyCell:
         # datapoints for each cycle in the dataset (only used in the old
         # summary method and for the new summary method if use_cellpy_stat_file is True)
 
-        c_txt = self.headers_normal.cycle_index_txt
-        d_txt = self.headers_normal.data_point_txt
+        c_txt = self.schema.raw.cycle_num
+        d_txt = self.schema.raw.datapoint_num
         steps = []
         unique_steps = raw[c_txt].unique()
         max_step = max(raw[c_txt])
@@ -3811,14 +3842,14 @@ class CellpyCell:
                 logging.debug("sorting columns")
                 new_first_col_list = [
                     self.headers_normal.datetime_txt,
-                    self.headers_normal.test_time_txt,
-                    self.headers_normal.data_point_txt,
-                    self.headers_normal.cycle_index_txt,
+                    self.schema.raw.test_time,
+                    self.schema.raw.datapoint_num,
+                    self.schema.raw.cycle_num,
                 ]
                 data.summary = self.set_col_first(data.summary, new_first_col_list)
 
         if cycle_index_as_index:
-            index_col = self.headers_summary.cycle_index
+            index_col = self.schema.summary.cycle_num
             try:
                 data.summary.set_index(index_col, inplace=True)
             except KeyError:
@@ -3871,8 +3902,8 @@ class CellpyCell:
                 f"(available: {sorted(raw.columns)})"
             )
 
-        hdrn_cycle = self.headers_normal.cycle_index_txt
-        hdrs_cycle = self.headers_summary.cycle_index
+        hdrn_cycle = self.schema.raw.cycle_num
+        hdrs_cycle = self.schema.summary.cycle_num
         target = new_name or column
 
         per_cycle = raw.groupby(hdrn_cycle)[column].agg(method)
@@ -3932,7 +3963,7 @@ class CellpyCell:
         """
         from cellpy.filters import filter_summary as _fs
 
-        h = self.headers_summary
+        h = self.schema.summary
         if rate_columns is None:
             rate_columns = (h.charge_c_rate, h.discharge_c_rate)
         return _fs(
@@ -3961,8 +3992,8 @@ class CellpyCell:
 
         try:
             nc = summary.loc[
-                summary[self.headers_normal.cycle_index_txt].isin(cycles),
-                self.headers_summary.discharge_capacity,
+                summary[self.schema.raw.cycle_num].isin(cycles),
+                self.schema.summary.discharge_capacity,
             ].mean()
             print("All I can say for now is that the average discharge capacity")
             print(f"for the cycles {cycles} is {nc:0.2f}")

--- a/cellpy/readers/slicing.py
+++ b/cellpy/readers/slicing.py
@@ -38,10 +38,10 @@ def mod_raw_split_cycle(cell: "CellpyCell", data_points: List) -> None:
 def _mod_raw_split_cycle(cell: "CellpyCell", data_point: int) -> None:
     r = cell.data.raw
 
-    hdr_data_point = cell.headers_normal.data_point_txt
-    hdr_cycle = cell.headers_normal.cycle_index_txt
-    hdr_c_cap = cell.headers_normal.charge_capacity_txt
-    hdr_d_cap = cell.headers_normal.discharge_capacity_txt
+    hdr_data_point = cell.schema.raw.datapoint_num
+    hdr_cycle = cell.schema.raw.cycle_num
+    hdr_c_cap = cell.schema.raw.cumulative_charge_capacity
+    hdr_d_cap = cell.schema.raw.cumulative_discharge_capacity
     hdr_c_energy = cell.headers_normal.charge_energy_txt
     hdr_d_energy = cell.headers_normal.discharge_energy_txt
 
@@ -125,9 +125,9 @@ def split_many(
         List of CellpyCell objects
 
     """
-    h_summary_index = cell.headers_summary.cycle_index
-    h_raw_index = cell.headers_normal.cycle_index_txt
-    h_step_cycle = cell.headers_step_table.cycle
+    h_summary_index = cell.schema.summary.cycle_num
+    h_raw_index = cell.schema.raw.cycle_num
+    h_step_cycle = cell.schema.steps.cycle_num
 
     if base_cycles is None:
         all_cycles = cell.get_cycle_numbers()
@@ -197,9 +197,9 @@ def with_cycles(cell: "CellpyCell", cycles: Union[int, List[int]]) -> "CellpyCel
         A new CellpyCell object containing only the selected cycles.
 
     """
-    h_summary_index = cell.headers_summary.cycle_index
-    h_raw_index = cell.headers_normal.cycle_index_txt
-    h_step_cycle = cell.headers_step_table.cycle
+    h_summary_index = cell.schema.summary.cycle_num
+    h_raw_index = cell.schema.raw.cycle_num
+    h_step_cycle = cell.schema.steps.cycle_num
 
     if isinstance(cycles, int):
         cycles = [cycles]

--- a/cellpy/utils/batch.py
+++ b/cellpy/utils/batch.py
@@ -425,7 +425,7 @@ class Batch:
     def _check_cell_cycles(self, cell_id):
         try:
             c = self.experiment.data[cell_id]
-            return c.data.steps[self.headers_step_table.cycle].max()
+            return c.data.steps[self.schema.steps.cycle_num].max()
         except Exception as e:
             logging.debug(f"Exception ignored: {e}")
             return None

--- a/cellpy/utils/ocv_rlx.py
+++ b/cellpy/utils/ocv_rlx.py
@@ -545,7 +545,7 @@ class MultiCycleOcvFit:
         """Convenience function for creating a dataframe of the summary of the
         fit (translated)"""
         data = self.get_best_fit_parameters_translated_grouped()
-        cycle_col = self.data.headers_step_table.cycle
+        cycle_col = self.data.schema.steps.cycle_num
         data[cycle_col] = self.get_fit_cycles()
         df = pd.DataFrame(data)
         df = df.set_index(cycle_col)

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -1162,7 +1162,7 @@ class SummaryPlotDataPreparer:
                 - max_val_normalized_col: max value for normalized columns
                 - formation_cycle_selector: boolean selector for formation cycles
         """
-        x = config.x if config.x is not None else c.headers_summary.cycle_index
+        x = config.x if config.x is not None else c.schema.summary.cycle_num
         y = config.y
 
         number_of_rows = 1
@@ -1604,7 +1604,7 @@ class PlotlyPlotBuilder:
         if title is None:
             title = f"Summary <b>{c.cell_name}</b>"
 
-        x = config.x if config.x is not None else c.headers_summary.cycle_index
+        x = config.x if config.x is not None else c.schema.summary.cycle_num
         y = config.y
         number_of_rows = prepared_data_info["number_of_rows"]
         x_label = prepared_data_info["x_label"]
@@ -2412,7 +2412,7 @@ class SeabornPlotBuilder:
         if title is None:
             title = f"Summary {c.cell_name}"
 
-        x = config.x if config.x is not None else c.headers_summary.cycle_index
+        x = config.x if config.x is not None else c.schema.summary.cycle_num
         y = config.y
         number_of_rows = prepared_data_info["number_of_rows"]
         x_label = prepared_data_info["x_label"]
@@ -3361,7 +3361,7 @@ def summary_plot_legacy(
             title = f"Summary {c.cell_name}"
 
     if x is None:
-        x = c.headers_summary.cycle_index
+        x = c.schema.summary.cycle_num
     xlim_formation = kwargs.pop("xlim_formation", (0.6, formation_cycles + 0.4))
 
     eff_lim = ce_range

--- a/tests/test_cell_schema.py
+++ b/tests/test_cell_schema.py
@@ -1,0 +1,170 @@
+"""Tests for the public ``CellpyCell.schema`` header API (#558, native-headers Phase 4).
+
+``c.schema`` is the sanctioned replacement for the legacy ``headers_*``
+attributes. Its contract: whatever ``c.schema.<frame>.<column>`` returns is a
+valid column key for the matching ``c.data.<frame>`` — on the native runtime
+that is the native cellpy-core name, on the legacy runtime the legacy one.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import pytest
+
+from cellpy import _deprecation, log
+from cellpy.parameters.cell_schema import CellSchema
+from cellpy.readers.cellreader import CellpyCell
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+@pytest.fixture
+def native_cell() -> CellpyCell:
+    return CellpyCell()
+
+
+@pytest.fixture
+def legacy_cell() -> CellpyCell:
+    return CellpyCell(native_schema=False)
+
+
+@pytest.mark.essential
+def test_schema_is_available_on_a_vacant_cell(native_cell):
+    # The null-object guarantee: no data required to ask for column names.
+    assert isinstance(native_cell.schema, CellSchema)
+    assert native_cell.schema.raw.potential == "potential"
+
+
+@pytest.mark.essential
+def test_schema_frames_are_named_after_the_data_frames(native_cell):
+    schema = native_cell.schema
+    # raw/steps/summary — matching c.data.raw / .steps / .summary, *not*
+    # cellpy-core's raw/step/cycle spelling. On the native runtime the frames
+    # pass through to the core schema untouched.
+    assert schema.raw is native_cell.core.schema.raw
+    assert schema.steps is native_cell.core.schema.step
+    assert schema.summary is native_cell.core.schema.cycle
+
+
+@pytest.mark.essential
+def test_schema_resolves_native_names(native_cell):
+    schema = native_cell.schema
+    assert schema.raw.potential == "potential"
+    assert schema.steps.cycle_num == "cycle_num"
+    assert schema.summary.charge_capacity == "charge_capacity"
+
+
+@pytest.mark.essential
+def test_schema_is_cached(native_cell):
+    assert native_cell.schema is native_cell.schema
+
+
+@pytest.mark.essential
+def test_native_spelling_resolves_on_the_legacy_runtime(legacy_cell):
+    # Native spelling everywhere; the *value* tracks the runtime. This is what
+    # lets cellpy internals — which run on both runtimes — be written once.
+    assert legacy_cell.schema.raw.potential == "voltage"
+    assert legacy_cell.schema.raw.cycle_num == "cycle_index"
+    assert legacy_cell.schema.steps.step_type == "type"
+    assert legacy_cell.schema.summary.charge_capacity == "charge_capacity"
+
+
+@pytest.mark.essential
+def test_legacy_runtime_still_accepts_legacy_spelling(legacy_cell):
+    # Unmigrated code keeps resolving on the legacy path.
+    assert legacy_cell.schema.raw.voltage_txt == "voltage"
+
+
+@pytest.mark.essential
+def test_legacy_runtime_specific_summary_columns(legacy_cell):
+    assert (
+        legacy_cell.schema.summary.charge_capacity_gravimetric
+        == "charge_capacity_gravimetric"
+    )
+
+
+@pytest.mark.essential
+def test_unknown_column_raises_on_both_runtimes(native_cell, legacy_cell):
+    for cell in (native_cell, legacy_cell):
+        with pytest.raises(AttributeError):
+            cell.schema.raw.not_a_column
+
+
+@pytest.mark.essential
+def test_schema_does_not_warn(native_cell):
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        native_cell.schema.raw.potential
+        native_cell.schema.summary.charge_capacity
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "legacy_attr, schema_frame, native_attr",
+    [
+        ("headers_normal", "raw", "potential"),
+        ("headers_step_table", "steps", "cycle_num"),
+        ("headers_summary", "summary", "charge_capacity"),
+    ],
+)
+def test_legacy_shim_and_schema_agree(
+    native_cell, legacy_attr, schema_frame, native_attr
+):
+    via_schema = getattr(getattr(native_cell.schema, schema_frame), native_attr)
+    via_shim = getattr(getattr(native_cell, legacy_attr), native_attr)
+    assert via_schema == via_shim
+
+
+@pytest.mark.essential
+def test_legacy_attribute_warns_and_names_the_schema_replacement(native_cell):
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        value = native_cell.headers_normal.voltage_txt
+
+    assert value == native_cell.schema.raw.potential
+    messages = [
+        str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(messages) == 1
+    # The warning must name the exact attribute to type, not the concept.
+    assert "c.schema.raw.potential" in messages[0]
+
+
+@pytest.mark.essential
+def test_core_pipeline_does_not_trip_its_own_deprecation(dataset):
+    """cellpy's own code must be migrated off ``headers_*`` (#558).
+
+    Guards the failure mode found while migrating: dropping a local
+    ``hdr = self.headers_step_table`` binding silently re-resolved a later use
+    to the module-level *legacy* singleton, which indexes a native frame with
+    legacy names. A warning from inside cellpy means a site is still on the
+    shim — or has fallen through to the legacy singleton.
+    """
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        dataset.make_step_table()
+        dataset.make_summary()
+        dataset._validate_step_table()
+
+    offenders = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "headers_" in str(w.message)
+    ]
+    assert not offenders, f"cellpy internals still on the header shim: {offenders}"
+
+
+@pytest.mark.essential
+def test_schema_columns_are_keys_into_the_frames(dataset):
+    """The contract, end to end: schema names index the real frames."""
+    schema = dataset.schema
+    assert schema.raw.potential in dataset.data.raw.columns
+    assert schema.summary.charge_capacity in dataset.data.summary.columns
+    assert schema.steps.cycle_num in dataset.data.steps.columns


### PR DESCRIPTION
Closes #558. First issue of the Stage 3 / 2.0 assembly set (#575).

## What

`CellpyCell.schema` is now the public way to ask a cell what its columns are
called. `headers_normal` / `headers_step_table` / `headers_summary` become the
deprecation shim they were always meant to be, with a 2.1 removal.

```python
c.data.raw[c.schema.raw.potential]
c.data.steps[c.schema.steps.cycle_num]
c.data.summary[c.schema.summary.charge_capacity]
```

## Two design calls worth reviewing

**1. Frames are spelled `raw` / `steps` / `summary`, not cellpy-core's
`raw` / `step` / `cycle`.** The frames a user holds are `c.data.raw` /
`.steps` / `.summary`, so `c.schema.summary` sits next to `c.data.summary`.
One public spelling per frame; internals that want the cellpy-core object keep
using `c.core.schema`.

**2. Columns are always spelled natively; the *value* tracks the runtime.**
On the legacy runtime (`native_schema=False`) `c.schema.raw.potential` returns
`"voltage"` — the name that actually indexes that frame. This was not the
first design: I started with "the schema reports whatever names the frames
carry", which made `c.schema.raw.potential` an `AttributeError` on the legacy
path and promptly broke `_make_summary`, because cellpy's own internals run on
**both** runtimes. Native-spelling-everywhere is what makes those internals
writable once.

The contract in one line: whatever `c.schema.<frame>.<column>` returns is a
valid key into `c.data.<frame>`.

## Migration

~90 in-repo call sites moved off the shim (cellreader, capacity_curves,
slicing, tabular, plotutils, batch, ocv_rlx), mostly by codemod through
`cellpycore.legacy.mapping`.

Deliberately **not** migrated:
- documented **pre-boundary** sites that run before `to_native()` and must
  stay legacy (`_append`, `_sort_data`, provenance stamping);
- **legacy-only** columns with no native equivalent — `datetime_txt`, `ustep`,
  `charge_energy` / `discharge_energy`. Note the native schema *defines*
  `cumulative_charge_energy` but the ingestion path does not populate it; that
  is loader-port territory (#559), flagged rather than papered over;
- the `hdr = c.headers_summary` **binding blocks** in `plotutils.py` and
  `ocv_rlx.py` — #567 rewrites the first and utils wave 3 (2.1) the second, so
  migrating them now is throwaway work.

## Tests

15 new tests in `tests/test_cell_schema.py`, including a guard that cellpy's
own pipeline never trips its own deprecation. That guard exists because of a
real bug found while migrating: deleting a local `hdr = self.headers_step_table`
binding silently re-resolved a *later* use in the same function to the
module-level **legacy** singleton, which then indexed a native frame with
legacy names (`KeyError: 'cycle'`). I verified the guard fails when a site
regresses rather than just passing vacuously.

Full suite: 693 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
