### PR TITLE
#562: MetaResolver with layered precedence and provenance

### DIFF
--- a/cellpy/readers/meta_resolver.py
+++ b/cellpy/readers/meta_resolver.py
@@ -1,0 +1,300 @@
+"""Layered metadata resolution with provenance (metadata plan Step 3, #562).
+
+Metadata about a cell arrives from four places at once — what the user passed
+in, what the batch journal or database says, what the instrument wrote into the
+file, and what the configuration defaults to. Until now they were merged
+ad hoc at whichever call site happened to run first, which is why *"why is my
+mass 1.0?"* was not answerable without reading the code.
+
+The precedence is fixed and boring, most specific first::
+
+    kwargs  >  journal / db  >  raw file  >  config defaults
+
+and every resolved field records **which layer won**. That record is the point:
+a batch run that silently used a default mass for one cell out of forty is
+otherwise invisible until the capacities look strange.
+
+A layer only contributes a field if it actually has a value for it — ``None``
+means "I don't know", not "make it None". So a journal that knows the mass but
+not the nominal capacity lets the file's nominal capacity through.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import IntEnum
+from typing import Any, Iterable, Mapping
+
+
+class Layer(IntEnum):
+    """Where a metadata value came from. Higher wins."""
+
+    CONFIG_DEFAULT = 0
+    RAW_FILE = 1
+    JOURNAL = 2
+    KWARGS = 3
+
+    @property
+    def label(self) -> str:
+        return {
+            Layer.CONFIG_DEFAULT: "config default",
+            Layer.RAW_FILE: "raw file",
+            Layer.JOURNAL: "journal/db",
+            Layer.KWARGS: "user argument",
+        }[self]
+
+
+@dataclass
+class Resolution:
+    """The outcome of resolving one metadata object."""
+
+    #: field name -> the layer that supplied the winning value
+    sources: dict[str, Layer] = field(default_factory=dict)
+
+    def source_of(self, name: str) -> Layer | None:
+        """Which layer supplied ``name``, or None if nothing did."""
+        return self.sources.get(name)
+
+    def fields_from(self, layer: Layer) -> tuple[str, ...]:
+        """Every field this layer won."""
+        return tuple(
+            sorted(name for name, won in self.sources.items() if won is layer)
+        )
+
+    def explain(self) -> str:
+        """Human-readable per-field provenance, for logs and debugging."""
+        if not self.sources:
+            return "no metadata resolved"
+        lines = [
+            f"  {name}: {layer.label}"
+            for name, layer in sorted(self.sources.items(), key=lambda kv: kv[0])
+        ]
+        return "resolved metadata:\n" + "\n".join(lines)
+
+
+def _as_mapping(source: Any) -> Mapping[str, Any]:
+    """Read a layer as a plain field→value mapping.
+
+    Layers arrive as dataclasses (a draft ``TestMeta``), pydantic models
+    (config defaults) or plain dicts (kwargs, journal rows); normalise them
+    rather than making every caller do it.
+    """
+    if source is None:
+        return {}
+    if isinstance(source, Mapping):
+        return source
+    if is_dataclass(source):
+        return {f.name: getattr(source, f.name) for f in fields(source)}
+    dump = getattr(source, "model_dump", None)
+    if callable(dump):
+        return dump()
+    return {
+        name: getattr(source, name)
+        for name in dir(source)
+        if not name.startswith("_") and not callable(getattr(source, name, None))
+    }
+
+
+class MetaResolver:
+    """Merge metadata layers into one object, remembering who won.
+
+    Args:
+        target_fields: the field names the result may carry. Anything a layer
+            offers that is not in here is ignored — a journal column that
+            happens to share a name with nothing in particular should not
+            invent a metadata field.
+    """
+
+    def __init__(self, target_fields: Iterable[str]) -> None:
+        self._target_fields = tuple(target_fields)
+
+    def resolve(
+        self,
+        *,
+        kwargs: Any = None,
+        journal: Any = None,
+        raw_file: Any = None,
+        config_defaults: Any = None,
+        into: Any = None,
+    ) -> tuple[Any, Resolution]:
+        """Resolve the layers onto ``into``.
+
+        Args:
+            kwargs: what the user passed explicitly. Wins over everything.
+            journal: batch journal or database row.
+            raw_file: the loader's draft — what the instrument file knew.
+            config_defaults: the session's ``ScienceDefaults``-style values.
+            into: the object to populate (mutated and returned). Required.
+
+        Returns:
+            ``(into, resolution)``.
+        """
+        if into is None:
+            raise ValueError("resolve() needs an object to populate (into=)")
+
+        layers = (
+            (Layer.CONFIG_DEFAULT, _as_mapping(config_defaults)),
+            (Layer.RAW_FILE, _as_mapping(raw_file)),
+            (Layer.JOURNAL, _as_mapping(journal)),
+            (Layer.KWARGS, _as_mapping(kwargs)),
+        )
+
+        resolution = Resolution()
+        for layer, values in layers:
+            for name in self._target_fields:
+                if name not in values:
+                    continue
+                value = values[name]
+                # None means "this layer has nothing to say", not "set None" —
+                # otherwise a journal with blank columns would erase what the
+                # instrument file knew.
+                if value is None:
+                    continue
+                setattr(into, name, value)
+                resolution.sources[name] = layer
+
+        return into, resolution
+
+
+def resolve_cell_meta(
+    cell_meta: Any,
+    *,
+    kwargs: Mapping[str, Any] | None = None,
+    journal: Any = None,
+    draft: Any = None,
+    config_defaults: Any = None,
+) -> tuple[Any, Resolution]:
+    """Resolve a ``CellMeta``: the cell's own properties (mass, area, …)."""
+    resolver = MetaResolver(_field_names(cell_meta))
+    return resolver.resolve(
+        kwargs=kwargs,
+        journal=journal,
+        raw_file=draft,
+        config_defaults=config_defaults,
+        into=cell_meta,
+    )
+
+
+def resolve_test_meta(
+    test_meta: Any,
+    *,
+    kwargs: Mapping[str, Any] | None = None,
+    journal: Any = None,
+    draft: Any = None,
+    config_defaults: Any = None,
+) -> tuple[Any, Resolution]:
+    """Resolve a ``TestMeta``: what this particular run was."""
+    resolver = MetaResolver(_field_names(test_meta))
+    return resolver.resolve(
+        kwargs=kwargs,
+        journal=journal,
+        raw_file=draft,
+        config_defaults=config_defaults,
+        into=test_meta,
+    )
+
+
+def _field_names(obj: Any) -> tuple[str, ...]:
+    if is_dataclass(obj):
+        return tuple(f.name for f in fields(obj))
+    return tuple(_as_mapping(obj))
+
+
+def science_defaults_for_cell(defaults: Any) -> dict[str, Any]:
+    """Map the config's ``ScienceDefaults`` onto ``CellMeta`` field names.
+
+    The configuration spells them ``default_mass`` / ``default_nom_cap``
+    (historically ``prms.Materials.*``); the metadata model spells them ``mass``
+    / ``nom_cap``. Translating here keeps the resolver ignorant of both.
+    """
+    if defaults is None:
+        return {}
+
+    materials = getattr(defaults, "materials", None)
+    cell_info = getattr(defaults, "cell_info", None)
+
+    mapped: dict[str, Any] = {}
+    if materials is not None:
+        mapped.update(
+            {
+                "mass": getattr(materials, "default_mass", None),
+                "nom_cap": getattr(materials, "default_nom_cap", None),
+                "nom_cap_specifics": getattr(
+                    materials, "default_nom_cap_specifics", None
+                ),
+                "material": getattr(materials, "default_material", None),
+            }
+        )
+    if cell_info is not None:
+        for name in (
+            "active_electrode_area",
+            "active_electrode_thickness",
+            "active_electrode_loading",
+            "electrolyte_volume",
+            "electrolyte_type",
+            "active_electrode_type",
+            "counter_electrode_type",
+            "reference_electrode_type",
+            "experiment_type",
+            "cell_type",
+        ):
+            mapped[name] = getattr(cell_info, name, None)
+
+    return {name: value for name, value in mapped.items() if value is not None}
+
+
+def resolve_from_loader_result(
+    result: Any,
+    *,
+    source: Any,
+    source_type: str,
+    kwargs: Mapping[str, Any] | None = None,
+    journal: Any = None,
+    config_defaults: Any = None,
+) -> tuple[Any, Any, Resolution, Resolution]:
+    """Turn a loader's drafts into populated metadata, with provenance.
+
+    This is the ingestion-side entry point: it takes what the loader learned
+    from the file, resolves it against the other layers, and stamps the
+    provenance the loader is not allowed to fill itself.
+
+    Args:
+        result: a ``LoaderResult`` carrying draft ``test_meta``/``cell_meta``.
+        source: the file the result came from.
+        source_type: the loader/instrument name.
+        kwargs: explicit user values.
+        journal: batch journal or database row.
+        config_defaults: session ``ScienceDefaults``.
+
+    Returns:
+        ``(cell_meta, test_meta, cell_resolution, test_resolution)``.
+    """
+    from cellpycore.metadata.models import CellMeta
+
+    from cellpy.readers.provenance import stamp_provenance
+
+    cell_draft = getattr(result, "cell_meta", None)
+    test_draft = getattr(result, "test_meta", None)
+
+    cell_meta, cell_resolution = resolve_cell_meta(
+        CellMeta(),
+        kwargs=kwargs,
+        journal=journal,
+        draft=cell_draft,
+        config_defaults=config_defaults,
+    )
+
+    test_meta, test_resolution = resolve_test_meta(
+        type(test_draft)() if test_draft is not None else None,
+        kwargs=kwargs,
+        journal=journal,
+        draft=test_draft,
+        config_defaults=None,
+    )
+
+    if test_meta is not None:
+        # Provenance last, and unconditionally: it is the framework's to state,
+        # and must not be something a layer can talk it out of.
+        stamp_provenance(test_meta, source=source, source_type=source_type)
+
+    return cell_meta, test_meta, cell_resolution, test_resolution

