### PR TITLE
Re-pin cellpycore 0.2.2 -> 0.2.3 (cellpy-core#139)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     # a known core revision. For dual-repo development, install the sibling
     # checkout editable after sync (see CONTRIBUTING.md); do not commit a
     # [tool.uv.sources] path override — it breaks Dependabot lock updates.
-    "cellpycore==0.2.2",
+    "cellpycore==0.2.3",
     "pydantic-settings>=2.14.2",
     "platformdirs>=4.10.0",
     "universal-pathlib>=0.3.10",

--- a/tests/test_derived_declarations.py
+++ b/tests/test_derived_declarations.py
@@ -127,16 +127,30 @@ def test_vendor_test_id_is_not_carried_into_raw():
 
 
 @pytest.mark.essential
-def test_energies_are_passthrough_until_the_core_mapping_lands():
-    """Documents the cellpy-core#139 gap as a tested fact, not a surprise.
+def test_energies_map_natively_since_cellpycore_0_2_3():
+    """cellpy-core#139 landed; the energies are real native columns now.
 
-    The native schema has ``cumulative_charge_energy`` but no legacy attribute
-    maps to it, so energy data survives only as a passthrough. When core adds
-    the entry this test should start failing — which is the point.
+    This test used to assert the opposite — that energy data survived only as a
+    passthrough — and was written to fail the moment core added the mapping.
+    It did, on the 0.2.3 re-pin, which is what a tripwire is for. No loader or
+    configuration changed: the derivation picked the new entries up on its own.
     """
     declarations = declarations_from_configuration(_config("neware_txt_one"))
-    assert "charge_energy" in declarations.passthrough.values()
-    assert SCHEMA.cumulative_charge_energy not in declarations.column_map.values()
+    assert SCHEMA.cumulative_charge_energy in declarations.column_map.values()
+    assert SCHEMA.cumulative_discharge_energy in declarations.column_map.values()
+    assert "charge_energy" not in declarations.passthrough.values()
+
+
+@pytest.mark.essential
+def test_date_time_is_still_a_passthrough():
+    """The mechanism is still needed: not every legacy column has a native home.
+
+    ``date_time`` has no native counterpart (the native schema carries
+    ``epoch_time_utc`` instead, which is not a rename), so it is still carried
+    through under its legacy name.
+    """
+    declarations = declarations_from_configuration(_config("neware_txt_one"))
+    assert "date_time" in declarations.passthrough.values()
 
 
 @pytest.mark.essential

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cellpycore", specifier = "==0.2.2" },
+    { name = "cellpycore", specifier = "==0.2.3" },
     { name = "charset-normalizer" },
     { name = "click" },
     { name = "cookiecutter" },
@@ -495,16 +495,16 @@ dev = [
 
 [[package]]
 name = "cellpycore"
-version = "0.2.2"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/5c/49aea4804168f05e5908a1dcf33b04a05a172b13554a1b7b6fef3fdb9cff/cellpycore-0.2.2.tar.gz", hash = "sha256:c76ec9a8da6a335d000cc654eed0acdcbc4e42012b903d102798bffceab2f8b1", size = 871522, upload-time = "2026-07-17T12:12:59.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/4b/0626ac1bdbb7f2c6d805e04acd435c31156b1fa8b29bdba47b07ebcc42c9/cellpycore-0.2.3.tar.gz", hash = "sha256:2f8cee3d78b6d5049b74b5f64ee211b8d004816f31d4596522ac0ca6a2411614", size = 874931, upload-time = "2026-07-19T12:11:38.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/c5/e8dee8412ef27357aad35e96d3c10f94b9a9628b171e2f76f45f889878ef/cellpycore-0.2.2-py3-none-any.whl", hash = "sha256:03736497da66ab3f34a106dea8ff491d3139cad1e0a3813efe593f551971d031", size = 90744, upload-time = "2026-07-17T12:12:57.694Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d7/b11b59bf45719ee951404c3040cd12458b3ff1052e11bc4983b2e3c9ff18/cellpycore-0.2.3-py3-none-any.whl", hash = "sha256:97a45f5a1ecade8524e71d67ad13ce3bf8860d73bb74858bdf2a556166f2822c", size = 90749, upload-time = "2026-07-19T12:11:37.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Re-pins cellpycore 0.2.2 → 0.2.3, consuming cellpy-core#139. Cross-repo order
per release plan §3: core PR → core release → cellpy re-pin.

## What core shipped

```python
charge_energy_txt    -> cumulative_charge_energy
discharge_energy_txt -> cumulative_discharge_energy
```

## The derivation picked it up by itself

No loader and no configuration changed. `neware_txt_one` went from
**10 native / 4 passthrough** to **12 native / 2 passthrough** on the re-pin
alone — which is the self-updating property #560 claimed, now demonstrated
rather than asserted.

## The tripwire fired

`test_energies_are_passthrough_until_the_core_mapping_lands` was written to
fail the moment core added the entries. It was the **only** failure in the
suite on the re-pin. It's now
`test_energies_map_natively_since_cellpycore_0_2_3`, asserting the new state,
with a companion test pinning that `date_time` is *still* a passthrough — the
mechanism is still needed for columns that have no native counterpart.

Everything else was green against 0.2.3 with no changes required.

## One thing this sharpened, flagged not fixed

The `Watt-hr` ambiguity in `maccor_txt_one` (same vendor column claimed by
`power_txt` and `charge_energy_txt`) now **costs a native column**: first
declaration wins, so `power_txt` keeps it and this becomes the only tier-1
config without a native charge-energy column.

The evidence says `power_txt` is the wrong winner — `Watt-hr` is energy, not
power, and the same file maps a separate `Power(...)` column to `power_txt`.
I've left it alone and written it up on #560: which attribute a vendor column
*means* is a data-semantics call, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
