### PR TITLE
#210: instrument-loader contract (Protocol) + entry-point plugin registry

### DIFF
--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -4405,4 +4405,21 @@ def print_instruments():
             model_text += ", ".join(instrument_models)
             print(model_text)
 
+    # Loaders installed by other packages via the ``cellpy.loaders`` entry
+    # point (#210). Listed separately: they are not shipped with cellpy, and
+    # "why can't cellpy see my loader?" should be answerable from here.
+    from cellpy.readers.instruments import registry
+
+    plugins = registry.available_loaders()
+    if plugins:
+        print()
+        print(80 * "=")
+        print("Instrument loaders installed by other packages")
+        print(80 * "=")
+        for name, info in plugins.items():
+            print(name)
+            print(f"  instrument: {info['instrument']}")
+            print(f"  suffixes: {', '.join(info['supported_suffixes']) or '-'}")
+            print(f"  from: {info['module']}")
+
 

--- a/cellpy/readers/instruments/contract.py
+++ b/cellpy/readers/instruments/contract.py
@@ -1,0 +1,146 @@
+"""The instrument-loader contract (cellpy 2, issue #210).
+
+One formal contract every loader satisfies — built-in or third-party — so the
+framework can discover, validate and route loaders without knowing anything
+about the vendor formats behind them.
+
+The contract is a :class:`typing.Protocol`, **not** a base class. A third-party
+loader inherits nothing and imports nothing from cellpy; conformance is
+structural. That is what makes an out-of-tree loader a first-class citizen
+rather than a special case (architecture plan §5.1.1).
+
+``load()`` **always returns a tuple**, even for a single test
+-------------------------------------------------------------
+Maintainer decision, 2026-07-19, frozen with the Protocol in 2.0: every caller
+writes one unpacking path, and a format that grows multi-test support later
+does not silently become a breaking change for its consumers. A loader for a
+single-test format returns a 1-tuple.
+
+What a loader fills in, and what it must not
+---------------------------------------------
+A loader fills only what the *file* actually knows. Provenance — where the file
+came from, when it was read, what identity it was given — is stamped by the
+framework, because the loader is not in a position to know it. A draft
+``TestMeta`` arriving with ``source_uri`` already set is a contract violation,
+and the conformance kit rejects it (architecture plan §5.1.3).
+
+See also
+--------
+``cellpy.readers.instruments.registry`` (discovery and routing) and
+``cellpy.readers.instruments.testing`` (the conformance kit).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import polars as pl
+    from cellpycore.metadata.models import CellMeta, TestMeta
+    from cellpycore.units import CellpyUnits
+
+
+@dataclass(frozen=True, slots=True)
+class LoaderResult:
+    """One test's worth of parsed data, on its way into the framework.
+
+    Attributes:
+        raw: the harmonized-raw frame — native ``RawCols`` names,
+            ``epoch_time_utc`` as int64 ns UTC, ``datapoint_num`` as a
+            *column* (never an index).
+        raw_units: a validated ``CellpyUnits``; every label pint-parsable.
+            Never an ad-hoc dict and never float scale factors.
+        test_meta: a **draft** ``TestMeta`` — only fields the source file
+            knows. Provenance fields must be left empty for the framework.
+        cell_meta: an optional partial ``CellMeta``, for the rare file that
+            carries masses or areas.
+        warnings: non-fatal notes the framework surfaces to the user. A
+            *fatal* problem is a ``LoaderError``, never a partial result.
+    """
+
+    raw: "pl.DataFrame"
+    raw_units: "CellpyUnits"
+    test_meta: "TestMeta"
+    cell_meta: "CellMeta | None" = None
+    warnings: tuple[str, ...] = field(default=())
+
+
+class LoaderCapabilities(Protocol):
+    """The class-level metadata the registry routes on.
+
+    Kept in its own Protocol for a language reason: a ``runtime_checkable``
+    Protocol carrying **non-method** members cannot be used with
+    ``issubclass()``, and the registry must check a loader *class* without
+    instantiating it. So the runtime structural check lives on
+    :class:`InstrumentLoader` (methods only) and these attributes are validated
+    explicitly by the registry, which can also say precisely which one is
+    missing. Use this Protocol for static typing.
+    """
+
+    #: Loader id, unique within the registry, e.g. ``"arbin_res"``.
+    name: ClassVar[str]
+    #: The instrument family, e.g. ``"arbin"``. Several loaders may share one.
+    instrument: ClassVar[str]
+    #: Suffixes this loader can route on, lowercase and dotted, e.g. ``(".res",)``.
+    supported_suffixes: ClassVar[tuple[str, ...]]
+
+
+@runtime_checkable
+class InstrumentLoader(Protocol):
+    """Structural contract for instrument loaders — the behaviour half.
+
+    Implementations need not import or inherit anything from cellpy. Register
+    via the ``cellpy.loaders`` entry-point group; see
+    :mod:`cellpy.readers.instruments.registry`.
+
+    A conforming loader also declares the :class:`LoaderCapabilities`
+    attributes (``name``, ``instrument``, ``supported_suffixes``); they are not
+    members of *this* Protocol only so that ``issubclass()`` keeps working —
+    the registry validates them separately and rejects a loader that omits
+    them.
+
+    Loaders must be **stateless across calls**: two ``load()`` calls on the
+    same source give equal results, and nothing from one call leaks into the
+    next. The registry routes on the class-level capability attributes without
+    instantiating, so those must not depend on instance state.
+    """
+
+    def can_load(self, source: Path) -> bool:
+        """Cheap sniff — suffix or magic bytes. Must not fully parse the file.
+
+        The registry calls this while choosing between candidates, so a slow
+        implementation makes every load slow. The conformance kit puts a time
+        budget on it.
+        """
+        ...
+
+    def load(
+        self,
+        source: Path,
+        *,
+        instrument_config: object | None = None,
+        **kwargs: object,
+    ) -> tuple[LoaderResult, ...]:
+        """Parse one source into one result per test it contains.
+
+        Args:
+            source: a **local** path. The framework has already resolved any
+                remote/OtherPath source to a local copy — a loader never
+                encodes ssh or scheme semantics (architecture plan §5.1.8).
+            instrument_config: the typed per-instrument configuration model,
+                when the framework has one for this loader.
+            **kwargs: loader-specific knobs. Unknown ones must be ignorable,
+                so that a caller passing a knob meant for another loader is
+                not an error.
+
+        Returns:
+            One :class:`LoaderResult` per test in the source — always a tuple,
+            length 1 for single-test formats.
+
+        Raises:
+            LoaderError: wrapping any vendor parse failure. Never return a
+                partial or empty result to signal failure (conventions §1).
+        """
+        ...

--- a/cellpy/readers/instruments/registry.py
+++ b/cellpy/readers/instruments/registry.py
@@ -1,0 +1,201 @@
+"""Loader discovery and routing via entry points (cellpy 2, issue #210).
+
+Third-party loaders install themselves by declaring an entry point; cellpy
+finds them without any registration call and without a shared base class::
+
+    # in the loader package's pyproject.toml
+    [project.entry-points."cellpy.loaders"]
+    mycycler = "cellpy_mycycler.loader:MyCyclerLoader"
+
+Discovery is **lazy** — the entry-point group is read on first use, not at
+import, so ``import cellpy`` neither scans nor imports third-party code.
+
+Failures are contained and loud in the right way: one broken plugin makes that
+plugin unavailable with a clear warning, it does not take down cellpy. A
+plugin that loads but does not satisfy the contract is rejected at registration
+with a message naming what it is missing, rather than failing later inside a
+load with something obscure.
+
+Scope note (2026-07-19): the built-in loaders do **not** route through this
+registry yet — they still go through the module-globbing
+``InstrumentFactory``. Moving them over is part of the loader port (#560),
+after they emit ``LoaderResult`` (#559). Until then this registry is the path
+for out-of-tree loaders, and the query API below reports both populations.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import EntryPoint, entry_points
+from pathlib import Path
+from typing import Iterable
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.contract import InstrumentLoader
+
+ENTRY_POINT_GROUP = "cellpy.loaders"
+
+_REGISTRY: dict[str, type] | None = None
+
+# Attributes the registry routes on; a loader missing any of them cannot be
+# registered, because the registry could not place it.
+_REQUIRED_CAPABILITIES = ("name", "instrument", "supported_suffixes")
+
+
+def _validate_capabilities(loader_cls: type, source: str) -> None:
+    """Reject a loader the registry could not route, and say why."""
+    missing = [
+        attribute
+        for attribute in _REQUIRED_CAPABILITIES
+        if getattr(loader_cls, attribute, None) is None
+    ]
+    if missing:
+        raise LoaderError(
+            f"{source}: {loader_cls!r} is missing required loader capability "
+            f"metadata {missing}; a loader must declare name, instrument and "
+            f"supported_suffixes at class level."
+        )
+
+    suffixes = loader_cls.supported_suffixes
+    if isinstance(suffixes, str) or not isinstance(suffixes, Iterable):
+        raise LoaderError(
+            f"{source}: {loader_cls!r}.supported_suffixes must be a tuple of "
+            f"suffixes like ('.res',), not {suffixes!r}."
+        )
+    bad = [s for s in suffixes if not (isinstance(s, str) and s.startswith("."))]
+    if bad:
+        raise LoaderError(
+            f"{source}: {loader_cls!r}.supported_suffixes entries must be "
+            f"dotted strings like '.res'; got {bad!r}."
+        )
+
+    if not isinstance(loader_cls, type) or not issubclass(loader_cls, InstrumentLoader):
+        # runtime_checkable Protocols check methods only, which is exactly the
+        # structural check we want here.
+        raise LoaderError(
+            f"{source}: {loader_cls!r} does not satisfy the InstrumentLoader "
+            f"contract; it must provide load() and can_load()."
+        )
+
+
+def _iter_entry_points() -> Iterable[EntryPoint]:
+    return entry_points(group=ENTRY_POINT_GROUP)
+
+
+def _discover() -> dict[str, type]:
+    """Load, validate and index every declared loader."""
+    found: dict[str, type] = {}
+    for entry_point in _iter_entry_points():
+        try:
+            loader_cls = entry_point.load()
+        except Exception as exc:
+            # A third-party package we cannot import must not break cellpy for
+            # everything else; make it visible and carry on.
+            logging.warning(
+                "could not load instrument loader %r from %s: %s",
+                entry_point.name,
+                getattr(entry_point, "value", "?"),
+                exc,
+            )
+            continue
+
+        try:
+            _validate_capabilities(loader_cls, f"entry point {entry_point.name!r}")
+        except LoaderError as exc:
+            logging.warning("%s", exc)
+            continue
+
+        key = loader_cls.name
+        if key in found:
+            logging.warning(
+                "instrument loader %r declared more than once; keeping %r",
+                key,
+                found[key],
+            )
+            continue
+        found[key] = loader_cls
+    return found
+
+
+def get_registry(*, refresh: bool = False) -> dict[str, type]:
+    """The registered loaders, keyed by ``name``. Discovers on first use."""
+    global _REGISTRY
+    if _REGISTRY is None or refresh:
+        _REGISTRY = _discover()
+    return dict(_REGISTRY)
+
+
+def clear_registry() -> None:
+    """Forget discovery results (tests, and after installing a plugin)."""
+    global _REGISTRY
+    _REGISTRY = None
+
+
+def register(loader_cls: type) -> None:
+    """Register a loader directly, bypassing entry points.
+
+    For tests and for notebook-defined loaders. Packaged loaders should
+    declare an entry point instead so they are found without a call.
+    """
+    _validate_capabilities(loader_cls, "direct registration")
+    get_registry()  # ensure discovery has happened before we add to it
+    assert _REGISTRY is not None
+    _REGISTRY[loader_cls.name] = loader_cls
+
+
+def available_loaders() -> dict[str, dict[str, object]]:
+    """Describe every registered loader — for ``print_instruments`` and docs."""
+    return {
+        name: {
+            "instrument": loader_cls.instrument,
+            "supported_suffixes": tuple(loader_cls.supported_suffixes),
+            "module": getattr(loader_cls, "__module__", "?"),
+        }
+        for name, loader_cls in sorted(get_registry().items())
+    }
+
+
+def find_loader(
+    source: Path | None = None,
+    *,
+    instrument: str | None = None,
+) -> type | None:
+    """Pick a loader for ``source``, or return None if none applies.
+
+    Routing order (architecture plan §5.3): an explicit ``instrument`` wins;
+    otherwise candidates are narrowed by suffix and confirmed with the loader's
+    own cheap ``can_load()`` sniff.
+    """
+    registry = get_registry()
+
+    if instrument is not None:
+        by_name = registry.get(instrument)
+        if by_name is not None:
+            return by_name
+        by_family = [
+            cls for cls in registry.values() if cls.instrument == instrument
+        ]
+        if by_family:
+            return by_family[0]
+        return None
+
+    if source is None:
+        return None
+
+    suffix = Path(source).suffix.lower()
+    candidates = [
+        cls for cls in registry.values() if suffix in tuple(cls.supported_suffixes)
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    for cls in candidates:
+        try:
+            if cls().can_load(Path(source)):
+                return cls
+        except Exception as exc:
+            # A misbehaving sniff disqualifies its loader, nothing more.
+            logging.warning("can_load() failed for %r: %s", cls, exc)
+    return None

--- a/cellpy/readers/instruments/testing.py
+++ b/cellpy/readers/instruments/testing.py
@@ -1,0 +1,170 @@
+"""Conformance kit for instrument loaders (cellpy 2, issue #210).
+
+Ships with cellpy so a third-party loader can prove it satisfies the contract
+without reverse-engineering it from cellpy's internals::
+
+    from cellpy.readers.instruments.testing import check_loader
+
+    def test_my_loader_conforms():
+        check_loader(MyCyclerLoader, fixture=Path("tests/data/sample.mcx"))
+
+Every check corresponds to a promise in
+:mod:`cellpy.readers.instruments.contract`; failures raise
+:class:`AssertionError` naming the promise that was broken.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from cellpy.readers.instruments.contract import InstrumentLoader, LoaderResult
+from cellpy.readers.instruments.registry import _validate_capabilities
+
+#: ``can_load()`` is called while routing, so it must stay cheap.
+CAN_LOAD_BUDGET_SECONDS = 1.0
+
+#: Provenance is the framework's to stamp; a draft carrying it is a violation.
+_PROVENANCE_FIELDS = (
+    "source_kind",
+    "source_type",
+    "source_uri",
+    "source_uuid",
+    "raw_file_names",
+    "loaded_datetime",
+)
+
+
+def check_capabilities(loader_cls: type) -> None:
+    """The class declares what the registry needs to route it."""
+    _validate_capabilities(loader_cls, "check_loader")
+    assert isinstance(loader_cls, type), "check_loader takes the class, not an instance"
+    assert issubclass(loader_cls, InstrumentLoader), (
+        f"{loader_cls!r} does not satisfy the InstrumentLoader contract "
+        f"(needs load() and can_load())"
+    )
+
+
+def check_result_types(results: Any) -> tuple[LoaderResult, ...]:
+    """``load()`` returns a tuple of ``LoaderResult`` — always a tuple."""
+    assert isinstance(results, tuple), (
+        f"load() must return a tuple of LoaderResult (a 1-tuple for "
+        f"single-test formats), got {type(results).__name__}"
+    )
+    assert results, "load() returned an empty tuple; raise LoaderError instead"
+    for result in results:
+        assert isinstance(result, LoaderResult), (
+            f"load() must yield LoaderResult objects, got {type(result).__name__}"
+        )
+    return results
+
+
+def check_raw_frame(result: LoaderResult) -> None:
+    """The frame is polars, in the harmonized-raw shape."""
+    import polars as pl
+
+    raw = result.raw
+    assert isinstance(raw, pl.DataFrame), (
+        f"LoaderResult.raw must be a polars DataFrame, got {type(raw).__name__}"
+    )
+    assert raw.height, "LoaderResult.raw is empty; raise LoaderError instead"
+
+    from cellpycore.config import default_schema
+
+    known = set(default_schema().raw.ordered_names())
+    unknown = [column for column in raw.columns if column not in known]
+    assert not unknown, (
+        f"raw carries columns outside the harmonized-raw schema: {unknown}. "
+        f"Declare vendor->native names in the loader's column_map."
+    )
+
+    schema = default_schema().raw
+    if schema.datapoint_num in raw.columns:
+        series = raw[schema.datapoint_num]
+        assert series.is_sorted(), (
+            "datapoint_num must be monotone; it is the frame's ordering key"
+        )
+    if schema.epoch_time_utc in raw.columns:
+        dtype = raw[schema.epoch_time_utc].dtype
+        assert dtype == pl.Int64, (
+            f"epoch_time_utc must be int64 nanoseconds UTC, got {dtype}"
+        )
+
+
+def check_units(result: LoaderResult) -> None:
+    """``raw_units`` is a validated ``CellpyUnits``, not an ad-hoc dict."""
+    from cellpycore.units import CellpyUnits, validate_units
+
+    assert isinstance(result.raw_units, CellpyUnits), (
+        f"LoaderResult.raw_units must be a CellpyUnits, got "
+        f"{type(result.raw_units).__name__}"
+    )
+    validate_units(result.raw_units)
+
+
+def check_meta_is_a_draft(result: LoaderResult) -> None:
+    """The loader fills what the file knows — never provenance."""
+    filled = [
+        name
+        for name in _PROVENANCE_FIELDS
+        if getattr(result.test_meta, name, None) not in (None, "", [], ())
+    ]
+    assert not filled, (
+        f"draft TestMeta carries provenance {filled}; those fields are stamped "
+        f"by the framework, which alone knows where the file came from"
+    )
+
+
+def check_can_load_is_cheap(loader_cls: type, fixture: Path) -> None:
+    """Routing calls ``can_load()``; a slow sniff makes every load slow."""
+    loader = loader_cls()
+    started = time.perf_counter()
+    verdict = loader.can_load(fixture)
+    elapsed = time.perf_counter() - started
+    assert isinstance(verdict, bool), "can_load() must return a bool"
+    assert elapsed < CAN_LOAD_BUDGET_SECONDS, (
+        f"can_load() took {elapsed:.2f}s (budget {CAN_LOAD_BUDGET_SECONDS}s); "
+        f"it must sniff, not parse"
+    )
+
+
+def check_determinism(loader_cls: type, fixture: Path, **kwargs: Any) -> None:
+    """Loaders are stateless across calls."""
+    first = loader_cls().load(fixture, **kwargs)
+    second = loader_cls().load(fixture, **kwargs)
+    assert len(first) == len(second), "load() is not deterministic (different lengths)"
+    for a, b in zip(first, second):
+        assert a.raw.equals(b.raw), "load() is not deterministic (raw frames differ)"
+
+
+def check_loader(loader_cls: type, fixture: Path, **kwargs: Any) -> None:
+    """Run the whole conformance suite for one loader against one fixture.
+
+    Args:
+        loader_cls: the loader **class** (the registry routes on class-level
+            capability metadata, so that is what is checked).
+        fixture: a small committed sample file the loader can parse.
+        **kwargs: forwarded to ``load()``.
+
+    Raises:
+        AssertionError: naming the contract promise that was broken.
+    """
+    fixture = Path(fixture)
+    assert fixture.is_file(), f"fixture {fixture} does not exist"
+
+    check_capabilities(loader_cls)
+    check_can_load_is_cheap(loader_cls, fixture)
+
+    results = check_result_types(loader_cls().load(fixture, **kwargs))
+    for result in results:
+        check_raw_frame(result)
+        check_units(result)
+        check_meta_is_a_draft(result)
+
+    check_determinism(loader_cls, fixture, **kwargs)
+
+
+# The reset-granularity property check (architecture plan §5.5 check 7 — the
+# one that catches silent capacity corruption) needs the harmonize() framework
+# to normalize against, so it lands with #559 and is added here then.

--- a/docs/other/index.md
+++ b/docs/other/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 1
 
+writing_a_loader_plugin.md
 authors.md
 project-history.md
 project-license.md

--- a/docs/other/writing_a_loader_plugin.md
+++ b/docs/other/writing_a_loader_plugin.md
@@ -1,0 +1,89 @@
+# Writing an instrument loader
+
+cellpy can load data from an instrument it has never heard of, from a package
+you maintain yourself. Your loader imports nothing from cellpy and inherits
+from no cellpy class — it just has to have the right shape.
+
+## The shape
+
+```python
+from pathlib import Path
+
+
+class MyCyclerLoader:
+    # How the registry finds and routes to you.
+    name = "mycycler"                 # unique loader id
+    instrument = "mycycler"           # instrument family
+    supported_suffixes = (".mcx",)    # lowercase, dotted
+
+    def can_load(self, source: Path) -> bool:
+        """Cheap sniff — suffix or magic bytes. Must not parse the file."""
+        return Path(source).suffix.lower() in self.supported_suffixes
+
+    def load(self, source: Path, *, instrument_config=None, **kwargs):
+        """Return one LoaderResult per test in the file — always a tuple."""
+        ...
+```
+
+Two rules catch most mistakes:
+
+- **`load()` always returns a tuple**, even when the format holds a single
+  test (return a 1-tuple). Callers get one unpacking path, and a format that
+  later grows multi-test support does not break its consumers.
+- **Fill only what the file knows.** cellpy stamps provenance — where the file
+  came from, when it was read, what identity it was given — because your loader
+  is not in a position to know it. A draft `TestMeta` arriving with
+  `source_uri` set is a contract violation and the conformance kit rejects it.
+
+Failures are exceptions, never partial results: raise `LoaderError` (wrapping
+whatever the vendor parser threw) rather than returning an empty tuple.
+
+## Registering it
+
+Declare an entry point; there is no registration call and no plugin API to
+call into:
+
+```toml
+# your package's pyproject.toml
+[project.entry-points."cellpy.loaders"]
+mycycler = "my_package.loader:MyCyclerLoader"
+```
+
+Install your package and cellpy finds it. Check with:
+
+```python
+import cellpy
+cellpy.print_instruments()      # your loader appears under "installed by other packages"
+```
+
+Discovery is lazy and failure-tolerant: a plugin that cannot be imported is
+reported as a warning and skipped, it does not stop cellpy from working. A
+plugin that loads but does not satisfy the contract is rejected when it is
+registered, with a message naming what is missing — rather than failing later,
+mid-load, with something obscure.
+
+## Proving it conforms
+
+cellpy ships the conformance kit it uses on its own loaders:
+
+```python
+from pathlib import Path
+from cellpy.readers.instruments.testing import check_loader
+
+def test_my_loader_conforms():
+    check_loader(MyCyclerLoader, Path("tests/data/sample.mcx"))
+```
+
+It checks the return shape, the frame schema and dtypes, the units, that your
+draft metadata carries no provenance, that `can_load()` is fast enough to be
+called during routing, and that two loads of the same file agree.
+
+Commit a small real sample file as the fixture — a loader test with a
+synthesised file mostly tests the synthesiser.
+
+## Status
+
+The contract and registry are in place as of cellpy 2.0. The built-in loaders
+still route through the older module-scanning factory and move over to this
+registry as they are ported; the entry-point path above is the supported way to
+add a loader from outside cellpy.

--- a/tests/test_loader_contract.py
+++ b/tests/test_loader_contract.py
@@ -1,0 +1,370 @@
+"""Loader contract, registry and conformance-kit tests (#210).
+
+The contract is frozen at 2.0, so these tests are as much a specification as a
+regression net: they pin the tuple return, the structural (no-base-class)
+conformance rule, and the framework-stamps-provenance division of labour.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+import pytest
+from cellpycore.config import default_schema
+from cellpycore.metadata.models import TestMeta
+from cellpycore.units import CellpyUnits
+
+from cellpy import log
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments import registry
+from cellpy.readers.instruments.contract import InstrumentLoader, LoaderResult
+from cellpy.readers.instruments.testing import check_loader
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+# -- a conforming loader that imports no cellpy base class ---------------------
+
+
+def _sample_frame(rows: int = 4) -> pl.DataFrame:
+    schema = default_schema().raw
+    return pl.DataFrame(
+        {
+            schema.datapoint_num: list(range(rows)),
+            schema.test_time: [float(i) for i in range(rows)],
+            schema.potential: [3.0 + 0.1 * i for i in range(rows)],
+            schema.current: [0.001] * rows,
+            schema.epoch_time_utc: [1_700_000_000_000_000_000 + i for i in range(rows)],
+        }
+    )
+
+
+class GoodLoader:
+    """A third-party loader: no cellpy base class, no cellpy imports needed."""
+
+    name = "good_loader"
+    instrument = "goodinstrument"
+    supported_suffixes = (".good",)
+
+    tests_per_file = 1
+
+    def can_load(self, source: Path) -> bool:
+        return Path(source).suffix.lower() in self.supported_suffixes
+
+    def load(self, source, *, instrument_config=None, **kwargs):
+        return tuple(
+            LoaderResult(
+                raw=_sample_frame(),
+                raw_units=CellpyUnits(),
+                test_meta=TestMeta(),
+            )
+            for _ in range(self.tests_per_file)
+        )
+
+
+class MultiTestLoader(GoodLoader):
+    name = "multi_loader"
+    instrument = "multiinstrument"
+    supported_suffixes = (".multi",)
+    tests_per_file = 3
+
+
+@pytest.fixture
+def fixture_file(tmp_path) -> Path:
+    path = tmp_path / "sample.good"
+    path.write_text("dummy", encoding="utf-8")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear_registry()
+    yield
+    registry.clear_registry()
+
+
+# -- the contract --------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_conformance_is_structural_not_inheritance():
+    # The whole point of a Protocol: GoodLoader inherits nothing from cellpy
+    # and imports no cellpy base class, yet conforms.
+    assert InstrumentLoader not in GoodLoader.__mro__
+    assert issubclass(GoodLoader, InstrumentLoader)
+    assert isinstance(GoodLoader(), InstrumentLoader)
+
+
+@pytest.mark.essential
+def test_issubclass_works_on_the_runtime_protocol():
+    # Guards the split in contract.py: a runtime_checkable Protocol carrying
+    # data members raises TypeError here, and the registry needs the class
+    # check (it must not instantiate a loader just to identify it).
+    assert issubclass(GoodLoader, InstrumentLoader) is True
+
+
+@pytest.mark.essential
+def test_load_returns_a_tuple_even_for_a_single_test(fixture_file):
+    results = GoodLoader().load(fixture_file)
+    assert isinstance(results, tuple)
+    assert len(results) == 1
+
+
+@pytest.mark.essential
+def test_load_returns_one_result_per_test(fixture_file):
+    results = MultiTestLoader().load(fixture_file)
+    assert len(results) == 3
+
+
+@pytest.mark.essential
+def test_loader_result_is_frozen():
+    result = LoaderResult(
+        raw=_sample_frame(), raw_units=CellpyUnits(), test_meta=TestMeta()
+    )
+    with pytest.raises(Exception):
+        result.raw = _sample_frame()
+
+
+# -- the conformance kit -------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_check_loader_passes_a_conforming_loader(fixture_file):
+    check_loader(GoodLoader, fixture_file)
+
+
+@pytest.mark.essential
+def test_check_loader_rejects_a_non_tuple_return(fixture_file):
+    class ReturnsBareResult(GoodLoader):
+        name = "bare"
+
+        def load(self, source, *, instrument_config=None, **kwargs):
+            return LoaderResult(
+                raw=_sample_frame(), raw_units=CellpyUnits(), test_meta=TestMeta()
+            )
+
+    with pytest.raises(AssertionError, match="must return a tuple"):
+        check_loader(ReturnsBareResult, fixture_file)
+
+
+@pytest.mark.essential
+def test_check_loader_rejects_provenance_in_a_draft(fixture_file):
+    class StampsProvenance(GoodLoader):
+        name = "stamper"
+
+        def load(self, source, *, instrument_config=None, **kwargs):
+            meta = TestMeta()
+            meta.source_uri = "/somewhere/on/disk"
+            return (
+                LoaderResult(
+                    raw=_sample_frame(), raw_units=CellpyUnits(), test_meta=meta
+                ),
+            )
+
+    with pytest.raises(AssertionError, match="provenance"):
+        check_loader(StampsProvenance, fixture_file)
+
+
+@pytest.mark.essential
+def test_check_loader_rejects_unknown_raw_columns(fixture_file):
+    class EmitsVendorNames(GoodLoader):
+        name = "vendor_names"
+
+        def load(self, source, *, instrument_config=None, **kwargs):
+            frame = _sample_frame().rename({default_schema().raw.potential: "Volts"})
+            return (
+                LoaderResult(
+                    raw=frame, raw_units=CellpyUnits(), test_meta=TestMeta()
+                ),
+            )
+
+    with pytest.raises(AssertionError, match="outside the harmonized-raw schema"):
+        check_loader(EmitsVendorNames, fixture_file)
+
+
+@pytest.mark.essential
+def test_check_loader_rejects_a_non_deterministic_loader(fixture_file):
+    class Stateful(GoodLoader):
+        name = "stateful"
+        _calls = 0
+
+        def load(self, source, *, instrument_config=None, **kwargs):
+            type(self)._calls += 1
+            return (
+                LoaderResult(
+                    raw=_sample_frame(rows=3 + type(self)._calls),
+                    raw_units=CellpyUnits(),
+                    test_meta=TestMeta(),
+                ),
+            )
+
+    with pytest.raises(AssertionError, match="deterministic"):
+        check_loader(Stateful, fixture_file)
+
+
+# -- the registry --------------------------------------------------------------
+
+
+@dataclass
+class _FakeEntryPoint:
+    name: str
+    value: str
+    target: object = None
+    boom: Exception | None = None
+
+    def load(self):
+        if self.boom is not None:
+            raise self.boom
+        return self.target
+
+
+def _patch_entry_points(monkeypatch, *eps):
+    monkeypatch.setattr(registry, "_iter_entry_points", lambda: list(eps))
+    registry.clear_registry()
+
+
+@pytest.mark.essential
+def test_entry_point_loader_is_discovered(monkeypatch):
+    _patch_entry_points(
+        monkeypatch, _FakeEntryPoint("good", "pkg:GoodLoader", GoodLoader)
+    )
+    assert "good_loader" in registry.get_registry()
+    assert registry.available_loaders()["good_loader"]["instrument"] == "goodinstrument"
+
+
+@pytest.mark.essential
+def test_discovery_is_lazy(monkeypatch):
+    calls = []
+
+    def _spy():
+        calls.append(1)
+        return []
+
+    monkeypatch.setattr(registry, "_iter_entry_points", _spy)
+    registry.clear_registry()
+    assert not calls, "importing/clearing must not scan entry points"
+    registry.get_registry()
+    assert len(calls) == 1
+    registry.get_registry()
+    assert len(calls) == 1, "discovery result should be cached"
+
+
+@pytest.mark.essential
+def test_a_broken_plugin_does_not_break_cellpy(monkeypatch, caplog):
+    _patch_entry_points(
+        monkeypatch,
+        _FakeEntryPoint("broken", "pkg:Nope", boom=ImportError("no such module")),
+        _FakeEntryPoint("good", "pkg:GoodLoader", GoodLoader),
+    )
+    with caplog.at_level(logging.WARNING):
+        found = registry.get_registry()
+    # the healthy one still registers, the broken one is reported
+    assert "good_loader" in found
+    assert "broken" in caplog.text
+
+
+@pytest.mark.essential
+def test_a_non_conforming_plugin_is_rejected_at_registration(monkeypatch, caplog):
+    class NotALoader:
+        name = "impostor"
+        instrument = "nothing"
+        supported_suffixes = (".x",)
+        # no load(), no can_load()
+
+    _patch_entry_points(
+        monkeypatch, _FakeEntryPoint("impostor", "pkg:NotALoader", NotALoader)
+    )
+    with caplog.at_level(logging.WARNING):
+        found = registry.get_registry()
+    assert "impostor" not in found
+    assert "does not satisfy the InstrumentLoader contract" in caplog.text
+
+
+@pytest.mark.essential
+def test_bad_capability_metadata_is_rejected():
+    class BadSuffixes(GoodLoader):
+        name = "bad_suffixes"
+        supported_suffixes = "res"  # a bare string, not a tuple
+
+    with pytest.raises(LoaderError, match="tuple of suffixes"):
+        registry.register(BadSuffixes)
+
+
+@pytest.mark.essential
+def test_undotted_suffixes_are_rejected():
+    class Undotted(GoodLoader):
+        name = "undotted"
+        supported_suffixes = ("res",)
+
+    with pytest.raises(LoaderError, match="dotted strings"):
+        registry.register(Undotted)
+
+
+# -- routing -------------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_routing_by_explicit_instrument_name():
+    registry.register(GoodLoader)
+    registry.register(MultiTestLoader)
+    assert registry.find_loader(instrument="good_loader") is GoodLoader
+    # ... and by instrument family, not just loader id
+    assert registry.find_loader(instrument="multiinstrument") is MultiTestLoader
+
+
+@pytest.mark.essential
+def test_routing_by_suffix(tmp_path):
+    registry.register(GoodLoader)
+    registry.register(MultiTestLoader)
+    assert registry.find_loader(tmp_path / "x.good") is GoodLoader
+    assert registry.find_loader(tmp_path / "x.multi") is MultiTestLoader
+
+
+@pytest.mark.essential
+def test_routing_falls_back_to_can_load_when_suffixes_collide(tmp_path):
+    class Sniffer(GoodLoader):
+        name = "sniffer"
+        supported_suffixes = (".shared",)
+
+        def can_load(self, source: Path) -> bool:
+            return Path(source).name.startswith("mine")
+
+    class OtherSniffer(GoodLoader):
+        name = "other_sniffer"
+        supported_suffixes = (".shared",)
+
+        def can_load(self, source: Path) -> bool:
+            return Path(source).name.startswith("theirs")
+
+    registry.register(Sniffer)
+    registry.register(OtherSniffer)
+    assert registry.find_loader(tmp_path / "mine.shared") is Sniffer
+    assert registry.find_loader(tmp_path / "theirs.shared") is OtherSniffer
+
+
+@pytest.mark.essential
+def test_unknown_source_routes_to_nothing(tmp_path):
+    registry.register(GoodLoader)
+    assert registry.find_loader(tmp_path / "x.unknown") is None
+    assert registry.find_loader(instrument="not_installed") is None
+
+
+@pytest.mark.essential
+def test_we_query_the_documented_entry_point_group(monkeypatch):
+    """The monkeypatched tests above stub _iter_entry_points, so nothing else
+    checks that we ask importlib for the group third-party packages declare."""
+    seen = {}
+
+    def _fake_entry_points(*, group):
+        seen["group"] = group
+        return []
+
+    import cellpy.readers.instruments.registry as reg
+
+    monkeypatch.setattr(reg, "entry_points", _fake_entry_points)
+    list(reg._iter_entry_points())
+    assert seen["group"] == "cellpy.loaders"
+    assert reg.ENTRY_POINT_GROUP == "cellpy.loaders"


### PR DESCRIPTION
Closes #210. Stage 3.0 — the foundation the rest of the loader chain (#559 →
#560/#561) builds on.

A third-party package can now add an instrument loader to cellpy by declaring
an entry point. No base class, no cellpy imports, no registration call.

## The contract

`LoaderResult` (frozen) + `InstrumentLoader` (a `runtime_checkable` Protocol).

**`load()` always returns `tuple[LoaderResult, ...]`** — including for
single-test formats — per your decision, frozen with the Protocol in 2.0.
Every caller writes one unpacking path, and a format that grows multi-test
support later doesn't become a breaking change for its consumers.

**One deviation from the plan's §5.2 sketch, forced by the language.** A
`runtime_checkable` Protocol carrying non-method members cannot be used with
`issubclass()` — and the registry must identify a loader *class* without
instantiating it. So the Protocol is split: `InstrumentLoader` holds the
methods, `LoaderCapabilities` holds `name` / `instrument` /
`supported_suffixes`, and the registry validates the latter explicitly. That
turned out better than the sketch anyway: the error says *"missing
supported_suffixes"* rather than just failing a structural check. I've noted
this in the architecture plan.

## Failure containment

This is a plugin system, so the interesting design is what happens when a
plugin misbehaves:

- **cannot be imported** → warning, skipped; cellpy keeps working. One broken
  third-party package must not take down someone's analysis.
- **imports but doesn't conform** → rejected at registration, naming what is
  missing, rather than failing obscurely mid-load.
- **misbehaving `can_load()`** → disqualifies that loader, nothing more.

Discovery is lazy: `import cellpy` neither scans nor imports third-party code.

## Verification

The in-repo tests stub the entry-point iterator, which would happily pass with
the *wrong group name* — so I also built an actual plugin package that imports
nothing from cellpy, installed it, and confirmed discovery, routing and
listing worked end to end, then uninstalled it. One test pins the group name
so the stubbing can't hide that class of error.

## User-facing

`print_instruments()` lists entry-point loaders separately from the built-ins,
so *"why can't cellpy see my loader?"* is answerable. That was this issue's
second, previously unimplemented checkbox.

There's a short authoring guide at `docs/other/writing_a_loader_plugin.md` —
a plugin architecture nobody knows how to write against isn't finished. #571
can restyle it with the rest of the docs.

## Not in scope

The built-in loaders still route through the module-scanning
`InstrumentFactory`; they move to this registry once they emit `LoaderResult`
(#559 `harmonize()`, #560 the port). The conformance kit covers §5.5 checks
1–6 — check 7 (reset granularity, the one that catches silent capacity
corruption) needs `harmonize()` to normalise against and lands with #559.

## Tests

21 new tests. Full suite: 757 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
