### PR TITLE
#560 (part 1): derive loader declarations from the existing configurations

### DIFF
--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -1,0 +1,190 @@
+"""Derive loader declarations from the existing configurations (issue #560).
+
+Every ``configurations/*`` module already says how its vendor columns map to
+the *legacy* header attributes, and cellpy-core already says how legacy
+attributes map to *native* columns. Composing the two gives vendor → native
+without anyone retyping sixteen column maps::
+
+    config: legacy_attr -> vendor        (normal_headers_renaming_dict)
+    core:   legacy_attr -> native        (mapping.LEGACY_ATTR_TO_SCHEMA)
+    ------------------------------------------------------------------
+    derived: vendor -> native
+
+Deriving beats transcribing for the obvious reason — a hand-copied map is a
+place for silent typos, and a wrong column mapping produces plausible numbers
+rather than an error. It also makes the port self-updating: a legacy attribute
+with no native counterpart lands in ``passthrough`` today and moves into
+``column_map`` by itself the moment cellpy-core adds the entry (the live case
+is the energy columns, cellpy-core#139).
+
+This module does **not** change how anything loads. It builds declarations so
+they can be compared against the legacy path (see
+``tests/test_derived_declarations.py``); switching ingestion over is separate.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import ModuleType
+from typing import Any
+
+from cellpycore.legacy import mapping
+from cellpycore.units import CellpyUnits
+
+from cellpy.parameters.internal_settings import get_headers_normal
+from cellpy.readers.instruments.declarations import (
+    LoaderDeclarations,
+    ResetGranularity,
+)
+
+#: Native columns whose reset granularity a vendor could plausibly differ on.
+#: Defaulted to the harmonized-raw target (cycle-cumulative per direction);
+#: a configuration that knows better overrides it explicitly.
+_CUMULATIVE_DEFAULTS = (
+    "cumulative_charge_capacity",
+    "cumulative_discharge_capacity",
+    "cumulative_charge_energy",
+    "cumulative_discharge_energy",
+)
+
+#: Legacy attributes that must not reach the raw frame at all.
+#:
+#: The vendor's own test identifier is *provenance*, not a measurement: it
+#: belongs on ``TestMeta`` (issue #508 routes it to
+#: ``meta_test_dependent.test_ID``). Passing it through would also collide with
+#: the native ``test_id``, which is the framework-assigned grouping key for
+#: merged tests — two different meanings, one name, and the vendor's value
+#: would quietly win.
+_PROVENANCE_ATTRS = frozenset({"test_id_txt"})
+
+
+def _legacy_column_name(legacy_attr: str) -> str | None:
+    """The column name the legacy path would have used for this attribute."""
+    return getattr(get_headers_normal(), legacy_attr, None)
+
+
+def derive_column_maps(
+    renaming: dict[str, str],
+) -> tuple[dict[str, str], dict[str, str], list[str]]:
+    """Split a configuration's renaming dict into native, passthrough, unknown.
+
+    Args:
+        renaming: ``legacy_attr -> vendor column``, as the configurations
+            declare it.
+
+    Returns:
+        ``(column_map, passthrough, unknown)`` where ``column_map`` is
+        vendor → native for attributes cellpy-core can map, ``passthrough`` is
+        vendor → legacy column name for real data with no native column yet,
+        and ``unknown`` lists attributes that are neither — a configuration
+        naming something no longer recognised anywhere.
+
+    A vendor column claimed by more than one legacy attribute is **ambiguous**:
+    only one target can win, and the other is silently lost. ``maccor_txt_one``
+    does this today, mapping ``Watt-hr`` to both ``power_txt`` and
+    ``charge_energy_txt``. The first declaration wins here, matching what the
+    legacy path is observed to produce, and the collision is logged rather than
+    resolved silently.
+    """
+    raw_mapping = mapping.LEGACY_ATTR_TO_SCHEMA["raw"]
+
+    column_map: dict[str, str] = {}
+    passthrough: dict[str, str] = {}
+    unknown: list[str] = []
+    claimed: dict[str, str] = {}
+
+    for legacy_attr, vendor in renaming.items():
+        if legacy_attr in _PROVENANCE_ATTRS:
+            continue
+
+        if vendor in claimed:
+            logging.warning(
+                "vendor column %r is claimed by both %r and %r; keeping %r "
+                "(the first declaration) — the configuration should name one",
+                vendor,
+                claimed[vendor],
+                legacy_attr,
+                claimed[vendor],
+            )
+            continue
+        claimed[vendor] = legacy_attr
+
+        native = raw_mapping.get(legacy_attr)
+        if native is not None:
+            column_map[vendor] = native
+            continue
+        legacy_name = _legacy_column_name(legacy_attr)
+        if legacy_name is not None:
+            passthrough[vendor] = legacy_name
+            continue
+        unknown.append(legacy_attr)
+
+    return column_map, passthrough, unknown
+
+
+def _units_from_configuration(config: ModuleType) -> CellpyUnits:
+    raw_units: dict[str, Any] | None = getattr(config, "raw_units", None)
+    if not raw_units:
+        return CellpyUnits()
+    known = {
+        key: value
+        for key, value in raw_units.items()
+        if hasattr(CellpyUnits(), key) and isinstance(value, str)
+    }
+    return CellpyUnits(**known)
+
+
+def declarations_from_configuration(
+    config: ModuleType,
+    *,
+    reset_granularity: dict[str, ResetGranularity] | None = None,
+    post_hooks: tuple = (),
+    timezone: str | None = None,
+) -> LoaderDeclarations:
+    """Build validated declarations from an existing configuration module.
+
+    Args:
+        config: a ``cellpy.readers.instruments.configurations.*`` module.
+        reset_granularity: overrides for columns whose vendor granularity is
+            not the harmonized-raw default. **Read the vendor's data before
+            setting one** — a wrong value here silently rescales capacities.
+        post_hooks: vendor-quirk callables (e.g. capacity splitting).
+        timezone: IANA zone for naive vendor timestamps.
+
+    Returns:
+        A validated :class:`LoaderDeclarations`.
+
+    Raises:
+        LoaderError: if the derived declarations do not validate — which is the
+            point: it happens at import of the configuration, not mid-load.
+    """
+    renaming = getattr(config, "normal_headers_renaming_dict", None)
+    if not renaming:
+        raise ValueError(
+            f"{config.__name__} has no normal_headers_renaming_dict; nothing to derive"
+        )
+
+    column_map, passthrough, unknown = derive_column_maps(renaming)
+    if unknown:
+        logging.debug(
+            "%s declares legacy attributes with no native or legacy column: %s",
+            config.__name__,
+            sorted(unknown),
+        )
+
+    granularity: dict[str, ResetGranularity] = {
+        column: ResetGranularity.PER_CYCLE
+        for column in _CUMULATIVE_DEFAULTS
+        if column in set(column_map.values())
+    }
+    if reset_granularity:
+        granularity.update(reset_granularity)
+
+    return LoaderDeclarations(
+        column_map=column_map,
+        raw_units=_units_from_configuration(config),
+        timezone=timezone,
+        reset_granularity=granularity,
+        passthrough=passthrough,
+        post_hooks=post_hooks,
+    )

--- a/cellpy/readers/instruments/configurations/batmo_bdf_bdf.py
+++ b/cellpy/readers/instruments/configurations/batmo_bdf_bdf.py
@@ -7,7 +7,7 @@ raw_units = {
     "voltage": "V",
     "energy": "Wh",
     "power": "W",
-    "resistance": "Ohm",
+    "resistance": "ohm",  # pint-parsable ("Ohm" is not); #560
 }
 
 normal_headers_renaming_dict = {

--- a/cellpy/readers/instruments/configurations/neware_txt_one.py
+++ b/cellpy/readers/instruments/configurations/neware_txt_one.py
@@ -7,7 +7,7 @@ raw_units = {
     "voltage": "V",
     "energy": "mWh",
     "power": "mW",
-    "resistance": "mOhm",
+    "resistance": "mohm",  # pint-parsable ("mOhm" is not); #560
 }
 
 unit_labels = {

--- a/cellpy/readers/instruments/configurations/neware_txt_two.py
+++ b/cellpy/readers/instruments/configurations/neware_txt_two.py
@@ -7,7 +7,7 @@ raw_units = {
     "voltage": "V",
     "energy": "mWh",
     "power": "mW",
-    "resistance": "mOhm",
+    "resistance": "mohm",  # pint-parsable ("mOhm" is not); #560
 }
 
 unit_labels = {

--- a/cellpy/readers/instruments/configurations/neware_txt_zero.py
+++ b/cellpy/readers/instruments/configurations/neware_txt_zero.py
@@ -7,7 +7,7 @@ raw_units = {
     "voltage": "V",
     "energy": "Wh",
     "power": "W",
-    "resistance": "mOhm",
+    "resistance": "mohm",  # pint-parsable ("mOhm" is not); #560
 }
 
 normal_headers_renaming_dict = {

--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -62,9 +62,23 @@ class LoaderDeclarations:
             vendor file. Columns not listed are assumed already cycle-
             cumulative, which is the common case and the target convention.
         aux_map: vendor column → ``aux_<quantity>_<name>``.
+        passthrough: vendor column → the name it keeps, for data the native
+            schema has no column for. See the note below.
         post_hooks: callables applied to the vendor frame *before* renaming,
             for quirks no declaration can express (e.g. Maccor's single
             signed capacity column that must be split by direction).
+
+    **On ``passthrough``.** ``harmonize()`` drops undeclared columns, which is
+    what stops vendor junk leaking into native frames. But some real
+    measurements have no native column *yet* — energies are the live example
+    (cellpy-core#139), and ``date_time`` may never get one. Dropping those
+    would lose data that the current ``to_native()`` path preserves, so they
+    are carried through under a stated name instead.
+
+    This is deliberately a transitional escape hatch, and it is derived rather
+    than hand-written (see ``declarations_from_configuration``): when the
+    legacy⇄native mapping gains an entry, that column moves from
+    ``passthrough`` into ``column_map`` on its own, with no loader edit.
     """
 
     column_map: Mapping[str, str]
