### PR TITLE
#565: secrets hardening + generated configuration reference

### DIFF
--- a/cellpy/config/credentials.py
+++ b/cellpy/config/credentials.py
@@ -1,0 +1,88 @@
+"""The one place that resolves cellpy credentials (config plan Step 6, #565).
+
+Before this module four call sites — ``internals/otherpath.py``,
+``internals/connections.py``, ``readers/filefinder.py`` and
+``readers/instruments/arbin_sql_config.py`` — each knew the ``CELLPY_*``
+environment variable names and each read them with a bare ``os.getenv``. That
+is the scatter the config plan set out to remove: four places to update when a
+variable is renamed, and four different answers when one of them is stale.
+
+Resolution order, per credential:
+
+1. the **session config** (``cellpy.config.secrets``) — this is where the
+   config loader has already deposited the environment and ``.env`` layers, and
+   where an explicit runtime assignment lands;
+2. the **live environment** — consulted only if the session value is unset, so
+   that a variable exported *after* cellpy was imported still works (a normal
+   notebook pattern) without letting the environment silently override a value
+   the user set deliberately at runtime.
+
+Credentials are never read from a config file: the loader refuses a
+``[secrets]`` section outright (config plan decision 5).
+"""
+
+from __future__ import annotations
+
+import os
+
+from cellpy.config.models import SecretsConfig
+
+# The only place these names are written down.
+ENV_VARS = {
+    "password": "CELLPY_PASSWORD",
+    "key_filename": "CELLPY_KEY_FILENAME",
+    "host": "CELLPY_HOST",
+    "user": "CELLPY_USER",
+}
+
+
+def _session_secrets() -> SecretsConfig:
+    # Imported lazily: cellpy.config builds the session on first attribute
+    # access, and this module must not trigger that at import time.
+    from cellpy.config.session import get_config
+
+    return get_config().secrets
+
+
+def _resolve(field: str) -> str | None:
+    secrets = _session_secrets()
+    value = (
+        secrets.get_password() if field == "password" else getattr(secrets, field, None)
+    )
+    if value:
+        return value
+    return os.getenv(ENV_VARS[field]) or None
+
+
+def get_password() -> str | None:
+    """The ssh/SQL password, or None if unset."""
+    return _resolve("password")
+
+
+def get_key_filename() -> str | None:
+    """Path to the ssh key file, or None if unset."""
+    return _resolve("key_filename")
+
+
+def get_host() -> str | None:
+    """Remote host, or None if unset."""
+    return _resolve("host")
+
+
+def get_user() -> str | None:
+    """Remote user name, or None if unset."""
+    return _resolve("user")
+
+
+def resolve_credentials() -> SecretsConfig:
+    """All four credentials as a fresh :class:`SecretsConfig`.
+
+    Convenience for callers that need more than one; the password comes back
+    wrapped in a ``SecretStr`` again, so use ``.get_password()`` on the result.
+    """
+    return SecretsConfig(
+        password=get_password(),
+        key_filename=get_key_filename(),
+        host=get_host(),
+        user=get_user(),
+    )

--- a/cellpy/config/loader.py
+++ b/cellpy/config/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tomllib
 from dataclasses import dataclass, field
@@ -13,6 +14,7 @@ from dotenv import dotenv_values
 
 from cellpy.config.models import CellpyConfig
 from cellpy.config.sources import ProvenanceRegistry, SourceLayer
+from cellpy.exceptions import ConfigurationError
 
 CONFIG_FILENAME = "cellpy.toml"
 
