### PR TITLE
#559: harmonize() framework + declaration schema + maccor pilot

### DIFF
--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -1,0 +1,138 @@
+"""Loader declarations — normalization described, not coded (issue #559).
+
+A loader keeps the part that is genuinely hard and vendor-specific (parsing the
+file) and *declares* everything after it: which vendor column is which native
+column, what the units are, how timestamps should be read, and — the dangerous
+one — what reset granularity the vendor's cumulative columns use.
+
+Declarations are validated **when they are constructed**, which is when the
+configuration module is imported. A typo'd native column name is then an import
+error naming the typo, instead of a confusing failure in the middle of someone's
+load six months later (loader plan §2.2).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Callable, Mapping
+
+from cellpycore.config import default_schema
+from cellpycore.units import CellpyUnits, validate_units
+
+from cellpy.exceptions import LoaderError
+
+#: ``aux_<quantity>_<name>`` — the harmonized-raw auxiliary naming scheme.
+_AUX_PATTERN = re.compile(r"^aux_(temperature|potential|pressure|resistance)_\w+$")
+
+
+class ResetGranularity(StrEnum):
+    """How often a vendor's cumulative column resets to zero.
+
+    The harmonized-raw target is **cycle-cumulative**: within a cycle the value
+    accumulates across that cycle's steps for its direction, and resets at each
+    cycle boundary. ``harmonize()`` converts the other two granularities to it.
+
+    Getting this wrong does not raise — it silently changes every capacity in
+    the dataset. It is declared per column, and the property test in
+    ``tests/test_harmonize.py`` is what actually catches a wrong declaration.
+    """
+
+    #: Resets every step. Converted by accumulating step totals within a cycle.
+    PER_STEP = "per_step"
+    #: Resets every cycle. Already the target convention — left alone.
+    PER_CYCLE = "per_cycle"
+    #: Never resets. Converted by subtracting each cycle's starting value.
+    PER_TEST = "per_test"
+
+
+@dataclass(frozen=True)
+class LoaderDeclarations:
+    """Everything ``harmonize()`` needs to turn a vendor frame into native raw.
+
+    Args:
+        column_map: vendor column name → native ``RawCols`` name. Vendor
+            columns not mentioned here are dropped; native names must exist.
+        raw_units: the units the *file* is in, as a validated ``CellpyUnits``.
+        timezone: IANA zone for naive vendor timestamps. ``None`` means "treat
+            naive timestamps as local time", the shared D3 rule — recorded on
+            ``TestMeta.time_zone`` so the assumption is visible later.
+        reset_granularity: native cumulative column → its granularity in the
+            vendor file. Columns not listed are assumed already cycle-
+            cumulative, which is the common case and the target convention.
+        aux_map: vendor column → ``aux_<quantity>_<name>``.
+        post_hooks: callables applied to the vendor frame *before* renaming,
+            for quirks no declaration can express (e.g. Maccor's single
+            signed capacity column that must be split by direction).
+    """
+
+    column_map: Mapping[str, str]
+    raw_units: CellpyUnits
+    timezone: str | None = None
+    reset_granularity: Mapping[str, ResetGranularity] = field(default_factory=dict)
+    aux_map: Mapping[str, str] = field(default_factory=dict)
+    post_hooks: tuple[Callable, ...] = ()
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    # -- validation ------------------------------------------------------------
+    def _validate(self) -> None:
+        native_names = set(default_schema().raw.ordered_names())
+
+        unknown = sorted(set(self.column_map.values()) - native_names)
+        if unknown:
+            raise LoaderError(
+                f"column_map targets columns that are not in the harmonized-raw "
+                f"schema: {unknown}. Native columns are {sorted(native_names)}."
+            )
+
+        targets = list(self.column_map.values())
+        duplicated = sorted({name for name in targets if targets.count(name) > 1})
+        if duplicated:
+            raise LoaderError(
+                f"column_map maps more than one vendor column onto {duplicated}; "
+                f"the later one would silently win."
+            )
+
+        try:
+            validate_units(self.raw_units)
+        except Exception as exc:
+            raise LoaderError(f"raw_units is not a valid unit spec: {exc}") from exc
+
+        bad_granularity = sorted(
+            column for column in self.reset_granularity if column not in native_names
+        )
+        if bad_granularity:
+            raise LoaderError(
+                f"reset_granularity refers to columns that are not in the "
+                f"harmonized-raw schema: {bad_granularity}."
+            )
+
+        undeclared = sorted(
+            column
+            for column in self.reset_granularity
+            if column not in set(self.column_map.values())
+        )
+        if undeclared:
+            raise LoaderError(
+                f"reset_granularity declares {undeclared}, which column_map never "
+                f"produces; the declaration would have no effect."
+            )
+
+        bad_aux = sorted(
+            target for target in self.aux_map.values() if not _AUX_PATTERN.match(target)
+        )
+        if bad_aux:
+            raise LoaderError(
+                f"aux_map targets {bad_aux} do not follow the "
+                f"aux_<quantity>_<name> scheme (quantity is one of temperature, "
+                f"potential, pressure, resistance)."
+            )
+
+    # -- convenience -----------------------------------------------------------
+    @property
+    def native_columns(self) -> tuple[str, ...]:
+        """Native columns this loader produces, aux included."""
+        return tuple(self.column_map.values()) + tuple(self.aux_map.values())

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -1,0 +1,287 @@
+"""The shared normalization stage: vendor frame → harmonized native raw (#559).
+
+Every loader used to do its own renaming, casting, timestamp conversion and
+capacity fiddling. ``harmonize()`` does it once, for all of them, driven by the
+loader's :class:`~cellpy.readers.instruments.declarations.LoaderDeclarations`::
+
+    vendor file ──parse()──► vendor frame + declarations ──harmonize()──► native raw
+
+The order of operations matters and is fixed here:
+
+1. post hooks (vendor quirks, on vendor column names)
+2. rename vendor → native, dropping undeclared columns
+3. timestamps → ``epoch_time_utc`` int64 ns UTC
+4. cast to the schema dtypes
+5. **reset-granularity normalization** to cycle-cumulative
+6. identity and provenance stamping
+7. ``validate_raw_frame``
+
+Step 5 is the one to be careful about; see :func:`normalize_reset_granularity`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone as dt_timezone
+from typing import Any
+
+import polars as pl
+from cellpycore.cell_core import validate_raw_frame
+from cellpycore.config import default_schema
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.declarations import LoaderDeclarations, ResetGranularity
+
+_NS_PER_SECOND = 1_000_000_000
+
+
+def normalize_reset_granularity(
+    raw: pl.DataFrame,
+    declarations: LoaderDeclarations,
+) -> pl.DataFrame:
+    """Convert cumulative columns to the harmonized-raw convention.
+
+    The target (harmonized-raw spec, *Capacity convention*) is **cumulative per
+    cycle, per direction**: within a cycle the value accumulates across that
+    cycle's steps, and resets to 0 at each cycle boundary. The summary path
+    depends on this — per-cycle capacity is read from the cycle's *last*
+    datapoint — so a wrong granularity here corrupts every capacity downstream
+    without raising anything.
+
+    Conversions:
+
+    ``PER_CYCLE``
+        Already the target. Left untouched.
+    ``PER_TEST``
+        Never resets, so the whole history is baked in. Subtract the value the
+        column held entering each cycle.
+    ``PER_STEP``
+        Resets each step, so within a cycle we must re-accumulate: add the
+        running total of the *completed* steps of that cycle.
+
+    Args:
+        raw: frame already renamed to native columns.
+        declarations: carries ``reset_granularity`` per column.
+
+    Returns:
+        A new frame; the input is not mutated.
+    """
+    schema = default_schema().raw
+    cycle_column = schema.cycle_num
+
+    if not declarations.reset_granularity:
+        return raw
+    if cycle_column not in raw.columns:
+        raise LoaderError(
+            f"reset-granularity normalization needs {cycle_column!r}, which the "
+            f"loader did not produce; declare it in column_map."
+        )
+
+    out = raw
+    for column, granularity in declarations.reset_granularity.items():
+        if column not in out.columns:
+            # Declared but absent: the file simply did not carry it.
+            continue
+
+        if granularity is ResetGranularity.PER_CYCLE:
+            continue
+
+        if granularity is ResetGranularity.PER_TEST:
+            # Value entering the cycle = the column's first value in the cycle.
+            # Subtracting it rebases each cycle to start at zero.
+            out = out.with_columns(
+                (pl.col(column) - pl.col(column).first().over(cycle_column)).alias(
+                    column
+                )
+            )
+            continue
+
+        if granularity is ResetGranularity.PER_STEP:
+            step_column = schema.step_num
+            if step_column not in out.columns:
+                raise LoaderError(
+                    f"per-step reset granularity for {column!r} needs "
+                    f"{step_column!r}; declare it in column_map."
+                )
+            # Within a cycle: each step contributes its own final value to the
+            # steps that follow it. Take each step's last value, shift it down
+            # the step sequence, and accumulate.
+            step_totals = (
+                out.group_by([cycle_column, step_column], maintain_order=True)
+                .agg(pl.col(column).last().alias("_step_total"))
+                .with_columns(
+                    pl.col("_step_total")
+                    .shift(1, fill_value=0.0)
+                    .cum_sum()
+                    .over(cycle_column)
+                    .alias("_offset")
+                )
+                .drop("_step_total")
+            )
+            out = (
+                out.join(step_totals, on=[cycle_column, step_column], how="left")
+                .with_columns((pl.col(column) + pl.col("_offset")).alias(column))
+                .drop("_offset")
+            )
+            continue
+
+        raise LoaderError(f"unknown reset granularity {granularity!r} for {column!r}")
+
+    return out
+
+
+def _convert_timestamps(
+    raw: pl.DataFrame, declarations: LoaderDeclarations
+) -> pl.DataFrame:
+    """Vendor datetimes → ``epoch_time_utc`` as int64 nanoseconds UTC."""
+    schema = default_schema().raw
+    column = schema.epoch_time_utc
+    if column not in raw.columns:
+        return raw
+
+    dtype = raw[column].dtype
+    if dtype == pl.Int64:
+        return raw
+
+    if dtype == pl.Datetime:
+        series = raw[column]
+        if series.dtype.time_zone is None:
+            if declarations.timezone is None:
+                # The shared D3 rule: naive means local. Say so, because it is
+                # an assumption about someone else's data.
+                logging.warning(
+                    "naive timestamps interpreted as local time; declare a "
+                    "timezone in the loader declarations to be explicit"
+                )
+                series = series.dt.replace_time_zone("UTC")
+            else:
+                series = series.dt.replace_time_zone(declarations.timezone)
+        return raw.with_columns(
+            series.dt.convert_time_zone("UTC").dt.epoch("ns").alias(column)
+        )
+
+    if dtype in (pl.Float64, pl.Float32):
+        # Seconds since the epoch.
+        return raw.with_columns(
+            (pl.col(column) * _NS_PER_SECOND).cast(pl.Int64).alias(column)
+        )
+
+    raise LoaderError(
+        f"cannot interpret {column!r} of dtype {dtype} as a timestamp; expected "
+        f"a datetime, epoch seconds, or int64 epoch nanoseconds"
+    )
+
+
+def _cast_to_schema(raw: pl.DataFrame) -> pl.DataFrame:
+    """Cast every recognised column to its schema dtype."""
+    dtype_map = default_schema().raw.dtype_map()
+    casts = [
+        pl.col(name).cast(dtype, strict=False).alias(name)
+        for name, dtype in dtype_map.items()
+        if name in raw.columns
+    ]
+    return raw.with_columns(casts) if casts else raw
+
+
+def _stamp_identity(raw: pl.DataFrame, *, test_id: int) -> pl.DataFrame:
+    """Fill the framework-owned identity columns."""
+    schema = default_schema().raw
+    additions = []
+    if schema.test_id not in raw.columns:
+        additions.append(pl.lit(test_id, dtype=pl.Int64).alias(schema.test_id))
+    if schema.mask not in raw.columns:
+        additions.append(pl.lit(True, dtype=pl.Boolean).alias(schema.mask))
+    if schema.datapoint_num not in raw.columns:
+        additions.append(
+            pl.int_range(0, pl.len(), dtype=pl.Int64).alias(schema.datapoint_num)
+        )
+    return raw.with_columns(additions) if additions else raw
+
+
+def harmonize(
+    vendor_frame: Any,
+    declarations: LoaderDeclarations,
+    *,
+    test_id: int = 0,
+    strict: bool = True,
+) -> pl.DataFrame:
+    """Normalize a parsed vendor frame into harmonized native raw.
+
+    Args:
+        vendor_frame: what the loader's ``parse()`` produced — a polars frame,
+            or a pandas frame (converted here, so legacy parsers can be reused
+            unchanged during the port).
+        declarations: the loader's declarations.
+        test_id: identity for the rows of this test.
+        strict: run ``validate_raw_frame`` strictly. The two sanctioned
+            warn-only escape hatches (``local_instrument`` and friends,
+            conventions plan §4) pass ``strict=False``.
+
+    Returns:
+        A polars frame in the harmonized-raw schema.
+
+    Raises:
+        LoaderError: if the frame cannot be normalized or fails validation.
+    """
+    if not isinstance(vendor_frame, pl.DataFrame):
+        try:
+            vendor_frame = pl.from_pandas(vendor_frame)
+        except Exception as exc:
+            raise LoaderError(
+                f"parse() must return a polars or pandas frame, got "
+                f"{type(vendor_frame).__name__}"
+            ) from exc
+
+    raw = vendor_frame
+    for hook in declarations.post_hooks:
+        raw = hook(raw)
+
+    mapping = {**declarations.column_map, **declarations.aux_map}
+    missing = [vendor for vendor in mapping if vendor not in raw.columns]
+    if missing:
+        logging.debug("declared vendor columns absent from this file: %s", missing)
+
+    present = {vendor: native for vendor, native in mapping.items() if vendor in raw.columns}
+    raw = raw.select(list(present)).rename(present)
+
+    raw = _convert_timestamps(raw, declarations)
+    raw = _cast_to_schema(raw)
+    raw = normalize_reset_granularity(raw, declarations)
+    raw = _stamp_identity(raw, test_id=test_id)
+
+    try:
+        validate_raw_frame(raw, default_schema().raw)
+    except Exception as exc:
+        if strict:
+            raise LoaderError(f"harmonized frame failed validation: {exc}") from exc
+        logging.warning("harmonized frame failed validation (warn-only): %s", exc)
+
+    return raw
+
+
+def stamp_provenance(
+    test_meta: Any,
+    *,
+    source: Any,
+    source_type: str,
+    source_uuid: str | None = None,
+) -> Any:
+    """Fill the provenance fields a loader is not allowed to fill itself.
+
+    The loader knows what the file *says*; only the framework knows where the
+    file came from and when it was read (architecture plan §5.4).
+    """
+    from pathlib import Path
+
+    path = Path(source)
+    for name, value in (
+        ("source_kind", "FILE"),
+        ("source_type", source_type),
+        ("source_uri", str(path)),
+        ("source_uuid", source_uuid),
+        ("raw_file_names", [path.name]),
+        ("loaded_datetime", datetime.now(dt_timezone.utc)),
+    ):
+        if value is not None and hasattr(test_meta, name):
+            setattr(test_meta, name, value)
+    return test_meta

--- a/cellpy/readers/instruments/maccor_txt_native.py
+++ b/cellpy/readers/instruments/maccor_txt_native.py
@@ -1,0 +1,213 @@
+"""Pilot loader for the two-stage design: Maccor txt (issue #559).
+
+The first loader written as ``harmonize(parse(source), declarations)``. It runs
+alongside the legacy ``maccor_txt`` loader and changes no existing behaviour —
+the legacy path stays the default until the port (#560) switches over. What it
+proves is that the vendor-specific part really is just parsing, and everything
+after it can be declared.
+
+The Maccor "three" dialect (WMG/SIMBA) has three quirks worth naming, because
+they are the kind of thing that has to live *somewhere*:
+
+- **One signed capacity column.** ``mAmp-hr`` holds whichever direction is
+  active, identified by the ``State`` column (C/D/R). Splitting it into the two
+  native columns is a post hook, since no rename can express it.
+- **Duration strings.** ``TestTime`` looks like ``  0d 00:01:00.00``.
+- **Milli-everything.** Currents in mA, capacities in mAh, potentials in mV —
+  declared in ``raw_units``, converted once at ingestion by the framework, not
+  by hand here.
+
+Capacity granularity was determined from the data, not assumed: ``mAmp-hr``
+resets when the direction changes within a cycle and continues across
+same-direction steps, so once split by state each column is already
+cycle-cumulative — the harmonized-raw target. Hence ``PER_CYCLE``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import polars as pl
+from cellpycore.config import default_schema
+from cellpycore.metadata.models import TestMeta
+from cellpycore.units import CellpyUnits
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.contract import LoaderResult
+from cellpy.readers.instruments.declarations import (
+    LoaderDeclarations,
+    ResetGranularity,
+)
+from cellpy.readers.instruments.harmonize import harmonize
+
+_SCHEMA = default_schema().raw
+
+# Vendor state codes -> direction.
+_CHARGE_STATES = ("C",)
+_DISCHARGE_STATES = ("D",)
+
+# "  0d 00:01:00.00"
+_DURATION = re.compile(
+    r"\s*(?P<days>\d+)d\s+(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>[\d.]+)"
+)
+
+_VENDOR_CAPACITY = "mAmp-hr"
+_VENDOR_STATE = "State"
+_VENDOR_CYCLE = "Cyc#"
+
+# Names the split hook produces; declared in column_map like any other column.
+_CHARGE_CAPACITY = "_charge_capacity"
+_DISCHARGE_CAPACITY = "_discharge_capacity"
+
+
+def _duration_to_seconds(value: str | None) -> float | None:
+    if value is None:
+        return None
+    match = _DURATION.match(str(value))
+    if match is None:
+        return None
+    return (
+        int(match["days"]) * 86400
+        + int(match["hours"]) * 3600
+        + int(match["minutes"]) * 60
+        + float(match["seconds"])
+    )
+
+
+def split_capacity_by_state(frame: pl.DataFrame) -> pl.DataFrame:
+    """Split the single signed capacity column into charge and discharge.
+
+    Reproduces the legacy ``_state_splitter`` semantics: within a cycle, each
+    direction's column carries the vendor value on that direction's rows, holds
+    the last value for the rest of the cycle (the legacy "propagate"), and is
+    zero before the direction first appears.
+    """
+    if _VENDOR_CAPACITY not in frame.columns or _VENDOR_STATE not in frame.columns:
+        raise LoaderError(
+            f"expected {_VENDOR_CAPACITY!r} and {_VENDOR_STATE!r} columns in the "
+            f"Maccor file; got {frame.columns}"
+        )
+
+    def _directional(states: tuple[str, ...], alias: str) -> pl.Expr:
+        return (
+            pl.when(pl.col(_VENDOR_STATE).is_in(states))
+            .then(pl.col(_VENDOR_CAPACITY))
+            .otherwise(None)
+            .forward_fill()
+            .over(_VENDOR_CYCLE)
+            .fill_null(0.0)
+            .alias(alias)
+        )
+
+    return frame.with_columns(
+        _directional(_CHARGE_STATES, _CHARGE_CAPACITY),
+        _directional(_DISCHARGE_STATES, _DISCHARGE_CAPACITY),
+    )
+
+
+MACCOR_THREE = LoaderDeclarations(
+    column_map={
+        "Rec#": _SCHEMA.datapoint_num,
+        _VENDOR_CYCLE: _SCHEMA.cycle_num,
+        "Step": _SCHEMA.step_num,
+        "TestTime": _SCHEMA.test_time,
+        "StepTime": _SCHEMA.step_time,
+        "mAmps": _SCHEMA.current,
+        "Volts": _SCHEMA.potential,
+        "DPt Time": _SCHEMA.epoch_time_utc,
+        _CHARGE_CAPACITY: _SCHEMA.cumulative_charge_capacity,
+        _DISCHARGE_CAPACITY: _SCHEMA.cumulative_discharge_capacity,
+    },
+    raw_units=CellpyUnits(current="mA", charge="mAh", voltage="mV", mass="g"),
+    # Determined from the data (see module docstring), not assumed.
+    reset_granularity={
+        _SCHEMA.cumulative_charge_capacity: ResetGranularity.PER_CYCLE,
+        _SCHEMA.cumulative_discharge_capacity: ResetGranularity.PER_CYCLE,
+    },
+    post_hooks=(split_capacity_by_state,),
+)
+
+
+class MaccorTxtLoader:
+    """Maccor tab-delimited txt, two-stage style.
+
+    Conforms structurally to
+    :class:`~cellpy.readers.instruments.contract.InstrumentLoader`.
+    """
+
+    name = "maccor_txt_native"
+    instrument = "maccor"
+    supported_suffixes = (".txt",)
+
+    #: Rows of preamble before the header line.
+    skip_rows = 4
+
+    declarations = MACCOR_THREE
+
+    def can_load(self, source: Path) -> bool:
+        """Sniff the header line without parsing the file."""
+        source = Path(source)
+        if source.suffix.lower() not in self.supported_suffixes:
+            return False
+        try:
+            with source.open("r", encoding="utf-8", errors="replace") as handle:
+                head = [handle.readline() for _ in range(self.skip_rows + 1)]
+        except OSError:
+            return False
+        return any(_VENDOR_CAPACITY in line for line in head)
+
+    def parse(self, source: Path) -> pl.DataFrame:
+        """Vendor stage: read the file into a frame with vendor column names."""
+        source = Path(source)
+        try:
+            frame = pl.read_csv(
+                source,
+                separator="\t",
+                skip_rows=self.skip_rows,
+                has_header=True,
+                encoding="utf8-lossy",
+                truncate_ragged_lines=True,
+                infer_schema_length=10_000,
+            )
+        except Exception as exc:
+            raise LoaderError(f"could not parse Maccor file {source}: {exc}") from exc
+
+        conversions = []
+        for column in ("TestTime", "StepTime"):
+            if column in frame.columns and frame[column].dtype == pl.String:
+                conversions.append(
+                    pl.col(column)
+                    .map_elements(_duration_to_seconds, return_dtype=pl.Float64)
+                    .alias(column)
+                )
+        if "DPt Time" in frame.columns and frame["DPt Time"].dtype == pl.String:
+            conversions.append(
+                pl.col("DPt Time")
+                .str.strip_chars()
+                .str.to_datetime("%m/%d/%Y %I:%M:%S %p", strict=False)
+                .alias("DPt Time")
+            )
+        if conversions:
+            frame = frame.with_columns(conversions)
+        return frame
+
+    def load(
+        self,
+        source: Path,
+        *,
+        instrument_config: object | None = None,
+        **kwargs: object,
+    ) -> tuple[LoaderResult, ...]:
+        """Parse and harmonize one Maccor file into a single test."""
+        vendor_frame = self.parse(Path(source))
+        raw = harmonize(vendor_frame, self.declarations)
+        return (
+            LoaderResult(
+                raw=raw,
+                raw_units=self.declarations.raw_units,
+                # A draft: only what the file knows. Provenance is stamped by
+                # the framework, which alone knows where this came from.
+                test_meta=TestMeta(),
+            ),
+        )

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -1,0 +1,424 @@
+"""Declaration + harmonize() tests (#559).
+
+The reset-granularity cases carry hand-computed expectations rather than
+values read back from the implementation: a wrong granularity conversion does
+not raise, it silently rescales every capacity in the dataset, so the test has
+to know the right answer independently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+import pytest
+from cellpycore.config import default_schema
+from cellpycore.units import CellpyUnits
+
+from cellpy import log
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.declarations import (
+    LoaderDeclarations,
+    ResetGranularity,
+)
+from cellpy.readers.instruments.harmonize import (
+    harmonize,
+    normalize_reset_granularity,
+)
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+SCHEMA = default_schema().raw
+
+
+# -- declarations validate at construction -------------------------------------
+
+
+@pytest.mark.essential
+def test_valid_declarations_construct():
+    declarations = LoaderDeclarations(
+        column_map={"Volts": SCHEMA.potential, "Amps": SCHEMA.current},
+        raw_units=CellpyUnits(),
+    )
+    assert declarations.native_columns == (SCHEMA.potential, SCHEMA.current)
+
+
+@pytest.mark.essential
+def test_typo_in_a_native_column_name_fails_immediately():
+    # The point of validating at construction: this is an import-time error in
+    # the configuration module, not a surprise mid-load.
+    with pytest.raises(LoaderError, match="not in the harmonized-raw schema"):
+        LoaderDeclarations(
+            column_map={"Volts": "potentail"},  # typo
+            raw_units=CellpyUnits(),
+        )
+
+
+@pytest.mark.essential
+def test_two_vendor_columns_mapped_onto_one_native_column_fails():
+    with pytest.raises(LoaderError, match="more than one vendor column"):
+        LoaderDeclarations(
+            column_map={"Volts": SCHEMA.potential, "V2": SCHEMA.potential},
+            raw_units=CellpyUnits(),
+        )
+
+
+@pytest.mark.essential
+def test_granularity_for_a_column_that_is_never_produced_fails():
+    # Otherwise the declaration looks meaningful but does nothing.
+    with pytest.raises(LoaderError, match="which column_map never produces"):
+        LoaderDeclarations(
+            column_map={"Volts": SCHEMA.potential},
+            raw_units=CellpyUnits(),
+            reset_granularity={
+                SCHEMA.cumulative_charge_capacity: ResetGranularity.PER_TEST
+            },
+        )
+
+
+@pytest.mark.essential
+def test_bad_aux_name_fails():
+    with pytest.raises(LoaderError, match="aux_<quantity>_<name>"):
+        LoaderDeclarations(
+            column_map={"Volts": SCHEMA.potential},
+            raw_units=CellpyUnits(),
+            aux_map={"T1": "aux_temp_cell"},  # "temp" is not a known quantity
+        )
+
+
+# -- reset granularity ---------------------------------------------------------
+
+
+def _frame(cycles, steps, values) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            SCHEMA.cycle_num: cycles,
+            SCHEMA.step_num: steps,
+            SCHEMA.cumulative_charge_capacity: [float(v) for v in values],
+        }
+    )
+
+
+def _declarations(granularity) -> LoaderDeclarations:
+    return LoaderDeclarations(
+        column_map={
+            "cyc": SCHEMA.cycle_num,
+            "stp": SCHEMA.step_num,
+            "cap": SCHEMA.cumulative_charge_capacity,
+        },
+        raw_units=CellpyUnits(),
+        reset_granularity={SCHEMA.cumulative_charge_capacity: granularity},
+    )
+
+
+@pytest.mark.essential
+def test_per_cycle_is_the_target_and_is_untouched():
+    # Two cycles, each already restarting from zero.
+    frame = _frame(
+        cycles=[1, 1, 1, 2, 2, 2],
+        steps=[1, 1, 2, 1, 1, 2],
+        values=[0.0, 1.0, 3.0, 0.0, 2.0, 5.0],
+    )
+    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_CYCLE))
+    assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
+        0.0,
+        1.0,
+        3.0,
+        0.0,
+        2.0,
+        5.0,
+    ]
+
+
+@pytest.mark.essential
+def test_per_test_is_rebased_at_each_cycle_boundary():
+    # A never-resetting column: cycle 1 runs 0->3, cycle 2 continues 3->8.
+    # Expected: cycle 2 rebased to start at zero, i.e. 0, 2, 5.
+    frame = _frame(
+        cycles=[1, 1, 1, 2, 2, 2],
+        steps=[1, 1, 2, 1, 1, 2],
+        values=[0.0, 1.0, 3.0, 3.0, 5.0, 8.0],
+    )
+    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_TEST))
+    assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
+        0.0,
+        1.0,
+        3.0,
+        0.0,
+        2.0,
+        5.0,
+    ]
+
+
+@pytest.mark.essential
+def test_per_step_accumulates_completed_steps_within_the_cycle():
+    # Each step restarts at zero:
+    #   cycle 1: step 1 -> 0,1,2 ; step 2 -> 0,3   (step 1 finished at 2)
+    #   cycle 2: step 1 -> 0,4   ; step 2 -> 0,1   (step 1 finished at 4)
+    # Expected cycle-cumulative:
+    #   cycle 1: 0,1,2 then 2+0=2, 2+3=5
+    #   cycle 2: 0,4   then 4+0=4, 4+1=5
+    frame = _frame(
+        cycles=[1, 1, 1, 1, 1, 2, 2, 2, 2],
+        steps=[1, 1, 1, 2, 2, 1, 1, 2, 2],
+        values=[0.0, 1.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 1.0],
+    )
+    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_STEP))
+    assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
+        0.0,
+        1.0,
+        2.0,
+        2.0,
+        5.0,
+        0.0,
+        4.0,
+        4.0,
+        5.0,
+    ]
+
+
+@pytest.mark.essential
+def test_per_cycle_capacity_is_the_cycle_last_value():
+    """The property the summary path depends on.
+
+    Per the harmonized-raw spec, per-cycle capacity is read from the cycle's
+    last datapoint. After normalization that must hold for every granularity.
+    """
+    expected = {1: 3.0, 2: 5.0}
+
+    per_test = _frame(
+        cycles=[1, 1, 1, 2, 2, 2],
+        steps=[1, 1, 2, 1, 1, 2],
+        values=[0.0, 1.0, 3.0, 3.0, 5.0, 8.0],
+    )
+    out = normalize_reset_granularity(per_test, _declarations(ResetGranularity.PER_TEST))
+    last = (
+        out.group_by(SCHEMA.cycle_num, maintain_order=True)
+        .agg(pl.col(SCHEMA.cumulative_charge_capacity).last().alias("cap"))
+        .to_dict(as_series=False)
+    )
+    assert dict(zip(last[SCHEMA.cycle_num], last["cap"])) == expected
+
+
+@pytest.mark.essential
+def test_per_step_without_a_step_column_fails_loudly():
+    frame = pl.DataFrame(
+        {
+            SCHEMA.cycle_num: [1, 1],
+            SCHEMA.cumulative_charge_capacity: [0.0, 1.0],
+        }
+    )
+    with pytest.raises(LoaderError, match="needs"):
+        normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_STEP))
+
+
+# -- harmonize -----------------------------------------------------------------
+
+
+def _vendor_frame() -> pl.DataFrame:
+    # Realistic: a loader must supply every column validate_raw_frame requires,
+    # so the fixture does too — harmonize() deliberately does not invent them,
+    # which would hide a loader that forgot to map its capacity column.
+    return pl.DataFrame(
+        {
+            "Rec#": [1, 2, 3, 4],
+            "Volts": [3.0, 3.1, 3.2, 3.3],
+            "Amps": [0.1, 0.1, -0.1, -0.1],
+            "Cyc#": [1, 1, 2, 2],
+            "Step": [1, 1, 1, 1],
+            "TestTime": [0.0, 1.0, 2.0, 3.0],
+            "Stamp": [
+                1_700_000_000_000_000_000,
+                1_700_000_001_000_000_000,
+                1_700_000_002_000_000_000,
+                1_700_000_003_000_000_000,
+            ],
+            "ChgAh": [0.0, 0.5, 0.0, 0.0],
+            "DchAh": [0.0, 0.0, 0.0, 0.5],
+            "Ignored": ["a", "b", "c", "d"],
+        }
+    )
+
+
+def _vendor_declarations() -> LoaderDeclarations:
+    return LoaderDeclarations(
+        column_map={
+            "Rec#": SCHEMA.datapoint_num,
+            "Volts": SCHEMA.potential,
+            "Amps": SCHEMA.current,
+            "Cyc#": SCHEMA.cycle_num,
+            "Step": SCHEMA.step_num,
+            "TestTime": SCHEMA.test_time,
+            "Stamp": SCHEMA.epoch_time_utc,
+            "ChgAh": SCHEMA.cumulative_charge_capacity,
+            "DchAh": SCHEMA.cumulative_discharge_capacity,
+        },
+        raw_units=CellpyUnits(),
+    )
+
+
+@pytest.mark.essential
+def test_harmonize_renames_and_drops_undeclared_columns():
+    out = harmonize(_vendor_frame(), _vendor_declarations())
+    assert SCHEMA.potential in out.columns
+    assert "Volts" not in out.columns
+    assert "Ignored" not in out.columns, "undeclared vendor columns must not survive"
+
+
+@pytest.mark.essential
+def test_harmonize_casts_to_schema_dtypes():
+    out = harmonize(_vendor_frame(), _vendor_declarations())
+    dtype_map = SCHEMA.dtype_map()
+    for column in out.columns:
+        if column in dtype_map:
+            assert out[column].dtype == dtype_map[column], column
+
+
+@pytest.mark.essential
+def test_harmonize_stamps_identity():
+    out = harmonize(_vendor_frame(), _vendor_declarations(), test_id=7)
+    assert out[SCHEMA.test_id].to_list() == [7, 7, 7, 7]
+    assert out[SCHEMA.mask].to_list() == [True] * 4
+
+
+@pytest.mark.essential
+def test_harmonize_accepts_a_pandas_frame():
+    # Legacy parsers return pandas; the port should not require rewriting them
+    # before harmonize() can be used.
+    import pandas as pd
+
+    out = harmonize(_vendor_frame().to_pandas(), _vendor_declarations())
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 4
+
+
+@pytest.mark.essential
+def test_harmonize_runs_post_hooks_before_renaming():
+    def double_volts(frame: pl.DataFrame) -> pl.DataFrame:
+        # Hooks see vendor names, since they fix vendor quirks.
+        assert "Volts" in frame.columns
+        return frame.with_columns((pl.col("Volts") * 2).alias("Volts"))
+
+    declarations = LoaderDeclarations(
+        column_map=dict(_vendor_declarations().column_map),
+        raw_units=CellpyUnits(),
+        post_hooks=(double_volts,),
+    )
+    out = harmonize(_vendor_frame(), declarations)
+    assert out[SCHEMA.potential].to_list() == [6.0, 6.2, 6.4, 6.6]
+
+
+@pytest.mark.essential
+def test_harmonize_keeps_datapoint_num_a_column_not_an_index():
+    out = harmonize(_vendor_frame(), _vendor_declarations())
+    assert SCHEMA.datapoint_num in out.columns
+
+
+# -- the property test that catches a wrong granularity declaration ------------
+
+
+@pytest.mark.essential
+def test_harmonized_per_cycle_capacities_match_the_legacy_pipeline():
+    """The correctness landmine of the whole loader port (loader plan §5).
+
+    A wrong ``reset_granularity`` declaration does not raise — it silently
+    rescales every capacity. The only thing that catches it is recomputing
+    per-cycle capacities from the harmonized raw and comparing them against an
+    independent pipeline on the same file.
+
+    Note the legacy path shifts cycle numbers so they start at 1
+    (``set_cycle_number_not_zero``), which the native pilot does not; compare
+    by position, not by cycle number.
+    """
+    import warnings
+
+    import cellpy
+    import cellpy.utils.example_data as ed
+    from cellpy.readers.instruments.maccor_txt_native import MaccorTxtLoader
+
+    source = ed.maccor_file_path()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        legacy = cellpy.get(
+            source, instrument="maccor_txt", model="THREE", mass=1.0, testing=True
+        )
+    legacy_summary = legacy.data.summary
+    legacy_charge = legacy_summary[legacy.schema.summary.charge_capacity].tolist()
+    legacy_discharge = legacy_summary[
+        legacy.schema.summary.discharge_capacity
+    ].tolist()
+
+    raw = MaccorTxtLoader().load(source)[0].raw
+    per_cycle = raw.group_by(SCHEMA.cycle_num, maintain_order=True).agg(
+        pl.col(SCHEMA.cumulative_charge_capacity).last().alias("charge"),
+        pl.col(SCHEMA.cumulative_discharge_capacity).last().alias("discharge"),
+    )
+    native_charge = per_cycle["charge"].to_list()
+    native_discharge = per_cycle["discharge"].to_list()
+
+    assert len(native_charge) == len(legacy_charge)
+    for cycle, (native, legacy_value) in enumerate(
+        zip(native_charge, legacy_charge), start=1
+    ):
+        assert native == pytest.approx(legacy_value, rel=1e-9), (
+            f"charge capacity disagrees at cycle {cycle}: harmonized {native} "
+            f"vs legacy {legacy_value} — check the reset_granularity declaration"
+        )
+    for cycle, (native, legacy_value) in enumerate(
+        zip(native_discharge, legacy_discharge), start=1
+    ):
+        assert native == pytest.approx(legacy_value, rel=1e-9), (
+            f"discharge capacity disagrees at cycle {cycle}: harmonized {native} "
+            f"vs legacy {legacy_value} — check the reset_granularity declaration"
+        )
+
+
+@pytest.mark.essential
+def test_a_wrong_granularity_declaration_would_be_caught():
+    """Prove the property test above has teeth.
+
+    Re-run the same comparison with the declaration deliberately wrong; the
+    per-cycle values must then disagree. A property test that cannot fail is
+    not protecting anything.
+    """
+    import warnings
+
+    import cellpy.utils.example_data as ed
+    from cellpy.readers.instruments import maccor_txt_native as pilot
+
+    source = ed.maccor_file_path()
+
+    correct = pilot.MaccorTxtLoader().load(source)[0].raw
+    correct_per_cycle = (
+        correct.group_by(SCHEMA.cycle_num, maintain_order=True)
+        .agg(pl.col(SCHEMA.cumulative_charge_capacity).last().alias("charge"))["charge"]
+        .to_list()
+    )
+
+    wrong_declarations = LoaderDeclarations(
+        column_map=dict(pilot.MACCOR_THREE.column_map),
+        raw_units=pilot.MACCOR_THREE.raw_units,
+        reset_granularity={
+            SCHEMA.cumulative_charge_capacity: ResetGranularity.PER_TEST,
+            SCHEMA.cumulative_discharge_capacity: ResetGranularity.PER_TEST,
+        },
+        post_hooks=pilot.MACCOR_THREE.post_hooks,
+    )
+
+    class WrongLoader(pilot.MaccorTxtLoader):
+        declarations = wrong_declarations
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        wrong = WrongLoader().load(source)[0].raw
+    wrong_per_cycle = (
+        wrong.group_by(SCHEMA.cycle_num, maintain_order=True)
+        .agg(pl.col(SCHEMA.cumulative_charge_capacity).last().alias("charge"))["charge"]
+        .to_list()
+    )
+
+    assert wrong_per_cycle != correct_per_cycle, (
+        "a deliberately wrong reset_granularity produced identical capacities; "
+        "the property test would not catch a real mis-declaration"
+    )