@@ -72,6 +86,7 @@ class LoaderDeclarations:
     timezone: str | None = None
     reset_granularity: Mapping[str, ResetGranularity] = field(default_factory=dict)
     aux_map: Mapping[str, str] = field(default_factory=dict)
+    passthrough: Mapping[str, str] = field(default_factory=dict)
     post_hooks: tuple[Callable, ...] = ()
 
     def __post_init__(self) -> None:
@@ -121,6 +136,14 @@ class LoaderDeclarations:
                 f"produces; the declaration would have no effect."
             )
 
+        shadowing = sorted(set(self.passthrough.values()) & native_names)
+        if shadowing:
+            raise LoaderError(
+                f"passthrough keeps {shadowing} under a name the native schema "
+                f"already owns; map those in column_map instead so they are "
+                f"cast and validated like any other native column."
+            )
+
         bad_aux = sorted(
             target for target in self.aux_map.values() if not _AUX_PATTERN.match(target)
         )
@@ -136,3 +159,8 @@ class LoaderDeclarations:
     def native_columns(self) -> tuple[str, ...]:
         """Native columns this loader produces, aux included."""
         return tuple(self.column_map.values()) + tuple(self.aux_map.values())
+
+    @property
+    def all_columns(self) -> tuple[str, ...]:
+        """Every column the loader emits, passthrough included."""
+        return self.native_columns + tuple(self.passthrough.values())

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -236,7 +236,13 @@ def harmonize(
     for hook in declarations.post_hooks:
         raw = hook(raw)
 
-    mapping = {**declarations.column_map, **declarations.aux_map}
+    # Passthrough columns are renamed alongside the native ones; they simply
+    # keep a name the schema does not own (see LoaderDeclarations.passthrough).
+    mapping = {
+        **declarations.column_map,
+        **declarations.aux_map,
+        **declarations.passthrough,
+    }
     missing = [vendor for vendor in mapping if vendor not in raw.columns]
     if missing:
         logging.debug("declared vendor columns absent from this file: %s", missing)

--- a/tests/data/goldens/loader_neware_txt/raw_units.json
+++ b/tests/data/goldens/loader_neware_txt/raw_units.json
@@ -9,7 +9,7 @@
   "nominal_capacity": "mAh/g",
   "power": "W",
   "pressure": "bar",
-  "resistance": "mOhm",
+  "resistance": "mohm",
   "specific_areal": "cm**2",
   "specific_gravimetric": "g",
   "specific_volumetric": "cm**3",

--- a/tests/test_derived_declarations.py
+++ b/tests/test_derived_declarations.py
@@ -170,21 +170,23 @@ PARITY_CASES = (
 
 
 def _vendor_header(source: str, config) -> set[str]:
-    """The vendor column names actually present in the file."""
-    import polars as pl
+    """The vendor column names actually present in the file.
 
+    Reads the header line directly rather than via a CSV parser: we only want
+    the names, and asking a parser for them means it also infers dtypes from
+    the data, which then fails on values the inference sample did not cover
+    (it did, on Linux, for neware's ``Capacity(Ah)``).
+    """
     formatters = getattr(config, "formatters", {}) or {}
-    frame = pl.read_csv(
-        source,
-        separator=formatters.get("sep") or ",",
-        skip_rows=formatters.get("skiprows", 0) or 0,
-        has_header=True,
-        encoding="utf8-lossy",
-        truncate_ragged_lines=True,
-        n_rows=1,
-        infer_schema_length=1,
-    )
-    return set(frame.columns)
+    separator = formatters.get("sep") or ","
+    skiprows = formatters.get("skiprows", 0) or 0
+
+    with open(source, "r", encoding="utf-8", errors="replace") as handle:
+        for _ in range(skiprows):
+            handle.readline()
+        header = handle.readline()
+
+    return {name.strip() for name in header.rstrip("\n").split(separator)}
 
 
 @pytest.mark.essential

--- a/tests/test_derived_declarations.py
+++ b/tests/test_derived_declarations.py
@@ -1,0 +1,268 @@
+"""Declarations derived from the existing configurations (#560).
+
+Deriving vendor→native from what the configurations already say — rather than
+retyping sixteen column maps — is the mechanical half of the loader port. These
+tests check the derivation against reality: the shipped configurations, and the
+frames the legacy path actually produces for the in-tree test files.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+import warnings
+
+import pytest
+from cellpycore.config import default_schema
+from cellpycore.units import validate_units
+
+from cellpy import log
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments import configurations
+from cellpy.readers.instruments.config_declarations import (
+    declarations_from_configuration,
+    derive_column_maps,
+)
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+SCHEMA = default_schema().raw
+
+#: Configurations that carry a vendor→legacy renaming dict.
+TIER_ONE_CONFIGS = (
+    "maccor_txt_one",
+    "maccor_txt_two",
+    "maccor_txt_three",
+    "neware_txt_zero",
+    "neware_txt_one",
+    "neware_txt_two",
+)
+
+
+def _config(name: str):
+    return importlib.import_module(
+        f"cellpy.readers.instruments.configurations.{name}"
+    )
+
+
+def _all_configuration_modules():
+    for info in pkgutil.iter_modules(configurations.__path__):
+        if info.name.startswith("_"):
+            continue
+        yield info.name, importlib.import_module(
+            f"cellpy.readers.instruments.configurations.{info.name}"
+        )
+
+
+# -- every shipped configuration must declare valid units ----------------------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", [n for n, _ in _all_configuration_modules()])
+def test_every_shipped_configuration_has_parsable_units(name):
+    """Loader plan §5: every shipped configuration passes validate_units.
+
+    This is the test that caught `resistance: "mOhm"` in the three neware
+    configurations — pint parses `mohm`, not `mOhm`, so the label had been
+    unusable since it was written.
+    """
+    config = _config(name)
+    raw_units = getattr(config, "raw_units", None)
+    if not raw_units:
+        pytest.skip(f"{name} declares no raw_units")
+
+    from cellpycore.units import CellpyUnits
+
+    known = {
+        key: value
+        for key, value in raw_units.items()
+        if hasattr(CellpyUnits(), key) and isinstance(value, str)
+    }
+    validate_units(CellpyUnits(**known))
+
+
+# -- the derivation ------------------------------------------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", TIER_ONE_CONFIGS)
+def test_tier_one_configurations_derive(name):
+    """A configuration that cannot be expressed as declarations blocks the port."""
+    declarations = declarations_from_configuration(_config(name))
+    assert declarations.column_map, f"{name} produced an empty column map"
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", TIER_ONE_CONFIGS)
+def test_derived_targets_are_real_native_columns(name):
+    declarations = declarations_from_configuration(_config(name))
+    native = set(SCHEMA.ordered_names())
+    assert set(declarations.column_map.values()) <= native
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", TIER_ONE_CONFIGS)
+def test_passthrough_never_shadows_a_native_column(name):
+    """A passthrough column must not squat on a name the schema owns."""
+    declarations = declarations_from_configuration(_config(name))
+    native = set(SCHEMA.ordered_names())
+    assert not (set(declarations.passthrough.values()) & native)
+
+
+@pytest.mark.essential
+def test_vendor_test_id_is_not_carried_into_raw():
+    """The vendor's Test_ID is provenance, and would collide with test_id.
+
+    Native ``test_id`` is the framework-assigned grouping key for merged tests.
+    The vendor's identifier means something else entirely and belongs on
+    TestMeta (#508) — letting it through would give one name two meanings, with
+    the vendor's value quietly winning.
+    """
+    config = _config("maccor_txt_one")
+    assert "test_id_txt" in config.normal_headers_renaming_dict
+    declarations = declarations_from_configuration(config)
+    assert SCHEMA.test_id not in declarations.column_map.values()
+    assert SCHEMA.test_id not in declarations.passthrough.values()
+
+
+@pytest.mark.essential
+def test_energies_are_passthrough_until_the_core_mapping_lands():
+    """Documents the cellpy-core#139 gap as a tested fact, not a surprise.
+
+    The native schema has ``cumulative_charge_energy`` but no legacy attribute
+    maps to it, so energy data survives only as a passthrough. When core adds
+    the entry this test should start failing — which is the point.
+    """
+    declarations = declarations_from_configuration(_config("neware_txt_one"))
+    assert "charge_energy" in declarations.passthrough.values()
+    assert SCHEMA.cumulative_charge_energy not in declarations.column_map.values()
+
+
+@pytest.mark.essential
+def test_passthrough_shrinks_when_the_mapping_gains_an_entry(monkeypatch):
+    """The self-updating property: no loader edit when core#139 lands.
+
+    Simulate the core mapping gaining the energy entry and assert the column
+    moves from passthrough into column_map on its own.
+    """
+    from cellpycore.legacy import mapping
+
+    patched = dict(mapping.LEGACY_ATTR_TO_SCHEMA["raw"])
+    patched["charge_energy_txt"] = SCHEMA.cumulative_charge_energy
+    monkeypatch.setitem(mapping.LEGACY_ATTR_TO_SCHEMA, "raw", patched)
+
+    renaming = _config("neware_txt_one").normal_headers_renaming_dict
+    column_map, passthrough, _ = derive_column_maps(renaming)
+
+    assert SCHEMA.cumulative_charge_energy in column_map.values()
+    assert "charge_energy" not in passthrough.values()
+
+
+# -- parity against the frames the legacy path actually produces ---------------
+
+PARITY_CASES = (
+    ("maccor_txt", "maccor_txt_one", "testdata/data/maccor_001.txt",
+     {"model": "one", "sep": "\t"}),
+    ("neware_txt", "neware_txt_one", "testdata/data/neware_uio.csv",
+     {"model": "one"}),
+)
+
+
+def _vendor_header(source: str, config) -> set[str]:
+    """The vendor column names actually present in the file."""
+    import polars as pl
+
+    formatters = getattr(config, "formatters", {}) or {}
+    frame = pl.read_csv(
+        source,
+        separator=formatters.get("sep") or ",",
+        skip_rows=formatters.get("skiprows", 0) or 0,
+        has_header=True,
+        encoding="utf8-lossy",
+        truncate_ragged_lines=True,
+        n_rows=1,
+        infer_schema_length=1,
+    )
+    return set(frame.columns)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, config_name, source, kwargs", PARITY_CASES)
+def test_declared_columns_present_in_the_file_reach_the_legacy_frame(
+    instrument, config_name, source, kwargs
+):
+    """Parity of the derivation against what the legacy path really produces.
+
+    Only columns the vendor file *actually contains* are checked: the
+    configurations legitimately declare columns for other variants of the same
+    format (maccor_txt_one has a whole block commented "not observed yet"), and
+    ``harmonize()`` tolerates declared-but-absent columns by design.
+
+    What must hold is the other direction — if the file has a declared vendor
+    column, the derivation's target name must be what the legacy path ends up
+    calling it. A mismatch here means the port would rename something to the
+    wrong place, which produces plausible numbers rather than an error.
+    """
+    import cellpy
+
+    config = _config(config_name)
+    declarations = declarations_from_configuration(config)
+    present_vendor = _vendor_header(source, config)
+
+    expected = {
+        target
+        for vendor, target in {
+            **declarations.column_map,
+            **declarations.passthrough,
+        }.items()
+        if vendor in present_vendor
+    }
+    assert expected, f"no declared column of {config_name} is present in {source}"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cell = cellpy.get(source, instrument=instrument, mass=1.0, testing=True, **kwargs)
+
+    actual = set(cell.data.raw.columns)
+    missing = sorted(expected - actual)
+    assert not missing, (
+        f"{config_name}: columns present in {source} but absent from the legacy "
+        f"frame under their derived names: {missing}"
+    )
+
+
+@pytest.mark.essential
+def test_derivation_rejects_an_invalid_configuration():
+    """A configuration that cannot be expressed must fail at derivation time."""
+
+    class BogusConfig:
+        __name__ = "bogus"
+        normal_headers_renaming_dict = {"voltage_txt": "V"}
+        raw_units = {"voltage": "not_a_unit"}
+
+    with pytest.raises(LoaderError, match="not a valid unit spec"):
+        declarations_from_configuration(BogusConfig)
+
+
+@pytest.mark.essential
+def test_ambiguous_vendor_column_is_detected_and_resolved_deterministically():
+    """One vendor column claimed by two legacy attributes loses one of them.
+
+    `maccor_txt_one` maps `Watt-hr` to both `power_txt` and
+    `charge_energy_txt`. Only one target can win; the derivation keeps the
+    first declaration (matching what the legacy path is observed to produce)
+    and logs the collision instead of picking silently.
+    """
+    renaming = _config("maccor_txt_one").normal_headers_renaming_dict
+    claimed_twice = [
+        vendor
+        for vendor in set(renaming.values())
+        if list(renaming.values()).count(vendor) > 1
+    ]
+    assert "Watt-hr" in claimed_twice, "fixture assumption changed"
+
+    column_map, passthrough, _ = derive_column_maps(renaming)
+    targets = {**column_map, **passthrough}
+    # power_txt is declared before charge_energy_txt, so power wins.
+    assert targets["Watt-hr"] == "power"


### PR DESCRIPTION
Part 1 of #560 — the declarations. **No ingestion change.**

## Derive, don't transcribe

Every configuration already says `legacy_attr -> vendor`, and cellpy-core says
`legacy_attr -> native`. Composing them gives `vendor -> native` without anyone
retyping sixteen column maps:

```
config: legacy_attr -> vendor   (normal_headers_renaming_dict)
core:   legacy_attr -> native   (LEGACY_ATTR_TO_SCHEMA)
------------------------------------------------------------
derived: vendor -> native
```

A hand-copied map is a place for silent typos, and a wrong column mapping
produces *plausible numbers* rather than an error — the worst failure mode.

It also self-updates: an attribute with no native counterpart lands in
`passthrough` and moves into `column_map` **by itself** when core adds the
entry. There's a test that simulates cellpy-core#139 landing and asserts the
energy column migrates with no loader edit.

## Why `passthrough` exists

`harmonize()` drops undeclared columns — that's what keeps vendor junk out of
native frames. But energies (core#139) and `date_time` have no native column,
and dropping them would lose data the current `to_native()` path preserves. So
they're carried under a stated name, and may not shadow a name the schema owns.

## Four defects this surfaced

Validating what was previously unvalidated turned up real problems:

1. **`resistance: "mOhm"`** in all three neware configs doesn't parse — pint
   wants `mohm`. **`"Ohm"`** in `batmo_bdf` likewise. Both had been unusable
   since they were written. The loader plan asks that every shipped
   configuration pass `validate_units`; there's now a test for exactly that,
   and it's what caught these.
2. **`maccor_txt_one` maps `Watt-hr` to two legacy attributes** (`power_txt`
   *and* `charge_energy_txt`). Only one can win; the other is silently lost.
   The derivation keeps the first (matching observed legacy behaviour) and
   **logs** the collision rather than choosing silently. Worth a follow-up to
   disambiguate the config properly.
3. **The vendor's `Test_ID` was heading for the native `test_id`** — which is
   the framework-assigned grouping key for merged tests. Two meanings, one
   name, vendor value quietly winning. Vendor test ids are provenance and
   belong on TestMeta (#508), so they're excluded from raw.
4. **The neware golden recorded the unparsable `mOhm`** and is regenerated —
   the same "golden captured from broken code" pattern as #580.

## On scope

I stopped short of switching ingestion over. There's no `LegacyLoaderAdapter`
class; the transitional mechanism is `to_native()` at `cellreader.py:1368`, so
retiring it means flipping every loader at once — a flag-day on the path all
data enters cellpy. That deserves its own PR, its own parity run, and it's
partly gated on core#139.

Worth noting for that PR: the legacy path passes *unrecognised* vendor columns
through (neware keeps `Step Type`, `dQ/dV(mAh/V)`, …) while `harmonize()` drops
them. Someone should decide whether any of those are load-bearing before the
switch.

## Tests

33 in `tests/test_derived_declarations.py`, including per-loader parity against
the frames the legacy path really produces (restricted to columns the vendor
file actually contains, since configs legitimately declare columns for other
variants of the same format). Full suite: 815 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