@@ -136,6 +138,45 @@ def _record_layer(registry: ProvenanceRegistry, layer: SourceLayer, payload: dic
         registry.record(layer, payload)
 
 
+def _reject_secrets_from_file(data: dict[str, Any], path: Path) -> None:
+    """Refuse a ``[secrets]`` section in a config file (config plan decision 5).
+
+    Secrets are env-only. Silently ignoring the section would be worse than
+    failing: the user would believe the credential was configured. Name the
+    env vars so the error is also the instruction.
+    """
+    secrets = data.get("secrets")
+    if not secrets:
+        return
+    fields = ", ".join(sorted(secrets)) if isinstance(secrets, dict) else "secrets"
+    env_vars = ", ".join(
+        _LEGACY_SECRET_ENV[f] for f in sorted(secrets) if f in _LEGACY_SECRET_ENV
+    ) or ", ".join(sorted(_LEGACY_SECRET_ENV.values()))
+    raise ConfigurationError(
+        f"{path} contains a [secrets] section ({fields}). Credentials are read "
+        f"from the environment only — set {env_vars} in your environment or "
+        f"your .env file instead, and remove the section from the file."
+    )
+
+
+def _drop_legacy_secrets(data: dict[str, Any], path: Path) -> None:
+    """Strip credentials from a *legacy YAML* layer, in place, with a warning.
+
+    Unlike a hand-written ``cellpy.toml``, a legacy YAML is a file the user is
+    migrating *from* — it may carry the old plain-text ``SQL_PWD``. Refusing to
+    load it would strand them, so drop the section and say so.
+    """
+    secrets = data.pop("secrets", None)
+    if secrets:
+        logging.warning(
+            "%s carries credentials (%s); these are ignored — cellpy 2 reads "
+            "them from the environment only (%s). See the configuration docs.",
+            path,
+            ", ".join(sorted(secrets)) if isinstance(secrets, dict) else "secrets",
+            ", ".join(sorted(_LEGACY_SECRET_ENV.values())),
+        )
+
+
 def load_config(
     overrides: dict[str, Any] | None = None,
     options: LoadOptions | None = None,
@@ -159,6 +200,7 @@ def load_config(
             user_file_path = user_file
             user_toml_loaded = True
             user_data = _read_toml(user_file)
+            _reject_secrets_from_file(user_data, user_file)
             merged = _deep_merge(merged, user_data)
             _record_layer(registry, SourceLayer.USER_FILE, user_data)
 
@@ -166,6 +208,10 @@ def load_config(
             legacy_path = opts.legacy_yaml_file or find_legacy_yaml_file()
             if legacy_path is not None and legacy_path.is_file():
                 legacy_data = load_legacy_yaml_dict(legacy_path)
+                # A legacy YAML may legitimately carry the old plain-text
+                # SQL_PWD; drop it with a warning rather than refusing to load
+                # a file the user did not write in this format.
+                _drop_legacy_secrets(legacy_data, legacy_path)
                 merged = _deep_merge(merged, legacy_data)
                 _record_layer(registry, SourceLayer.USER_FILE, legacy_data)
 
@@ -178,6 +224,7 @@ def load_config(
             and project_file != user_file_path
         ):
             project_data = _read_toml(project_file)
+            _reject_secrets_from_file(project_data, project_file)
             merged = _deep_merge(merged, project_data)
             _record_layer(registry, SourceLayer.PROJECT_FILE, project_data)
 

--- a/cellpy/config/models.py
+++ b/cellpy/config/models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from cellpycore.units import CellpyUnits
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from cellpy.config.types import LimitLoadedCycles, OtherPathField, PathField
 
@@ -246,12 +246,28 @@ class UnitsConfig(BaseModel):
 
 
 class SecretsConfig(BaseModel):
-    """Credentials — env / ``.env`` only; never written to TOML."""
+    """Credentials — env / ``.env`` only; never read from or written to TOML.
 
-    password: str | None = None
+    ``password`` is a :class:`~pydantic.SecretStr`, so it does not leak through
+    ``repr()``, logs, tracebacks or ``model_dump()``. Read the actual value with
+    :meth:`get_password` at the point of use, never earlier.
+
+    The other three are *not* secret material — a host, a user name and a path
+    to a key file — so they stay plain strings. They live here because they
+    arrive from the same env layer and the same consumers need them together
+    (config plan decision 5).
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    password: SecretStr | None = None
     key_filename: str | None = None
     host: str | None = None
     user: str | None = None
+
+    def get_password(self) -> str | None:
+        """The plain password, or None. Call at the point of use."""
+        return None if self.password is None else self.password.get_secret_value()
 
 
 class CellpyConfig(BaseModel):

--- a/cellpy/config/reference.py
+++ b/cellpy/config/reference.py
@@ -1,0 +1,170 @@
+"""Generate the configuration reference from the models (config plan Step 7).
+
+Every setting cellpy has, with its type, default and section, rendered straight
+from the pydantic models — so the documentation cannot drift from the code.
+A test asserts that regenerating produces no diff; if you add a field, run:
+
+```shell
+uv run python -m cellpy.config.reference
+```
+
+Secrets are listed but never valued: the ``[secrets]`` section is env-only and
+its members are documented by the environment variable that supplies them
+(config plan decision 5).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePath
+from typing import Any
+
+from pydantic import BaseModel
+
+from cellpy.config.credentials import ENV_VARS
+from cellpy.config.models import CellpyConfig
+
+DOC_PATH = Path("docs") / "getting_started" / "configuration_reference.md"
+
+_HEADER = """# Configuration reference
+
+Auto-generated from the configuration models. Do not edit by hand — regenerate with:
+
+```shell
+uv run python -m cellpy.config.reference
+```
+
+Settings are resolved in layers, later winning over earlier: **defaults → user
+`cellpy.toml` → project `cellpy.toml` → environment / `.env` → runtime
+overrides**. Ask where a value came from with `cellpy.config.sources()`.
+
+Environment variables use the pattern `CELLPY_<SECTION>__<FIELD>` (two
+underscores between section and field), e.g. `CELLPY_READER__AUTO_DIRS=0`.
+"""
+
+_SECRETS_NOTE = """
+## secrets
+
+Credentials are read from the **environment only** — never from a config file.
+A `[secrets]` section in a `cellpy.toml` is an error, not a silent override, so
+that a credential you thought was configured cannot quietly fail to be.
+
+| Setting | Environment variable | Notes |
+| --- | --- | --- |
+"""
+
+
+def _type_name(annotation: Any) -> str:
+    name = getattr(annotation, "__name__", None)
+    if name and name not in {"Union", "Optional"}:
+        return name
+    # Unions and Optionals: the bare __name__ ("Union") says nothing useful.
+    return str(annotation).replace("typing.", "").replace("NoneType", "None")
+
+
+def _placeholders() -> list[tuple[str, str]]:
+    """Machine-specific prefixes and the tokens that stand in for them.
+
+    Several path defaults are computed from the current directory or the user's
+    home. Rendering them literally would put the generating machine's directory
+    layout (and user name) into published documentation, and would make the
+    no-diff check fail for everyone else.
+
+    The prefixes are read from the model's *own* defaults rather than from a
+    live ``Path.cwd()`` / ``Path.home()``: those defaults are evaluated when
+    ``models.py`` is imported, so a later ``chdir`` (pytest does this) would
+    make a live lookup miss and leak the real path into the file.
+    """
+    paths = CellpyConfig.model_fields["paths"].annotation.model_fields
+    cwd_at_import = str(paths["outdatadir"].default)
+    home_at_import = str(Path(str(paths["env_file"].default)).parent)
+    return [
+        (cwd_at_import, "<current directory>"),
+        (home_at_import, "<home>"),
+    ]
+
+
+def _is_path_like(value: Any) -> bool:
+    # OtherPath is not a PurePath subclass, so go by protocol as well.
+    return isinstance(value, PurePath) or hasattr(value, "raw_path")
+
+
+def _format_default(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, str) and not value:
+        return '`""`'
+    text = str(value)
+    # Longest prefix first, so a home inside cwd (or vice versa) resolves to
+    # the more specific token.
+    for actual, token in sorted(_placeholders(), key=lambda p: -len(p[0])):
+        if text.startswith(actual):
+            text = token + text[len(actual) :]
+            break
+    if _is_path_like(value):
+        # Normalise separators: otherwise the file generated on Windows differs
+        # from the one generated on Linux and the no-diff check can never hold
+        # on both. Only for path values — `localhost\SQLEXPRESS` is a literal
+        # backslash that must survive.
+        text = text.replace("\\", "/")
+    return f"`{text}`"
+
+
+def _render_section(name: str, model: type[BaseModel]) -> list[str]:
+    lines = [
+        f"## {name}",
+        "",
+        (model.__doc__ or "").strip().splitlines()[0] if model.__doc__ else "",
+        "",
+        "| Setting | Type | Default |",
+        "| --- | --- | --- |",
+    ]
+    for field_name, field in model.model_fields.items():
+        default = field.get_default(call_default_factory=True)
+        if isinstance(default, BaseModel):
+            # Nested model: its own fields are documented in their own section.
+            default = None
+        lines.append(
+            f"| `{field_name}` | `{_type_name(field.annotation)}` | "
+            f"{_format_default(default)} |"
+        )
+    lines.append("")
+    return lines
+
+
+def render_reference_md() -> str:
+    """Render the whole configuration reference as markdown."""
+    lines = _HEADER.splitlines()
+
+    for section_name, field in CellpyConfig.model_fields.items():
+        model = field.annotation
+        if not (isinstance(model, type) and issubclass(model, BaseModel)):
+            continue
+        if section_name == "secrets":
+            continue  # rendered separately, without defaults
+        lines.append("")
+        lines.extend(_render_section(section_name, model))
+
+    lines.extend(_SECRETS_NOTE.splitlines())
+    for field_name in CellpyConfig.model_fields["secrets"].annotation.model_fields:
+        env = ENV_VARS.get(field_name, "—")
+        note = (
+            "never echoed in reprs, dumps or logs"
+            if field_name == "password"
+            else "not secret material; grouped here because it arrives with them"
+        )
+        lines.append(f"| `{field_name}` | `{env}` | {note} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_reference_md(path: str | Path) -> None:
+    """Write the rendered reference to *path*."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_reference_md(), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    target = Path(__file__).resolve().parents[2] / DOC_PATH
+    write_reference_md(target)
+    print(f"wrote {target}")

--- a/cellpy/internals/connections.py
+++ b/cellpy/internals/connections.py
@@ -69,10 +69,12 @@ def check_connection(
     if scheme not in IMPLEMENTED_PROTOCOLS:
         print(f"   - uri_prefix {scheme.replace(':', '')} not implemented yet")
 
-    password = os.getenv(ENV_VAR_CELLPY_PASSWORD, None)
+    from cellpy.config import credentials
+
+    password = credentials.get_password()
     info["password"] = "********" if password is not None else None
 
-    key_filename = os.getenv(ENV_VAR_CELLPY_KEY_FILENAME, None)
+    key_filename = credentials.get_key_filename()
     if password is None and key_filename is None:
         print(
             f"   - You must define either {ENV_VAR_CELLPY_PASSWORD} "

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -101,9 +101,13 @@ def _scheme_from_uri_prefix(uri_prefix: str) -> str:
 
 
 def _credentials_from_env(*, testing: bool = False) -> Dict[str, Any]:
-    """Build Paramiko/fsspec ``storage_options`` from cellpy env vars."""
-    password = os.getenv(ENV_VAR_CELLPY_PASSWORD, None)
-    key_filename = os.getenv(ENV_VAR_CELLPY_KEY_FILENAME, None)
+    """Build Paramiko/fsspec ``storage_options`` from cellpy credentials."""
+    # Single resolution path (config plan Step 6): session config first, live
+    # environment as fallback — see cellpy.config.credentials.
+    from cellpy.config import credentials
+
+    password = credentials.get_password()
+    key_filename = credentials.get_key_filename()
     if password is None and key_filename is None:
         raise UnderDefined(
             f"You must define either {ENV_VAR_CELLPY_PASSWORD} "

--- a/cellpy/parameters/_shim.py
+++ b/cellpy/parameters/_shim.py
@@ -104,7 +104,12 @@ class _InstrumentConfigProxy:
             secret_field, replacement = _LEGACY_ARBIN_SQL_KEYS[key]
             if secret_field is not None and replacement is not None:
                 warn_once(f"prms.Instruments.Arbin[{key!r}]", replacement)
-                return getattr(get_config().secrets, secret_field)
+                secrets = get_config().secrets
+                # The legacy shim promised a plain string; unwrap the SecretStr
+                # here rather than leaking the wrapper into 1.x-shaped code.
+                if secret_field == "password":
+                    return secrets.get_password()
+                return getattr(secrets, secret_field)
         if hasattr(self._model, key):
             return getattr(self._model, key)
         extras = getattr(self._model, "model_extra", None) or {}

--- a/cellpy/readers/instruments/arbin_sql_config.py
+++ b/cellpy/readers/instruments/arbin_sql_config.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-import os
-
 import cellpy.config as config
+from cellpy.config import credentials
+from cellpy.exceptions import ConfigurationError
 
+# No password default: shipping "ChangeMe123" meant a misconfigured setup
+# silently attempted a login with a known credential instead of telling the
+# user what was missing (config plan decision 5 — removed, not migrated).
 _DEFAULTS = {
     "SQL_server": r"localhost\SQLEXPRESS",
     "SQL_UID": "sa",
-    "SQL_PWD": "ChangeMe123",
     "SQL_Driver": "SQL Server",
 }
 
@@ -19,23 +21,29 @@ _SECRET_MAP = {
     "SQL_PWD": "password",
 }
 
+_SECRET_ENV = {
+    "host": "CELLPY_HOST",
+    "user": "CELLPY_USER",
+    "password": "CELLPY_PASSWORD",
+}
+
 
 def arbin_sql_value(key: str) -> str:
     """Resolve a legacy Arbin SQL setting from secrets, extras, or defaults."""
 
     secret_field = _SECRET_MAP.get(key)
     if secret_field is not None:
-        secret_val = getattr(config.secrets, secret_field, None)
+        # One resolution path for every consumer: session config first, live
+        # environment as fallback (cellpy.config.credentials).
+        secret_val = getattr(credentials, f"get_{secret_field}")()
         if secret_val:
             return secret_val
-        env_key = {
-            "host": "CELLPY_HOST",
-            "user": "CELLPY_USER",
-            "password": "CELLPY_PASSWORD",
-        }[secret_field]
-        env_val = os.getenv(env_key)
-        if env_val:
-            return env_val
+        if secret_field == "password":
+            raise ConfigurationError(
+                f"No Arbin SQL password configured. Set {_SECRET_ENV['password']} "
+                f"in your environment or .env file — cellpy 2 does not ship a "
+                f"default password."
+            )
 
     arbin = config.instruments.Arbin
     if hasattr(arbin, key):
@@ -53,6 +61,8 @@ def set_arbin_sql_value(key: str, value: str) -> None:
 
     secret_field = _SECRET_MAP.get(key)
     if secret_field is not None:
+        # SecretsConfig validates on assignment, so a plain string is coerced
+        # into the SecretStr for the password field.
         setattr(config.secrets, secret_field, value)
         return
     setattr(config.instruments.Arbin, key, value)

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -276,3 +276,26 @@ prms.Reader.sep = ','
 # Changing the default folder for processed (output) data
 prms.Paths.outdatadir = 'experiment01/processed_data'
 ```
+
+## Credentials
+
+Passwords, ssh keys and remote host details are **not** stored in the
+configuration file. They are read from the environment (or your `.env` file)
+only:
+
+| Setting | Environment variable |
+| --- | --- |
+| password | `CELLPY_PASSWORD` |
+| ssh key file | `CELLPY_KEY_FILENAME` |
+| host | `CELLPY_HOST` |
+| user | `CELLPY_USER` |
+
+Putting a `[secrets]` section in a `cellpy.toml` is an error rather than a
+silent override — a credential you believe is configured should never quietly
+fail to be. The password is held as a `SecretStr`, so it does not appear in
+reprs, logs, tracebacks or any config dump.
+
+## Every setting
+
+See the generated [configuration reference](configuration_reference.md) for the
+full list of settings, their types and defaults.

--- a/docs/getting_started/configuration_reference.md
+++ b/docs/getting_started/configuration_reference.md
@@ -1,0 +1,217 @@
+# Configuration reference
+
+Auto-generated from the configuration models. Do not edit by hand — regenerate with:
+
+```shell
+uv run python -m cellpy.config.reference
+```
+
+Settings are resolved in layers, later winning over earlier: **defaults → user
+`cellpy.toml` → project `cellpy.toml` → environment / `.env` → runtime
+overrides**. Ask where a value came from with `cellpy.config.sources()`.
+
+Environment variables use the pattern `CELLPY_<SECTION>__<FIELD>` (two
+underscores between section and field), e.g. `CELLPY_READER__AUTO_DIRS=0`.
+
+## paths
+
+Paths used in cellpy.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `outdatadir` | `Path` | `<current directory>` |
+| `rawdatadir` | `OtherPath` | `<current directory>` |
+| `cellpydatadir` | `OtherPath` | `<current directory>` |
+| `db_path` | `Path` | `<current directory>` |
+| `filelogdir` | `Path` | `<current directory>` |
+| `examplesdir` | `Path` | `<current directory>` |
+| `notebookdir` | `Path` | `<current directory>` |
+| `templatedir` | `Path` | `<current directory>` |
+| `batchfiledir` | `Path` | `<current directory>` |
+| `instrumentdir` | `Path` | `<current directory>` |
+| `db_filename` | `str` | `cellpy_db.xlsx` |
+| `env_file` | `Path` | `<home>/.env_cellpy` |
+
+
+## file_names
+
+Settings for file names and file handling.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `file_name_format` | `str` | `YYYYMMDD_[NAME]EEE_CC_TT_RR` |
+| `raw_extension` | `str` | `res` |
+| `reg_exp` | `str | None` | — |
+| `sub_folders` | `bool` | `True` |
+| `file_list_location` | `str | None` | — |
+| `file_list_type` | `str | None` | — |
+| `file_list_name` | `str | None` | — |
+| `cellpy_file_extension` | `str` | `h5` |
+
+
+## reader
+
+Settings for reading data.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `diagnostics` | `bool` | `False` |
+| `filestatuschecker` | `str` | `size` |
+| `force_step_table_creation` | `bool` | `True` |
+| `force_all` | `bool` | `False` |
+| `sep` | `str` | `;` |
+| `cycle_mode` | `str` | `anode` |
+| `sorted_data` | `bool` | `True` |
+| `select_minimal` | `bool` | `False` |
+| `limit_loaded_cycles` | `int | tuple[int, int] | list[int] | None` | — |
+| `ensure_step_table` | `bool` | `False` |
+| `ensure_summary_table` | `bool` | `False` |
+| `voltage_interpolation_step` | `float` | `0.01` |
+| `time_interpolation_step` | `float` | `10.0` |
+| `capacity_interpolation_step` | `float` | `2.0` |
+| `use_cellpy_stat_file` | `bool` | `False` |
+| `auto_dirs` | `bool` | `True` |
+| `max_raw_files_to_merge` | `int` | `20` |
+| `jupyter_executable` | `str` | `jupyter` |
+
+
+## db
+
+Settings for the simple database.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `db_type` | `str` | `simple_excel_reader` |
+| `db_table_name` | `str` | `db_table` |
+| `db_header_row` | `int` | `0` |
+| `db_unit_row` | `int` | `1` |
+| `db_data_start_row` | `int` | `2` |
+| `db_search_start_row` | `int` | `2` |
+| `db_search_end_row` | `int` | `-1` |
+| `db_file_sqlite` | `str` | `excel.db` |
+| `db_connection` | `str | None` | — |
+
+
+## db_cols
+
+Column names for the simple excel database reader.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `id` | `str` | `id` |
+| `exists` | `str` | `exists` |
+| `project` | `str` | `project` |
+| `label` | `str` | `label` |
+| `group` | `str` | `group` |
+| `selected` | `str` | `selected` |
+| `cell_name` | `str` | `cell` |
+| `cell_type` | `str` | `cell_type` |
+| `experiment_type` | `str` | `experiment_type` |
+| `mass_active` | `str` | `mass_active_material` |
+| `area` | `str` | `area` |
+| `mass_total` | `str` | `mass_total` |
+| `loading` | `str` | `loading_active_material` |
+| `nom_cap` | `str` | `nominal_capacity` |
+| `nom_cap_specifics` | `str` | `nominal_capacity_specifics` |
+| `file_name_indicator` | `str` | `file_name_indicator` |
+| `instrument` | `str` | `instrument` |
+| `raw_file_names` | `str` | `raw_file_names` |
+| `cellpy_file_name` | `str` | `cellpy_file_name` |
+| `comment_slurry` | `str` | `comment_slurry` |
+| `comment_cell` | `str` | `comment_cell` |
+| `comment_general` | `str` | `comment_general` |
+| `freeze` | `str` | `freeze` |
+| `argument` | `str` | `argument` |
+| `batch` | `str` | `batch` |
+| `sub_batch_01` | `str` | `b01` |
+| `sub_batch_02` | `str` | `b02` |
+| `sub_batch_03` | `str` | `b03` |
+| `sub_batch_04` | `str` | `b04` |
+| `sub_batch_05` | `str` | `b05` |
+| `sub_batch_06` | `str` | `b06` |
+| `sub_batch_07` | `str` | `b07` |
+
+
+## batch
+
+Settings for batch processing.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `auto_use_file_list` | `bool` | `False` |
+| `template` | `str` | `standard` |
+| `fig_extension` | `str` | `png` |
+| `backend` | `str` | `plotly` |
+| `notebook` | `bool` | `True` |
+| `dpi` | `int` | `300` |
+| `markersize` | `int` | `4` |
+| `symbol_label` | `str` | `simple` |
+| `color_style_label` | `str` | `seaborn-deep` |
+| `figure_type` | `str` | `unlimited` |
+| `summary_plot_width` | `int` | `900` |
+| `summary_plot_height` | `int` | `800` |
+| `summary_plot_height_fractions` | `list` | `[0.2, 0.5, 0.3]` |
+
+
+## instruments
+
+Instrument settings (legacy capitalized instrument keys preserved).
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `tester` | `str | None` | — |
+| `custom_instrument_definitions_file` | `str | None` | — |
+| `Arbin` | `ArbinConfig` | — |
+| `Maccor` | `MaccorConfig` | — |
+| `Neware` | `NewareConfig` | — |
+| `Batmo` | `BatmoConfig` | — |
+
+
+## defaults
+
+Merged CellInfo + Materials defaults for metadata construction.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `cell_info` | `CellInfoDefaults` | — |
+| `materials` | `MaterialsDefaults` | — |
+
+
+## units
+
+Session unit policy; keys validated against ``cellpycore.units.CellpyUnits``.
+
+| Setting | Type | Default |
+| --- | --- | --- |
+| `current` | `str` | `A` |
+| `charge` | `str` | `mAh` |
+| `voltage` | `str` | `V` |
+| `time` | `str` | `sec` |
+| `resistance` | `str` | `ohm` |
+| `power` | `str` | `W` |
+| `energy` | `str` | `Wh` |
+| `frequency` | `str` | `hz` |
+| `mass` | `str` | `mg` |
+| `nominal_capacity` | `str` | `mAh/g` |
+| `specific_gravimetric` | `str` | `g` |
+| `specific_areal` | `str` | `cm**2` |
+| `specific_volumetric` | `str` | `cm**3` |
+| `length` | `str` | `cm` |
+| `area` | `str` | `cm**2` |
+| `volume` | `str` | `cm**3` |
+| `temperature` | `str` | `C` |
+| `pressure` | `str` | `bar` |
+
+
+## secrets
+
+Credentials are read from the **environment only** — never from a config file.
+A `[secrets]` section in a `cellpy.toml` is an error, not a silent override, so
+that a credential you thought was configured cannot quietly fail to be.
+
+| Setting | Environment variable | Notes |
+| --- | --- | --- |
+| `password` | `CELLPY_PASSWORD` | never echoed in reprs, dumps or logs |
+| `key_filename` | `CELLPY_KEY_FILENAME` | not secret material; grouped here because it arrives with them |
+| `host` | `CELLPY_HOST` | not secret material; grouped here because it arrives with them |
+| `user` | `CELLPY_USER` | not secret material; grouped here because it arrives with them |

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -5,6 +5,7 @@
 
 installation.md
 configuration.md
+configuration_reference.md
 checkup.md
 basic_usage.md
 migration_v1_to_v2.md

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,7 +136,9 @@ def test_secrets_read_legacy_env(monkeypatch):
     monkeypatch.setenv("CELLPY_PASSWORD", "secret-pass")
     monkeypatch.setenv("CELLPY_USER", "alice")
     result = load_config(options=LoadOptions(skip_files=True, skip_env=False))
-    assert result.config.secrets.password == "secret-pass"
+    # password is a SecretStr as of #565 — the value only comes out on request
+    assert result.config.secrets.get_password() == "secret-pass"
+    assert "secret-pass" not in repr(result.config.secrets)
     assert result.config.secrets.user == "alice"
 
 

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -1,0 +1,226 @@
+"""Secrets hardening tests (#565, config plan Step 6 / decision 5).
+
+The contract: credentials come from the environment only, never from a config
+file, and the password value does not leak through reprs, dumps or logs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cellpy import log
+from cellpy.config import credentials
+from cellpy.config.loader import LoadOptions, load_config, write_toml
+from cellpy.config.models import CellpyConfig, SecretsConfig
+from cellpy.exceptions import ConfigurationError
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+@pytest.fixture
+def hermetic_session():
+    """A session config built from defaults only.
+
+    Without this the result depends on whether the machine running the tests
+    happens to have a ``~/.env_cellpy`` or a user ``cellpy.toml`` — a real
+    developer machine does, CI does not, so a credential test that reads the
+    ambient layers passes or fails by accident.
+    """
+    from cellpy.config import session
+
+    session.reset_session()
+    session.reload(options=LoadOptions(skip_env=True, skip_files=True))
+    try:
+        yield session
+    finally:
+        session.reset_session()
+
+
+# -- the password does not leak ------------------------------------------------
+
+
+@pytest.mark.essential
+def test_password_is_not_in_repr():
+    secrets = SecretsConfig(password="hunter2")
+    assert "hunter2" not in repr(secrets)
+    assert "hunter2" not in str(secrets)
+
+
+@pytest.mark.essential
+def test_password_is_not_in_a_model_dump():
+    config = CellpyConfig(secrets=SecretsConfig(password="hunter2"))
+    assert "hunter2" not in str(config.model_dump())
+
+
+@pytest.mark.essential
+def test_password_is_not_in_the_file_dump():
+    config = CellpyConfig(secrets=SecretsConfig(password="hunter2"))
+    dumped = config.model_dump_for_file()
+    assert "secrets" not in dumped
+    assert "hunter2" not in str(dumped)
+
+
+@pytest.mark.essential
+def test_password_comes_out_on_request():
+    secrets = SecretsConfig(password="hunter2")
+    assert secrets.get_password() == "hunter2"
+
+
+@pytest.mark.essential
+def test_get_password_is_none_when_unset():
+    assert SecretsConfig().get_password() is None
+
+
+# -- credentials never come from a config file ---------------------------------
+
+
+@pytest.mark.essential
+def test_secrets_in_a_user_toml_are_rejected(tmp_path):
+    path = tmp_path / "cellpy.toml"
+    write_toml(path, {"secrets": {"password": "in-a-file"}})
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        load_config(options=LoadOptions(user_config_file=path, skip_env=True))
+
+    message = str(excinfo.value)
+    # The error must also be the instruction: name the env var to use instead.
+    assert "CELLPY_PASSWORD" in message
+    # ... and must not echo the credential it is refusing.
+    assert "in-a-file" not in message
+
+
+@pytest.mark.essential
+def test_secrets_in_a_project_toml_are_rejected(tmp_path):
+    user = tmp_path / "user" / "cellpy.toml"
+    write_toml(user, {"reader": {"auto_dirs": False}})
+    project = tmp_path / "project" / "cellpy.toml"
+    write_toml(project, {"secrets": {"host": "in-a-file"}})
+
+    with pytest.raises(ConfigurationError):
+        load_config(
+            options=LoadOptions(
+                user_config_file=user, project_config_file=project, skip_env=True
+            )
+        )
+
+
+@pytest.mark.essential
+def test_a_clean_toml_still_loads(tmp_path):
+    path = tmp_path / "cellpy.toml"
+    write_toml(path, {"reader": {"auto_dirs": False}})
+    result = load_config(options=LoadOptions(user_config_file=path, skip_env=True))
+    assert result.config.reader.auto_dirs is False
+
+
+# -- resolution order ----------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_environment_is_picked_up_when_the_session_value_is_unset(
+    hermetic_session, monkeypatch
+):
+    # Exporting a variable after import is a normal notebook pattern; the
+    # session here was built with skip_env, so this exercises the fallback.
+    monkeypatch.setenv("CELLPY_PASSWORD", "from-env")
+    assert credentials.get_password() == "from-env"
+
+
+@pytest.mark.essential
+def test_a_runtime_assignment_beats_the_environment(hermetic_session, monkeypatch):
+    # The environment must not silently override a value set deliberately.
+    monkeypatch.setenv("CELLPY_HOST", "from-env")
+    hermetic_session.get_config().secrets.host = "set-at-runtime"
+    assert credentials.get_host() == "set-at-runtime"
+
+
+@pytest.mark.essential
+def test_env_var_names_live_in_one_place():
+    # The point of the module: four call sites no longer each know these.
+    assert credentials.ENV_VARS == {
+        "password": "CELLPY_PASSWORD",
+        "key_filename": "CELLPY_KEY_FILENAME",
+        "host": "CELLPY_HOST",
+        "user": "CELLPY_USER",
+    }
+
+
+# -- no shipped default password ------------------------------------------------
+
+
+@pytest.mark.essential
+def test_no_default_arbin_sql_password(hermetic_session, monkeypatch):
+    """Shipping "ChangeMe123" made a misconfigured setup look like a bad login."""
+    from cellpy.readers.instruments import arbin_sql_config
+
+    monkeypatch.delenv("CELLPY_PASSWORD", raising=False)
+    with pytest.raises(ConfigurationError, match="CELLPY_PASSWORD"):
+        arbin_sql_config.arbin_sql_value("SQL_PWD")
+
+
+@pytest.mark.essential
+def test_arbin_sql_password_from_env(hermetic_session, monkeypatch):
+    from cellpy.readers.instruments import arbin_sql_config
+
+    monkeypatch.setenv("CELLPY_PASSWORD", "from-env")
+    assert arbin_sql_config.arbin_sql_value("SQL_PWD") == "from-env"
+
+
+@pytest.mark.essential
+def test_non_secret_arbin_settings_still_resolve(hermetic_session):
+    from cellpy.readers.instruments import arbin_sql_config
+
+    # Resolves from the Arbin instrument config; the point is only that
+    # dropping the password default did not disturb the non-secret path.
+    assert arbin_sql_config.arbin_sql_value("SQL_Driver")
+    assert arbin_sql_config.arbin_sql_value("SQL_server")
+
+
+# -- the generated configuration reference --------------------------------------
+
+
+@pytest.mark.essential
+def test_configuration_reference_matches_the_models():
+    """The docs page is generated; if you add a field, regenerate it.
+
+    ```shell
+    uv run python -m cellpy.config.reference
+    ```
+    """
+    from pathlib import Path
+
+    from cellpy.config import reference
+
+    repo_root = Path(__file__).resolve().parents[1]
+    on_disk = (repo_root / reference.DOC_PATH).read_text(encoding="utf-8")
+    assert on_disk == reference.render_reference_md()
+
+
+@pytest.mark.essential
+def test_configuration_reference_has_no_machine_specific_paths():
+    """Defaults are computed from cwd/home; they must not reach the page.
+
+    Otherwise the generating machine's directory layout and user name end up
+    in published documentation, and the check above can only pass on one
+    machine.
+    """
+    from pathlib import Path
+
+    from cellpy.config import reference
+
+    rendered = reference.render_reference_md()
+    assert str(Path.home()) not in rendered
+    assert str(Path.cwd()) not in rendered
+    assert "<home>" in rendered
+    assert "<current directory>" in rendered
+
+
+@pytest.mark.essential
+def test_configuration_reference_documents_secrets_without_values():
+    from cellpy.config import reference
+
+    rendered = reference.render_reference_md()
+    assert "CELLPY_PASSWORD" in rendered
+    # The secrets section documents the env var, never a default value.
+    assert "ChangeMe123" not in rendered


### PR DESCRIPTION
Closes #565. Config plan Steps 6–7, Stage 3 / 2.0 assembly (#575).

## Secrets are env-only, and stay unreadable

- `SecretsConfig.password` is a `SecretStr`: the value stays out of reprs,
  logs, tracebacks and every model dump. `get_password()` returns it at the
  point of use. `host` / `user` / `key_filename` remain plain strings — they
  are not secret material, they just arrive on the same layer.
- **A `[secrets]` section in a `cellpy.toml` is now an error**, naming the env
  var to use instead. Silently ignoring it would be the worse failure: the user
  would believe the credential was configured. A *legacy YAML* is treated more
  gently — that is the file they are migrating **from**, so the section is
  dropped with a warning rather than refusing to load.
- **The shipped `ChangeMe123` Arbin SQL password is gone.** A default password
  turns a misconfigured setup into what looks like a failed login, instead of
  an error that says what is missing.

## One resolution path

`otherpath.py`, `connections.py` and `arbin_sql_config.py` each knew the
`CELLPY_*` variable names and each read them with a bare `os.getenv` — four
places to update on a rename, four possible answers when one goes stale.

New `cellpy/config/credentials.py` owns the names and the order: **session
config first** (where the loader deposits the env/`.env` layers, and where a
runtime assignment lands), **live environment as fallback** so a variable
exported after import still works. Deliberately not "env wins" — that would let
the environment silently override a value the user set on purpose at runtime.

The remaining `os.getenv` hits in `filefinder.py` are inside `_check_01` /
`_check_02` dev scratch functions with hardcoded local paths; left alone.

## Generated configuration reference

`docs/getting_started/configuration_reference.md` is rendered from the models
and guarded by a no-diff test, so the docs cannot drift from the code.

The interesting part was the **machine-specific defaults**. Path defaults are
`Path.cwd()` / `Path.home()` evaluated at import, so a naive generator:

- publishes the generating machine's directory layout and user name (my
  `C:\Users\jepe\...` was in the first draft), and
- can only ever pass the no-diff check on one machine.

They now render as `<current directory>` / `<home>`, with the prefixes read
from the **model's own defaults** rather than a live lookup — pytest chdirs,
which would make a live lookup miss and leak the real path. Separators are
normalised so Windows and Linux generate the same file, but only for path
values: `localhost\SQLEXPRESS` is a literal backslash that has to survive.
There is a test for each of those two traps.

## A note on test hygiene

While writing these I found that the first version of the no-default-password
test passed on my machine only because a real `~/.env_cellpy` exists here — it
would have behaved differently in CI. The credential tests now build a
hermetic session (`skip_env`, `skip_files`) instead of reading ambient layers.

## Tests

17 new tests. Full suite: 736 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
