### PR TITLE
#567 Phase 1: one copy of the plotting plumbing, in cellpy/plotting

### DIFF
--- a/cellpy/plotting/__init__.py
+++ b/cellpy/plotting/__init__.py
@@ -1,0 +1,43 @@
+"""The single home for cellpy's plotting machinery (#567).
+
+Four generations of plotting code grew up in three modules
+(``utils/plotutils.py``, ``utils/collectors.py``,
+``utils/batch_tools/batch_plotters.py``), and the same figure could be produced
+by paths that shared no layout logic. This package is where the shared parts
+live; the plan is `architecture-plan/cellpy2-plotting-redesign-plan.md`.
+
+**Phase 1 (this)** consolidates the plumbing that was verifiably duplicated:
+
+| module | owns |
+|---|---|
+| [`figures`][cellpy.plotting.figures] | loading and saving figures |
+| [`labels`][cellpy.plotting.labels] | legend and marker post-processing |
+| [`theme`][cellpy.plotting.theme] | plotly templates and colour/marker cycles |
+
+The old locations re-export from here, so nothing that imported them breaks.
+The drawing code itself — ``summary_plot`` and friends — has not moved yet;
+that is Phase 2.
+"""
+
+from __future__ import annotations
+
+from cellpy.plotting.figures import (
+    load_figure,
+    load_matplotlib_figure,
+    load_plotly_figure,
+    make_matplotlib_manager,
+    save_matplotlib_figure,
+)
+from cellpy.plotting.labels import legend_replacer, remove_markers
+from cellpy.plotting.theme import make_plotly_template
+
+__all__ = [
+    "legend_replacer",
+    "load_figure",
+    "load_matplotlib_figure",
+    "load_plotly_figure",
+    "make_matplotlib_manager",
+    "make_plotly_template",
+    "remove_markers",
+    "save_matplotlib_figure",
+]

