### PR TITLE
#564: units_label() / with_cellpy_unit() presentation helpers

### DIFF
--- a/cellpy/units.py
+++ b/cellpy/units.py
@@ -1,0 +1,132 @@
+"""Unit presentation helpers (unit plan Phase 4, issue #564).
+
+Plots and reports need to *say* what a number is measured in. Before this
+module every caller composed that string by hand::
+
+    f"Capacity ({c.cellpy_units.charge}/{c.cellpy_units.specific_gravimetric})"
+
+which is where gravimetric/areal/absolute mix-ups live: the mode is encoded in
+the choice of attribute, so picking the wrong one is a silent mislabel rather
+than an error. These two helpers make the mode an argument instead:
+
+    >>> units_label("charge", mode="gravimetric")          # doctest: +SKIP
+    'mAh/g'
+    >>> with_cellpy_unit("Capacity", "charge", "areal")    # doctest: +SKIP
+    'Capacity (mAh/cm**2)'
+
+``units`` defaults to the session's cellpy units. Pass a cell's own units
+explicitly — ``units_label("charge", "gravimetric", units=c.cellpy_units)`` —
+whenever the label describes that cell's frames rather than session policy.
+Values cross the seam, never config objects (architecture plan §4).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from cellpy.exceptions import UnitsError
+from cellpy.parameters.internal_settings import get_cellpy_units
+
+if TYPE_CHECKING:
+    from cellpycore.units import CellpyUnits
+
+# Specific mode -> the CellpyUnits field holding that mode's denominator.
+_SPECIFIC_FIELD = {
+    "gravimetric": "specific_gravimetric",
+    "areal": "specific_areal",
+    "volumetric": "specific_volumetric",
+}
+
+# Modes that mean "no denominator".
+_ABSOLUTE_MODES = (None, "absolute")
+
+# Convenience spellings. The native schema calls it ``potential`` while the
+# unit spec calls it ``voltage``; accept both so callers can use the column
+# vocabulary they already have.
+_PROPERTY_ALIASES = {
+    "potential": "voltage",
+    "capacity": "charge",
+    "charge_capacity": "charge",
+    "discharge_capacity": "charge",
+}
+
+
+def _resolve_units(units: Optional["CellpyUnits"]) -> "CellpyUnits":
+    return get_cellpy_units() if units is None else units
+
+
+def _unit_for(units: "CellpyUnits", physical_property: str) -> str:
+    prop = _PROPERTY_ALIASES.get(physical_property, physical_property)
+    try:
+        unit = units[prop]
+    except (KeyError, AttributeError):
+        unit = getattr(units, prop, None)
+    if not isinstance(unit, str):
+        raise UnitsError(
+            f"{physical_property!r} is not a known physical property "
+            f"(no such field in the cellpy unit spec)"
+        )
+    return unit
+
+
+def units_label(
+    physical_property: str,
+    mode: Optional[str] = None,
+    *,
+    units: Optional["CellpyUnits"] = None,
+) -> str:
+    """Return the unit string for a physical property, e.g. ``"mAh/g"``.
+
+    Args:
+        physical_property: what is being measured — a field of the cellpy unit
+            spec (``"charge"``, ``"voltage"``, ``"time"``, ``"energy"``, …).
+            ``"potential"`` and ``"capacity"`` are accepted spellings of
+            ``"voltage"`` and ``"charge"``.
+        mode: ``"gravimetric"``, ``"areal"``, ``"volumetric"``, or
+            ``"absolute"``/``None`` for the bare unit. A specific mode
+            appends that mode's denominator.
+        units: the unit spec to read. Defaults to the session's cellpy units;
+            pass ``c.cellpy_units`` when labelling a particular cell.
+
+    Returns:
+        The unit string — ``"mAh"``, ``"mAh/g"``, ``"mAh/cm**2"``, ``"V"``, …
+
+    Raises:
+        UnitsError: if the property or the mode is unknown. Mislabelled axes
+            are worse than a traceback, so this fails loudly rather than
+            returning a placeholder (conventions plan §4).
+    """
+    spec = _resolve_units(units)
+    unit = _unit_for(spec, physical_property)
+
+    if mode in _ABSOLUTE_MODES:
+        return unit
+
+    field = _SPECIFIC_FIELD.get(mode)
+    if field is None:
+        raise UnitsError(
+            f"unknown unit mode {mode!r}; expected one of "
+            f"{sorted(_SPECIFIC_FIELD)} or 'absolute'"
+        )
+    return f"{unit}/{getattr(spec, field)}"
+
+
+def with_cellpy_unit(
+    name: str,
+    physical_property: str,
+    mode: Optional[str] = None,
+    *,
+    units: Optional["CellpyUnits"] = None,
+) -> str:
+    """Return an axis label: ``name`` followed by its unit in parentheses.
+
+    Args:
+        name: the human-readable quantity name, e.g. ``"Capacity"``.
+        physical_property: as :func:`units_label`.
+        mode: as :func:`units_label`.
+        units: as :func:`units_label`.
+
+    Returns:
+        e.g. ``"Capacity (mAh/g)"``, ``"Voltage (V)"``.
+    """
+    return f"{name} ({units_label(physical_property, mode, units=units)})"

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -27,6 +27,8 @@ from cellpy.parameters.internal_settings import (
     get_headers_step_table,
     get_headers_summary,
 )
+from cellpy.exceptions import UnitsError
+from cellpy.units import units_label, with_cellpy_unit
 from cellpy.utils import helpers
 
 # get_cap curve frames use native CurveCols names (#540): potential/cycle_num
@@ -604,14 +606,14 @@ def create_colormarkerlist(
     return _color_list, _symbol_list
 
 
-def _get_capacity_unit(c, mode="gravimetric", seperator="/"):
-    specific_selector = {
-        "gravimetric": f"{c.cellpy_units.charge}{seperator}{c.cellpy_units.specific_gravimetric}",
-        "areal": f"{c.cellpy_units.charge}{seperator}{c.cellpy_units.specific_areal}",
-        "volumetric": f"{c.cellpy_units.charge}{seperator}{c.cellpy_units.specific_volumetric}",
-        "absolute": f"{c.cellpy_units.charge}",
-    }
-    return specific_selector.get(mode, "-")
+def _get_capacity_unit(c, mode="gravimetric"):
+    # Callers derive the mode from a y-spec suffix (``y.split("_")[-1]``), so
+    # it is routinely something that is not a mode at all; keep returning the
+    # "-" placeholder for those rather than letting units_label raise.
+    try:
+        return units_label("charge", mode, units=c.cellpy_units)
+    except UnitsError:
+        return "-"
 
 
 # Per-row y-axis labels for predefined ``y`` sets that route a different
@@ -824,22 +826,22 @@ class SummaryPlotInfo:
         x_axis_labels = {
             hdr.cycle_index: "Cycle Number",
             hdr.data_point: "Point",
-            hdr.test_time: f"Test Time ({c.cellpy_units.time})",
+            hdr.test_time: with_cellpy_unit("Test Time", "time", units=c.cellpy_units),
             hdr.datetime: "Date",
             hdr.normalized_cycle_index: "Equivalent Full Cycle",  # hdr.normalized_cycle_index: "Normalized Cycle Number",
         }
 
-        _cap_gravimetric_label = (
-            f"Capacity ({c.cellpy_units.charge}/{c.cellpy_units.specific_gravimetric})"
+        _units = c.cellpy_units
+        _cap_gravimetric_label = with_cellpy_unit(
+            "Capacity", "charge", "gravimetric", units=_units
         )
-        _cap_areal_label = (
-            f"Capacity ({c.cellpy_units.charge}/{c.cellpy_units.specific_areal})"
-        )
-        _cap_absolute_label = f"Capacity ({c.cellpy_units.charge})"
-        _cap_label = f"Capacity ({c.data.raw_units.charge})"
+        _cap_areal_label = with_cellpy_unit("Capacity", "charge", "areal", units=_units)
+        _cap_absolute_label = with_cellpy_unit("Capacity", "charge", units=_units)
+        # the raw frame's own units, not the session's
+        _cap_label = with_cellpy_unit("Capacity", "charge", units=c.data.raw_units)
 
         y_axis_label = {
-            "voltages": f"Voltage ({c.cellpy_units.voltage})",
+            "voltages": with_cellpy_unit("Voltage", "voltage", units=_units),
             "capacities_gravimetric": _cap_gravimetric_label,
             "capacities_areal": _cap_areal_label,
             "capacities_absolute": _cap_absolute_label,
@@ -5973,7 +5975,7 @@ def _cycles_plotter_matplotlib(
     # cbar.ax.yaxis.set_ticks_position("left")
 
     ax.set_xlabel(f"Capacity ({config.capacity_unit})")
-    ax.set_ylabel(f"Voltage ({c.cellpy_units.voltage})")
+    ax.set_ylabel(with_cellpy_unit("Voltage", "voltage", units=c.cellpy_units))
 
     ax.set_title(config.fig_title, loc="left", wrap=True)
 
@@ -6032,7 +6034,7 @@ def _cycles_plotter_plotly(
             title=config.fig_title,
             labels={
                 "capacity": f"Capacity ({config.capacity_unit})",
-                _CCOLS.potential: f"Voltage ({c.cellpy_units.voltage})",
+                _CCOLS.potential: with_cellpy_unit("Voltage", "voltage", units=c.cellpy_units),
             },
             color_discrete_sequence=cmap,
         )
@@ -6048,7 +6050,7 @@ def _cycles_plotter_plotly(
             color=_CCOLS.cycle_num,
             labels={
                 "capacity": f"Capacity ({config.capacity_unit})",
-                _CCOLS.potential: f"Voltage ({c.cellpy_units.voltage})",
+                _CCOLS.potential: with_cellpy_unit("Voltage", "voltage", units=c.cellpy_units),
             },
             color_continuous_scale=colormap,
             range_color=range_color,

--- a/tests/test_units_label.py
+++ b/tests/test_units_label.py
@@ -1,0 +1,114 @@
+"""Tests for the unit presentation helpers (#564, unit plan Phase 4).
+
+The expectation table below is the committed contract for the label helpers:
+if a label changes, this table changes with it, deliberately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from cellpycore.units import CellpyUnits
+
+from cellpy import log
+from cellpy.exceptions import UnitsError
+from cellpy.units import units_label, with_cellpy_unit
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+# (physical_property, mode) -> expected label, against the default unit spec.
+EXPECTED = {
+    ("charge", None): "mAh",
+    ("charge", "absolute"): "mAh",
+    ("charge", "gravimetric"): "mAh/g",
+    ("charge", "areal"): "mAh/cm**2",
+    ("charge", "volumetric"): "mAh/cm**3",
+    ("voltage", None): "V",
+    ("current", None): "A",
+    ("time", None): "sec",
+    ("mass", None): "mg",
+    ("energy", None): "Wh",
+    ("energy", "gravimetric"): "Wh/g",
+    ("power", None): "W",
+    ("area", None): "cm**2",
+    ("resistance", None): "ohm",
+}
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("key, expected", sorted(EXPECTED.items(), key=str))
+def test_units_label_expectation_table(key, expected):
+    physical_property, mode = key
+    assert units_label(physical_property, mode) == expected
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "alias, canonical",
+    [
+        ("potential", "voltage"),
+        ("capacity", "charge"),
+        ("charge_capacity", "charge"),
+        ("discharge_capacity", "charge"),
+    ],
+)
+def test_property_aliases(alias, canonical):
+    # The native schema says "potential" while the unit spec says "voltage";
+    # callers should be able to use the vocabulary they already have.
+    assert units_label(alias) == units_label(canonical)
+    assert units_label(alias, "gravimetric") == units_label(canonical, "gravimetric")
+
+
+@pytest.mark.essential
+def test_units_argument_overrides_the_session_spec():
+    custom = CellpyUnits(charge="Ah", specific_gravimetric="kg")
+    assert units_label("charge", "gravimetric", units=custom) == "Ah/kg"
+    # ... and the session default is untouched by that call.
+    assert units_label("charge", "gravimetric") == "mAh/g"
+
+
+@pytest.mark.essential
+def test_with_cellpy_unit_composes_an_axis_label():
+    assert with_cellpy_unit("Capacity", "charge", "gravimetric") == "Capacity (mAh/g)"
+    assert with_cellpy_unit("Voltage", "voltage") == "Voltage (V)"
+    assert with_cellpy_unit("Test Time", "time") == "Test Time (sec)"
+
+
+@pytest.mark.essential
+def test_unknown_property_raises():
+    # Fail loudly: a mislabelled axis is worse than a traceback.
+    with pytest.raises(UnitsError):
+        units_label("not_a_property")
+
+
+@pytest.mark.essential
+def test_unknown_mode_raises():
+    with pytest.raises(UnitsError):
+        units_label("charge", "sideways")
+
+
+@pytest.mark.essential
+def test_error_names_the_valid_modes():
+    with pytest.raises(UnitsError, match="gravimetric"):
+        units_label("charge", "sideways")
+
+
+@pytest.mark.essential
+def test_plotutils_capacity_unit_matches_the_helper(dataset):
+    """The plotutils wrapper must agree with the helper it now delegates to."""
+    from cellpy.utils.plotutils import _get_capacity_unit
+
+    for mode in ("gravimetric", "areal", "absolute", "volumetric"):
+        assert _get_capacity_unit(dataset, mode=mode) == units_label(
+            "charge", mode, units=dataset.cellpy_units
+        )
+
+
+@pytest.mark.essential
+def test_plotutils_capacity_unit_keeps_its_placeholder(dataset):
+    """Callers pass a y-spec suffix as the mode, so non-modes must not raise."""
+    from cellpy.utils.plotutils import _get_capacity_unit
+
+    assert _get_capacity_unit(dataset, mode="not_a_mode") == "-"


