### PR TITLE
#591: ICA direction is cell-centric; ica_collector migrates to the specced frame

### DIFF
--- a/cellpy/ica.py
+++ b/cellpy/ica.py
@@ -84,6 +84,12 @@ _CCOLS = CurveCols()
 #: *last* +1. Which physical direction that is depends on ``cycle_mode``: an
 #: anode cell is discharged first, everything else is charged first. The old
 #: output frame exposed the raw code and left the reader to work this out.
+#:
+#: The spelled-out labels are **cell-centric** (decision #591, 2026-07-20):
+#: "charge" is the *cell* charging, agreeing with ``get_ccap``/``get_dcap``
+#: and the summary's charge/discharge columns. The electrode-centric reading
+#: (lithiating the anode as "charging the electrode") can be derived by
+#: swapping the labels when ``cycle_mode == "anode"``.
 _DIRECTION_BY_CYCLE_MODE = {
     "anode": {-1: "discharge", 1: "charge"},
     "cathode": {-1: "charge", 1: "discharge"},

--- a/cellpy/utils/collectors.py
+++ b/cellpy/utils/collectors.py
@@ -1631,7 +1631,8 @@ def ica_collector(
         number_of_points: number of points to interpolate to
         max_cycle: drop all cycles above this value
         abort_on_missing: if True, abort if a cell is empty
-        label_direction: how the voltage curves are given (back-and-forth, forth, forth-and-forth)
+        label_direction: no-op since 2.0 (kept for signature compatibility; the
+            specced ICA frame always carries a direction column)
         label_mapper: function (or dict) that changes the cell names.
         only_selected (bool): only process selected cells.
         **kwargs: passed on to ica.dqdv
@@ -1657,22 +1658,16 @@ def ica_collector(
                 inverse=inverse,
             )
             cycles = list(set(filtered_cycles).intersection(set(cycles)))
-        # Deliberately still on the 1.x frame (private entry point, so no
-        # user-facing DeprecationWarning fires from inside a collector).
-        #
-        # The blocker is a convention clash, not effort: `ica_plotter` selects
-        # `direction < 0` and calls it "charge", while `get_cap` gives -1 to
-        # the *first* half-cycle, which for cellpy's default cycle_mode="anode"
-        # is the cell **discharge**. Both readings are defensible - one is
-        # electrode-centric, the other cell-centric - so moving this to the
-        # specced frame's spelled-out "charge"/"discharge" would flip the
-        # labels on every batch ICA plot depending on which one we pick.
-        # That needs a maintainer decision, not a refactor. See cellpy#566.
-        curves = ica._dqdv_combined_frame(
+        # The specced ICA frame (#566): cycle, direction, voltage, capacity,
+        # dqdv (+ the deprecated `dq` duplicate until 2.1). `direction` is
+        # spelled "charge"/"discharge" and is **cell-centric** — decision
+        # #591: it agrees with get_ccap/get_dcap and the summary columns, so
+        # for an anode cell the first half-cycle is "discharge". Film-plot
+        # labels flipped accordingly (release-noted on #572).
+        curves = ica.dqdv(
             c,
-            cycle=cycles,
+            cycles=cycles,
             voltage_resolution=voltage_resolution,
-            label_direction=label_direction,
             number_of_points=number_of_points,
             **kwargs,
         )
@@ -1893,6 +1888,37 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
     return fig
 
 
+def _select_direction(curves, direction, direction_col="direction"):
+    """Select one direction from a collected curve frame.
+
+    Handles both direction encodings that reach the plotters:
+
+    - The specced ICA frame (#566) spells direction out ("charge" /
+      "discharge"), **cell-centric** per decision #591.
+    - Frames straight from ``get_cap(categorical_column=True)`` still carry
+      the raw ±1 half-cycle code. For those the historical mapping is kept
+      (-1 selected as "charge") so non-ICA film plots are unchanged; the code
+      is positional, and relabelling it needs the cell's cycle_mode, which a
+      collected frame no longer knows.
+    """
+    if direction_col not in curves.columns:
+        logging.debug(
+            "no %r column in the collected frame - direction filter skipped",
+            direction_col,
+        )
+        return curves
+
+    column = curves[direction_col]
+    if pd.api.types.is_numeric_dtype(column):
+        if direction == "charge":
+            return curves.loc[column < 0]
+        if direction == "discharge":
+            return curves.loc[column > 0]
+        return curves
+
+    return curves.loc[column == direction]
+
+
 def sequence_plotter(
     collected_curves: pd.DataFrame,
     x: str = _CCOLS.capacity,
@@ -2050,11 +2076,7 @@ def sequence_plotter(
         logging.debug(f"filtered_curves:\n{curves}")
 
         if method == "film":
-            # selecting direction
-            if direction == "charge":
-                curves = curves.query(f"{direction_col} < 0")
-            elif direction == "discharge":
-                curves = curves.query(f"{direction_col} > 0")
+            curves = _select_direction(curves, direction, direction_col)
             # scaling (assuming 'y' is the "value" axis):
             if histscale == "abs-log":
                 curves[y] = curves[y].apply(np.abs).apply(np.log)
@@ -2874,7 +2896,7 @@ def ica_plotter(
     return _cycles_plotter(
         collected_curves,
         x="voltage",
-        y="dq",
+        y="dqdv",
         z="cycle",
         g="cell",
         x_label="Voltage",

--- a/cellpy/utils/ica.py
+++ b/cellpy/utils/ica.py
@@ -27,7 +27,6 @@ from cellpy.ica import (  # noqa: F401
     IcaCols,
     IcaOptions,
     ICA_COLS,
-    _dqdv_combined_frame,
     dqdv,
     dqdv_cycle,
     dqdv_cycles,

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -62,3 +62,44 @@ def test_batch_ica_collector_runs(populated_batch):
     """ICA (dQ/dV) collector collects + plots."""
     collector = BatchICACollector(populated_batch)
     _assert_ran(collector)
+
+
+def test_batch_ica_collector_uses_the_specced_frame(populated_batch):
+    """ica_collector migrated off the 1.x frame (#591 resolved #566's leftover).
+
+    The collected frame is now the specced ICA frame: direction spelled out
+    "charge"/"discharge" (cell-centric, decision #591) plus the dqdv column.
+    """
+    collector = BatchICACollector(populated_batch)
+    cols = set(collector.data.columns)
+    assert {"cycle", "direction", "voltage", "capacity", "dqdv"} <= cols, cols
+    directions = set(collector.data["direction"].unique())
+    assert directions <= {"charge", "discharge"}, directions
+
+
+def test_batch_ica_collector_film_mode(populated_batch):
+    """Film mode filters by direction, which now means matching the string."""
+    collector = BatchICACollector(populated_batch, plot_type="film")
+    _assert_ran(collector)
+
+
+def test_select_direction_handles_both_encodings():
+    """The plotters see specced string frames and raw ±1 get_cap frames."""
+    import pandas as pd
+
+    from cellpy.utils.collectors import _select_direction
+
+    specced = pd.DataFrame(
+        {"direction": ["charge", "discharge", "charge"], "v": [1, 2, 3]}
+    )
+    picked = _select_direction(specced, "charge")
+    assert list(picked["v"]) == [1, 3]
+
+    legacy = pd.DataFrame({"direction": [-1, 1, -1], "v": [1, 2, 3]})
+    picked = _select_direction(legacy, "charge")
+    assert list(picked["v"]) == [1, 3]  # historical -1 -> "charge" mapping kept
+    picked = _select_direction(legacy, "discharge")
+    assert list(picked["v"]) == [2]
+
+    without = pd.DataFrame({"v": [1, 2]})
+    assert len(_select_direction(without, "charge")) == 2


### PR DESCRIPTION
Closes #591. Executes the maintainer decision (2026-07-20): **option (a), cell-centric.**

## The convention

`direction` in the specced ICA/DVA frame means the **cell's** direction: "charge" is the cell charging, agreeing with `get_ccap`/`get_dcap` and the summary's charge/discharge columns — one convention across the whole API. The electrode-centric reading (lithiating the anode as "charging the electrode") is derivable by swapping labels when `cycle_mode == "anode"`. Documented at the definition site in `cellpy/ica.py`.

## What lands with it

The half of #566's Phase 3 that this decision was blocking:

- **`ica_collector` collects the specced frame** (`cycle, direction, voltage, capacity, dqdv` + the deprecated `dq` duplicate) via `ica.dqdv`, instead of the 1.x frame via the private legacy builder. `label_direction` is a documented no-op.
- The film-mode direction filter is extracted to `_select_direction`, handling **both encodings the plotters actually see**: specced frames match on the string; raw `get_cap` frames still carry the positional ±1 code and keep the historical `-1 → "charge"` selection — relabelling a positional code needs `cycle_mode`, which a collected frame no longer knows.
- `ica_plotter` draws the spec-named `dqdv` column instead of the deprecated `dq` alias.

## User-visible change (release-noted on #572)

For **anode cells**, batch ICA film plots labelled "charge" now show the cell charge — the branch previously labelled "discharge". The labels were electrode-centric until now; with cell-centric chosen, they flip once and then agree with everything else in cellpy.

## Tests

Collector output columns and string directions pinned; film mode runs end-to-end on the batch fixture; `_select_direction` covered for both encodings and the missing-column case. Full suite: **1116 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)