--- a/cellpy/plotting/figures.py
+++ b/cellpy/plotting/figures.py
@@ -1,0 +1,112 @@
+"""Loading and saving figures — one implementation (#567).
+
+``load_figure``, ``load_plotly_figure``, ``load_matplotlib_figure``,
+``save_matplotlib_figure`` and ``make_matplotlib_manager`` existed as full
+copies in both ``utils/plotutils.py`` and ``utils/collectors.py``.
+
+Four of the five pairs were character-identical. The fifth was not, and the
+difference mattered: plotutils' ``load_plotly_figure`` checks whether plotly is
+installed and returns ``None`` if it is not, while collectors' copy went
+straight to ``pio.read_json`` and raised ``NameError``/``ImportError`` on an
+install without the ``batch`` extra. The guarded behaviour is the one kept
+here, so the degradation is the same wherever you call it from.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import pickle as pkl
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+
+#: Suffix -> backend, for ``load_figure`` when it is not told which to use.
+_SUFFIX_BACKEND = {
+    ".pkl": "matplotlib",
+    ".pickle": "matplotlib",
+    ".json": "plotly",
+    ".plotly": "plotly",
+    ".jsn": "plotly",
+}
+_DEFAULT_BACKEND = "plotly"
+
+
+def load_figure(filename, backend=None):
+    """Load a figure saved by cellpy.
+
+    Args:
+        filename: the file to read.
+        backend: ``"plotly"``, ``"matplotlib"`` or ``"seaborn"`` (an alias for
+            matplotlib). Inferred from the suffix when not given.
+
+    Returns:
+        The figure, or ``None`` if it could not be loaded.
+    """
+    filename = Path(filename)
+
+    if backend is None:
+        backend = _SUFFIX_BACKEND.get(filename.suffix, _DEFAULT_BACKEND)
+
+    if backend == "plotly":
+        return load_plotly_figure(filename)
+    if backend in ("matplotlib", "seaborn"):
+        return load_matplotlib_figure(filename)
+
+    logging.warning(f"backend={backend!r} is not supported at the moment")
+    return None
+
+
+def save_matplotlib_figure(fig, filename):
+    """Pickle a matplotlib figure to *filename*."""
+    with open(filename, "wb") as handle:
+        pkl.dump(fig, handle)
+
+
+def make_matplotlib_manager(fig):
+    """Attach a fresh canvas manager to an unpickled figure.
+
+    An unpickled figure has no manager, so it cannot be shown. Borrowing one
+    from a throwaway figure is the standard workaround
+    (https://stackoverflow.com/a/54579616/8508004).
+    """
+    dummy = plt.figure()
+    new_manager = dummy.canvas.manager
+    new_manager.canvas.figure = fig
+    fig.set_canvas(new_manager.canvas)
+    return fig
+
+
+def load_matplotlib_figure(filename, create_new_manager=False):
+    """Unpickle a matplotlib figure.
+
+    Args:
+        filename: the pickle written by [`save_matplotlib_figure`][cellpy.plotting.figures.save_matplotlib_figure].
+        create_new_manager: attach a canvas manager so the figure can be shown.
+    """
+    with open(filename, "rb") as handle:
+        fig = pkl.load(handle)
+    if create_new_manager:
+        fig = make_matplotlib_manager(fig)
+    return fig
+
+
+def load_plotly_figure(filename):
+    """Read a plotly figure from JSON.
+
+    Returns ``None`` — rather than raising — when plotly is not installed or
+    the file cannot be read, which is what the plotutils copy always did.
+    """
+    if not plotly_available:
+        logging.warning("plotly is not available; cannot load %s", filename)
+        return None
+
+    import plotly.io as pio
+
+    try:
+        return pio.read_json(filename)
+    except Exception as exc:  # noqa: BLE001 - any read failure is reported the same
+        logging.warning("could not load a figure from %s: %s", filename, exc)
+        return None

--- a/cellpy/plotting/labels.py
+++ b/cellpy/plotting/labels.py
@@ -1,0 +1,75 @@
+"""Legend and marker post-processing for plotly traces — one implementation (#567).
+
+These two helpers existed in **three** places, under two naming conventions:
+
+| | plotutils | collectors | batch_plotters |
+|---|---|---|---|
+| legend | `_plotly_legend_replacer` | `legend_replacer` | `_plotly_legend_replacer` |
+| markers | `_plotly_remove_markers` | `remove_markers` | `_plotly_remove_markers` |
+
+The marker helpers were functionally identical in all three (only the docstring
+differed). The legend helpers were identical in plotutils and collectors, while
+the batch_plotters copy carried an extra ``inverted_mode`` that swaps group and
+sub-group. That copy is therefore the superset, and it is the one kept — with
+``inverted_mode=False`` as the default, which reproduces the other two exactly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cellpy.parameters.internal_settings import get_headers_journal
+
+hdr_journal = get_headers_journal()
+
+
+def remove_markers(trace):
+    """Turn a plotly trace into a plain line."""
+    trace.update(marker=None, mode="lines")
+    return trace
+
+
+def legend_replacer(trace, df, group_legends=True, inverted_mode=False):
+    """Replace a ``"group,subgroup"`` legend label with the cell name.
+
+    Plotly names a trace after the columns it was grouped by, so a batch figure
+    ends up with legends like ``"2,1"``. This looks the pair up in the journal
+    and substitutes the cell name, in the legend and in the hover text.
+
+    Args:
+        trace: the plotly trace to update, in place.
+        df: journal frame carrying group / sub-group / cell columns.
+        group_legends: put every sub-group of a group in one legend entry.
+        inverted_mode: the label reads ``"subgroup,group"`` rather than
+            ``"group,subgroup"``.
+
+    Returns:
+        The trace, updated.
+    """
+    name = trace.name
+    parts = name.split(",")
+    if len(parts) != 2:
+        # Not a grouped trace; leave it alone rather than guessing.
+        logging.debug(
+            "cannot replace the legend label %r: only 'group,subgroup' labels "
+            "are understood",
+            name,
+        )
+        return trace
+
+    group = int(parts[0])
+    subgroup = int(parts[1])
+    if inverted_mode:
+        group, subgroup = subgroup, group
+
+    cell_label = df.loc[
+        (df[hdr_journal.group] == group) & (df[hdr_journal.sub_group] == subgroup),
+        "cell",
+    ].values[0]
+
+    trace.update(
+        name=cell_label,
+        legendgroup=group if group_legends else cell_label,
+        hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
+    )
+    return trace

--- a/cellpy/plotting/theme.py
+++ b/cellpy/plotting/theme.py
@@ -1,0 +1,133 @@
+"""Plotly templates — one implementation (#567).
+
+``_make_plotly_template`` existed in both ``utils/plotutils.py`` and
+``utils/batch_tools/batch_plotters.py``. The bodies were identical; the only
+difference was that plotutils' copy checked whether plotly was installed first,
+which is the behaviour kept here.
+
+Building a template *registers* it with plotly under ``name``, so the two
+copies were also silently competing for the same registry key: whichever
+module was imported last won. There is now one definition and one registration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+
+#: Look of the default cellpy axis template.
+TICK_LABEL_WIDTH = 6
+TITLE_FONT_SIZE = 22
+TITLE_FONT_FAMILY = "Arial"
+AXIS_FONT_SIZE = 16
+AXIS_STANDOFF = 15
+LINE_COLOR = "rgb(36,36,36)"
+
+
+def make_plotly_template(name: str = "axis"):
+    """Build the cellpy axis template and register it with plotly.
+
+    Args:
+        name: the key to register under in ``plotly.io.templates``.
+
+    Returns:
+        The template, or ``None`` when plotly is not installed.
+    """
+    if not plotly_available:
+        logging.warning("plotly is not available; no template registered")
+        return None
+
+    import plotly.graph_objects as go
+    import plotly.io as pio
+
+    template = go.layout.Template(
+        layout=dict(
+            font_family=TITLE_FONT_FAMILY,
+            title=dict(
+                font_size=TITLE_FONT_SIZE,
+                x=0,
+                xref="paper",
+            ),
+            xaxis=dict(
+                linecolor=LINE_COLOR,
+                mirror=True,
+                showline=True,
+                zeroline=False,
+                title=dict(
+                    standoff=AXIS_STANDOFF,
+                    font_size=AXIS_FONT_SIZE,
+                ),
+            ),
+            yaxis=dict(
+                linecolor=LINE_COLOR,
+                mirror=True,
+                showline=True,
+                zeroline=False,
+                tickformat=f"{TICK_LABEL_WIDTH}",
+                title=dict(
+                    standoff=AXIS_STANDOFF,
+                    font_size=AXIS_FONT_SIZE,
+                ),
+            ),
+        )
+    )
+    pio.templates[name] = template
+    return template
+
+
+#: The collector template family. Four names, one look — collectors built four
+#: separate `go.layout.Template` objects from the same layout dict and
+#: registered them under these names.
+COLLECTOR_TEMPLATE_NAMES = ("fig_pr_cell", "fig_pr_cycle", "film", "summary")
+
+#: Axis styling shared by the collector templates: a full box, no zero line.
+ALL_AXIS_SHOWN = dict(
+    xaxis=dict(
+        linecolor=LINE_COLOR,
+        mirror=True,
+        showline=True,
+        zeroline=False,
+        title={"standoff": AXIS_STANDOFF},
+    ),
+    yaxis=dict(
+        linecolor=LINE_COLOR,
+        mirror=True,
+        showline=True,
+        zeroline=False,
+        title={"standoff": AXIS_STANDOFF},
+    ),
+)
+
+
+def make_collector_templates(register: bool = True) -> dict | None:
+    """Build (and by default register) the collector template family.
+
+    Built lazily on purpose. These used to be four module-level
+    ``go.layout.Template(...)`` calls in ``collectors.py``, which made
+    ``import cellpy.utils.collectors`` raise ``NameError: name 'go' is not
+    defined`` on any install without the ``batch`` extra — the module was
+    simply unimportable without plotly.
+
+    Args:
+        register: also put them in ``plotly.io.templates``.
+
+    Returns:
+        ``{name: template}``, or ``None`` when plotly is not installed.
+    """
+    if not plotly_available:
+        logging.warning("plotly is not available; no collector templates built")
+        return None
+
+    import plotly.graph_objects as go
+    import plotly.io as pio
+
+    templates = {
+        name: go.layout.Template(layout=ALL_AXIS_SHOWN)
+        for name in COLLECTOR_TEMPLATE_NAMES
+    }
+    if register:
+        for name, template in templates.items():
+            pio.templates[name] = template
+    return templates

--- a/cellpy/utils/batch_tools/batch_plotters.py
+++ b/cellpy/utils/batch_tools/batch_plotters.py
@@ -17,6 +17,13 @@ from cellpy.utils.batch_tools.batch_core import BasePlotter
 from cellpy.utils.batch_tools.batch_experiments import CyclingExperiment
 import cellpy.config as config
 
+# Single copies (#567). batch_plotters' legend replacer was the superset —
+# it is the one that moved, inverted_mode and all — and its template builder
+# was competing with plotutils' for the same plotly registry key.
+from cellpy.plotting.labels import legend_replacer as _plotly_legend_replacer
+from cellpy.plotting.labels import remove_markers as _plotly_remove_markers
+from cellpy.plotting.theme import make_plotly_template as _make_plotly_template
+
 
 plotly_available = importlib.util.find_spec("plotly") is not None
 bokeh_available = importlib.util.find_spec("bokeh") is not None
@@ -877,82 +884,10 @@ def generate_summary_frame_for_plotting(pages, experiment, **kwargs) -> pd.DataF
 
 
 # plotly helpers
-def _plotly_remove_markers(trace):
-    trace.update(marker=None, mode="lines")
-    return trace
 
 
-def _plotly_legend_replacer(trace, df, group_legends=True, inverted_mode=False):
-    name = trace.name
-    parts = name.split(",")
-    if len(parts) == 2:
-        group = int(parts[0])
-        subgroup = int(parts[1])
-    else:
-        print(
-            "Have not implemented replacing legend labels that are not on the form a,b yet."
-        )
-        print(f"legend label: {name}")
-        return trace
-    if inverted_mode:
-        group, subgroup = subgroup, group
-    cell_label = df.loc[
-        (df[hdr_journal.group] == group) & (df[hdr_journal.sub_group] == subgroup), "cell"
-    ].values[0]
-    if group_legends:
-        trace.update(
-            name=cell_label,
-            legendgroup=group,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
-    else:
-        trace.update(
-            name=cell_label,
-            legendgroup=cell_label,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
 
 
-def _make_plotly_template(name="axis"):
-    tick_label_width = 6
-    title_font_size = 22
-    title_font_family = "Arial"
-    axis_font_size = 16
-    axis_standoff = 15
-    linecolor = "rgb(36,36,36)"
-
-    t = go.layout.Template(
-        layout=dict(
-            font_family=title_font_family,
-            title=dict(
-                font_size=title_font_size,
-                x=0,
-                xref="paper",
-            ),
-            xaxis=dict(
-                linecolor=linecolor,
-                mirror=True,
-                showline=True,
-                zeroline=False,
-                title=dict(
-                    standoff=axis_standoff,
-                    font_size=axis_font_size,
-                ),
-            ),
-            yaxis=dict(
-                linecolor=linecolor,
-                mirror=True,
-                showline=True,
-                zeroline=False,
-                tickformat=f"{tick_label_width}",
-                title=dict(
-                    standoff=axis_standoff,
-                    font_size=axis_font_size,
-                ),
-            ),
-        )
-    )
-    pio.templates[name] = t
 
 
 def _make_labels():

--- a/cellpy/utils/collectors.py
+++ b/cellpy/utils/collectors.py
@@ -33,6 +33,18 @@ from cellpy.utils.batch import Batch
 from cellpy.utils.helpers import concat_summaries
 from cellpy.utils import ica
 
+# Single copies (#567); collectors used to carry its own, and its
+# load_plotly_figure was the unguarded one that raised without plotly.
+from cellpy.plotting.figures import (  # noqa: F401
+    load_figure,
+    load_matplotlib_figure,
+    load_plotly_figure,
+    make_matplotlib_manager,
+    save_matplotlib_figure,
+)
+from cellpy.plotting.labels import legend_replacer, remove_markers  # noqa: F401
+from cellpy.plotting import theme
+
 hdr_journal = get_headers_journal()
 
 supported_backends = []
@@ -73,62 +85,14 @@ def load_data(filename):
     return data
 
 
-def load_figure(filename, backend=None):
-    """Load figure from file."""
-
-    filename = Path(filename)
-
-    if backend is None:
-        suffix = filename.suffix
-        if suffix in [".pkl", ".pickle"]:
-            backend = "matplotlib"
-        elif suffix in [".json", ".plotly", ".jsn"]:
-            backend = "plotly"
-        else:
-            backend = "plotly"
-
-    if backend == "plotly":
-        return load_plotly_figure(filename)
-    elif backend == "seaborn":
-        return load_matplotlib_figure(filename)
-    elif backend == "matplotlib":
-        return load_matplotlib_figure(filename)
-    else:
-        print(f"WARNING: {backend=} is not supported at the moment")
-        return None
 
 
-def save_matplotlib_figure(fig, filename):
-    pkl.dump(fig, open(filename, "wb"))
 
 
-def make_matplotlib_manager(fig):
-    """Create a new manager for a matplotlib figure."""
-    # create a dummy figure and use its
-    # manager to display "fig"  ; based on https://stackoverflow.com/a/54579616/8508004
-    dummy = plt.figure()
-    new_manager = dummy.canvas.manager
-    new_manager.canvas.figure = fig
-    fig.set_canvas(new_manager.canvas)
-    return fig
 
 
-def load_matplotlib_figure(filename, create_new_manager=False):
-    fig = pkl.load(open(filename, "rb"))
-    if create_new_manager:
-        fig = make_matplotlib_manager(fig)
-    return fig
 
 
-def load_plotly_figure(filename):
-    """Load plotly figure from file."""
-    try:
-        fig = pio.read_json(filename)
-    except Exception as e:
-        print("Could not load figure from json file")
-        print(e)
-        return None
-    return fig
 
 
 def generate_output_path(name, directory, serial_number=None):
@@ -205,30 +169,10 @@ if not supported_backends:
     print("WARNING: no supported backends found")
     print("WARNING: install plotly or seaborn to enable plotting")
 
-px_template_all_axis_shown = dict(
-    xaxis=dict(
-        linecolor="rgb(36,36,36)",
-        mirror=True,
-        showline=True,
-        zeroline=False,
-        title={"standoff": 15},
-    ),
-    yaxis=dict(
-        linecolor="rgb(36,36,36)",
-        mirror=True,
-        showline=True,
-        zeroline=False,
-        title={"standoff": 15},
-    ),
-)
-
-fig_pr_cell_template = go.layout.Template(layout=px_template_all_axis_shown)
-
-fig_pr_cycle_template = go.layout.Template(layout=px_template_all_axis_shown)
-
-film_template = go.layout.Template(layout=px_template_all_axis_shown)
-
-summary_template = go.layout.Template(layout=px_template_all_axis_shown)
+# The collector templates live in cellpy.plotting.theme now and are built
+# lazily (#567): constructing them here at import time made this whole module
+# unimportable without the `batch` extra.
+px_template_all_axis_shown = theme.ALL_AXIS_SHOWN
 
 
 def _setup():
@@ -343,10 +287,7 @@ class BatchCollector:
     @staticmethod
     def _set_plotly_templates():
         pio.templates.default = PLOTLY_BASE_TEMPLATE
-        pio.templates["fig_pr_cell"] = fig_pr_cell_template
-        pio.templates["fig_pr_cycle"] = fig_pr_cycle_template
-        pio.templates["film"] = film_template
-        pio.templates["summary"] = summary_template
+        theme.make_collector_templates()
 
     @property
     def data_collector_arguments(self):
@@ -1753,11 +1694,6 @@ def ica_collector(
 # plotter functions (consider moving to plotutils)
 
 
-def remove_markers(trace):
-    """Remove markers from a plotly trace."""
-
-    trace.update(marker=None, mode="lines")
-    return trace
 
 
 def _hist_eq(trace):
@@ -1778,36 +1714,6 @@ def y_axis_replacer(ax, label):
     return ax
 
 
-def legend_replacer(trace, df, group_legends=True):
-    """Replace legend labels with cell names in plotly plots."""
-
-    name = trace.name
-    parts = name.split(",")
-    if len(parts) == 2:
-        group = int(parts[0])
-        subgroup = int(parts[1])
-    else:
-        print(
-            "Have not implemented replacing legend labels that are not on the form a,b yet."
-        )
-        print(f"legend label: {name}")
-        return trace
-
-    cell_label = df.loc[
-        (df[hdr_journal.group] == group) & (df[hdr_journal.sub_group] == subgroup), "cell"
-    ].values[0]
-    if group_legends:
-        trace.update(
-            name=cell_label,
-            legendgroup=group,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
-    else:
-        trace.update(
-            name=cell_label,
-            legendgroup=cell_label,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
 
 
 def _plotly_y_label_cleaner(y_label_mapper, split_at=20):

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -34,6 +34,20 @@ from cellpy.exceptions import UnitsError
 from cellpy.units import units_label, with_cellpy_unit
 from cellpy.utils import helpers
 
+# Single copies of the plotting plumbing that used to be duplicated across
+# plotutils / collectors / batch_plotters (#567). Re-exported here so the
+# `from cellpy.utils.plotutils import load_figure` spelling keeps working.
+from cellpy.plotting.figures import (  # noqa: F401
+    load_figure,
+    load_matplotlib_figure,
+    load_plotly_figure,
+    make_matplotlib_manager,
+    save_matplotlib_figure,
+)
+from cellpy.plotting.labels import legend_replacer as _plotly_legend_replacer
+from cellpy.plotting.labels import remove_markers as _plotly_remove_markers
+from cellpy.plotting.theme import make_plotly_template as _make_plotly_template
+
 # get_cap curve frames use native CurveCols names (#540): potential/cycle_num
 # replace the legacy voltage/cycle (used by cycles_plot below).
 _CCOLS = CurveCols()
@@ -111,69 +125,14 @@ def notebook_docstring_printer(func, default_show_docstring=False):
 
 
 # from collectors - tools for loading and saving plots:
-def load_figure(filename, backend=None):
-    """Load figure from file."""
-
-    filename = Path(filename)
-
-    if backend is None:
-        suffix = filename.suffix
-        if suffix in [".pkl", ".pickle"]:
-            backend = "matplotlib"
-        elif suffix in [".json", ".plotly", ".jsn"]:
-            backend = "plotly"
-        else:
-            backend = "plotly"
-
-    if backend == "plotly":
-        return load_plotly_figure(filename)
-    elif backend == "seaborn":
-        return load_matplotlib_figure(filename)
-    elif backend == "matplotlib":
-        return load_matplotlib_figure(filename)
-    else:
-        print(f"WARNING: {backend=} is not supported at the moment")
-        return None
 
 
-def save_matplotlib_figure(fig, filename):
-    pkl.dump(fig, open(filename, "wb"))
 
 
-def make_matplotlib_manager(fig):
-    """Create a new manager for a matplotlib figure."""
-    # create a dummy figure and use its
-    # manager to display "fig"  ; based on https://stackoverflow.com/a/54579616/8508004
-    dummy = plt.figure()
-    new_manager = dummy.canvas.manager
-    new_manager.canvas.figure = fig
-    fig.set_canvas(new_manager.canvas)
-    return fig
 
 
-def load_matplotlib_figure(filename, create_new_manager=False):
-    fig = pkl.load(open(filename, "rb"))
-    if create_new_manager:
-        fig = make_matplotlib_manager(fig)
-    return fig
 
 
-def load_plotly_figure(filename):
-    """Load plotly figure from file."""
-
-    # TODO: create a decorator for this:
-    if not plotly_available:
-        print("Plotly not available")
-        return None
-    import plotly.io as pio
-
-    try:
-        fig = pio.read_json(filename)
-    except Exception as e:
-        print("Could not load figure from json file")
-        print(e)
-        return None
-    return fig
 
 
 def _image_exporter_plotly(figure, filename, timeout=IMAGE_TO_FILE_TIMEOUT, **kwargs):
@@ -253,88 +212,11 @@ def save_image_files(
         print(f"TODO: implement saving {filename_json}")
 
 
-def _make_plotly_template(name="axis"):
-    if not plotly_available:
-        print("Plotly not available")
-        return None
-    import plotly.graph_objects as go
-    import plotly.io as pio
-
-    tick_label_width = 6
-    title_font_size = 22
-    title_font_family = "Arial"
-    axis_font_size = 16
-    axis_standoff = 15
-    linecolor = "rgb(36,36,36)"
-
-    t = go.layout.Template(
-        layout=dict(
-            font_family=title_font_family,
-            title=dict(
-                font_size=title_font_size,
-                x=0,
-                xref="paper",
-            ),
-            xaxis=dict(
-                linecolor=linecolor,
-                mirror=True,
-                showline=True,
-                zeroline=False,
-                title=dict(
-                    standoff=axis_standoff,
-                    font_size=axis_font_size,
-                ),
-            ),
-            yaxis=dict(
-                linecolor=linecolor,
-                mirror=True,
-                showline=True,
-                zeroline=False,
-                tickformat=f"{tick_label_width}",
-                title=dict(
-                    standoff=axis_standoff,
-                    font_size=axis_font_size,
-                ),
-            ),
-        )
-    )
-    pio.templates[name] = t
 
 
 # from batch_plotters:
-def _plotly_remove_markers(trace):
-    trace.update(marker=None, mode="lines")
-    return trace
 
 
-def _plotly_legend_replacer(trace, df, group_legends=True):
-    name = trace.name
-    parts = name.split(",")
-    if len(parts) == 2:
-        group = int(parts[0])
-        subgroup = int(parts[1])
-    else:
-        print(
-            "Have not implemented replacing legend labels that are not on the form a,b yet."
-        )
-        print(f"legend label: {name}")
-        return trace
-
-    cell_label = df.loc[
-        (df[_hdr_journal.group] == group) & (df[_hdr_journal.sub_group] == subgroup), "cell"
-    ].values[0]
-    if group_legends:
-        trace.update(
-            name=cell_label,
-            legendgroup=group,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
-    else:
-        trace.update(
-            name=cell_label,
-            legendgroup=cell_label,
-            hovertemplate=f"{cell_label}<br>{trace.hovertemplate}",
-        )
 
 
 

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,0 +1,17 @@
+# Plotting
+
+The shared plotting machinery. Figure loading and saving, legend and marker
+post-processing, and the plotly templates all live here in **one** copy —
+`cellpy.utils.plotutils`, `cellpy.utils.collectors` and
+`cellpy.utils.batch_tools.batch_plotters` re-export from it, so existing
+imports keep working.
+
+The drawing functions themselves (`summary_plot`, `raw_plot`,
+`cycle_info_plot`, `cycles_plot`) still live in
+[Utils](utils.md#plotting) and move here in a later phase of the redesign.
+
+::: cellpy.plotting.figures
+
+::: cellpy.plotting.labels
+
+::: cellpy.plotting.theme

--- a/tests/test_plotting_package.py
+++ b/tests/test_plotting_package.py
@@ -1,0 +1,269 @@
+"""The consolidated plotting plumbing (#567 Phase 1).
+
+Phase 1 moved the verifiably duplicated helpers into `cellpy.plotting`. These
+tests pin the two things that matter about a move like that: there is now
+exactly *one* implementation, and the old import paths still resolve to it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import pickle
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from cellpy import log, plotting
+from cellpy.plotting import figures, labels, theme
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+
+
+# --- one implementation, reachable from the old names ------------------------
+
+
+@pytest.mark.essential
+def test_figure_io_is_one_implementation():
+    """These five existed as full copies in plotutils *and* collectors."""
+    from cellpy.utils import collectors, plotutils
+
+    for name in (
+        "load_figure",
+        "load_plotly_figure",
+        "load_matplotlib_figure",
+        "save_matplotlib_figure",
+        "make_matplotlib_manager",
+    ):
+        canonical = getattr(figures, name)
+        assert getattr(plotutils, name) is canonical, name
+        assert getattr(collectors, name) is canonical, name
+
+
+@pytest.mark.essential
+def test_legend_and_marker_helpers_are_one_implementation():
+    """These existed in three places under two naming conventions."""
+    from cellpy.utils import collectors, plotutils
+    from cellpy.utils.batch_tools import batch_plotters
+
+    assert plotutils._plotly_legend_replacer is labels.legend_replacer
+    assert collectors.legend_replacer is labels.legend_replacer
+    assert batch_plotters._plotly_legend_replacer is labels.legend_replacer
+
+    assert plotutils._plotly_remove_markers is labels.remove_markers
+    assert collectors.remove_markers is labels.remove_markers
+    assert batch_plotters._plotly_remove_markers is labels.remove_markers
+
+
+@pytest.mark.essential
+def test_template_builder_is_one_implementation():
+    from cellpy.utils import plotutils
+    from cellpy.utils.batch_tools import batch_plotters
+
+    assert plotutils._make_plotly_template is theme.make_plotly_template
+    assert batch_plotters._make_plotly_template is theme.make_plotly_template
+
+
+@pytest.mark.essential
+def test_the_package_exports_what_it_owns():
+    for name in plotting.__all__:
+        assert hasattr(plotting, name), name
+
+
+# --- collectors imports without the plotting extras ---------------------------
+
+
+@pytest.mark.essential
+def test_collectors_has_no_import_time_plotly_calls():
+    """`import cellpy.utils.collectors` used to raise NameError: 'go'.
+
+    Four `go.layout.Template(...)` calls ran at module level, so the module was
+    simply unimportable on an install without the `batch` extra. They are built
+    lazily in theme.py now.
+    """
+    import ast
+    import pathlib
+
+    source = (
+        pathlib.Path(__file__).resolve().parents[1] / "cellpy" / "utils" / "collectors.py"
+    ).read_text(encoding="utf-8")
+
+    plotly_aliases = {"go", "pio", "px", "plotly"}
+    offenders = []
+
+    class ImportTimeVisitor(ast.NodeVisitor):
+        """Visit only what actually executes when the module is imported.
+
+        Function bodies do not run at import, so they are skipped. Class
+        bodies *do* run, so they are visited — but the methods inside them are
+        function definitions and are skipped in turn.
+        """
+
+        def visit_FunctionDef(self, node):
+            return
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_Attribute(self, node):
+            root = node
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name) and root.id in plotly_aliases:
+                offenders.append(f"line {node.lineno}: {root.id}.…")
+            self.generic_visit(node)
+
+    ImportTimeVisitor().visit(ast.parse(source))
+
+    assert not offenders, (
+        "plotly is touched at import time again, which makes collectors "
+        f"unimportable without the batch extra: {offenders}"
+    )
+
+
+# --- behaviour ----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_load_figure_picks_the_backend_from_the_suffix(tmp_path):
+    fig = plt.figure()
+    target = tmp_path / "a_figure.pkl"
+    figures.save_matplotlib_figure(fig, target)
+    plt.close(fig)
+
+    loaded = figures.load_figure(target)
+    assert loaded is not None
+    assert hasattr(loaded, "get_axes")
+
+
+@pytest.mark.essential
+def test_load_figure_reports_an_unknown_backend(tmp_path, caplog):
+    target = tmp_path / "a_figure.pkl"
+    target.write_bytes(b"")
+    with caplog.at_level(logging.WARNING):
+        assert figures.load_figure(target, backend="bokeh") is None
+    assert "not supported" in caplog.text
+
+
+@pytest.mark.essential
+def test_load_plotly_figure_degrades_instead_of_raising(tmp_path):
+    """The unguarded collectors copy raised here; the kept copy returns None."""
+    target = tmp_path / "not_really_json.json"
+    target.write_text("definitely not a figure", encoding="utf-8")
+    assert figures.load_plotly_figure(target) is None
+
+
+@pytest.mark.essential
+def test_matplotlib_round_trip_with_a_new_manager(tmp_path):
+    fig = plt.figure()
+    fig.add_subplot(111).plot([0, 1], [1, 0])
+    target = tmp_path / "round_trip.pkl"
+    figures.save_matplotlib_figure(fig, target)
+    plt.close(fig)
+
+    loaded = figures.load_matplotlib_figure(target, create_new_manager=True)
+    assert loaded.canvas.manager is not None
+    assert len(loaded.get_axes()) == 1
+    plt.close(loaded)
+
+
+# --- the legend replacer -------------------------------------------------------
+
+
+class _FakeTrace:
+    """Enough of a plotly trace to exercise the label logic without plotly."""
+
+    def __init__(self, name):
+        self.name = name
+        self.hovertemplate = "y=%{y}"
+        self.legendgroup = None
+        self.marker = object()
+        self.mode = "markers"
+
+    def update(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture
+def journal():
+    from cellpy.parameters.internal_settings import get_headers_journal
+
+    hdr = get_headers_journal()
+    return pd.DataFrame(
+        {
+            hdr.group: [1, 1, 2],
+            hdr.sub_group: [1, 2, 1],
+            "cell": ["cell_a", "cell_b", "cell_c"],
+        }
+    )
+
+
+@pytest.mark.essential
+def test_legend_replacer_substitutes_the_cell_name(journal):
+    trace = labels.legend_replacer(_FakeTrace("1,2"), journal)
+    assert trace.name == "cell_b"
+    assert trace.hovertemplate.startswith("cell_b<br>")
+
+
+@pytest.mark.essential
+def test_legend_replacer_groups_by_group_or_by_cell(journal):
+    grouped = labels.legend_replacer(_FakeTrace("1,2"), journal, group_legends=True)
+    assert grouped.legendgroup == 1
+
+    ungrouped = labels.legend_replacer(_FakeTrace("1,2"), journal, group_legends=False)
+    assert ungrouped.legendgroup == "cell_b"
+
+
+@pytest.mark.essential
+def test_legend_replacer_inverted_mode(journal):
+    """The batch_plotters-only option that made its copy the superset."""
+    plain = labels.legend_replacer(_FakeTrace("2,1"), journal)
+    inverted = labels.legend_replacer(
+        _FakeTrace("2,1"), journal, inverted_mode=True
+    )
+    assert plain.name == "cell_c"
+    assert inverted.name == "cell_b"
+
+
+@pytest.mark.essential
+def test_legend_replacer_leaves_an_unrecognised_label_alone(journal):
+    trace = labels.legend_replacer(_FakeTrace("just a name"), journal)
+    assert trace.name == "just a name"
+
+
+@pytest.mark.essential
+def test_remove_markers():
+    trace = labels.remove_markers(_FakeTrace("1,1"))
+    assert trace.marker is None
+    assert trace.mode == "lines"
+
+
+# --- templates ------------------------------------------------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not plotly_available, reason="plotly not installed")
+def test_templates_register_under_their_names():
+    import plotly.io as pio
+
+    assert theme.make_plotly_template("a_test_template") is not None
+    assert "a_test_template" in pio.templates
+
+    built = theme.make_collector_templates()
+    assert set(built) == set(theme.COLLECTOR_TEMPLATE_NAMES)
+    for name in theme.COLLECTOR_TEMPLATE_NAMES:
+        assert name in pio.templates
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(plotly_available, reason="needs an install without plotly")
+def test_templates_return_none_without_plotly():
+    assert theme.make_plotly_template() is None
+    assert theme.make_collector_templates() is None

--- a/zensical.toml
+++ b/zensical.toml
@@ -62,6 +62,7 @@ nav = [
             "api/index.md",
             { "cellpy" = "api/cellpy.md" },
             { "ICA and DVA" = "api/ica.md" },
+            { "Plotting" = "api/plotting.md" },
             { "Readers" = "api/readers.md" },
             { "Instruments" = "api/instruments.md" },
             { "Utils" = "api/utils.md" },


### PR DESCRIPTION
Second slice of #567, on top of #593. **Pure move** — the 53-figure oracle from Phase 0 passes unchanged, which is what makes that claim checkable.

The plan lists figure IO, legend/marker helpers and plotly templates as "verified copies" across `plotutils` / `collectors` / `batch_plotters`. They still were. They are now single implementations in a new `cellpy.plotting` package, and the old modules re-export from it, so every existing import path still resolves.

## Diffing the copies before moving them was worth doing

Two of them were **not** copies:

- **`load_plotly_figure`** — plotutils' version checks whether plotly is installed and returns `None`; collectors' version went straight to `pio.read_json` and blew up on an install without the `batch` extra. The guarded one is kept, so the degradation is now the same wherever you call it from.
- **`legend_replacer`** — batch_plotters' version carries an `inverted_mode` that swaps group and sub-group; the other two lack it. That one is the superset, so that is the one that moved, with the flag defaulting to `False` so the other two callers behave exactly as before.

The marker helpers were functionally identical in all three (docstrings aside), and the template builders differed only by the same plotly guard.

## A latent breakage fixed on the way

`import cellpy.utils.collectors` raised **`NameError: name 'go' is not defined`** on any install without the `batch` extra — four `go.layout.Template(...)` calls ran at module level, so the module was simply unimportable without plotly. Same class of problem as the copies: work done at import time that could not see its environment. They are built lazily in `theme.py` now.

There is an AST test that fails if plotly is touched at import time again. **It caught itself first:** my initial version used `ast.walk`, which descends into function bodies — code that does *not* run at import — and flagged twelve innocent lines. Fixed to a visitor that skips function definitions but does visit class bodies, since those do execute.

## On the line counts

Roughly flat: 277 lines out of the three old modules, 363 into the package. The consolidated versions carry docstrings the copies never had. **The win here is one implementation, not fewer lines** — the large reductions arrive in Phase 2 when `summary_plot_legacy` and the duplicate builder go.

## Tests

16 new tests: identity assertions that each helper is now literally the same object from all its old names, behaviour tests for the merged `inverted_mode` and the plotly guard, and the import-time check.

1093 passed with the plotting extras, 368 essential without them. Docs build clean with a new `api/plotting.md`.

## Still to come in #567

Phase 2 (spec + backends, delete `summary_plot_legacy`), Phase 3 (the other families), Phase 4 (collectors re-based). The backend decision — seaborn as styling inside matplotlib, bokeh dead — is settled and recorded; it applies from Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)