### PR TITLE
#569 groundwork: pin the CLI surface as a machine-checked contract

### DIFF
--- a/dev/snapshot_cli_surface.py
+++ b/dev/snapshot_cli_surface.py
@@ -1,0 +1,78 @@
+"""Snapshot the cellpy command-line surface (#569).
+
+The snapshot is the contract ``tests/test_cli_surface.py`` checks against, so
+that changing the CLI *framework* cannot quietly change the CLI. Regenerate it
+only when a surface change is intended, and in the same commit as the change,
+so review sees it:
+
+```shell
+uv run python dev/snapshot_cli_surface.py
+```
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "data" / "cli_surface.json"
+
+
+def _describe(command: Any, name: str) -> dict:
+    import click
+
+    entry: dict[str, Any] = {"name": name, "params": []}
+    for param in command.params:
+        entry["params"].append(
+            {
+                "kind": "argument"
+                if isinstance(param, click.Argument)
+                else "option",
+                "opts": sorted(param.opts + param.secondary_opts),
+                "is_flag": bool(getattr(param, "is_flag", False)),
+                "required": bool(getattr(param, "required", False)),
+                "multiple": bool(getattr(param, "multiple", False)),
+            }
+        )
+    entry["params"].sort(key=lambda item: (item["kind"], item["opts"]))
+    if isinstance(command, click.Group):
+        entry["subcommands"] = sorted(command.commands)
+    return entry
+
+
+def build_surface() -> dict:
+    """Describe the live CLI.
+
+    Typer builds on Click, so a Typer app is inspected the same way once it is
+    converted to its underlying Click command — which is what keeps this
+    snapshot meaningful across the framework change.
+    """
+    from cellpy.cli import cli
+
+    command = cli
+    if not hasattr(command, "commands"):
+        import typer.main
+
+        command = typer.main.get_command(command)
+
+    return {
+        "commands": [
+            _describe(sub, name) for name, sub in sorted(command.commands.items())
+        ]
+    }
+
+
+def main() -> None:
+    surface = build_surface()
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SNAPSHOT_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(surface, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(f"wrote {SNAPSHOT_PATH}")
+    print("commands:", [c["name"] for c in surface["commands"]])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -1,0 +1,555 @@
+{
+  "commands": [
+    {
+      "name": "convert",
+      "params": [
+        {
+          "is_flag": false,
+          "kind": "argument",
+          "multiple": false,
+          "opts": [
+            "new_h5"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "argument",
+          "multiple": false,
+          "opts": [
+            "old_h5"
+          ],
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "edit",
+      "params": [
+        {
+          "is_flag": false,
+          "kind": "argument",
+          "multiple": false,
+          "opts": [
+            "name"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--debug",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--default-editor",
+            "-e"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--silent",
+            "-s"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "info",
+      "params": [
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--check",
+            "-c"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--config",
+            "-C"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--configloc",
+            "-l"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--params",
+            "-p"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--version",
+            "-v"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "new",
+      "params": [
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--directory",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--experiment",
+            "-e"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--jupyter-executable"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--lab",
+            "-j"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--list",
+            "-l"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--local-user-template",
+            "-u"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--project",
+            "-p"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--run",
+            "-r"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--serve",
+            "-s"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--template",
+            "-t"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "pull",
+      "params": [
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--clone",
+            "-c"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--directory",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--examples",
+            "-e"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--password",
+            "-p"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--tests",
+            "-t"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "run",
+      "params": [
+        {
+          "is_flag": false,
+          "kind": "argument",
+          "multiple": false,
+          "opts": [
+            "name"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--batch_col"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--cellpy-project",
+            "-p"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--cellpyfile"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--debug",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--folder",
+            "-f"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--journal",
+            "-j"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--key",
+            "-k"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--list",
+            "-l"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--minimal"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--nom-cap"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--project"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--raw"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--silent",
+            "-s"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "serve",
+      "params": [
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--directory",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--executable",
+            "-e"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--lab",
+            "-l"
+          ],
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "params": [
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--dry-run",
+            "-dr"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--folder-name",
+            "-n"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--interactive",
+            "-i"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--no-deps"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--not-relative",
+            "-nr"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--reset",
+            "-r"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--root-dir",
+            "-d"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--silent",
+            "-s"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--test_user",
+            "-t"
+          ],
+          "required": false
+        }
+      ],
+      "subcommands": [
+        "migrate"
+      ]
+    }
+  ]
+}

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -1,0 +1,125 @@
+"""The command-line surface is a contract (#569).
+
+Changing the CLI framework must not change the CLI. This test compares the
+live app against ``tests/data/cli_surface.json``, a snapshot taken from the
+Click implementation before the Typer cutover, so a dropped flag or a renamed
+option is a failing test rather than a user's broken script.
+
+If a change to the surface is *intended*, regenerate the snapshot in the same
+commit — that makes it visible in review instead of invisible:
+
+```shell
+uv run python dev/snapshot_cli_surface.py
+```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from cellpy import log
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+SNAPSHOT = Path(__file__).parent / "data" / "cli_surface.json"
+
+
+def _live_surface() -> dict:
+    """Describe the live CLI using the same code the snapshot script uses.
+
+    Loaded by path rather than imported as ``dev.snapshot_cli_surface``:
+    ``dev/`` is a scripts directory, not a package, so whether it is importable
+    depends on how pytest was invoked. Sharing the *implementation* is the
+    point; sharing an import path is not.
+    """
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "dev" / "snapshot_cli_surface.py"
+    spec = importlib.util.spec_from_file_location("_cli_surface_snapshot", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build_surface()
+
+
+@pytest.fixture(scope="module")
+def expected() -> dict:
+    return json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def actual() -> dict:
+    return _live_surface()
+
+
+@pytest.mark.essential
+def test_the_command_set_is_unchanged(expected, actual):
+    assert [c["name"] for c in actual["commands"]] == [
+        c["name"] for c in expected["commands"]
+    ]
+
+
+@pytest.mark.essential
+def test_every_command_keeps_its_flags(expected, actual):
+    """The check that matters: no option silently renamed or dropped."""
+    expected_by_name = {c["name"]: c for c in expected["commands"]}
+    differences = []
+
+    for command in actual["commands"]:
+        name = command["name"]
+        before = expected_by_name.get(name)
+        if before is None:
+            differences.append(f"{name}: new command not in the snapshot")
+            continue
+
+        before_opts = {tuple(p["opts"]) for p in before["params"]}
+        after_opts = {tuple(p["opts"]) for p in command["params"]}
+
+        for missing in sorted(before_opts - after_opts):
+            differences.append(f"{name}: lost {'/'.join(missing)}")
+        for added in sorted(after_opts - before_opts):
+            differences.append(f"{name}: added {'/'.join(added)}")
+
+    assert not differences, "the CLI surface changed:\n  " + "\n  ".join(differences)
+
+
+@pytest.mark.essential
+def test_flags_stay_flags(expected, actual):
+    """A flag that becomes a value option breaks `cellpy run --raw`."""
+    expected_by_name = {c["name"]: c for c in expected["commands"]}
+    differences = []
+
+    for command in actual["commands"]:
+        before = expected_by_name.get(command["name"])
+        if before is None:
+            continue
+        before_flags = {
+            tuple(p["opts"]): p["is_flag"] for p in before["params"]
+        }
+        for param in command["params"]:
+            key = tuple(param["opts"])
+            if key in before_flags and before_flags[key] != param["is_flag"]:
+                differences.append(
+                    f"{command['name']}: {'/'.join(key)} flag-ness changed "
+                    f"({before_flags[key]} -> {param['is_flag']})"
+                )
+
+    assert not differences, "\n  ".join(differences)
+
+
+@pytest.mark.essential
+def test_subcommands_are_unchanged(expected, actual):
+    expected_by_name = {c["name"]: c for c in expected["commands"]}
+    for command in actual["commands"]:
+        before = expected_by_name.get(command["name"], {})
+        assert command.get("subcommands") == before.get("subcommands"), command["name"]
+
+
+@pytest.mark.essential
+def test_the_snapshot_is_not_empty(expected):
+    """Guard against a truncated snapshot silently passing everything."""
+    assert len(expected["commands"]) >= 8
+    assert sum(len(c["params"]) for c in expected["commands"]) >= 50


### PR DESCRIPTION
Groundwork for #569 — **the contract, not the cutover.**

## Why separately

Changing the CLI *framework* must not change the CLI. That needs an oracle, not
a careful read of the help text — so this lands the oracle first, green against
the current Click app, ready for the conversion to be checked against.

## What's here

`tests/data/cli_surface.json` snapshots **8 commands and 52 parameters**: every
option and short flag, whether each is a flag or takes a value, and the `setup`
subcommand structure. Five tests compare the live app against it, so a dropped
or renamed option is a failing test rather than a user's broken script.

The snapshot is taken through the *underlying Click command* — which Typer also
builds — so the same contract keeps working across the framework change.

`dev/snapshot_cli_surface.py` regenerates it, for when a surface change is
intended and should be visible in review rather than silent.

**Verified both directions:** green against the current implementation, and it
genuinely fails when a flag goes missing (`run: lost --raw`) rather than
passing vacuously.

## Why the cutover isn't in this PR

The inventory changed my estimate, so I'd rather say so than half-do it.

In `cli.py` the click-decorated function **is** the command body — `setup` is
~170 lines of interactive prompting under its decorators, `pull` ~500, `new`
~270. Converting means rewriting 52 parameter declarations in place, including
`setup` as a Group with `invoke_without_command=True` plus a `migrate`
subcommand, options with underscores (`--batch_col`, `--test_user`), two-letter
shorts (`-nr`, `-dr`), and a custom `Sentinel.UNSET` default.

None of it is hard; all of it is surface every user touches, and the acceptance
criterion (`click` removed from dependencies) needs all 8 done, including the
six whose bodies #568 deliberately left alone. That deserves a focused pass
against this contract rather than being rushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
