### PR TITLE
#567 Phase 0: a figure oracle, and the four regressions it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Sync dependencies (PyPI cellpycore only)
         run: uv sync
       - name: Run essential tests
-        run: uv run pytest -m essential --ignore=tests/test_plotutils_summary_plot.py
+        # No plotutils ignore: the summary-plot suite was excluded because it
+        # "needs a display", but it selects the Agg backend itself and runs
+        # headless fine. The exclusion was hiding real breakage (#567).
+        env:
+          MPLBACKEND: Agg
+        run: uv run pytest -m essential
       - name: Run cellpy setup
         run: uv run cellpy setup --silent
       - name: Run cellpy check
@@ -74,7 +79,10 @@ jobs:
         # before — the flip's curve-consumer migration needs this net).
         run: uv sync --extra batch
       - name: Run the full test suite
-        # same ignore as the tier-3 linux job (plotutils summary plot needs a
-        # display); everything else runs — this is the gate that catches
-        # non-essential regressions (issue #530)
-        run: uv run pytest --ignore=tests/test_plotutils_summary_plot.py
+        # The gate that catches non-essential regressions (issue #530). The
+        # plotutils exclusion is gone (#567): with --extra batch this job has
+        # plotly and seaborn, so it is the only place the figure menu actually
+        # renders. Agg keeps matplotlib headless.
+        env:
+          MPLBACKEND: Agg
+        run: uv run pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,9 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run pytest -m essential --ignore=tests/test_plotutils_summary_plot.py
+        env:
+          MPLBACKEND: Agg
+        run: uv run pytest -m essential
 
   publish:
     needs: test

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -20,6 +20,9 @@ import pandas as pd
 import numpy as np
 
 from cellpycore.config import CurveCols