--- a/cellpy/readers/provenance.py
+++ b/cellpy/readers/provenance.py
@@ -1,0 +1,133 @@
+"""Provenance stamping — the framework's half of metadata (#562).
+
+A loader knows what the file *says*. Only the framework knows where the file
+came from, when it was read and what identity the resulting cell was given, so
+those fields are stamped here and a draft that arrives carrying them is a
+contract violation (architecture plan §5.1.3, enforced by the conformance kit).
+
+Two identifiers, deliberately different:
+
+``source_uuid``
+    A stable hash of *file identity*. The same file yields the same value on
+    every load and on every machine, so "have I already loaded this?" and "is
+    this the same raw file the cellpy file was built from?" are answerable.
+
+``uuid``
+    Identity of *this cell object*, minted once at first load and then
+    preserved through save, load and merge. Two loads of the same file are two
+    cells and get different values.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import logging
+import uuid as uuid_module
+from pathlib import Path
+from typing import Any
+
+#: Read in chunks: raw files run to hundreds of MB and hashing should not
+#: require holding one in memory.
+_CHUNK = 1024 * 1024
+
+#: How much of the file identifies it. Hashing a whole multi-GB file to answer
+#: "same file?" is not worth the wall time; the head plus the size is a strong
+#: enough discriminator for provenance, and it is stable across machines.
+_IDENTITY_BYTES = 1024 * 1024
+
+
+def file_identity_hash(source: Path | str) -> str | None:
+    """A stable identity hash for a raw file, or None if unreadable.
+
+    Deliberately *not* a full-content checksum — see ``_IDENTITY_BYTES``. Two
+    different files sharing both a 1 MB head and an exact byte size would
+    collide; that is acceptable for provenance, and it is not used as a
+    security or integrity control.
+    """
+    path = Path(source)
+    try:
+        size = path.stat().st_size
+        digest = hashlib.sha256()
+        digest.update(str(size).encode("utf-8"))
+        with path.open("rb") as handle:
+            remaining = _IDENTITY_BYTES
+            while remaining > 0:
+                chunk = handle.read(min(_CHUNK, remaining))
+                if not chunk:
+                    break
+                digest.update(chunk)
+                remaining -= len(chunk)
+        return digest.hexdigest()
+    except OSError as exc:
+        # A missing or unreadable source should not fail a load that otherwise
+        # succeeded (e.g. loading from a cellpy file whose raw has moved).
+        logging.debug("could not hash %s for provenance: %s", path, exc)
+        return None
+
+
+def stamp_provenance(
+    test_meta: Any,
+    *,
+    source: Path | str,
+    source_type: str,
+    source_kind: str = "file",
+    raw_file_names: list[str] | None = None,
+    loaded_datetime: datetime.datetime | None = None,
+) -> Any:
+    """Fill the provenance fields on a draft ``TestMeta``.
+
+    Args:
+        test_meta: the loader's draft, mutated in place.
+        source: the raw file this test came from.
+        source_type: the instrument/loader name (``"maccor_txt"``).
+        source_kind: ``"file"`` or ``"db"``.
+        raw_file_names: override for multi-file loads; defaults to ``source``.
+        loaded_datetime: override for reproducible tests; defaults to now, UTC.
+
+    Returns:
+        The same object, for chaining.
+    """
+    path = Path(source)
+    stamps = {
+        "source_kind": source_kind,
+        "source_type": source_type,
+        "source_uri": str(path),
+        "source_uuid": file_identity_hash(path),
+        "raw_file_names": raw_file_names or [path.name],
+        "loaded_datetime": loaded_datetime
+        or datetime.datetime.now(datetime.timezone.utc),
+    }
+
+    for name, value in stamps.items():
+        if value is not None and hasattr(test_meta, name):
+            setattr(test_meta, name, value)
+    return test_meta
+
+
+def new_cell_uuid() -> str:
+    """Mint the identity for a freshly loaded cell.
+
+    Preserved through save/load/merge — see ``preserve_cell_uuid``.
+    """
+    return str(uuid_module.uuid4())
+
+
+def preserve_cell_uuid(target: Any, *sources: Any) -> str | None:
+    """Carry an existing cell uuid onto ``target``, or mint one.
+
+    Merging keeps the *first* uuid it finds rather than minting a new one: the
+    merged object is a continuation of that cell, and a fresh identity would
+    break the link back to files already saved from it.
+    """
+    for source in sources:
+        existing = getattr(source, "uuid", None) if source is not None else None
+        if existing:
+            if hasattr(target, "uuid"):
+                target.uuid = existing
+            return existing
+
+    minted = new_cell_uuid()
+    if hasattr(target, "uuid"):
+        target.uuid = minted
+    return minted

--- a/tests/test_meta_resolver.py
+++ b/tests/test_meta_resolver.py
@@ -1,0 +1,344 @@
+"""MetaResolver and provenance stamping (#562, metadata plan Steps 3-4).
+
+The resolver exists to make one question answerable: *where did this value come
+from?* So most of these tests assert the recorded source, not just the value —
+a resolver that picks correctly but cannot say why leaves "my batch used a
+default mass for one cell in forty" just as invisible as before.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+import pytest
+from cellpycore.metadata.models import CellMeta, TestMeta
+
+from cellpy import log
+from cellpy.readers.meta_resolver import (
+    Layer,
+    MetaResolver,
+    resolve_cell_meta,
+    science_defaults_for_cell,
+)
+from cellpy.readers.provenance import (
+    file_identity_hash,
+    new_cell_uuid,
+    preserve_cell_uuid,
+    stamp_provenance,
+)
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+# -- precedence ----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_kwargs_beat_every_other_layer():
+    meta, resolution = resolve_cell_meta(
+        CellMeta(),
+        kwargs={"mass": 1.0},
+        journal={"mass": 2.0},
+        draft=CellMeta(mass=3.0),
+        config_defaults={"mass": 4.0},
+    )
+    assert meta.mass == 1.0
+    assert resolution.source_of("mass") is Layer.KWARGS
+
+
+@pytest.mark.essential
+def test_journal_beats_file_and_defaults():
+    meta, resolution = resolve_cell_meta(
+        CellMeta(),
+        journal={"mass": 2.0},
+        draft=CellMeta(mass=3.0),
+        config_defaults={"mass": 4.0},
+    )
+    assert meta.mass == 2.0
+    assert resolution.source_of("mass") is Layer.JOURNAL
+
+
+@pytest.mark.essential
+def test_file_beats_defaults():
+    meta, resolution = resolve_cell_meta(
+        CellMeta(), draft=CellMeta(mass=3.0), config_defaults={"mass": 4.0}
+    )
+    assert meta.mass == 3.0
+    assert resolution.source_of("mass") is Layer.RAW_FILE
+
+
+@pytest.mark.essential
+def test_defaults_are_the_last_resort():
+    meta, resolution = resolve_cell_meta(CellMeta(), config_defaults={"mass": 4.0})
+    assert meta.mass == 4.0
+    assert resolution.source_of("mass") is Layer.CONFIG_DEFAULT
+
+
+@pytest.mark.essential
+def test_the_acceptance_case_all_four_layers_at_once():
+    """Issue #562's stated acceptance: kwarg wins, and every field reports."""
+    meta, resolution = resolve_cell_meta(
+        CellMeta(),
+        kwargs={"mass": 1.0},
+        journal={"nom_cap": 22.0},
+        draft=CellMeta(material="graphite"),
+        config_defaults={"cell_type": "standard"},
+    )
+    assert meta.mass == 1.0
+    assert meta.nom_cap == 22.0
+    assert meta.material == "graphite"
+    assert meta.cell_type == "standard"
+
+    assert resolution.source_of("mass") is Layer.KWARGS
+    assert resolution.source_of("nom_cap") is Layer.JOURNAL
+    assert resolution.source_of("material") is Layer.RAW_FILE
+    assert resolution.source_of("cell_type") is Layer.CONFIG_DEFAULT
+
+
+# -- "I don't know" is not "set it to None" ------------------------------------
+
+
+@pytest.mark.essential
+def test_a_none_in_a_higher_layer_does_not_erase_a_lower_one():
+    """A journal with blank columns must not wipe what the instrument knew."""
+    meta, resolution = resolve_cell_meta(
+        CellMeta(),
+        journal={"mass": None},
+        draft=CellMeta(mass=3.0),
+    )
+    assert meta.mass == 3.0
+    assert resolution.source_of("mass") is Layer.RAW_FILE
+
+
+@pytest.mark.essential
+def test_unresolved_fields_report_no_source():
+    _, resolution = resolve_cell_meta(CellMeta(), kwargs={"mass": 1.0})
+    assert resolution.source_of("nom_cap") is None
+
+
+# -- the provenance record itself ----------------------------------------------
+
+
+@pytest.mark.essential
+def test_fields_from_lists_what_a_layer_contributed():
+    _, resolution = resolve_cell_meta(
+        CellMeta(),
+        kwargs={"mass": 1.0, "nom_cap": 2.0},
+        config_defaults={"cell_type": "standard"},
+    )
+    assert resolution.fields_from(Layer.KWARGS) == ("mass", "nom_cap")
+    assert resolution.fields_from(Layer.CONFIG_DEFAULT) == ("cell_type",)
+
+
+@pytest.mark.essential
+def test_explain_names_the_layer_in_words():
+    _, resolution = resolve_cell_meta(CellMeta(), config_defaults={"mass": 4.0})
+    explanation = resolution.explain()
+    assert "mass" in explanation
+    assert "config default" in explanation
+
+
+@pytest.mark.essential
+def test_unknown_fields_are_ignored():
+    """A journal column that matches nothing must not invent a field."""
+    meta, resolution = resolve_cell_meta(
+        CellMeta(), journal={"not_a_metadata_field": 1.0}
+    )
+    assert not hasattr(meta, "not_a_metadata_field")
+    assert resolution.source_of("not_a_metadata_field") is None
+
+
+@pytest.mark.essential
+def test_resolver_accepts_dataclass_mapping_and_model_layers():
+    """Layers arrive in three shapes; the resolver normalises them."""
+
+    class ModelLike:
+        def model_dump(self):
+            return {"mass": 9.0}
+
+    resolver = MetaResolver(("mass",))
+    meta, resolution = resolver.resolve(config_defaults=ModelLike(), into=CellMeta())
+    assert meta.mass == 9.0
+    assert resolution.source_of("mass") is Layer.CONFIG_DEFAULT
+
+
+# -- config defaults translation -----------------------------------------------
+
+
+@pytest.mark.essential
+def test_science_defaults_are_translated_to_metadata_names():
+    """Config says default_mass; the model says mass."""
+    import cellpy.config as config
+
+    mapped = science_defaults_for_cell(config.defaults)
+    assert "mass" in mapped
+    assert "default_mass" not in mapped
+    assert "nom_cap" in mapped
+
+
+@pytest.mark.essential
+def test_science_defaults_flow_through_the_resolver():
+    import cellpy.config as config
+
+    meta, resolution = resolve_cell_meta(
+        CellMeta(), config_defaults=science_defaults_for_cell(config.defaults)
+    )
+    assert meta.mass is not None
+    assert resolution.source_of("mass") is Layer.CONFIG_DEFAULT
+
+
+# -- provenance stamping --------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_stamp_provenance_fills_the_framework_fields(tmp_path):
+    source = tmp_path / "cell.res"
+    source.write_bytes(b"some raw data")
+
+    meta = stamp_provenance(
+        TestMeta(),
+        source=source,
+        source_type="arbin_res",
+        loaded_datetime=datetime.datetime(2026, 7, 19, tzinfo=datetime.timezone.utc),
+    )
+
+    assert meta.source_kind == "file"
+    assert meta.source_type == "arbin_res"
+    assert meta.source_uri == str(source)
+    assert meta.raw_file_names == ["cell.res"]
+    assert meta.loaded_datetime.year == 2026
+    assert meta.source_uuid
+
+
+@pytest.mark.essential
+def test_file_identity_hash_is_stable_for_the_same_file(tmp_path):
+    source = tmp_path / "cell.res"
+    source.write_bytes(b"identical bytes")
+    assert file_identity_hash(source) == file_identity_hash(source)
+
+
+@pytest.mark.essential
+def test_file_identity_hash_differs_for_different_content(tmp_path):
+    a = tmp_path / "a.res"
+    b = tmp_path / "b.res"
+    a.write_bytes(b"content one")
+    b.write_bytes(b"content two")
+    assert file_identity_hash(a) != file_identity_hash(b)
+
+
+@pytest.mark.essential
+def test_file_identity_hash_ignores_the_path(tmp_path):
+    """Identity is the file's content, not where it happens to sit."""
+    first = tmp_path / "one" / "cell.res"
+    second = tmp_path / "two" / "renamed.res"
+    for path in (first, second):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same bytes")
+    assert file_identity_hash(first) == file_identity_hash(second)
+
+
+@pytest.mark.essential
+def test_missing_source_does_not_break_the_load(tmp_path):
+    """Loading a cellpy file whose raw has moved must still work."""
+    assert file_identity_hash(tmp_path / "gone.res") is None
+
+
+# -- cell uuid ------------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_new_cell_uuids_are_unique():
+    assert new_cell_uuid() != new_cell_uuid()
+
+
+@pytest.mark.essential
+def test_merge_keeps_the_first_uuid_rather_than_minting_one():
+    """The merged object continues that cell; a new identity would break the
+    link back to files already saved from it."""
+
+    class Holder:
+        uuid = None
+
+    original = Holder()
+    original.uuid = "the-original"
+    other = Holder()
+    other.uuid = "the-other"
+
+    target = Holder()
+    kept = preserve_cell_uuid(target, original, other)
+    assert kept == "the-original"
+    assert target.uuid == "the-original"
+
+
+@pytest.mark.essential
+def test_uuid_is_minted_when_no_source_has_one():
+    class Holder:
+        uuid = None
+
+    target = Holder()
+    minted = preserve_cell_uuid(target, Holder())
+    assert minted
+    assert target.uuid == minted
+
+
+# -- the null-object guarantee ---------------------------------------------------
+
+
+@pytest.mark.essential
+def test_resolving_nothing_leaves_a_usable_empty_object():
+    """Engines must run on empty metadata (architecture plan §4)."""
+    meta, resolution = resolve_cell_meta(CellMeta())
+    assert isinstance(meta, CellMeta)
+    assert resolution.sources == {}
+
+
+# -- end to end through a real loader -------------------------------------------
+
+
+@pytest.mark.essential
+def test_resolution_end_to_end_through_the_pilot_loader():
+    """The ingestion entry point, on a real file and a real loader draft.
+
+    Unit tests above use hand-built layers; this one proves the pieces fit
+    together on the path the port will actually take.
+    """
+    import cellpy.config as config
+    import cellpy.utils.example_data as ed
+    from cellpy.readers.instruments.maccor_txt_native import MaccorTxtLoader
+    from cellpy.readers.meta_resolver import resolve_from_loader_result
+
+    source = ed.maccor_file_path()
+    result = MaccorTxtLoader().load(source)[0]
+
+    cell_meta, test_meta, cell_resolution, _ = resolve_from_loader_result(
+        result,
+        source=source,
+        source_type="maccor_txt",
+        kwargs={"mass": 2.5},
+        config_defaults=science_defaults_for_cell(config.defaults),
+    )
+
+    # the user's kwarg wins over the config default
+    assert cell_meta.mass == 2.5
+    assert cell_resolution.source_of("mass") is Layer.KWARGS
+    # ... and a field only the defaults know still gets filled
+    assert cell_resolution.source_of("cell_type") is Layer.CONFIG_DEFAULT
+
+    # provenance is stamped by the framework, not by the loader
+    assert test_meta.source_type == "maccor_txt"
+    assert test_meta.source_uri == str(source)
+    assert test_meta.source_uuid
+    assert test_meta.loaded_datetime is not None
+
+
+@pytest.mark.essential
+def test_the_loader_draft_carried_no_provenance():
+    """Restates the contract from the other side: the draft must be clean."""
+    import cellpy.utils.example_data as ed
+    from cellpy.readers.instruments.maccor_txt_native import MaccorTxtLoader
+
+    draft = MaccorTxtLoader().load(ed.maccor_file_path())[0].test_meta
+    assert draft.source_uri is None
+    assert draft.source_uuid is None
+    assert draft.loaded_datetime is None


### PR DESCRIPTION
Closes #562 (metadata plan Steps 3–4). Stage 3.5.

## The problem it solves

Metadata arrives from four places at once — user kwargs, the batch journal/db,
the instrument file, config defaults — and they were merged at whichever call
site happened to run first. That's why *"why is my mass 1.0?"* wasn't
answerable without reading the code.

Fixed precedence, most specific first:

```
kwargs > journal/db > raw file > config defaults
```

…and **every resolved field records which layer won**. That record is the whole
point: a batch that quietly used a default mass for one cell in forty is
otherwise invisible until the capacities look strange. `Resolution.explain()`
prints it per field.

## The subtle rule

A layer only contributes a field it actually has a value for — `None` means
*"I don't know"*, not *"set it to None"*. So a journal with blank columns can't
erase what the instrument file knew. There's a dedicated test, because the
opposite behaviour is the easy accident and it destroys data silently.

## Two identifiers, deliberately different

- **`source_uuid`** — a stable hash of *file identity*, same value for the same
  file on any machine. Answers "have I loaded this before?"
- **`uuid`** — identity of the *cell object*, minted at first load and preserved
  through save/load/merge. **Merge keeps the first uuid** rather than minting a
  new one: the merged object continues that cell, and a fresh identity would
  break the link to files already saved from it.

The identity hash covers the first megabyte plus exact byte size, not the whole
file — hashing multi-GB raw files to answer "same file?" isn't worth the wall
time. Documented as such, and explicitly **not** an integrity control. An
unreadable source returns `None` rather than failing a load that otherwise
succeeded (e.g. a cellpy file whose raw has since moved).

## Not tested in isolation

`resolve_from_loader_result()` is the ingestion entry point and is exercised end
to end against the #559 maccor pilot: the loader's draft carries no provenance
(asserted from both sides — the kit rejects it, and the real draft is clean),
the user's kwarg beats the config default, and the framework's stamps land.

## Scope

`get()` still applies mass/nom_cap through its imperative `if not None: set`
chain. That chain *is* the same precedence, but reconstructing which layer won
after the fact would be guesswork, so I didn't fake it — routing it through the
resolver properly needs the loader-draft path, i.e. the #560 switchover.

## Tests

24 in `tests/test_meta_resolver.py`. Full suite: 839 passed, 62 skipped,
12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
