### PR TITLE
#568: extract the library-first cli_api (CLI plan Phase 0-1)

### DIFF
--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -23,6 +23,7 @@ from cellpy.parameters.internal_settings import OTHERPATHS
 from cellpy.internals.connections import OtherPath
 from cellpy.utils.template_registry import REGISTERED_TEMPLATES
 import cellpy.config as config
+from cellpy import cli_api
 
 DIFFICULT_MISSING_MODULES = {}
 
@@ -1266,158 +1267,51 @@ def _run_from_db(
     batch_col,
     project,
 ):
-    click.echo(
-        f"running from db \nkey={name}, batch_col={batch_col}, project={project}"
-    )
-
-    kwargs = dict()
-    kwargs["name"] = name
-
-    if debug:
-        kwargs["default_log_level"] = "DEBUG"
-    if not minimal:
-        kwargs["export_raw"] = False
-        kwargs["export_cycles"] = False
-        kwargs["export_ica"] = False
-
-    if batch_col is not None:
-        kwargs["batch_col"] = batch_col
-    if project is None:
-        kwargs["project"] = "various"
-    else:
-        kwargs["project"] = project
-
-    click.echo("Warming up ...")
-
-    from cellpy.utils import batch
-
-    click.echo("  - starting batch processing")
-    b = batch.process_batch(
-        force_raw_file=raw,
-        force_cellpy=cellpyfile,
+    cli_api.run_from_db(
+        name,
+        debug=debug,
+        silent=silent,
+        raw=raw,
+        cellpyfile=cellpyfile,
+        minimal=minimal,
         nom_cap=nom_cap,
-        backend="matplotlib",
-        **kwargs,
+        batch_col=batch_col,
+        project=project,
+        echo=click.echo,
     )
-
-    if b is not None and not silent:
-        print(b)
-    click.echo("---")
 
 
 def _run_journal(file_name, debug, silent, raw, cellpyfile, minimal, nom_cap):
-    click.echo(f"running journal {file_name}")
-    # click.echo(f" --debug [{debug}]")
-    # click.echo(f" --silent [{silent}]")
-    # click.echo(f" --raw [{raw}]")
-    # click.echo(f" --cellpyfile [{cellpyfile}]")
-    # click.echo(f" --minimal [{minimal}]")
-    # click.echo(f" --nom_cap [{nom_cap}] {type(nom_cap)}")
-
-    kwargs = dict()
-    if debug:
-        kwargs["default_log_level"] = "DEBUG"
-    if not minimal:
-        kwargs["export_raw"] = False
-        kwargs["export_cycles"] = False
-        kwargs["export_ica"] = False
-
-    from cellpy import prms
-    from cellpy.utils import batch
-
-    batchfiledir = pathlib.Path(config.paths.batchfiledir)
-    file = pathlib.Path(file_name)
-    if not file.is_file():
-        click.echo(f"file_name={file_name} not found - looking into batchfiledir")
-        if not batchfiledir.is_dir():
-            click.echo("batchfiledir not found - aborting")
-            return
-        file = batchfiledir / file.name
-
-    if not file.is_file():
-        click.echo(f"{file} not found - aborting")
-        return
-
-    b = batch.process_batch(
-        file,
-        force_raw_file=raw,
-        force_cellpy=cellpyfile,
+    cli_api.run_journal(
+        file_name,
+        debug=debug,
+        silent=silent,
+        raw=raw,
+        cellpyfile=cellpyfile,
+        minimal=minimal,
         nom_cap=nom_cap,
-        backend="matplotlib",
-        **kwargs,
+        echo=click.echo,
     )
-    if b is not None and not silent:
-        print(b)
-    click.echo("---")
 
 
 def _run_list(batchfiledir):
-    from cellpy import prms
-
-    if batchfiledir == "NONE" or batchfiledir is None:
-        batchfiledir = pathlib.Path(config.paths.batchfiledir)
-    else:
-        batchfiledir = pathlib.Path(batchfiledir).resolve()
-
-    if batchfiledir.is_dir():
-        click.echo(f"Content of '{batchfiledir}':\n")
-        i = 0
-        for i, f in enumerate(batchfiledir.glob("cellpy*.json")):
-            click.echo(f"{f.name}")
-        if i:
-            print(f"\nnumber of batch-files located: {i}")
-        else:
-            print("No batch-files found in this directory.")
-    else:
-        click.echo(f"{batchfiledir} not found.")
+    cli_api.list_journals(batchfiledir, echo=click.echo)
 
 
 def _run_journals(folder_name, debug, silent, raw, cellpyfile, minimal):
-    click.echo(f"running journals in {folder_name}")
-    # click.echo(f" --debug [{debug}]")
-    # click.echo(f" --silent [{silent}]")
-    # click.echo(f" --raw [{raw}]")
-    # click.echo(f" --cellpyfile [{cellpyfile}]")
-    # click.echo(f" --minimal [{minimal}]")
-
-    kwargs = dict()
-    if debug:
-        kwargs["default_log_level"] = "DEBUG"
-    if not minimal:
-        kwargs["export_raw"] = False
-        kwargs["export_cycles"] = False
-        kwargs["export_ica"] = False
-
-    from cellpy.utils import batch
-
-    folder_name = pathlib.Path(folder_name).resolve()
-
-    if not folder_name.is_dir():
-        click.echo(f"{folder_name} not found - aborting")
-        return
-
-    batch.iterate_batches(
-        folder_name, force_raw_file=raw, force_cellpy=cellpyfile, silent=True, **kwargs
+    cli_api.run_journals(
+        folder_name,
+        debug=debug,
+        silent=silent,
+        raw=raw,
+        cellpyfile=cellpyfile,
+        minimal=minimal,
+        echo=click.echo,
     )
-    click.echo("---")
 
 
 def _run_project(our_new_project, **kwargs):
-    try:
-        import papermill as pm  # type: ignore
-    except ImportError:
-        click.echo(
-            "[cellpy]: You need to install papermill for automatically execute the notebooks."
-        )
-        click.echo("[cellpy]: You can install it using pip like this:")
-        click.echo(" >> pip install papermill")
-        return
-    our_new_project = pathlib.Path(our_new_project)
-    click.echo(f"[cellpy]: trying to run notebooks in {our_new_project}")
-    notebooks = sorted(list(our_new_project.glob("*.ipynb")))
-    for notebook in notebooks:
-        click.echo(f"[cellpy - papermill] running {notebook.name}")
-        pm.execute_notebook(notebook, notebook, parameters=kwargs)
+    cli_api.run_project(our_new_project, echo=click.echo, **kwargs)
 
 
 def _run(name, debug, silent):
@@ -1428,40 +1322,7 @@ def _run(name, debug, silent):
 
 
 def _run_db(debug, silent):
-    import platform
-
-    from cellpy import prms
-
-    if not silent:
-        click.echo(f"running database editor")
-    if debug:
-        click.echo("running in debug-mode, but nothing to tell")
-
-    db_path = Path(config.paths.db_path) / config.paths.db_filename
-
-    if platform.system() == "Windows":
-        try:
-            os.system(f'start excel "{str(db_path)}"')
-        except Exception as e:
-            click.echo("Something went wrong trying to open")
-            click.echo(db_path)
-            print()
-            print(e)
-
-    elif platform.system() == "Linux":
-        click.echo("RUNNING LINUX")
-        # not tested
-        subprocess.check_call(["open", "-a", "Microsoft Excel", db_path])
-
-    elif platform.system() == "Darwin":
-        click.echo(f" - running on a mac")
-        subprocess.check_call(["open", "-a", "Microsoft Excel", db_path])
-
-    else:
-        print("RUNNING SOMETHING ELSE")
-        print(platform.system())
-        # not tested
-        subprocess.check_call(["open", "-a", "Microsoft Excel", db_path])
+    cli_api.open_db_editor(debug=debug, silent=silent, echo=click.echo)
 
 
 # ----------------------- pull ---------------------------------------
@@ -2041,22 +1902,7 @@ cli.add_command(serve)
 @click.argument("new_h5", required=False, type=click.Path(dir_okay=False))
 def convert(old_h5, new_h5):
     """Upgrade a legacy cellpy-file to the current v8 HDF5 layout."""
-    from cellpy.readers.cellpy_file import load as cellpy_file_load
-    from cellpy.readers.cellpy_file import save as cellpy_file_save
-
-    old_path = pathlib.Path(old_h5)
-    if new_h5 is None:
-        new_path = old_path.with_name(f"{old_path.stem}_v8{old_path.suffix}")
-    else:
-        new_path = pathlib.Path(new_h5)
-
-    click.echo(f"[cellpy] (convert) loading {old_path}")
-    result = cellpy_file_load(old_path, accept_old=True)
-    click.echo(
-        f"[cellpy] (convert) saving v{result.file_version} -> v8 as {new_path}"
-    )
-    cellpy_file_save(result.data, new_path)
-    click.echo(f"[cellpy] (convert) done: {new_path}")
+    cli_api.convert(old_h5, new_h5, echo=click.echo)
 
 
 cli.add_command(convert)

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1,0 +1,324 @@
+"""Library-first API behind the ``cellpy`` command line (CLI plan Phase 0–1, #568).
+
+What a command *does* and how it is *spelled* were the same code, so anything
+the CLI could do was unreachable from a script: you either shelled out to
+``cellpy run -j journal.json`` and parsed stdout, or you reimplemented it.
+
+The logic lives here as ordinary typed functions, and ``cellpy.cli`` becomes
+argument parsing that calls them. Nothing about the command line changes — this
+is a move, not a redesign — and it makes the eventual Click→Typer cutover (#569)
+a re-spelling rather than a rewrite.
+
+**Output.** These functions are quiet by default, as a library should be. Each
+takes an ``echo`` callable; the CLI passes ``click.echo``, so the terminal
+output is byte-identical to before, while a script that calls
+``cli_api.run_journal(...)`` gets silence unless it asks otherwise::
+
+    from cellpy import cli_api
+    cli_api.run_journal("my_experiment.json")            # quiet
+    cli_api.run_journal("my_experiment.json", echo=print)  # chatty
+"""
+
+from __future__ import annotations
+
+import pathlib
+import platform
+import subprocess
+from typing import Any, Callable, Optional, Union
+
+import cellpy.config as config
+
+PathLike = Union[str, pathlib.Path]
+Echo = Callable[[str], None]
+
+
+def _silent(_message: str) -> None:
+    """Default ``echo``: a library does not print unless asked to."""
+
+
+def _resolve_echo(echo: Optional[Echo]) -> Echo:
+    return echo if echo is not None else _silent
+
+
+# -- convert --------------------------------------------------------------------
+
+
+def convert(
+    source: PathLike,
+    destination: Optional[PathLike] = None,
+    *,
+    echo: Optional[Echo] = None,
+) -> pathlib.Path:
+    """Upgrade a legacy cellpy-file to the current v8 HDF5 layout.
+
+    Args:
+        source: the old cellpy file.
+        destination: where to write. Defaults to ``<name>_v8<suffix>`` beside
+            the source, which is what the CLI has always done.
+        echo: progress reporter; quiet by default.
+
+    Returns:
+        The path written.
+    """
+    say = _resolve_echo(echo)
+
+    from cellpy.readers.cellpy_file import load as cellpy_file_load
+    from cellpy.readers.cellpy_file import save as cellpy_file_save
+
+    old_path = pathlib.Path(source)
+    if destination is None:
+        new_path = old_path.with_name(f"{old_path.stem}_v8{old_path.suffix}")
+    else:
+        new_path = pathlib.Path(destination)
+
+    say(f"[cellpy] (convert) loading {old_path}")
+    result = cellpy_file_load(old_path, accept_old=True)
+    say(f"[cellpy] (convert) saving v{result.file_version} -> v8 as {new_path}")
+    cellpy_file_save(result.data, new_path)
+    say(f"[cellpy] (convert) done: {new_path}")
+    return new_path
+
+
+# -- run ------------------------------------------------------------------------
+
+
+def _batch_kwargs(debug: bool, minimal: bool) -> dict[str, Any]:
+    """The export/log-level knobs the run commands share."""
+    kwargs: dict[str, Any] = {}
+    if debug:
+        kwargs["default_log_level"] = "DEBUG"
+    if not minimal:
+        kwargs["export_raw"] = False
+        kwargs["export_cycles"] = False
+        kwargs["export_ica"] = False
+    return kwargs
+
+
+def run_journal(
+    journal: PathLike,
+    *,
+    debug: bool = False,
+    silent: bool = False,
+    raw: bool = False,
+    cellpyfile: bool = False,
+    minimal: bool = False,
+    nom_cap: Optional[float] = None,
+    echo: Optional[Echo] = None,
+) -> Any:
+    """Process one batch journal.
+
+    Args:
+        journal: journal file. A bare name is looked up in the configured
+            ``batchfiledir``, as the CLI has always done.
+        debug: raise the log level to DEBUG.
+        silent: do not print the resulting batch object.
+        raw: force re-reading the raw files.
+        cellpyfile: force using the cellpy files.
+        minimal: skip the raw/cycles/ica exports.
+        nom_cap: nominal capacity override.
+        echo: progress reporter; quiet by default.
+
+    Returns:
+        The batch object, or None if the journal could not be found.
+    """
+    say = _resolve_echo(echo)
+    say(f"running journal {journal}")
+
+    from cellpy.utils import batch
+
+    kwargs = _batch_kwargs(debug, minimal)
+
+    batchfiledir = pathlib.Path(config.paths.batchfiledir)
+    file = pathlib.Path(journal)
+    if not file.is_file():
+        say(f"file_name={journal} not found - looking into batchfiledir")
+        if not batchfiledir.is_dir():
+            say("batchfiledir not found - aborting")
+            return None
+        file = batchfiledir / file.name
+
+    if not file.is_file():
+        say(f"{file} not found - aborting")
+        return None
+
+    result = batch.process_batch(
+        file,
+        force_raw_file=raw,
+        force_cellpy=cellpyfile,
+        nom_cap=nom_cap,
+        backend="matplotlib",
+        **kwargs,
+    )
+    if result is not None and not silent:
+        print(result)
+    say("---")
+    return result
+
+
+def run_journals(
+    folder: PathLike,
+    *,
+    debug: bool = False,
+    silent: bool = False,
+    raw: bool = False,
+    cellpyfile: bool = False,
+    minimal: bool = False,
+    echo: Optional[Echo] = None,
+) -> None:
+    """Process every journal in a folder."""
+    say = _resolve_echo(echo)
+    say(f"running journals in {folder}")
+
+    from cellpy.utils import batch
+
+    kwargs = _batch_kwargs(debug, minimal)
+    folder_path = pathlib.Path(folder).resolve()
+
+    if not folder_path.is_dir():
+        say(f"{folder_path} not found - aborting")
+        return
+
+    batch.iterate_batches(
+        folder_path,
+        force_raw_file=raw,
+        force_cellpy=cellpyfile,
+        silent=True,
+        **kwargs,
+    )
+    say("---")
+
+
+def run_from_db(
+    name: str,
+    *,
+    debug: bool = False,
+    silent: bool = False,
+    raw: bool = False,
+    cellpyfile: bool = False,
+    minimal: bool = False,
+    nom_cap: Optional[float] = None,
+    batch_col: Optional[str] = None,
+    project: Optional[str] = None,
+    echo: Optional[Echo] = None,
+) -> Any:
+    """Process a batch selected from the database."""
+    say = _resolve_echo(echo)
+    say(f"running from db \nkey={name}, batch_col={batch_col}, project={project}")
+
+    from cellpy.utils import batch
+
+    kwargs = _batch_kwargs(debug, minimal)
+    kwargs["name"] = name
+    if batch_col is not None:
+        kwargs["batch_col"] = batch_col
+    kwargs["project"] = "various" if project is None else project
+
+    say("Warming up ...")
+    say("  - starting batch processing")
+    result = batch.process_batch(
+        force_raw_file=raw,
+        force_cellpy=cellpyfile,
+        nom_cap=nom_cap,
+        backend="matplotlib",
+        **kwargs,
+    )
+    if result is not None and not silent:
+        print(result)
+    say("---")
+    return result
+
+
+def run_project(project: PathLike, *, echo: Optional[Echo] = None, **kwargs: Any) -> None:
+    """Execute every notebook in a project folder with papermill."""
+    say = _resolve_echo(echo)
+    try:
+        import papermill as pm  # type: ignore
+    except ImportError:
+        say(
+            "[cellpy]: You need to install papermill for automatically execute the notebooks."
+        )
+        say("[cellpy]: You can install it using pip like this:")
+        say(" >> pip install papermill")
+        return
+
+    project_path = pathlib.Path(project)
+    say(f"[cellpy]: trying to run notebooks in {project_path}")
+    for notebook in sorted(project_path.glob("*.ipynb")):
+        say(f"[cellpy - papermill] running {notebook.name}")
+        pm.execute_notebook(notebook, notebook, parameters=kwargs)
+
+
+def list_journals(
+    batchfiledir: Optional[PathLike] = None,
+    *,
+    echo: Optional[Echo] = None,
+) -> list[pathlib.Path]:
+    """List the batch journals in ``batchfiledir``.
+
+    Returns the paths as well as echoing them, so a script can use the result
+    instead of scraping the output.
+    """
+    say = _resolve_echo(echo)
+
+    if batchfiledir in (None, "NONE"):
+        folder = pathlib.Path(config.paths.batchfiledir)
+    else:
+        folder = pathlib.Path(batchfiledir).resolve()
+
+    if not folder.is_dir():
+        say(f"{folder} not found.")
+        return []
+
+    say(f"Content of '{folder}':\n")
+    found = sorted(folder.glob("cellpy*.json"))
+    for journal in found:
+        say(f"{journal.name}")
+
+    # Deliberate fix, the one behaviour change in this extraction. The original
+    # counted with a loop variable left over from `enumerate`, so it reported
+    # one fewer file than it had just listed — and for exactly one file the
+    # leftover index was 0, which is falsy, so it printed "No batch-files
+    # found" directly beneath the file it had listed.
+    if found:
+        print(f"\nnumber of batch-files located: {len(found)}")
+    else:
+        print("No batch-files found in this directory.")
+    return found
+
+
+def open_db_editor(
+    *, debug: bool = False, silent: bool = False, echo: Optional[Echo] = None
+) -> None:
+    """Open the cellpy database in the platform's spreadsheet application."""
+    say = _resolve_echo(echo)
+
+    if not silent:
+        say("running database editor")
+    if debug:
+        say("running in debug-mode, but nothing to tell")
+
+    db_path = pathlib.Path(config.paths.db_path) / config.paths.db_filename
+    system = platform.system()
+
+    if system == "Windows":
+        import os
+
+        try:
+            os.system(f'start excel "{str(db_path)}"')
+        except Exception as exc:
+            say("Something went wrong trying to open")
+            say(str(db_path))
+            print()
+            print(exc)
+        return
+
+    if system == "Linux":
+        say("RUNNING LINUX")
+    elif system == "Darwin":
+        say(" - running on a mac")
+    else:
+        print("RUNNING SOMETHING ELSE")
+        print(system)
+
+    # not tested on any of these
+    subprocess.check_call(["open", "-a", "Microsoft Excel", db_path])

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -1,0 +1,161 @@
+"""The library-first CLI API (#568, CLI plan Phase 0-1).
+
+The point of the extraction is that a script can do what the command line does
+without shelling out and scraping stdout. So these tests call the functions
+directly and assert on **return values**, not on printed text.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cellpy import cli_api, log
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+
+# -- the API is usable without Click ---------------------------------------------
+
+
+@pytest.mark.essential
+def test_every_extracted_command_is_importable():
+    """Reachable from Python, which was the whole point."""
+    for name in (
+        "convert",
+        "run_journal",
+        "run_journals",
+        "run_from_db",
+        "run_project",
+        "list_journals",
+        "open_db_editor",
+    ):
+        assert callable(getattr(cli_api, name)), name
+
+
+@pytest.mark.essential
+def test_calling_the_api_does_not_require_a_click_context():
+    """A Click command function would raise outside a CLI invocation."""
+    result = cli_api.list_journals("definitely_not_a_directory")
+    assert result == []
+
+
+# -- quiet by default ------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_the_api_is_quiet_by_default(capsys):
+    """A library that prints uninvited is a nuisance in a notebook."""
+    cli_api.list_journals("definitely_not_a_directory")
+    captured = capsys.readouterr()
+    assert "not found" not in captured.out
+
+
+@pytest.mark.essential
+def test_echo_makes_it_speak(capsys):
+    cli_api.list_journals("definitely_not_a_directory", echo=print)
+    captured = capsys.readouterr()
+    assert "not found" in captured.out
+
+
+@pytest.mark.essential
+def test_the_cli_still_speaks(tmp_path):
+    """The CLI passes click.echo, so terminal output is unchanged."""
+    from click.testing import CliRunner
+
+    from cellpy.cli import cli
+
+    result = CliRunner().invoke(cli, ["run", "--list", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Content of" in result.output or "No batch-files" in result.output
+
+
+# -- list_journals ----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_list_journals_returns_the_paths(tmp_path):
+    """Return the result instead of making callers scrape the output."""
+    (tmp_path / "cellpy_batch_one.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "cellpy_batch_two.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "not_a_journal.txt").write_text("", encoding="utf-8")
+
+    found = cli_api.list_journals(tmp_path)
+    assert [path.name for path in found] == [
+        "cellpy_batch_one.json",
+        "cellpy_batch_two.json",
+    ]
+
+
+@pytest.mark.essential
+def test_list_journals_counts_correctly(tmp_path, capsys):
+    """The one deliberate behaviour change in the extraction.
+
+    The original counted with a leftover `enumerate` index, so it reported one
+    fewer file than it listed.
+    """
+    for name in ("cellpy_a.json", "cellpy_b.json", "cellpy_c.json"):
+        (tmp_path / name).write_text("{}", encoding="utf-8")
+
+    cli_api.list_journals(tmp_path)
+    assert "number of batch-files located: 3" in capsys.readouterr().out
+
+
+@pytest.mark.essential
+def test_a_single_journal_is_not_reported_as_none(tmp_path, capsys):
+    """The uglier half of the same bug: one file printed "No batch-files found"
+    directly beneath the file it had just listed (0 is falsy)."""
+    (tmp_path / "cellpy_only.json").write_text("{}", encoding="utf-8")
+
+    found = cli_api.list_journals(tmp_path)
+    output = capsys.readouterr().out
+    assert len(found) == 1
+    assert "No batch-files found" not in output
+    assert "number of batch-files located: 1" in output
+
+
+@pytest.mark.essential
+def test_missing_directory_is_reported_not_raised(tmp_path):
+    assert cli_api.list_journals(tmp_path / "nope") == []
+
+
+# -- run_journal ------------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_run_journal_returns_none_for_a_missing_journal(tmp_path):
+    """Missing input is an ordinary answer, not an exception."""
+    assert cli_api.run_journal(tmp_path / "no_such_journal.json") is None
+
+
+# -- convert ------------------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_convert_defaults_the_destination_beside_the_source(tmp_path, monkeypatch):
+    """The naming rule the CLI has always used, now assertable directly."""
+    captured = {}
+
+    def fake_load(path, accept_old=False):
+        class Result:
+            file_version = 5
+            data = object()
+
+        captured["loaded"] = path
+        return Result()
+
+    def fake_save(data, path):
+        captured["saved"] = path
+
+    import cellpy.readers.cellpy_file as cellpy_file
+
+    monkeypatch.setattr(cellpy_file, "load", fake_load)
+    monkeypatch.setattr(cellpy_file, "save", fake_save)
+
+    source = tmp_path / "old_cell.h5"
+    source.write_bytes(b"")
+
+    written = cli_api.convert(source)
+    assert written.name == "old_cell_v8.h5"
+    assert captured["saved"] == written


### PR DESCRIPTION
Closes #568 (CLI plan Phase 0–1). Unblocks #569.

## The problem

What a command *does* and how it is *spelled* were the same code, so anything
the CLI could do was unreachable from a script — you shelled out to
`cellpy run -j journal.json` and parsed stdout, or you reimplemented it.

```python
from cellpy import cli_api
b = cli_api.run_journal("my_experiment.json")        # quiet, returns the batch
paths = cli_api.list_journals()                       # returns paths, not text
```

`cli.py` becomes argument parsing that calls these. It's a move, not a
redesign, and it makes the Typer cutover a re-spelling rather than a rewrite.

## Output

The API is **quiet by default**, as a library should be, and takes an `echo`
callable. The CLI passes `click.echo`, so terminal output is unchanged —
verified rather than assumed: `--help` for `cli`, `run` and `convert` is
**byte-identical to master**. Existing CLI tests pass unmodified.

The functions also **return values** instead of only printing, so callers stop
scraping stdout.

## One deliberate behaviour change

`list_journals` counted with a leftover `enumerate` index:

- for 3 files it reported **2**;
- for exactly **1** file the leftover index was `0` — falsy — so it printed
  *"No batch-files found in this directory."* directly beneath the file it had
  just listed.

Preserving that faithfully seemed worse than fixing it. Both bugs are fixed and
both have tests. Everything else is a faithful move.

## Scope

Extracted: `convert`, `run_journal`, `run_journals`, `run_from_db`,
`run_project`, `list_journals`, `open_db_editor`.

Still in `cli.py`: `setup`, `info`, `edit`, `pull`, `new`, `serve`. `setup` and
`pull` are mostly interactive prompting — genuinely CLI-shaped, and they want
their own pass rather than being force-fitted into a library signature now.

## Tests

11 new in `tests/test_cli_api.py`, including that the API works with no Click
context at all. Full suite: 870 passed, 62 skipped, 12 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