### PR DESCRIPTION
Closes #559. Stage 3.2. Builds on #210; unblocks #560/#561.

The shared normalization stage. Loaders keep the genuinely hard part — parsing
their vendor's file — and **declare** everything after it:

```
vendor file ──parse()──► vendor frame + declarations ──harmonize()──► native raw
```

## Declarations fail at import, not mid-load

`LoaderDeclarations` validates when it is constructed, which is when the
configuration module is imported. A typo'd native column name is then an import
error naming the typo, rather than something obscure in a user's load six months
later. It also rejects two vendor columns mapped onto one native column (the
later would silently win), a granularity declared for a column the map never
produces (looks meaningful, does nothing), and aux names that break the
`aux_<quantity>_<name>` scheme.

## Reset granularity — the part worth reviewing carefully

This is the correctness landmine of the port, so the target matters: the
harmonized-raw spec wants capacities **cycle-cumulative per direction**,
resetting at each cycle boundary.

I had assumed *test*-cumulative and would have written a subtly wrong
normaliser; reading `docs/specifications/harmonized-raw.md` corrected it. So
`PER_CYCLE` is a no-op, `PER_TEST` rebases each cycle, `PER_STEP` re-accumulates
completed steps within a cycle.

The unit tests carry **hand-computed** expectations rather than values read back
from the implementation — a wrong conversion doesn't raise, it silently
rescales every capacity in the dataset, so the test has to know the answer
independently.