+from cellpycore.legacy import mapping
+
+from cellpy._deprecation import warn_once
 
 from cellpy.parameters.internal_settings import (
     get_headers_journal,
@@ -461,9 +464,13 @@ def _plotly_label_dict(text, x, y):
     return d
 
 
-_hdr_summary = get_headers_summary()
-_hdr_raw = get_headers_normal()
-_hdr_steps = get_headers_step_table()
+#: ``normalized_cycle_index`` is spelled the same in both dialects (asserted in
+#: tests/test_plotutils_headers.py), so comparing against it needs no schema.
+#: The other three module-level header singletons that used to live here were
+#: removed in #567: they answered with *legacy* names regardless of the cell,
+#: which silently broke every raw-frame lookup after the native-headers flip.
+#: Use ``_LiveHeaders(cell, frame)`` instead.
+_NORMALIZED_CYCLE_INDEX = "normalized_cycle_index"
 _hdr_journal = get_headers_journal()
 
 
@@ -614,6 +621,125 @@ def _get_capacity_unit(c, mode="gravimetric"):
         return units_label("charge", mode, units=c.cellpy_units)
     except UnitsError:
         return "-"
+
+
+def _resolve_summary_column(c, name):
+    """Accept the legacy spelling of a summary column and return the live one.
+
+    The native-headers flip renamed summary columns, so ``summary_plot(c,
+    x="cycle_index")`` — the spelling in this module's own docstrings and in
+    every 1.x script — stopped indexing the frame and raised ``KeyError`` deep
+    inside a ``melt``. The default path was unaffected (it reads the name off
+    the schema), which is why nothing caught it.
+
+    Resolution is checked against the *frame*, so this works on both runtimes:
+    on the legacy runtime the frame still carries ``cycle_index`` and the name
+    is returned untouched.
+    """
+    if not isinstance(name, str):
+        return name
+
+    summary = getattr(getattr(c, "data", None), "summary", None)
+    columns = set(summary.columns) if summary is not None else set()
+
+    if not columns or name in columns:
+        return name
+
+    native = mapping.legacy_to_native_summary().get(name)
+    if native is None or native not in columns:
+        # Not a legacy spelling we know: leave it alone and let the caller
+        # raise its own error, which will name the column the user asked for.
+        return name
+
+    warn_once(
+        f"legacy summary column name {name!r} in a plot argument",
+        f"the native name {native!r} (see c.schema.summary)",
+        removal="2.1",
+    )
+    return native
+
+
+def _resolve_summary_columns(c, names):
+    """``_resolve_summary_column`` over a list, preserving order and Nones."""
+    if not names:
+        return names
+    return [_resolve_summary_column(c, name) for name in names]
+
+
+#: cellpy-core mapping key per frame, for ``_LiveHeaders``.
+_MAPPING_FRAME = {"raw": "raw", "steps": "step", "summary": "cycle"}
+
+
+class _LiveHeaders:
+    """Column names for *this cell's* frames, keyed by the 1.x attribute names.
+
+    Replaces the module-level ``_hdr_raw = get_headers_normal()`` /
+    ``_hdr_steps`` / ``_hdr_summary`` singletons. Those were built once at
+    import time and always answered with the **legacy** names, so after the
+    native-headers flip every lookup through them produced a key the frame no
+    longer had. That is why ``raw_plot`` and ``cycle_info_plot`` raised
+    ``KeyError: 'voltage'`` on any cellpy 2 cell — a module-level binding that
+    could not see the runtime, which is the same trap that bit the schema
+    migration in #558.
+
+    Resolution goes through the cell's own schema, so this is correct on both
+    runtimes: on the legacy runtime ``schema.raw.potential`` still answers
+    ``"voltage"``.
+
+    Both spellings the old singletons supported are kept, because call sites
+    use both: ``hdr["voltage_txt"]`` and ``hdr.voltage_txt``.
+    """
+
+    __slots__ = ("_schema", "_frame", "_attrs")
+
+    def __init__(self, c, frame: str):
+        self._frame = frame
+        self._schema = getattr(c.schema, frame)
+        self._attrs = mapping.LEGACY_ATTR_TO_SCHEMA[_MAPPING_FRAME[frame]]
+
+    def _resolve(self, legacy_attr: str) -> str:
+        native = self._attrs.get(legacy_attr)
+        if native is None:
+            # Either unknown, or a legacy-only column with no native
+            # counterpart. Fall back to the schema's own attribute so native
+            # spellings work too, and let it raise if that fails as well.
+            try:
+                return getattr(self._schema, legacy_attr)
+            except AttributeError:
+                raise KeyError(
+                    f"no {self._frame} column named {legacy_attr!r} on this cell"
+                ) from None
+        return getattr(self._schema, native)
+
+    def base(self, legacy_attr: str) -> str:
+        """The native *stem* of a step-table statistic family.
+
+        Step-table columns are ``<stem>_<statistic>`` (``potential_delta``,
+        ``current_min``). The schema exposes the composed columns, not the
+        stem, so this reads the stem straight off the mapping — and falls back
+        to the legacy spelling on the legacy runtime, where the stem is what
+        the frame already uses.
+        """
+        native = self._attrs.get(legacy_attr)
+        if native is None:
+            return legacy_attr
+        # On the legacy runtime the schema resolves the native name back to the
+        # legacy one; when it cannot (a stem is not a column) keep the native
+        # stem, which is what a native frame is built from.
+        try:
+            return getattr(self._schema, native)
+        except AttributeError:
+            return native
+
+    def stat(self, legacy_attr: str, statistic: str) -> str:
+        """``stat("voltage", "delta")`` -> ``"potential_delta"`` (native)."""
+        return f"{self.base(legacy_attr)}_{statistic}"
+
+    def __getitem__(self, legacy_attr: str) -> str:
+        return self._resolve(legacy_attr)
+
+    def __getattr__(self, legacy_attr: str) -> str:
+        return self._resolve(legacy_attr)
 
 
 # Per-row y-axis labels for predefined ``y`` sets that route a different
@@ -1799,7 +1925,7 @@ class PlotlyPlotBuilder:
         max_cycle_formation = data.loc[formation_cycle_selector, x].max()
         min_cycle_rest = data.loc[~formation_cycle_selector, x].min()
 
-        if x == _hdr_summary.normalized_cycle_index:
+        if x == _NORMALIZED_CYCLE_INDEX:
             dd = 0.1
         else:
             dd = 0.4
@@ -3657,7 +3783,7 @@ def summary_plot_legacy(
             ]
             max_cycle_formation = s.loc[formation_cycle_selector, x].max()
             min_cycle_rest = s.loc[~formation_cycle_selector, x].min()
-            if x == _hdr_summary.normalized_cycle_index:
+            if x == _NORMALIZED_CYCLE_INDEX:
                 dd = 0.1
             else:
                 dd = 0.4
@@ -4880,6 +5006,11 @@ def summary_plot(
         **kwargs,
     )
 
+    # Column names the caller spelled out are resolved against the frame, so
+    # 1.x spellings ("cycle_index") keep working after the native-headers flip.
+    config.x = _resolve_summary_column(c, config.x)
+    config.hover_columns = _resolve_summary_columns(c, config.hover_columns)
+
     # Check if interactive mode is requested and plotly is available
     if config.interactive:
         if not plotly_available:
@@ -4973,7 +5104,11 @@ def partition_summary_cv_steps(
     """
     import pandas as pd
 
-    summary = c.data.summary
+    # A copy, because `set_index(..., inplace=True)` below would otherwise move
+    # the x column out of the *cell's own* summary frame and leave it there:
+    # one CV-split plot and `c.data.summary` has permanently lost `cycle_num`,
+    # breaking every later plot and any user code reading that column (#567).
+    summary = c.data.summary.copy()
 
     summary_no_cv = c.make_summary(
         selector_type="non-cv", create_copy=True
@@ -5055,6 +5190,8 @@ def raw_plot(
     _set_individual_y_labels = False
     _special_height = None
 
+    # Per-cell, not the module-level legacy singleton (#567).
+    hdr_raw = _LiveHeaders(cell, "raw")
     raw = cell.data.raw.copy()
     if y is not None:
         if y_label is None:
@@ -5065,9 +5202,9 @@ def raw_plot(
     elif plot_type is not None:
         # special pre-defined plot types
         if plot_type == "voltage-current":
-            y1 = _hdr_raw["voltage_txt"]
+            y1 = hdr_raw["voltage_txt"]
             y1_label = f"Voltage ({cell.data.raw_units.voltage})"
-            y2 = _hdr_raw["current_txt"]
+            y2 = hdr_raw["current_txt"]
             y2_label = f"Current ({cell.data.raw_units.current})"
             y = [y1, y2]
             y_label = [y1_label, y2_label]
@@ -5075,11 +5212,11 @@ def raw_plot(
         elif plot_type == "capacity":
             _y = [
                 (
-                    _hdr_raw["charge_capacity_txt"],
+                    hdr_raw["charge_capacity_txt"],
                     f"Charge capacity ({cell.data.raw_units.charge})",
                 ),
                 (
-                    _hdr_raw["discharge_capacity_txt"],
+                    hdr_raw["discharge_capacity_txt"],
                     f"Discharge capacity ({cell.data.raw_units.charge})",
                 ),
             ]
@@ -5088,15 +5225,15 @@ def raw_plot(
         elif plot_type == "raw":
             _y = [
                 (
-                    _hdr_raw["cycle_index_txt"],
+                    hdr_raw["cycle_index_txt"],
                     f"Cycle index (#)",
                 ),
                 (
-                    _hdr_raw["step_index_txt"],
+                    hdr_raw["step_index_txt"],
                     f"Step index (#)",
                 ),
-                (_hdr_raw["voltage_txt"], f"Voltage ({cell.data.raw_units.voltage})"),
-                (_hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
+                (hdr_raw["voltage_txt"], f"Voltage ({cell.data.raw_units.voltage})"),
+                (hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
             ]
             y, y_label = zip(*_y)
             _special_height = 600
@@ -5104,36 +5241,36 @@ def raw_plot(
         elif plot_type == "capacity-current":
             _y = [
                 (
-                    _hdr_raw["charge_capacity_txt"],
+                    hdr_raw["charge_capacity_txt"],
                     f"Charge capacity ({cell.data.raw_units.charge})",
                 ),
                 (
-                    _hdr_raw["discharge_capacity_txt"],
+                    hdr_raw["discharge_capacity_txt"],
                     f"Discharge capacity ({cell.data.raw_units.charge})",
                 ),
-                (_hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
+                (hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
             ]
             y, y_label = zip(*_y)
             _special_height = 500
 
         elif plot_type == "full":
             _y = [
-                (_hdr_raw["voltage_txt"], f"Voltage ({cell.data.raw_units.voltage})"),
-                (_hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
+                (hdr_raw["voltage_txt"], f"Voltage ({cell.data.raw_units.voltage})"),
+                (hdr_raw["current_txt"], f"Current ({cell.data.raw_units.current})"),
                 (
-                    _hdr_raw["charge_capacity_txt"],
+                    hdr_raw["charge_capacity_txt"],
                     f"Charge capacity ({cell.data.raw_units.charge})",
                 ),
                 (
-                    _hdr_raw["discharge_capacity_txt"],
+                    hdr_raw["discharge_capacity_txt"],
                     f"Discharge capacity ({cell.data.raw_units.charge})",
                 ),
                 (
-                    _hdr_raw["cycle_index_txt"],
+                    hdr_raw["cycle_index_txt"],
                     f"Cycle index (#)",
                 ),
                 (
-                    _hdr_raw["step_index_txt"],
+                    hdr_raw["step_index_txt"],
                     f"Step index (#)",
                 ),
             ]
@@ -5145,7 +5282,7 @@ def raw_plot(
             return None
     else:
         # default to voltage if y is not given
-        y = [_hdr_raw["voltage_txt"]]
+        y = [hdr_raw["voltage_txt"]]
         y_label = [f"Voltage ({cell.data.raw_units.voltage})"]
 
     if x is None:
@@ -5154,17 +5291,17 @@ def raw_plot(
     if x in ["test_time_hrs", "test_time_hours"]:
         raw_time_unit = cell.raw_units.time
         conv_factor = Q(raw_time_unit).to("hours").magnitude
-        raw[x] = raw[_hdr_raw["test_time_txt"]] * conv_factor
+        raw[x] = raw[hdr_raw["test_time_txt"]] * conv_factor
         x_label = x_label or "Time (hours)"
     elif x == "test_time_days":
         raw_time_unit = cell.raw_units.time
         conv_factor = Q(raw_time_unit).to("days").magnitude
-        raw[x] = raw[_hdr_raw["test_time_txt"]] * conv_factor
+        raw[x] = raw[hdr_raw["test_time_txt"]] * conv_factor
         x_label = x_label or "Time (days)"
     elif x == "test_time_years":
         raw_time_unit = cell.raw_units.time
         conv_factor = Q(raw_time_unit).to("years").magnitude
-        raw[x] = raw[_hdr_raw["test_time_txt"]] * conv_factor
+        raw[x] = raw[hdr_raw["test_time_txt"]] * conv_factor
         x_label = x_label or "Time (years)"
 
     if title is None:
@@ -5369,23 +5506,24 @@ def _cycle_info_plot_plotly(
     if kwargs.get("xlim"):
         logging.info("xlim is not supported for plotly yet")
 
-    raw_hdr = get_headers_normal()
-    step_hdr = get_headers_step_table()
+    # Per-cell, not the module-level legacy singletons (#567).
+    raw_hdr = _LiveHeaders(cell, "raw")
+    step_hdr = _LiveHeaders(cell, "steps")
 
     data = cell.data.raw.copy()
     table = cell.data.steps.copy()
 
     if cycle is None:
-        cycle = list(data[_hdr_raw.cycle_index_txt].unique())
+        cycle = list(data[raw_hdr.cycle_index_txt].unique())
 
     if not isinstance(cycle, (list, tuple)):
         cycle = [cycle]
 
     delta = "_delta"
-    v_delta = step_hdr.voltage + delta
-    i_delta = step_hdr.current + delta
-    c_delta = step_hdr.charge + delta
-    dc_delta = step_hdr.discharge + delta
+    v_delta = step_hdr.stat("voltage", "delta")
+    i_delta = step_hdr.stat("current", "delta")
+    c_delta = step_hdr.stat("charge", "delta")
+    dc_delta = step_hdr.stat("discharge", "delta")
     cycle_ = step_hdr.cycle
     step_ = step_hdr.step
     type_ = step_hdr.type
@@ -5497,19 +5635,34 @@ def _plot_step(ax, x, y, color):
     ax.plot(x, y, color=color, linewidth=3)
 
 
-def _get_info(table, cycle, step):
-    m_table = (table[_hdr_steps.cycle] == cycle) & (table[_hdr_steps.step] == step)
-    p1, p2 = table.loc[m_table, ["point_min", "point_max"]].values[0]
-    c1, c2 = table.loc[m_table, ["current_min", "current_max"]].abs().values[0]
+def _get_info(table, cycle, step, step_hdr):
+    """``step_hdr`` is passed in: this helper never sees the cell, and the
+    module-level singleton it used to read answered with legacy names (#567)."""
+    m_table = (table[step_hdr.cycle] == cycle) & (table[step_hdr.step] == step)
+    # Step-table statistic columns, composed from the live stems rather than
+    # hard-coded legacy spellings ("voltage_delta" is "potential_delta" on a
+    # native frame).
+    p1, p2 = table.loc[
+        m_table, [step_hdr.stat("point", "min"), step_hdr.stat("point", "max")]
+    ].values[0]
+    c1, c2 = (
+        table.loc[
+            m_table,
+            [step_hdr.stat("current", "min"), step_hdr.stat("current", "max")],
+        ]
+        .abs()
+        .values[0]
+    )
     d_voltage, d_current = table.loc[
-        m_table, ["voltage_delta", "current_delta"]
+        m_table, [step_hdr.stat("voltage", "delta"), step_hdr.stat("current", "delta")]
     ].values[0]
     d_discharge, d_charge = table.loc[
-        m_table, ["discharge_delta", "charge_delta"]
+        m_table,
+        [step_hdr.stat("discharge", "delta"), step_hdr.stat("charge", "delta")],
     ].values[0]
     current_max = (c1 + c2) / 2
-    rate = table.loc[m_table, _hdr_steps.rate_avr].values[0]
-    step_type = table.loc[m_table, _hdr_steps.type].values[0]
+    rate = table.loc[m_table, step_hdr.rate_avr].values[0]
+    step_type = table.loc[m_table, step_hdr.type].values[0]
     return [step_type, rate, current_max, d_voltage, d_current, d_discharge, d_charge]
 
 
@@ -5537,13 +5690,17 @@ def _cycle_info_plot_matplotlib(
     data = cell.data.raw
     table = cell.data.steps
 
+    # Per-cell, not the module-level legacy singletons (#567).
+    raw_hdr = _LiveHeaders(cell, "raw")
+    step_hdr = _LiveHeaders(cell, "steps")
+
     span_colors = ["#4682B4", "#FFA07A"]
 
     voltage_color = "#008B8B"
     current_color = "#CD5C5C"
 
-    m_cycle_data = data[_hdr_raw.cycle_index_txt] == cycle
-    all_steps = data[m_cycle_data][_hdr_raw.step_index_txt].unique()
+    m_cycle_data = data[raw_hdr.cycle_index_txt] == cycle
+    all_steps = data[m_cycle_data][raw_hdr.step_index_txt].unique()
 
     color = itertools.cycle(span_colors)
 
@@ -5564,12 +5721,12 @@ def _cycle_info_plot_matplotlib(
     annotations_4 = []  # info
 
     for i, s in enumerate(all_steps):
-        m = m_cycle_data & (data[_hdr_raw.step_index_txt] == s)
-        c = data.loc[m, _hdr_raw.current_txt] * i_scaler
-        v = data.loc[m, _hdr_raw.voltage_txt] * v_scaler
-        t = data.loc[m, _hdr_raw.test_time_txt] * t_scaler
+        m = m_cycle_data & (data[raw_hdr.step_index_txt] == s)
+        c = data.loc[m, raw_hdr.current_txt] * i_scaler
+        v = data.loc[m, raw_hdr.voltage_txt] * v_scaler
+        t = data.loc[m, raw_hdr.test_time_txt] * t_scaler
         step_type, rate, current_max, dv, dc, d_discharge, d_charge = _get_info(
-            table, cycle, s
+            table, cycle, s, step_hdr
         )
         if len(t) > 1:
             fcolor = next(color)

--- a/dev/snapshot_figure_specs.py
+++ b/dev/snapshot_figure_specs.py
@@ -1,0 +1,61 @@
+"""Snapshot the structure of every figure cellpy can draw (#567).
+
+The snapshot is the contract ``tests/test_figure_specs.py`` checks against, so
+that moving the plotting stack around cannot quietly change the figures.
+Regenerate it only when a change to a figure is *intended*, and in the same
+commit as the change, so review sees it:
+
+```shell
+uv sync --extra batch          # plotly + seaborn; the menu is skipped without them
+uv run python dev/snapshot_figure_specs.py
+```
+
+Structural, not pixels: trace counts, trace names, axis assignment, series
+lengths and endpoints, axis titles. See ``tests/figure_spec_support.py`` for
+why.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+if str(REPO_ROOT / "tests") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "tests"))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from figure_spec_support import (  # noqa: E402
+    FIGURE_CASES,
+    SNAPSHOT_PATH,
+    build_figure_specs,
+    plotly_available,
+    seaborn_available,
+)
+
+
+def main() -> None:
+    if not (plotly_available and seaborn_available):
+        raise SystemExit(
+            "plotly and seaborn are both needed to render the full menu.\n"
+            "Run `uv sync --extra batch` first — regenerating without them "
+            "would silently drop cases from the snapshot."
+        )
+
+    specs = build_figure_specs()
+
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SNAPSHOT_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(specs, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    rendered = len(specs["figures"])
+    print(f"wrote {SNAPSHOT_PATH}")
+    print(f"figures: {rendered} of {len(FIGURE_CASES)} cases")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/figure_specs.json
+++ b/tests/data/figure_specs.json
@@ -1,0 +1,7677 @@
+{
+  "figures": {
+    "cycle_info_plot[matplotlib]": {
+      "backend": null,
+      "empty": true
+    },
+    "cycle_info_plot[plotly]": {
+      "backend": null,
+      "empty": true
+    },
+    "cycles_plot[matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 3,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "Cycle 1",
+              "x": {
+                "first": 0.000315,
+                "last": null,
+                "n": 2347
+              },
+              "y": {
+                "first": 2.839894,
+                "last": null,
+                "n": 2347
+              }
+            },
+            {
+              "label": "Cycle 2",
+              "x": {
+                "first": 0.001349,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.860937,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 3",
+              "x": {
+                "first": 0.002021,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.84431,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 4",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.833225,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 5",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.792888,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 6",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.787654,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 7",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.787038,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 8",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.783035,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 9",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.784574,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 10",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.781495,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 11",
+              "x": {
+                "first": 0.001266,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.778108,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 12",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.776569,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 13",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.774721,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 14",
+              "x": {
+                "first": 0.00118,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.773182,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 15",
+              "x": {
+                "first": 0.001095,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.770718,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 16",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.766408,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 17",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 402
+              },
+              "y": {
+                "first": 0.761789,
+                "last": null,
+                "n": 402
+              }
+            },
+            {
+              "label": "Cycle 18",
+              "x": {
+                "first": 0.0,
+                "last": null,
+                "n": 201
+              },
+              "y": {
+                "first": 0.75717,
+                "last": null,
+                "n": 201
+              }
+            }
+          ],
+          "n_collections": 0,
+          "n_lines": 18,
+          "title": "",
+          "xlabel": "Capacity (mAh/g)",
+          "ylabel": "Voltage (V)"
+        },
+        {
+          "lines": [],
+          "n_collections": 2,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Form. Cycle"
+        },
+        {
+          "lines": [],
+          "n_collections": 2,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Cycle"
+        }
+      ]
+    },
+    "cycles_plot[plotly]": {
+      "backend": null,
+      "empty": true
+    },
+    "raw_plot[matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "Voltage (V)",
+              "x": {
+                "first": 0.083336,
+                "last": 238.632567,
+                "n": 10261
+              },
+              "y": {
+                "first": 3.097617,
+                "last": 0.294069,
+                "n": 10261
+              }
+            }
+          ],
+          "n_collections": 0,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Time (hours)",
+          "ylabel": "Voltage (V)"
+        },
+        {
+          "lines": [
+            {
+              "label": "Current (A)",
+              "x": {
+                "first": 0.083336,
+                "last": 238.632567,
+                "n": 10261
+              },
+              "y": {
+                "first": 0.0,
+                "last": -0.000304,
+                "n": 10261
+              }
+            }
+          ],
+          "n_collections": 0,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Current (A)"
+        }
+      ]
+    },
+    "raw_plot[plotly]": {
+      "axis_titles": {
+        "xaxis": null,
+        "xaxis2": null,
+        "yaxis": null,
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 2,
+      "traces": [
+        {
+          "mode": null,
+          "name": "Voltage (V)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": null,
+          "name": "Current (A)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 0.001625,
+                "last": 0.001732,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 0.001755,
+                "last": 0.001586,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_capacity",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (Ah)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.001576,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.001517,
+                "last": 0.000239,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "yaxis": "Capacity (Ah)",
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 4,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            },
+            {
+              "label": "discharge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "yaxis": "Capacity (mAh)",
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 4,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute_coulombic_efficiency][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Efficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute_coulombic_efficiency][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute_with_rate][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 153.61986,
+                "last": 153.59407,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 152.21136,
+                "last": 152.32096,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 6,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "C-rate\n(1/h)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 17.0,
+                "n": 14
+              },
+              "y": {
+                "first": 305.52629,
+                "last": 305.51966,
+                "n": 14
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 304.43801,
+                "last": 304.4204,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_absolute_with_rate][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh)",
+        "yaxis2": null,
+        "yaxis3": "C-rate (1/h)",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_areal][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_areal][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "yaxis": "Capacity (mAh/cm**2)",
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 4,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_coulombic_efficiency][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Efficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_coulombic_efficiency][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/cm**2)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_split_constant_voltage][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 6,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal_non_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal_non_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 8,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_split_constant_voltage][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "yaxis": "Capacity (mAh/cm**2)",
+        "yaxis2": null,
+        "yaxis3": "Capacity (mAh/cm**2)",
+        "yaxis4": null,
+        "yaxis5": "Capacity (mAh/cm**2)",
+        "yaxis6": null
+      },
+      "backend": "plotly",
+      "n_axes": 12,
+      "n_traces": 12,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_with_rate][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 153.61986,
+                "last": 153.59407,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 152.21136,
+                "last": 152.32096,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 6,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "C-rate\n(1/h)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 17.0,
+                "n": 14
+              },
+              "y": {
+                "first": 305.52629,
+                "last": 305.51966,
+                "n": 14
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 304.43801,
+                "last": 304.4204,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_areal_with_rate][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/cm**2)",
+        "yaxis2": null,
+        "yaxis3": "C-rate (1/h)",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 4,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_coulombic_efficiency][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Efficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_coulombic_efficiency][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_split_constant_voltage][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 6,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric_non_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric_non_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 8,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_split_constant_voltage][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Capacity (mAh/g)",
+        "yaxis4": null,
+        "yaxis5": "Capacity (mAh/g)",
+        "yaxis6": null
+      },
+      "backend": "plotly",
+      "n_axes": 12,
+      "n_traces": 12,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav. (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav. (without CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_with_rate][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 4,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 153.61986,
+                "last": 153.59407,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 152.21136,
+                "last": 152.32096,
+                "n": 3
+              }
+            },
+            {
+              "label": "charge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_c_rate",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 6,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "C-rate\n(1/h)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 17.0,
+                "n": 14
+              },
+              "y": {
+                "first": 305.52629,
+                "last": 305.51966,
+                "n": 14
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 304.43801,
+                "last": 304.4204,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Capacity (mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[capacities_gravimetric_with_rate][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "C-rate (1/h)",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge C Rate",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[formation_10][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_absolute][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_retention_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_absolute_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.0,
+                "last": 0.903497,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.864523,
+                "last": 0.136354,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_absolute][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_areal][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_retention_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.0,
+                "last": 0.903497,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.864523,
+                "last": 0.136354,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_areal][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh/cm**2)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh/cm**2)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh/cm**2)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_absolute][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "test_cumulated_discharge_capacity_loss_absolute",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_absolute_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh)"
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_absolute][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Absolute",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Absolute (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_areal][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "test_cumulated_discharge_capacity_loss_areal",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_areal_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.755094,
+                "last": 1.585721,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.517318,
+                "last": 0.239313,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh/cm**2)"
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.625406,
+                "last": 1.731508,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh/cm**2)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1.575978,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_areal][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh/cm**2)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh/cm**2)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh/cm**2)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Areal",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Areal (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_gravimetric][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "test_cumulated_discharge_capacity_loss_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh/g)"
+        },
+        {
+          "lines": [],
+          "n_collections": 0,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_cumloss_gravimetric][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh/g)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh/g)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Test Cumulated Discharge Capacity Loss Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_dev][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_retention_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(-)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.0,
+                "last": 0.903497,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(-)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.864523,
+                "last": 0.136354,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(-)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_dev][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(-)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (-)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(-)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_gravimetric][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 8,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 92.610791,
+                "last": 109.19373,
+                "n": 3
+              }
+            },
+            {
+              "label": "coulombic_efficiency",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "discharge_capacity_retention_gravimetric",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "charge_capacity_gravimetric_cv",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 5,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Coulombic\nEfficiency (%)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 103.86601,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1755.093529,
+                "last": 1585.720948,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\n(mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1517.317964,
+                "last": 239.313156,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.0,
+                "last": 0.903497,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "Capacity\nRetention\n(mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.864523,
+                "last": 0.136354,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "",
+          "ylabel": ""
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1625.405999,
+                "last": 1731.507851,
+                "n": 3
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "CV Capacity\n(mAh/g)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 1575.977622,
+                "last": 0.0,
+                "n": 15
+              }
+            }
+          ],
+          "n_collections": 1,
+          "n_lines": 1,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[fullcell_standard_gravimetric][plotly]": {
+      "axis_titles": {
+        "xaxis": "",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "xaxis5": null,
+        "xaxis6": null,
+        "xaxis7": null,
+        "xaxis8": null,
+        "yaxis": "CV Capacity<br>(mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Capacity<br>Retention (mAh/g)",
+        "yaxis4": null,
+        "yaxis5": "Capacity<br>(mAh/g)",
+        "yaxis6": null,
+        "yaxis7": "Coulombic<br>Efficiency (%)",
+        "yaxis8": null
+      },
+      "backend": "plotly",
+      "n_axes": 16,
+      "n_traces": 8,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x7",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y7"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x8",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y8"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x5",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y5"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x6",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y6"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Retention Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav. (CV)",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[no_formation][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": "Coulombic Efficiency"
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 3,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        }
+      ]
+    },
+    "summary_plot[no_legend][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "coulombic_efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "coulombic_efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "discharge_capacity_gravimetric",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "discharge_capacity_gravimetric",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "charge_capacity_gravimetric",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "charge_capacity_gravimetric",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[no_markers][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[shared_y][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[titled][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[voltages][matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 0.049894,
+                "last": 0.049894,
+                "n": 3
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 1.0,
+                "last": 3.0,
+                "n": 3
+              },
+              "y": {
+                "first": 1.000113,
+                "last": 1.000113,
+                "n": 3
+              }
+            },
+            {
+              "label": "potential_end_discharge",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            },
+            {
+              "label": "potential_end_charge",
+              "x": {
+                "first": null,
+                "last": null,
+                "n": 0
+              },
+              "y": {
+                "first": null,
+                "last": null,
+                "n": 0
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 4,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": "Voltage (V)"
+        },
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 4.0,
+                "last": 18.0,
+                "n": 15
+              },
+              "y": {
+                "first": 0.049894,
+                "last": 0.294069,
+                "n": 15
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 4.0,
+                "last": 17.0,
+                "n": 14
+              },
+              "y": {
+                "first": 1.000113,
+                "last": 1.000113,
+                "n": 14
+              }
+            }
+          ],
+          "n_collections": 2,
+          "n_lines": 2,
+          "title": "",
+          "xlabel": "Cycle Number",
+          "ylabel": ""
+        }
+      ]
+    },
+    "summary_plot[voltages][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "yaxis": "Voltage (V)",
+        "yaxis2": null
+      },
+      "backend": "plotly",
+      "n_axes": 4,
+      "n_traces": 4,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Potential End Discharge",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Potential End Discharge",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Potential End Charge",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Potential End Charge",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    },
+    "summary_plot[x_cycle_index_legacy_spelling][plotly]": {
+      "axis_titles": {
+        "xaxis": "Cycle Number",
+        "xaxis2": "Cycle Number",
+        "xaxis3": null,
+        "xaxis4": null,
+        "yaxis": "Capacity (mAh/g)",
+        "yaxis2": null,
+        "yaxis3": "Coulombic Efficiency",
+        "yaxis4": null
+      },
+      "backend": "plotly",
+      "n_axes": 8,
+      "n_traces": 6,
+      "traces": [
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x3",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y3"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Coulombic Efficiency",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x4",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y4"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Discharge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines+markers",
+          "name": "Charge Capacity Grav.",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x2",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y2"
+        }
+      ]
+    }
+  }
+}

--- a/tests/figure_spec_support.py
+++ b/tests/figure_spec_support.py
@@ -1,0 +1,317 @@
+"""Structural figure snapshots for the plotting redesign (#567, Phase 0).
+
+The plotting stack is ~11 000 lines across three modules with four overlapping
+generations, and the redesign moves all of it. Pixel diffing is the wrong
+instrument — brittle, huge, and it tells you *that* something moved, not what.
+These snapshots record the **structure** of each figure instead: how many
+traces, on which axes, with which names, how many points, and what the axis
+titles say.
+
+That is enough to catch the failures that matter in a refactor of this kind —
+a lost trace, a panel that stopped being drawn, a mislabelled axis, a series
+plotted against the wrong column — while staying stable across plotly and
+matplotlib version bumps.
+
+Both backends are described into the *same* shape, so the plan's "one spec,
+two renderers" claim becomes checkable: a family that renders differently
+under plotly and matplotlib shows up as a diff between two entries here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "data" / "figure_specs.json"
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+seaborn_available = importlib.util.find_spec("seaborn") is not None
+
+#: Values are rounded before they are recorded. Figure data is derived through
+#: interpolation and unit conversion, so the last bits differ between
+#: platforms — the ICA goldens (#566) were bitten by exactly that.
+VALUE_DIGITS = 6
+
+
+def _round(value: Any) -> Any:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:  # NaN
+        return None
+    return round(number, VALUE_DIGITS)
+
+
+def _series_fingerprint(values) -> dict[str, Any]:
+    """Length plus endpoints — enough to spot a series plotted from the wrong column."""
+    try:
+        sequence = list(values)
+    except TypeError:
+        return {"n": 0, "first": None, "last": None}
+    if not sequence:
+        return {"n": 0, "first": None, "last": None}
+    return {
+        "n": len(sequence),
+        "first": _round(sequence[0]),
+        "last": _round(sequence[-1]),
+    }
+
+
+def _describe_plotly(figure) -> dict[str, Any]:
+    document = figure.to_dict()
+    layout = document.get("layout", {})
+
+    traces = []
+    for trace in document.get("data", []):
+        traces.append(
+            {
+                "name": trace.get("name"),
+                "type": trace.get("type"),
+                "mode": trace.get("mode"),
+                "xaxis": trace.get("xaxis", "x"),
+                "yaxis": trace.get("yaxis", "y"),
+                "x": _series_fingerprint(trace.get("x")),
+                "y": _series_fingerprint(trace.get("y")),
+            }
+        )
+
+    axis_titles = {}
+    for key, value in layout.items():
+        if not key.startswith(("xaxis", "yaxis")):
+            continue
+        if isinstance(value, dict):
+            title = value.get("title")
+            if isinstance(title, dict):
+                title = title.get("text")
+            axis_titles[key] = title
+
+    return {
+        "backend": "plotly",
+        "n_traces": len(traces),
+        "traces": traces,
+        "axis_titles": dict(sorted(axis_titles.items())),
+        "n_axes": len(axis_titles),
+    }
+
+
+def _describe_matplotlib(figure) -> dict[str, Any]:
+    panels = []
+    for axes in figure.get_axes():
+        lines = []
+        for line in axes.get_lines():
+            lines.append(
+                {
+                    "label": line.get_label(),
+                    "x": _series_fingerprint(line.get_xdata()),
+                    "y": _series_fingerprint(line.get_ydata()),
+                }
+            )
+        panels.append(
+            {
+                "title": axes.get_title(),
+                "xlabel": axes.get_xlabel(),
+                "ylabel": axes.get_ylabel(),
+                "n_lines": len(lines),
+                "n_collections": len(axes.collections),
+                "lines": lines,
+            }
+        )
+
+    return {
+        "backend": "matplotlib",
+        "n_panels": len(panels),
+        "panels": panels,
+    }
+
+
+def describe_figure(figure) -> dict[str, Any]:
+    """Describe *figure* structurally, whichever backend produced it."""
+    if figure is None:
+        return {"backend": None, "empty": True}
+    if hasattr(figure, "to_dict") and hasattr(figure, "data"):
+        return _describe_plotly(figure)
+    if hasattr(figure, "get_axes"):
+        return _describe_matplotlib(figure)
+    raise TypeError(f"cannot describe a figure of type {type(figure)!r}")
+
+
+# --- the figure menu ---------------------------------------------------------
+
+#: Every predefined y-set `summary_plot` accepts, read off `_create_col_info`.
+#: A family missing from this list is a family with no regression net.
+SUMMARY_FAMILIES = (
+    "voltages",
+    "capacities",
+    "capacities_gravimetric",
+    "capacities_areal",
+    "capacities_absolute",
+    "capacities_gravimetric_split_constant_voltage",
+    "capacities_areal_split_constant_voltage",
+    "capacities_gravimetric_coulombic_efficiency",
+    "capacities_areal_coulombic_efficiency",
+    "capacities_absolute_coulombic_efficiency",
+    "capacities_gravimetric_with_rate",
+    "capacities_areal_with_rate",
+    "capacities_absolute_with_rate",
+    "fullcell_standard_gravimetric",
+    "fullcell_standard_areal",
+    "fullcell_standard_absolute",
+    "fullcell_standard_cumloss_gravimetric",
+    "fullcell_standard_cumloss_areal",
+    "fullcell_standard_cumloss_absolute",
+    "fullcell_standard_dev",
+)
+
+
+@dataclass(frozen=True)
+class FigureCase:
+    """One figure in the menu."""
+
+    name: str
+    function: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    needs_plotly: bool = False
+    needs_seaborn: bool = False
+
+    def skip_reason(self) -> str | None:
+        if self.needs_plotly and not plotly_available:
+            return "plotly not installed"
+        if self.needs_seaborn and not seaborn_available:
+            return "seaborn not installed"
+        return None
+
+
+def _summary_cases() -> list[FigureCase]:
+    cases: list[FigureCase] = []
+    for family in SUMMARY_FAMILIES:
+        cases.append(
+            FigureCase(
+                name=f"summary_plot[{family}][plotly]",
+                function="summary_plot",
+                kwargs={"y": family, "interactive": True},
+                needs_plotly=True,
+            )
+        )
+        cases.append(
+            FigureCase(
+                name=f"summary_plot[{family}][matplotlib]",
+                function="summary_plot",
+                kwargs={"y": family, "interactive": False},
+                needs_seaborn=True,
+            )
+        )
+    return cases
+
+
+#: Options that change layout rather than data — the ones a layout engine
+#: rewrite is most likely to break.
+def _summary_option_cases() -> list[FigureCase]:
+    family = "capacities_gravimetric_coulombic_efficiency"
+    variants = {
+        "no_formation": {"show_formation": False},
+        "formation_10": {"formation_cycles": 10},
+        "no_legend": {"show_legend": False},
+        "no_markers": {"markers": False},
+        "shared_y": {"share_y": True},
+        "titled": {"title": "a title"},
+        "x_cycle_index_legacy_spelling": {"x": "cycle_index"},
+    }
+    cases = []
+    for label, kwargs in variants.items():
+        cases.append(
+            FigureCase(
+                name=f"summary_plot[{label}][plotly]",
+                function="summary_plot",
+                kwargs={"y": family, "interactive": True, **kwargs},
+                needs_plotly=True,
+            )
+        )
+    return cases
+
+
+def _other_family_cases() -> list[FigureCase]:
+    return [
+        FigureCase(
+            name="raw_plot[plotly]",
+            function="raw_plot",
+            kwargs={"interactive": True},
+            needs_plotly=True,
+        ),
+        FigureCase(
+            name="raw_plot[matplotlib]",
+            function="raw_plot",
+            kwargs={"interactive": False},
+        ),
+        FigureCase(
+            name="cycle_info_plot[plotly]",
+            function="cycle_info_plot",
+            kwargs={"cycle": 3, "interactive": True},
+            needs_plotly=True,
+        ),
+        FigureCase(
+            name="cycle_info_plot[matplotlib]",
+            function="cycle_info_plot",
+            kwargs={"cycle": 3, "interactive": False},
+        ),
+        FigureCase(
+            name="cycles_plot[plotly]",
+            function="cycles_plot",
+            kwargs={"interactive": True},
+            needs_plotly=True,
+        ),
+        FigureCase(
+            name="cycles_plot[matplotlib]",
+            function="cycles_plot",
+            kwargs={"interactive": False},
+        ),
+    ]
+
+
+FIGURE_CASES: tuple[FigureCase, ...] = tuple(
+    _summary_cases() + _summary_option_cases() + _other_family_cases()
+)
+
+
+def load_figure_cell():
+    """The canonical Arbin cell, with the summary the plots need."""
+    from tests.ica_golden_support import load_golden_cell
+
+    return load_golden_cell()
+
+
+def render_case(case: FigureCase, cell) -> dict[str, Any]:
+    """Render one case and return its structural description."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    from cellpy.utils import plotutils
+
+    function: Callable = getattr(plotutils, case.function)
+    figure = function(cell, **case.kwargs)
+    description = describe_figure(figure)
+
+    # Free the matplotlib figure; the menu renders ~50 of them in one process.
+    if hasattr(figure, "get_axes"):
+        import matplotlib.pyplot as plt
+
+        plt.close(figure)
+
+    return description
+
+
+def build_figure_specs(cell=None) -> dict[str, Any]:
+    """Render the whole menu and describe each figure."""
+    if cell is None:
+        cell = load_figure_cell()
+
+    specs: dict[str, Any] = {}
+    for case in FIGURE_CASES:
+        if case.skip_reason():
+            continue
+        specs[case.name] = render_case(case, cell)
+    return {"figures": specs}

--- a/tests/test_figure_specs.py
+++ b/tests/test_figure_specs.py
@@ -1,0 +1,193 @@
+"""The figure menu is a contract (#567).
+
+The plotting redesign moves ~11 000 lines across three modules. These tests
+compare the live figures against ``tests/data/figure_specs.json`` so that
+moving the code cannot quietly change what is drawn.
+
+If a change to a figure is *intended*, regenerate the snapshot in the same
+commit — that makes it visible in review instead of invisible:
+
+```shell
+uv sync --extra batch
+uv run python dev/snapshot_figure_specs.py
+```
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from cellpy import log
+from tests.figure_spec_support import (
+    FIGURE_CASES,
+    SNAPSHOT_PATH,
+    FigureCase,
+    describe_figure,
+    render_case,
+    plotly_available,
+    seaborn_available,
+)
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+#: Data endpoints are compared with a tolerance rather than exactly. Figure
+#: values come out of interpolation and unit conversion, and the ICA goldens
+#: (#566) showed those differ between platforms at ~5e-7 relative.
+VALUE_TOLERANCE = 1e-5
+
+
+@pytest.fixture(scope="module")
+def expected() -> dict:
+    if not SNAPSHOT_PATH.is_file():
+        pytest.skip(f"missing snapshot {SNAPSHOT_PATH}")
+    return json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))["figures"]
+
+
+@pytest.fixture(scope="module")
+def cell():
+    from tests.figure_spec_support import load_figure_cell
+
+    return load_figure_cell()
+
+
+def _case_id(case: FigureCase) -> str:
+    return case.name
+
+
+def _compare_series(actual: dict, want: dict, where: str) -> list[str]:
+    problems = []
+    if actual["n"] != want["n"]:
+        problems.append(f"{where}: {want['n']} points -> {actual['n']}")
+    for edge in ("first", "last"):
+        a, w = actual[edge], want[edge]
+        if a is None or w is None:
+            if a is not w:
+                problems.append(f"{where}.{edge}: {w} -> {a}")
+            continue
+        if w == 0:
+            if abs(a) > VALUE_TOLERANCE:
+                problems.append(f"{where}.{edge}: {w} -> {a}")
+        elif abs(a - w) / abs(w) > VALUE_TOLERANCE:
+            problems.append(f"{where}.{edge}: {w} -> {a}")
+    return problems
+
+
+def _compare_plotly(actual: dict, want: dict) -> list[str]:
+    problems = []
+    if actual["n_traces"] != want["n_traces"]:
+        problems.append(f"trace count: {want['n_traces']} -> {actual['n_traces']}")
+        return problems
+
+    for index, (a, w) in enumerate(zip(actual["traces"], want["traces"])):
+        tag = f"trace[{index}] {w.get('name')!r}"
+        for key in ("name", "type", "mode", "xaxis", "yaxis"):
+            if a.get(key) != w.get(key):
+                problems.append(f"{tag}.{key}: {w.get(key)!r} -> {a.get(key)!r}")
+        problems += _compare_series(a["x"], w["x"], f"{tag}.x")
+        problems += _compare_series(a["y"], w["y"], f"{tag}.y")
+
+    if actual["axis_titles"] != want["axis_titles"]:
+        problems.append(
+            f"axis titles: {want['axis_titles']} -> {actual['axis_titles']}"
+        )
+    return problems
+
+
+def _compare_matplotlib(actual: dict, want: dict) -> list[str]:
+    problems = []
+    if actual["n_panels"] != want["n_panels"]:
+        problems.append(f"panel count: {want['n_panels']} -> {actual['n_panels']}")
+        return problems
+
+    for index, (a, w) in enumerate(zip(actual["panels"], want["panels"])):
+        tag = f"panel[{index}]"
+        for key in ("title", "xlabel", "ylabel", "n_lines", "n_collections"):
+            if a.get(key) != w.get(key):
+                problems.append(f"{tag}.{key}: {w.get(key)!r} -> {a.get(key)!r}")
+        if a["n_lines"] != w["n_lines"]:
+            continue
+        for line_index, (al, wl) in enumerate(zip(a["lines"], w["lines"])):
+            line_tag = f"{tag}.line[{line_index}] {wl.get('label')!r}"
+            if al.get("label") != wl.get("label"):
+                problems.append(
+                    f"{line_tag}.label: {wl.get('label')!r} -> {al.get('label')!r}"
+                )
+            problems += _compare_series(al["x"], wl["x"], f"{line_tag}.x")
+            problems += _compare_series(al["y"], wl["y"], f"{line_tag}.y")
+    return problems
+
+
+@pytest.mark.parametrize("case", FIGURE_CASES, ids=_case_id)
+def test_figure_structure_matches_the_snapshot(case: FigureCase, expected, cell):
+    reason = case.skip_reason()
+    if reason:
+        pytest.skip(reason)
+    if case.name not in expected:
+        pytest.skip(f"{case.name} is not in the snapshot; regenerate it")
+
+    want = expected[case.name]
+    actual = render_case(case, cell)
+
+    assert actual["backend"] == want["backend"], (
+        f"{case.name}: backend {want['backend']} -> {actual['backend']}"
+    )
+
+    # `cycle_info_plot` (both backends) and `cycles_plot` under plotly return
+    # None rather than a figure, while `summary_plot`, `raw_plot` and
+    # `cycles_plot` under matplotlib return one. That asymmetry is recorded
+    # here as today's contract, not endorsed — unifying the return value is a
+    # user-visible change and belongs with the redesign, not with its oracle.
+    if want.get("empty"):
+        assert actual.get("empty"), f"{case.name} now returns a figure"
+        return
+
+    if want["backend"] == "plotly":
+        problems = _compare_plotly(actual, want)
+    else:
+        problems = _compare_matplotlib(actual, want)
+
+    assert not problems, f"{case.name} changed:\n  " + "\n  ".join(problems)
+
+
+@pytest.mark.essential
+def test_the_snapshot_covers_the_whole_menu(expected):
+    """A snapshot that quietly lost half its cases would pass everything."""
+    if not (plotly_available and seaborn_available):
+        pytest.skip("the full menu needs plotly and seaborn")
+    missing = [c.name for c in FIGURE_CASES if c.name not in expected]
+    assert not missing, f"cases with no snapshot: {missing}"
+    assert len(expected) >= 50
+
+
+@pytest.mark.essential
+def test_plotting_does_not_mutate_the_cell(cell):
+    """Drawing a figure must not change the data it drew from.
+
+    `partition_summary_cv_steps` used to `set_index(..., inplace=True)` on
+    `c.data.summary` itself, so one CV-split plot permanently removed the
+    cycle column from the user's cell and broke every later plot (#567).
+    """
+    summary_before = list(cell.data.summary.columns)
+    raw_before = list(cell.data.raw.columns)
+    steps_before = list(cell.data.steps.columns)
+    n_rows_before = len(cell.data.summary)
+
+    from cellpy.utils.plotutils import summary_plot
+
+    summary_plot(
+        cell, y="capacities_gravimetric_split_constant_voltage", interactive=False
+    )
+
+    assert list(cell.data.summary.columns) == summary_before
+    assert list(cell.data.raw.columns) == raw_before
+    assert list(cell.data.steps.columns) == steps_before
+    assert len(cell.data.summary) == n_rows_before
+
+
+@pytest.mark.essential
+def test_describe_figure_rejects_a_non_figure():
+    with pytest.raises(TypeError, match="cannot describe"):
+        describe_figure(object())

--- a/tests/test_plotutils_headers.py
+++ b/tests/test_plotutils_headers.py
@@ -1,0 +1,181 @@
+"""Regressions found by the figure oracle (#567).
+
+Every test here corresponds to something that was broken on cellpy 2 and that
+no test caught, because the only plotting test file in the repo was excluded
+from CI and the other plot families had no tests at all.
+
+The common cause is a binding that could not see the runtime: module-level
+header singletons built at import time, which answered with *legacy* column
+names no matter which cell you handed them. The native-headers flip then made
+every lookup through them miss.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+from cellpy import log
+from cellpy.utils import plotutils
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+seaborn_available = importlib.util.find_spec("seaborn") is not None
+
+
+@pytest.fixture(scope="module")
+def cell():
+    from tests.figure_spec_support import load_figure_cell
+
+    return load_figure_cell()
+
+
+# --- the module-level singletons are gone ------------------------------------
+
+
+@pytest.mark.essential
+def test_no_module_level_header_singletons():
+    """The trap itself: a header table fixed at import time.
+
+    `_hdr_raw = get_headers_normal()` could not know whether the cell it was
+    used with carried native or legacy columns, so it was wrong for every
+    cellpy 2 cell. Guarding the name keeps it from creeping back.
+    """
+    for name in ("_hdr_raw", "_hdr_steps", "_hdr_summary"):
+        assert not hasattr(plotutils, name), (
+            f"plotutils.{name} is back — use _LiveHeaders(cell, frame) instead"
+        )
+
+
+@pytest.mark.essential
+def test_live_headers_track_the_cell(cell):
+    hdr = plotutils._LiveHeaders(cell, "raw")
+    columns = set(cell.data.raw.columns)
+    for legacy_attr in (
+        "voltage_txt",
+        "current_txt",
+        "cycle_index_txt",
+        "step_index_txt",
+        "test_time_txt",
+    ):
+        assert hdr[legacy_attr] in columns, legacy_attr
+        assert getattr(hdr, legacy_attr) == hdr[legacy_attr]
+
+
+@pytest.mark.essential
+def test_live_headers_compose_step_statistics(cell):
+    hdr = plotutils._LiveHeaders(cell, "steps")
+    columns = set(cell.data.steps.columns)
+    assert hdr.stat("voltage", "delta") in columns
+    assert hdr.stat("current", "min") in columns
+    assert hdr.stat("point", "max") in columns
+    assert hdr.stat("charge", "delta") in columns
+
+
+@pytest.mark.essential
+def test_live_headers_name_the_column_they_cannot_find(cell):
+    hdr = plotutils._LiveHeaders(cell, "raw")
+    with pytest.raises(KeyError, match="no raw column named"):
+        hdr["not_a_column_txt"]
+
+
+@pytest.mark.essential
+def test_normalized_cycle_index_is_dialect_invariant():
+    """plotutils compares against this name literally, so it must not move."""
+    from cellpycore.legacy import mapping
+
+    from cellpy.parameters.internal_settings import get_headers_summary
+
+    legacy = get_headers_summary().normalized_cycle_index
+    native = mapping.LEGACY_ATTR_TO_SCHEMA["cycle"]["normalized_cycle_index"]
+    assert legacy == native == plotutils._NORMALIZED_CYCLE_INDEX
+
+
+# --- the plot families that were simply broken --------------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("interactive", [False, True])
+def test_raw_plot_runs_on_a_native_cell(cell, interactive):
+    """`raw_plot` raised KeyError: 'voltage' on every cellpy 2 cell."""
+    if interactive and not plotly_available:
+        pytest.skip("plotly not installed")
+    figure = plotutils.raw_plot(cell, interactive=interactive)
+    assert figure is not None
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("plot_type", ["voltage-current", "capacity", "raw"])
+def test_raw_plot_predefined_types_run(cell, plot_type):
+    """Each plot_type reaches a different set of raw columns."""
+    figure = plotutils.raw_plot(cell, interactive=False, plot_type=plot_type)
+    assert figure is not None
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("interactive", [False, True])
+def test_cycle_info_plot_runs_on_a_native_cell(cell, interactive):
+    """`cycle_info_plot` raised on both the raw and the step frame."""
+    if interactive and not plotly_available:
+        pytest.skip("plotly not installed")
+    plotutils.cycle_info_plot(cell, cycle=3, interactive=interactive)
+
+
+# --- user-supplied column names ----------------------------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not seaborn_available, reason="seaborn not installed")
+def test_summary_plot_accepts_the_legacy_x_spelling(cell):
+    """`x="cycle_index"` is what this module's own docstring tells you to pass."""
+    figure = plotutils.summary_plot(
+        cell, y="capacities_gravimetric", x="cycle_index", interactive=False
+    )
+    assert figure is not None
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not seaborn_available, reason="seaborn not installed")
+def test_summary_plot_accepts_the_native_x_spelling(cell):
+    figure = plotutils.summary_plot(
+        cell, y="capacities_gravimetric", x="cycle_num", interactive=False
+    )
+    assert figure is not None
+
+
+@pytest.mark.essential
+def test_resolving_an_unknown_column_leaves_it_alone(cell):
+    """So the eventual error names what the user actually asked for."""
+    assert plotutils._resolve_summary_column(cell, "wibble") == "wibble"
+    assert plotutils._resolve_summary_column(cell, None) is None
+
+
+@pytest.mark.essential
+def test_resolving_a_native_name_is_a_no_op(cell):
+    assert plotutils._resolve_summary_column(cell, "cycle_num") == "cycle_num"
+
+
+# --- plotting must not touch the data ----------------------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not seaborn_available, reason="seaborn not installed")
+def test_cv_split_plot_leaves_the_summary_frame_alone(cell):
+    """`partition_summary_cv_steps` used to set_index in place on c.data.summary.
+
+    One CV-split plot and the cell permanently lost its cycle column — which
+    broke every later plot, and any user code reading that column.
+    """
+    before = list(cell.data.summary.columns)
+    plotutils.summary_plot(
+        cell, y="capacities_gravimetric_split_constant_voltage", interactive=False
+    )
+    assert list(cell.data.summary.columns) == before
+    assert cell.data.summary.index.name != "cycle_num"


### PR DESCRIPTION
First slice of #567. **Phase 0 only** — the net. Phase 1 (consolidating the duplicated figure IO / templates / legend helpers into `cellpy/plotting/`) is next and separate.

## The oracle

53 figures snapshotted **structurally**, not as pixels: trace counts, trace names, axis assignment, series lengths and endpoints, axis titles. Every predefined summary y-set × both backends, seven layout options, plus `raw_plot` / `cycle_info_plot` / `cycles_plot`.

Both backends are described into the same shape, so the plan's "one spec, two renderers" claim becomes checkable — a family that renders differently under plotly and matplotlib shows up as a diff between two entries.

## Plotting had no CI coverage at all

The only plotting test file in the repo was excluded from **every** workflow with the comment *"needs a display"*. That reason is stale — the file selects the Agg backend itself and runs headless fine. 46 of its 47 tests passed on the first try. The 47th was a real failure that had been sitting behind the exclusion. The other plot families had no tests whatsoever.

## Four regressions, all found by the oracle

All from the native-headers flip, all invisible because nothing ran.

1. **`raw_plot` and `cycle_info_plot` were completely broken** on any cellpy 2 cell — `KeyError: 'voltage'`. Two of the four headline plot functions. Cause: `_hdr_raw = get_headers_normal()` and friends — module-level singletons built at import time that always answered with *legacy* column names no matter which cell you handed them. This is the same trap that bit #558. Replaced with `_LiveHeaders(cell, frame)`, which resolves through the cell's own schema and is correct on both runtimes; the singletons are deleted and a test asserts they stay deleted.

2. **`summary_plot(c, x="cycle_index")` raised `KeyError`** — the spelling in this module's own docstrings and in every 1.x script. User-supplied column names now resolve against the frame; both spellings work, the legacy one warns once.

3. **Plotting mutated the cell.** `partition_summary_cv_steps` did `set_index(..., inplace=True)` on `c.data.summary` *itself*, not a copy. One CV-split plot permanently removed the cycle column from the user's cell — breaking every later plot and any user code reading that column. This is the one I'd most want a second opinion on, since it means anyone who plotted a CV-split figure in 2.0.0a5 had their in-memory cell quietly altered.

4. `cycle_info_plot` also read hard-coded legacy step-table column names (`"voltage_delta"`, `"point_min"`). Composed from the live stems now.

## The oracle bites

A snapshot that cannot go red is decoration, so I checked:

| mutation | result |
|---|---|
| formation split turned off | **46 of 56 red** |
| axis label changed | 2 red |
| legacy-header trap re-armed | 2 red |
| `SummaryPlotConfig` field default flipped | **inert** — see below |

That last one is worth recording: changing a config *field* default changes nothing, because `summary_plot`'s own signature default shadows it. The same shadowing made a mutation inert in #566. Defaults live in two places in this module.

## CI

Both required linux jobs and the release job now run the plotting tests with `MPLBACKEND=Agg`. The `full` job has `--extra batch`, so it is the only place the figure menu actually renders; without the extras the seaborn/plotly cases skip cleanly.

The **nightly tier-3 matrix still carries the old exclusion** — deliberately left for a follow-up, since I can't verify macOS/Windows behaviour from here.

## Also recorded, not changed

`cycle_info_plot` (both backends) and `cycles_plot` under plotly return `None` instead of a figure, while `summary_plot`, `raw_plot` and `cycles_plot` under matplotlib return one. The snapshot records that asymmetry as today's contract. Unifying the return value is user-visible and belongs with the redesign, not with its oracle.

**Tests:** 1078 passed with the plotting extras, 353 essential without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)