### PR DESCRIPTION
Closes #564. Stage 3 / 2.0 assembly (#575). Independent of #576 — merge in
either order.

## What

Unit plan Phase 4. Two presentation helpers in a new `cellpy.units`:

```python
units_label("charge", mode="gravimetric")        # -> "mAh/g"
with_cellpy_unit("Capacity", "charge", "areal")  # -> "Capacity (mAh/cm**2)"
```

## Why this shape

Every caller used to compose the label by hand:

```python
f"Capacity ({c.cellpy_units.charge}/{c.cellpy_units.specific_gravimetric})"
```

The mode is encoded in **which attribute you reach for**, so reaching for the
wrong one produces a confidently mislabelled axis rather than an error. Making
the mode an argument turns that class of bug into a `UnitsError`.

Failing loudly is deliberate (conventions plan §4) — a plot labelled `mAh/g`
when it is really `mAh/cm**2` is worse than a traceback.

`"potential"` and `"capacity"` are accepted spellings of `"voltage"` and
`"charge"`, so callers can use the native column vocabulary they already have
rather than translating to the unit spec's.

## Migration

Every hand-composed label in `plotutils` now goes through the helpers.
`grep "cellpy_units\."` in utils returns exactly one docstring mention, which
is the Phase 4 acceptance criterion.

I verified the rendered strings are **byte-identical** to the old ones rather
than assuming it — this is a presentation change users would notice.

The private `_get_capacity_unit` wrapper keeps its `"-"` placeholder: callers
pass a y-spec suffix (`y.split("_")[-1]`) as the mode, so it is routinely
handed something that is not a mode at all. That tolerance stays at the
wrapper; the helper itself is strict.

## Also

The other Phase 4 bullet — routing `unit_scaler_from_raw` through cellpy-core's
`calculate_scaler` — already landed with #451. No work needed; noting it so the
phase can be closed out.

## Tests

25 new tests, built around a committed expectation table so a label change is a
deliberate diff. Full suite: 704 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