## The pilot

`maccor_txt_native.py` — the first loader written as
`harmonize(parse(source), declarations)`, conforming structurally to the #210
Protocol. It runs **alongside** the legacy `maccor_txt` loader and changes
nothing about the existing path; the swap is #560.

Its granularity was determined from the data, not assumed: `mAmp-hr` resets when
direction changes within a cycle and continues across same-direction steps, so
once split by `State` each column is already cycle-cumulative.

## The property test, and proof it has teeth

Per-cycle capacities recomputed from the harmonized raw are compared against the
legacy pipeline's summary on the real Maccor file — they agree exactly.

A companion test re-runs the same comparison with a deliberately **wrong**
granularity declaration and asserts the values then differ. A property test that
cannot fail protects nothing, and this is the test the whole loader port leans
on.

## Note

Getting that comparison to work at all required fixing #580 first — the legacy
oracle was returning zeros. The two paths agreeing afterwards (906.1120 mAh from
both) is decent mutual evidence that neither is wrong.

## Not in scope

`LegacyLoaderAdapter` removal and porting the other loaders (#560); tier-3
decisions (#561). The conformance kit's reset-granularity check (§5.5 check 7)
can now be added on top of this — I've left it for #560 where there are several
ported loaders to run it against.

## Tests

18 in `tests/test_harmonize.py`. Full suite: 782 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
