### PR TITLE
#560: a value-parity oracle for harmonize(), and the two bugs it found

### DIFF
--- a/cellpy/readers/instruments/base.py
+++ b/cellpy/readers/instruments/base.py
@@ -456,6 +456,9 @@ class AutoLoader(BaseLoader):
 
     def __init__(self, *args, **kwargs):
         self.auto_register_config = True
+        #: Whether `parse()` has run. Guards `declarations()`, whose answer is
+        #: only correct once the file's own units have been read (see there).
+        self._parsed = False
         self.pre_init()
 
         if not hasattr(self, "supported_models"):
@@ -556,6 +559,71 @@ class AutoLoader(BaseLoader):
                     raise NotImplementedError(
                         f"{processor_name} is not currently supported - aborting!"
                     )
+
+    def parse(self, source: Union[str, pathlib.Path], **kwargs) -> pd.DataFrame:
+        """Vendor stage: read the file into a frame with **vendor** column names.
+
+        The first half of the two-stage design (#559): everything after this is
+        declared rather than coded, and handled by ``harmonize()``. This is the
+        same work ``loader()`` does before it starts building a ``Data`` — the
+        pre-processors, the formatter parameters, and ``query_file`` — exposed
+        on its own so the two stages can be driven, tested and compared
+        separately. It does not change how ``loader()`` behaves.
+
+        Args:
+            source: path to the vendor file.
+            **kwargs: loader knobs, as ``loader()`` takes them.
+
+        Returns:
+            The parsed vendor frame, before any renaming.
+        """
+        self.refuse_copying = kwargs.pop("refuse_copying", False)
+        self.name = source
+        if not self.is_db:
+            self.copy_to_temporary()
+        if self.pre_processors:
+            self._pre_process()
+        self.parse_loader_parameters(**kwargs)
+        frame = self.query_file(self.temp_file_path)
+        self._parsed = True
+        return frame
+
+    def declarations(self):
+        """The :class:`LoaderDeclarations` for the file most recently parsed.
+
+        **Call this after :meth:`parse`, not before** — and it raises if you do
+        not, which is the point. Declarations are *not* a static property of the
+        loader class for every instrument: neware writes its units into the
+        column names (``Current(A)``), and which units those are is read from
+        the file, so the configuration's defaults (``mA``) are corrected during
+        parsing. Reading declarations first would hand back vendor column names
+        no file contains, and those columns would be silently unmapped rather
+        than raising — the failure mode this whole arc keeps running into.
+
+        Deriving from ``config_params`` after the parse is what makes the
+        declarations per-file without any loader having to opt in.
+
+        Returns:
+            A validated ``LoaderDeclarations`` derived from this loader's
+            configuration.
+
+        Raises:
+            LoaderError: if called before ``parse()``, or if the configuration
+                does not carry a renaming dict to derive from.
+        """
+        from cellpy.exceptions import LoaderError
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_configuration,
+        )
+
+        if not getattr(self, "_parsed", False):
+            raise LoaderError(
+                f"{type(self).__name__}.declarations() was called before "
+                f"parse(); for instruments whose column names carry units read "
+                f"from the file, the declarations are only correct once the "
+                f"file has been parsed."
+            )
+        return declarations_from_configuration(self.config_params)
 
     def loader(self, name: Union[str, pathlib.Path], **kwargs: str) -> core.Data:
         """returns a Data object with loaded data.

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -37,7 +37,7 @@ from cellpy.readers.instruments.declarations import (
     LoaderDeclarations,
     ResetGranularity,
 )
-from cellpy.readers.instruments.hooks import state_splitter
+from cellpy.readers.instruments.hooks import cycle_number_not_zero, state_splitter
 
 #: Native columns whose reset granularity a vendor could plausibly differ on.
 #: Defaulted to the harmonized-raw target (cycle-cumulative per direction);
@@ -174,11 +174,25 @@ def _state_splitting(
         ``(post_hooks, dropped)`` — the hooks to run, and vendor columns now
         consumed by them (so they do not trip the unrecognised-column warning).
     """
+    renaming_all = getattr(config, "normal_headers_renaming_dict", {}) or {}
     states = getattr(config, "states", None) or {}
     wants_capacity = bool(post_processors.get("split_capacity"))
     wants_current = bool(post_processors.get("split_current"))
+    wants_cycle_shift = bool(post_processors.get("set_cycle_number_not_zero"))
+
+    # Independent of state splitting: it needs only the cycle column.
+    cycle_hooks: tuple = ()
+    if wants_cycle_shift:
+        cycle_vendor = renaming_all.get("cycle_index_txt")
+        if not cycle_vendor:
+            raise LoaderError(
+                f"{_config_name(config)} enables set_cycle_number_not_zero but "
+                f"maps no cycle_index_txt; there is no column to shift."
+            )
+        cycle_hooks = (cycle_number_not_zero(cycle_column=cycle_vendor),)
+
     if not (wants_capacity or wants_current):
-        return (), ()
+        return cycle_hooks, ()
 
     if not states:
         raise LoaderError(
@@ -276,7 +290,11 @@ def _state_splitting(
             )
         )
 
-    return tuple(hooks), tuple(dropped)
+    # Cycle shift last, mirroring 1.x: the unordered post-processor pass runs in
+    # configuration-declaration order, and every splitting configuration lists
+    # set_cycle_number_not_zero after the splits. A uniform +1 cannot change the
+    # per-cycle grouping either way, but matching the order costs nothing.
+    return tuple(hooks) + cycle_hooks, tuple(dropped)
 
 
 def _units_from_configuration(config: ModuleType) -> CellpyUnits:

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -47,6 +47,19 @@ _CUMULATIVE_DEFAULTS = (
     "cumulative_discharge_energy",
 )
 
+#: Capacity columns the legacy ``cumulate_capacity_within_cycle`` post-processor
+#: acts on. It touches only the capacities, never the energies.
+_CUMULATED_CAPACITIES = (
+    "cumulative_charge_capacity",
+    "cumulative_discharge_capacity",
+)
+
+#: Legacy post-processor → the native column it parses from a duration string.
+_DURATION_POST_PROCESSORS = {
+    "convert_step_time_to_timedelta": "step_time",
+    "convert_test_time_to_timedelta": "test_time",
+}
+
 #: Legacy attributes that must not reach the raw frame at all.
 #:
 #: The vendor's own test identifier is *provenance*, not a measurement: it
@@ -122,6 +135,17 @@ def derive_column_maps(
     return column_map, passthrough, unknown
 
 
+def _config_name(config: Any) -> str:
+    """A name for messages, for either shape of configuration.
+
+    Derivation accepts both a ``configurations.*`` **module** (what the shipped
+    configurations are) and a live :class:`ModelParameters` **instance** (what a
+    loader carries as ``config_params``, including the ones assembled at runtime
+    from a YAML file). The two spell their name differently.
+    """
+    return getattr(config, "__name__", None) or getattr(config, "name", "<configuration>")
+
+
 def _units_from_configuration(config: ModuleType) -> CellpyUnits:
     raw_units: dict[str, Any] | None = getattr(config, "raw_units", None)
     if not raw_units:
@@ -135,7 +159,7 @@ def _units_from_configuration(config: ModuleType) -> CellpyUnits:
 
 
 def declarations_from_configuration(
-    config: ModuleType,
+    config: ModuleType | Any,
     *,
     reset_granularity: dict[str, ResetGranularity] | None = None,
     post_hooks: tuple = (),
@@ -144,7 +168,10 @@ def declarations_from_configuration(
     """Build validated declarations from an existing configuration module.
 
     Args:
-        config: a ``cellpy.readers.instruments.configurations.*`` module.
+        config: a ``cellpy.readers.instruments.configurations.*`` module, or a
+            live ``ModelParameters`` instance (a loader's ``config_params``).
+            Both expose the same attribute names, which is what lets the port
+            derive declarations from a loader that is already running.
         reset_granularity: overrides for columns whose vendor granularity is
             not the harmonized-raw default. **Read the vendor's data before
             setting one** — a wrong value here silently rescales capacities.
@@ -161,30 +188,61 @@ def declarations_from_configuration(
     renaming = getattr(config, "normal_headers_renaming_dict", None)
     if not renaming:
         raise ValueError(
-            f"{config.__name__} has no normal_headers_renaming_dict; nothing to derive"
+            f"{_config_name(config)} has no normal_headers_renaming_dict; "
+            f"nothing to derive"
         )
 
     column_map, passthrough, unknown = derive_column_maps(renaming)
     if unknown:
         logging.debug(
             "%s declares legacy attributes with no native or legacy column: %s",
-            config.__name__,
+            _config_name(config),
             sorted(unknown),
         )
 
+    targets = set(column_map.values())
     granularity: dict[str, ResetGranularity] = {
         column: ResetGranularity.PER_CYCLE
         for column in _CUMULATIVE_DEFAULTS
-        if column in set(column_map.values())
+        if column in targets
     }
+
+    # A configuration that runs ``cumulate_capacity_within_cycle`` is *stating*
+    # that its vendor capacities reset every step: the post-processor offsets
+    # each step by the running total of the cycle's completed steps, which is
+    # exactly what ``ResetGranularity.PER_STEP`` means. Reading it here is the
+    # difference between deriving the granularity and guessing it — and a wrong
+    # guess rescales capacities silently.
+    post_processors = getattr(config, "post_processors", None) or {}
+    if post_processors.get("cumulate_capacity_within_cycle"):
+        granularity.update(
+            {
+                column: ResetGranularity.PER_STEP
+                for column in _CUMULATED_CAPACITIES
+                if column in targets
+            }
+        )
+
     if reset_granularity:
         granularity.update(reset_granularity)
+
+    # Same trick as the granularity above: a configuration that runs
+    # ``convert_*_to_timedelta`` is saying its vendor writes that column as an
+    # elapsed-time string. The legacy post-processor tolerates both spellings,
+    # so declaring it when the vendor already writes seconds costs nothing —
+    # ``harmonize()`` only converts string columns.
+    durations = tuple(
+        column
+        for processor, column in _DURATION_POST_PROCESSORS.items()
+        if post_processors.get(processor) and column in targets
+    )
 
     return LoaderDeclarations(
         column_map=column_map,
         raw_units=_units_from_configuration(config),
         timezone=timezone,
         reset_granularity=granularity,
+        duration_columns=durations,
         passthrough=passthrough,
         post_hooks=post_hooks,
     )

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -31,11 +31,13 @@ from typing import Any
 from cellpycore.legacy import mapping
 from cellpycore.units import CellpyUnits
 
+from cellpy.exceptions import LoaderError
 from cellpy.parameters.internal_settings import get_headers_normal
 from cellpy.readers.instruments.declarations import (
     LoaderDeclarations,
     ResetGranularity,
 )
+from cellpy.readers.instruments.hooks import state_splitter
 
 #: Native columns whose reset granularity a vendor could plausibly differ on.
 #: Defaulted to the harmonized-raw target (cycle-cumulative per direction);
@@ -146,6 +148,137 @@ def _config_name(config: Any) -> str:
     return getattr(config, "__name__", None) or getattr(config, "name", "<configuration>")
 
 
+#: Names the capacity-splitting hook synthesises. They are vendor-side names —
+#: hooks run before renaming — so they must not collide with a real vendor
+#: column; the leading underscore is not a convention any tester uses.
+_SPLIT_CHARGE = "_split_charge_capacity"
+_SPLIT_DISCHARGE = "_split_discharge_capacity"
+
+
+def _state_splitting(
+    config: Any,
+    post_processors: dict,
+    column_map: dict[str, str],
+) -> tuple[tuple, tuple[str, ...]]:
+    """Derive the state-splitting hooks, reshaping ``column_map`` in place.
+
+    ``split_capacity`` is the one post-processor that changes the *shape* of the
+    mapping rather than the values in it: one vendor column ("Amp-hr") becomes
+    two native columns. So the vendor column stops being mapped directly, the
+    hook synthesises two columns under vendor-side names, and those get mapped
+    instead.
+
+    ``split_current`` rewrites its column in place, so the mapping is untouched.
+
+    Returns:
+        ``(post_hooks, dropped)`` — the hooks to run, and vendor columns now
+        consumed by them (so they do not trip the unrecognised-column warning).
+    """
+    states = getattr(config, "states", None) or {}
+    wants_capacity = bool(post_processors.get("split_capacity"))
+    wants_current = bool(post_processors.get("split_current"))
+    if not (wants_capacity or wants_current):
+        return (), ()
+
+    if not states:
+        raise LoaderError(
+            f"{_config_name(config)} enables state splitting but declares no "
+            f"`states`; the splitter cannot know which flag means charge."
+        )
+
+    schema_raw = mapping.LEGACY_ATTR_TO_SCHEMA["raw"]
+    renaming = getattr(config, "normal_headers_renaming_dict", {}) or {}
+    state_column = states["column_name"]
+    cycle_column = renaming.get("cycle_index_txt")
+    datapoint_column = renaming.get("data_point_txt")
+    if not cycle_column or not datapoint_column:
+        raise LoaderError(
+            f"{_config_name(config)} enables state splitting but does not map "
+            f"cycle_index_txt and data_point_txt; splitting is per cycle and "
+            f"ordered by datapoint, so both are required."
+        )
+
+    common = dict(
+        state_column=state_column,
+        cycle_column=cycle_column,
+        datapoint_column=datapoint_column,
+        charge_keys=states.get("charge_keys", ()),
+        discharge_keys=states.get("discharge_keys", ()),
+    )
+
+    hooks: list = []
+    dropped: list[str] = [state_column]
+
+    if wants_capacity:
+        base = renaming.get("charge_capacity_txt")
+        if not base:
+            raise LoaderError(
+                f"{_config_name(config)} enables split_capacity but maps no "
+                f"charge_capacity_txt; there is nothing to split."
+            )
+        hooks.append(
+            state_splitter(
+                base_column=base,
+                charge_output=_SPLIT_CHARGE,
+                discharge_output=_SPLIT_DISCHARGE,
+                n_charge=1.0,
+                n_discharge=1.0,
+                propagate=True,
+                **common,
+            )
+        )
+        # The shared vendor column stops being mapped; its two halves take over.
+        column_map.pop(base, None)
+        dropped.append(base)
+
+        charge_target = schema_raw["charge_capacity_txt"]
+        discharge_target = schema_raw["discharge_capacity_txt"]
+
+        # Any *other* vendor column claiming those targets loses. This mirrors
+        # 1.x rather than inventing a rule: `split_capacity` is not in
+        # ORDERED_POST_PROCESSING_STEPS, so it runs after `rename_headers` and
+        # overwrites whatever the rename produced. `maccor_txt_one` is the live
+        # case — it declares a `Discharge_Capacity(Ah)` column under a "not
+        # observed yet" comment, which the split would have overwritten had the
+        # file carried it. Without this, the declarations fail validation for
+        # mapping two vendor columns onto one native column.
+        for vendor, target in list(column_map.items()):
+            if target in (charge_target, discharge_target):
+                logging.debug(
+                    "split_capacity supersedes the direct mapping %r -> %r "
+                    "(the legacy post-processor overwrote it too)",
+                    vendor,
+                    target,
+                )
+                column_map.pop(vendor)
+                dropped.append(vendor)
+
+        column_map[_SPLIT_CHARGE] = charge_target
+        column_map[_SPLIT_DISCHARGE] = discharge_target
+
+    if wants_current:
+        base = renaming.get("current_txt")
+        if not base:
+            raise LoaderError(
+                f"{_config_name(config)} enables split_current but maps no "
+                f"current_txt; there is nothing to split."
+            )
+        # One output column: charge positive, discharge negated, rest zero.
+        hooks.append(
+            state_splitter(
+                base_column=base,
+                charge_output=base,
+                discharge_output=base,
+                n_charge=1.0,
+                n_discharge=-1.0,
+                propagate=False,
+                **common,
+            )
+        )
+
+    return tuple(hooks), tuple(dropped)
+
+
 def _units_from_configuration(config: ModuleType) -> CellpyUnits:
     raw_units: dict[str, Any] | None = getattr(config, "raw_units", None)
     if not raw_units:
@@ -200,6 +333,10 @@ def declarations_from_configuration(
             sorted(unknown),
         )
 
+    post_processors = getattr(config, "post_processors", None) or {}
+    hooks, dropped = _state_splitting(config, post_processors, column_map)
+    hooks += tuple(post_hooks)
+
     targets = set(column_map.values())
     granularity: dict[str, ResetGranularity] = {
         column: ResetGranularity.PER_CYCLE
@@ -213,7 +350,6 @@ def declarations_from_configuration(
     # exactly what ``ResetGranularity.PER_STEP`` means. Reading it here is the
     # difference between deriving the granularity and guessing it — and a wrong
     # guess rescales capacities silently.
-    post_processors = getattr(config, "post_processors", None) or {}
     if post_processors.get("cumulate_capacity_within_cycle"):
         granularity.update(
             {
@@ -244,5 +380,6 @@ def declarations_from_configuration(
         reset_granularity=granularity,
         duration_columns=durations,
         passthrough=passthrough,
-        post_hooks=post_hooks,
+        post_hooks=hooks,
+        dropped=dropped,
     )

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -37,7 +37,11 @@ from cellpy.readers.instruments.declarations import (
     LoaderDeclarations,
     ResetGranularity,
 )
-from cellpy.readers.instruments.hooks import cycle_number_not_zero, state_splitter
+from cellpy.readers.instruments.hooks import (
+    cycle_number_not_zero,
+    drop_last_row_if_worse,
+    state_splitter,
+)
 
 #: Native columns whose reset granularity a vendor could plausibly differ on.
 #: Defaulted to the harmonized-raw target (cycle-cumulative per direction);
@@ -137,6 +141,65 @@ def derive_column_maps(
     return column_map, passthrough, unknown
 
 
+def substitute_unit_templates(renaming: dict[str, str], config: Any) -> dict[str, str]:
+    """Resolve ``{{ unit }}`` placeholders in vendor column names.
+
+    Neware spells its columns with the unit baked in — ``Current({{ current }})``
+    becomes ``Current(A)``. The legacy ``update_headers_with_units``
+    post-processor did this by **mutating** ``config_params`` in place at load
+    time, which makes the substitution a side effect of having loaded something.
+
+    That side effect does not reach the configuration *module*: a
+    ``ModelParameters`` instance carries its own copy. So deriving declarations
+    from a module yielded seven neware vendor names still spelled
+    ``Current({{ current }})`` — names no file contains, so those columns were
+    silently unmapped, while deriving from a post-load ``config_params`` worked.
+    Same configuration, different answer depending on what had run first.
+
+    Doing it here makes the derivation self-contained and order-independent.
+
+    Args:
+        renaming: ``legacy_attr -> vendor column``; not mutated.
+        config: the configuration, for ``unit_labels`` / ``raw_units``.
+
+    Returns:
+        A new dict with placeholders resolved.
+
+    Raises:
+        LoaderError: if a placeholder names a unit the configuration does not
+            define. Legacy substituted the string ``"None"``, producing a column
+            name that matches nothing — a silent unmapped column rather than an
+            error.
+    """
+    labels = getattr(config, "unit_labels", None) or getattr(config, "raw_units", None)
+    labels = labels or {}
+
+    resolved: dict[str, str] = {}
+    for legacy_attr, vendor in renaming.items():
+        if not isinstance(vendor, str) or "{{" not in vendor:
+            resolved[legacy_attr] = vendor
+            continue
+
+        name = vendor
+        # Legacy only substituted keys that appear in headers_normal; this
+        # substitutes every entry. That can only ever fix a name, never break
+        # one — an unsubstituted template matched no vendor column anyway.
+        for fragment in vendor.split("{{")[1:]:
+            placeholder = fragment.split("}}")[0]
+            unit = labels.get(placeholder.strip())
+            if unit is None:
+                raise LoaderError(
+                    f"{_config_name(config)} spells {legacy_attr!r} as "
+                    f"{vendor!r}, but defines no unit named "
+                    f"{placeholder.strip()!r}; the column name would be "
+                    f"unmatchable. Known units: {sorted(labels)}."
+                )
+            name = name.replace(f"{{{{{placeholder}}}}}", f"{unit}")
+        resolved[legacy_attr] = name
+
+    return resolved
+
+
 def _config_name(config: Any) -> str:
     """A name for messages, for either shape of configuration.
 
@@ -159,6 +222,7 @@ def _state_splitting(
     config: Any,
     post_processors: dict,
     column_map: dict[str, str],
+    renaming: dict[str, str],
 ) -> tuple[tuple, tuple[str, ...]]:
     """Derive the state-splitting hooks, reshaping ``column_map`` in place.
 
@@ -174,7 +238,6 @@ def _state_splitting(
         ``(post_hooks, dropped)`` — the hooks to run, and vendor columns now
         consumed by them (so they do not trip the unrecognised-column warning).
     """
-    renaming_all = getattr(config, "normal_headers_renaming_dict", {}) or {}
     states = getattr(config, "states", None) or {}
     wants_capacity = bool(post_processors.get("split_capacity"))
     wants_current = bool(post_processors.get("split_current"))
@@ -183,7 +246,7 @@ def _state_splitting(
     # Independent of state splitting: it needs only the cycle column.
     cycle_hooks: tuple = ()
     if wants_cycle_shift:
-        cycle_vendor = renaming_all.get("cycle_index_txt")
+        cycle_vendor = renaming.get("cycle_index_txt")
         if not cycle_vendor:
             raise LoaderError(
                 f"{_config_name(config)} enables set_cycle_number_not_zero but "
@@ -201,7 +264,6 @@ def _state_splitting(
         )
 
     schema_raw = mapping.LEGACY_ATTR_TO_SCHEMA["raw"]
-    renaming = getattr(config, "normal_headers_renaming_dict", {}) or {}
     state_column = states["column_name"]
     cycle_column = renaming.get("cycle_index_txt")
     datapoint_column = renaming.get("data_point_txt")
@@ -343,6 +405,12 @@ def declarations_from_configuration(
             f"nothing to derive"
         )
 
+    # Before anything reads the renaming: resolve `{{ unit }}` placeholders, so
+    # the derivation gives the same answer from a module as from a post-load
+    # config_params. Everything downstream — the column map, the splitting
+    # hooks' vendor column names — depends on these being real names.
+    renaming = substitute_unit_templates(renaming, config)
+
     column_map, passthrough, unknown = derive_column_maps(renaming)
     if unknown:
         logging.debug(
@@ -352,7 +420,22 @@ def declarations_from_configuration(
         )
 
     post_processors = getattr(config, "post_processors", None) or {}
-    hooks, dropped = _state_splitting(config, post_processors, column_map)
+    hooks, dropped = _state_splitting(
+        config, post_processors, column_map, renaming
+    )
+
+    # Last, and only now: `remove_last_if_bad` counts missing values over the
+    # columns cellpy *keeps*, which is only known once the column map is final
+    # (state splitting can add and remove entries). It also has to run after the
+    # splitters, as it did in 1.x, so a row the splitters filled is judged on
+    # its filled state.
+    if post_processors.get("remove_last_if_bad"):
+        hooks += (
+            drop_last_row_if_worse(
+                columns=tuple(column_map) + tuple(passthrough),
+            ),
+        )
+
     hooks += tuple(post_hooks)
 
     targets = set(column_map.values())

--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -94,6 +94,15 @@ class LoaderDeclarations:
     #: listing one here only suppresses the unrecognised-column warning
     #: (#560 decision, 2026-07-20: unknown vendor columns are warn + drop).
     dropped: tuple[str, ...] = ()
+    #: Native columns whose vendor form is an elapsed-time **string**
+    #: (``"00:01:00"``, ``"0d 00:01:00.00"``) rather than a number of seconds.
+    #: Parsed to float seconds by ``harmonize()``.
+    #:
+    #: This is not a nicety: the schema dtype for these columns is Float64, so
+    #: without it the cast turns every value into null — the whole column, with
+    #: no error. Neware and Maccor both ship such columns, which is why it is a
+    #: framework feature rather than a per-loader post hook.
+    duration_columns: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         self._validate()
@@ -159,6 +168,17 @@ class LoaderDeclarations:
                 f"passthrough keeps {shadowing} under a name the native schema "
                 f"already owns; map those in column_map instead so they are "
                 f"cast and validated like any other native column."
+            )
+
+        bad_durations = sorted(
+            column
+            for column in self.duration_columns
+            if column not in set(self.column_map.values())
+        )
+        if bad_durations:
+            raise LoaderError(
+                f"duration_columns declares {bad_durations}, which column_map "
+                f"never produces; the declaration would have no effect."
             )
 
         bad_aux = sorted(

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -11,17 +11,22 @@ The order of operations matters and is fixed here:
 1. post hooks (vendor quirks, on vendor column names)
 2. rename vendor → native, dropping undeclared columns
 3. timestamps → ``epoch_time_utc`` int64 ns UTC
-4. cast to the schema dtypes
-5. **reset-granularity normalization** to cycle-cumulative
-6. identity and provenance stamping
-7. ``validate_raw_frame``
+4. elapsed-time strings → float seconds (``duration_columns``)
+5. cast to the schema dtypes
+6. **reset-granularity normalization** to cycle-cumulative
+7. identity and provenance stamping
+8. ``validate_raw_frame``
 
-Step 5 is the one to be careful about; see :func:`normalize_reset_granularity`.
+Step 6 is the one to be careful about; see :func:`normalize_reset_granularity`.
+Step 4 must precede step 5: the schema dtype for those columns is numeric, so
+casting a duration string first would null the column outright — see
+:func:`_cast_to_schema`, which now refuses to do that quietly.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone as dt_timezone
 from typing import Any
 
@@ -172,15 +177,118 @@ def _convert_timestamps(
     )
 
 
+#: ``[[D d] HH:]MM:SS[.frac]`` — the elapsed-time spellings vendors use.
+_DURATION = re.compile(
+    r"^\s*(?:(?P<days>\d+)\s*d\s+)?"
+    r"(?:(?P<hours>\d+):)?"
+    r"(?P<minutes>\d+):(?P<seconds>\d+(?:\.\d+)?)\s*$"
+)
+
+
+def _duration_to_seconds(value: str | None) -> float | None:
+    match = _DURATION.match(str(value)) if value is not None else None
+    if match is None:
+        return None
+    return (
+        int(match["days"] or 0) * 86_400
+        + int(match["hours"] or 0) * 3_600
+        + int(match["minutes"]) * 60
+        + float(match["seconds"])
+    )
+
+
+def _convert_durations(
+    raw: pl.DataFrame, declarations: LoaderDeclarations
+) -> pl.DataFrame:
+    """Elapsed-time strings → float seconds.
+
+    Matches the legacy ``pd.to_timedelta(...).dt.total_seconds()`` semantics.
+    Only string columns are touched; a vendor that already writes seconds needs
+    no declaration and is left alone.
+    """
+    columns = [
+        column
+        for column in declarations.duration_columns
+        if column in raw.columns and raw[column].dtype == pl.String
+    ]
+    if not columns:
+        return raw
+
+    out = raw.with_columns(
+        pl.col(column)
+        .map_elements(_duration_to_seconds, return_dtype=pl.Float64)
+        .alias(column)
+        for column in columns
+    )
+    for column in columns:
+        failed = out[column].null_count() - raw[column].null_count()
+        if failed:
+            raise LoaderError(
+                f"{column!r} is declared as a duration column but {failed} of "
+                f"{raw.height} values could not be parsed as an elapsed time "
+                f"(examples: {raw[column].head(3).to_list()})"
+            )
+    return out
+
+
 def _cast_to_schema(raw: pl.DataFrame) -> pl.DataFrame:
-    """Cast every recognised column to its schema dtype."""
+    """Cast every recognised column to its schema dtype.
+
+    Casts are non-strict, because real vendor files carry the occasional junk
+    row and the legacy path tolerated it (``pd.to_numeric(errors="coerce")``);
+    making those fatal would refuse files 1.x loaded happily.
+
+    But a cast that empties a column **completely** is not a stray value, it is
+    the wrong dtype assumption, and that raises. Observed while porting #560:
+    neware writes ``Time`` as ``"00:01:00"``, and casting that to the schema's
+    Float64 nulled all 9065 rows without a word — the same silent-data-loss
+    shape as #580. Partial losses warn, so they are visible without being
+    fatal.
+    """
     dtype_map = default_schema().raw.dtype_map()
     casts = [
         pl.col(name).cast(dtype, strict=False).alias(name)
         for name, dtype in dtype_map.items()
         if name in raw.columns
     ]
-    return raw.with_columns(casts) if casts else raw
+    if not casts:
+        return raw
+
+    out = raw.with_columns(casts)
+
+    def _describe(name: str, lost: int) -> str:
+        return (
+            f"{name} ({lost}/{raw.height} values, {raw[name].dtype} -> "
+            f"{dtype_map[name]})"
+        )
+
+    emptied, damaged = [], []
+    for name in dtype_map:
+        if name not in raw.columns:
+            continue
+        lost = out[name].null_count() - raw[name].null_count()
+        if lost <= 0:
+            continue
+        had_data = raw[name].null_count() < raw.height
+        if had_data and out[name].null_count() == raw.height:
+            emptied.append(_describe(name, lost))
+        else:
+            damaged.append(_describe(name, lost))
+
+    if damaged:
+        logging.warning(
+            "casting to the schema dtypes produced nulls: %s; the affected "
+            "values could not be read as the native dtype",
+            ", ".join(sorted(damaged)),
+        )
+    if emptied:
+        raise LoaderError(
+            f"casting to the schema dtypes emptied column(s) entirely: "
+            f"{', '.join(sorted(emptied))}. The vendor column is not what the "
+            f"native column expects - declare a conversion (e.g. "
+            f"duration_columns) or fix the column_map target."
+        )
+    return out
 
 
 def _stamp_identity(raw: pl.DataFrame, *, test_id: int) -> pl.DataFrame:
@@ -268,6 +376,7 @@ def harmonize(
     raw = raw.select(list(present)).rename(present)
 
     raw = _convert_timestamps(raw, declarations)
+    raw = _convert_durations(raw, declarations)
     raw = _cast_to_schema(raw)
     raw = normalize_reset_granularity(raw, declarations)
     raw = _stamp_identity(raw, test_id=test_id)

--- a/cellpy/readers/instruments/hooks.py
+++ b/cellpy/readers/instruments/hooks.py
@@ -29,6 +29,51 @@ import polars as pl
 from cellpy.exceptions import LoaderError
 
 
+def cycle_number_not_zero(
+    *, cycle_column: str
+) -> Callable[[pl.DataFrame], pl.DataFrame]:
+    """Shift zero-based vendor cycle numbering to start at 1.
+
+    A port of the legacy ``set_cycle_number_not_zero``, quirk included: the
+    shift is applied **only when the minimum cycle number is 0**, so a file
+    already starting at 1 is untouched, and a file starting at 2 is *not*
+    rebased to 1.
+
+    **Decision (2026-07-20, #560): 2.0 keeps 1-based cycle numbering.** Whether
+    cycles start at 0 or 1 is a user-visible contract — it reaches summary
+    indices, plot axes and ``get_cap(cycle=N)`` — so the port reproduces 1.x
+    rather than adopting the vendor's numbering. Unlike the frame schemas this
+    one *can* be shimmed, so revisiting it in 2.1 stays open.
+
+    Args:
+        cycle_column: the **vendor** cycle column (hooks run before renaming).
+    """
+
+    def hook(frame: pl.DataFrame) -> pl.DataFrame:
+        if cycle_column not in frame.columns:
+            raise LoaderError(
+                f"cycle-number normalization needs vendor column "
+                f"{cycle_column!r}; the parsed frame has {sorted(frame.columns)}"
+            )
+        if not frame[cycle_column].dtype.is_numeric():
+            # Silence here would be the bug: a string column compares unequal
+            # to 0, so the shift would simply never happen and every cycle
+            # index would be off by one with nothing to show for it.
+            raise LoaderError(
+                f"cycle column {cycle_column!r} is {frame[cycle_column].dtype}, "
+                f"not numeric; cycle-number normalization cannot tell whether "
+                f"it starts at zero"
+            )
+        if frame.height == 0:
+            return frame
+        if frame[cycle_column].min() != 0:
+            return frame
+        return frame.with_columns((pl.col(cycle_column) + 1).alias(cycle_column))
+
+    hook.__name__ = f"cycle_number_not_zero[{cycle_column}]"
+    return hook
+
+
 def state_splitter(
     *,
     base_column: str,

--- a/cellpy/readers/instruments/hooks.py
+++ b/cellpy/readers/instruments/hooks.py
@@ -22,11 +22,75 @@ doing it inside a port is how a refactor silently changes someone's data.
 
 from __future__ import annotations
 
+import logging
+import math
 from typing import Callable, Sequence
 
 import polars as pl
 
 from cellpy.exceptions import LoaderError
+
+
+def drop_last_row_if_worse(
+    *, columns: Sequence[str]
+) -> Callable[[pl.DataFrame], pl.DataFrame]:
+    """Drop the final row when it is more incomplete than the one before it.
+
+    A port of the legacy ``remove_last_if_bad``, which exists because some
+    testers write a partial final row when a run is interrupted. The rule is
+    comparative, not absolute: the last row goes only if it has **strictly
+    more** missing values than the second-to-last, so a file whose rows are
+    uniformly sparse keeps all of them.
+
+    Args:
+        columns: the vendor columns to count missing values over. This matters:
+            the legacy post-processor ran after ``rename_headers`` **and**
+            ``select_columns_to_keep``, so it counted over the columns cellpy
+            keeps, not over every column the vendor wrote. Hooks run before
+            renaming, so the caller passes the declared vendor columns to get
+            the same denominator. Counting over all vendor columns instead
+            would let undeclared junk columns decide whether a row survives.
+
+    Note:
+        This is the only shipped post-processor that changes the **row count**,
+        which is why it is worth being careful about: a row dropped here shifts
+        nothing else, but a row dropped *wrongly* silently loses a measurement.
+    """
+
+    def _missing(row: tuple) -> int:
+        return sum(
+            1
+            for value in row
+            if value is None or (isinstance(value, float) and math.isnan(value))
+        )
+
+    def hook(frame: pl.DataFrame) -> pl.DataFrame:
+        if frame.height < 2:
+            # Legacy indexes iloc[-2]; with fewer than two rows there is
+            # nothing to compare against.
+            return frame
+
+        present = [column for column in columns if column in frame.columns]
+        if not present:
+            raise LoaderError(
+                f"drop-last-if-worse was given no column it could check; it "
+                f"expected some of {sorted(columns)} but the frame has "
+                f"{sorted(frame.columns)}"
+            )
+
+        tail = frame.select(present).tail(2)
+        if _missing(tail.row(1)) > _missing(tail.row(0)):
+            logging.debug(
+                "dropping the final row: %d missing values against %d in the "
+                "row before it",
+                _missing(tail.row(1)),
+                _missing(tail.row(0)),
+            )
+            return frame.head(frame.height - 1)
+        return frame
+
+    hook.__name__ = "drop_last_row_if_worse"
+    return hook
 
 
 def cycle_number_not_zero(

--- a/cellpy/readers/instruments/hooks.py
+++ b/cellpy/readers/instruments/hooks.py
@@ -1,0 +1,139 @@
+"""Reusable vendor post hooks for ``harmonize()`` (issue #560).
+
+Post hooks are the escape valve for quirks no declaration can express. Most are
+one vendor's problem, but *state splitting* is not: several testers write one
+signed or shared column plus a state flag (``C``/``D``/``R``) and expect the
+reader to separate the directions. The legacy path did this with
+``post_processors._state_splitter``; this is the same operation for the
+two-stage design.
+
+Two differences from the legacy version, both structural rather than semantic:
+
+- **Hooks run before renaming**, so these work on *vendor* column names. A hook
+  that synthesises a column gives it a vendor-side name which the declarations
+  then map like any other (the ``maccor_txt_native`` pilot established the
+  pattern).
+- **Polars, expression-based**, so the per-cycle Python loop is gone.
+
+The semantics are deliberately a faithful port, quirks included — see
+:func:`state_splitter`. Improving them is a separate, release-noted decision;
+doing it inside a port is how a refactor silently changes someone's data.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import polars as pl
+
+from cellpy.exceptions import LoaderError
+
+
+def state_splitter(
+    *,
+    base_column: str,
+    state_column: str,
+    cycle_column: str,
+    datapoint_column: str,
+    charge_keys: Sequence[str],
+    discharge_keys: Sequence[str],
+    charge_output: str,
+    discharge_output: str,
+    n_charge: float = 1.0,
+    n_discharge: float = 1.0,
+    propagate: bool = True,
+) -> Callable[[pl.DataFrame], pl.DataFrame]:
+    """Build a hook that splits one column by the vendor's state flag.
+
+    Args:
+        base_column: the vendor column holding both directions.
+        state_column: the vendor column holding the state flag.
+        cycle_column: vendor cycle column — propagation is per cycle.
+        datapoint_column: vendor datapoint column, used to order within a cycle.
+        charge_keys/discharge_keys: state values meaning each direction.
+        charge_output/discharge_output: names for the results. **Passing the
+            same name for both** produces one combined column (what
+            ``split_current`` does: charge positive, discharge negated).
+        n_charge/n_discharge: sign applied to each direction.
+        propagate: hold each direction's final value for the remainder of the
+            cycle. See the note on its exact meaning below.
+
+    Returns:
+        A callable suitable for ``LoaderDeclarations.post_hooks``.
+
+    **On ``propagate``.** It is *not* a forward fill, though it looks like one.
+    The legacy rule is: a direction's rows carry their own value; rows after
+    that direction's **last** row in the cycle carry its final value; everything
+    else is zero. A rest *between* two charge rows therefore reads 0, not the
+    preceding charge value — which a forward fill would give. That is arguably
+    wrong physically, but it is what 1.x produced, and the port's job is to not
+    change numbers. Reproduced exactly, and pinned by a test.
+    """
+    if not charge_keys and not discharge_keys:
+        raise LoaderError(
+            "state_splitter needs at least one of charge_keys/discharge_keys"
+        )
+
+    combined = charge_output == discharge_output
+
+    def _directional(keys: Sequence[str], sign: float) -> pl.Expr:
+        """Value on this direction's rows, null elsewhere."""
+        return (
+            pl.when(pl.col(state_column).is_in(list(keys)))
+            .then(pl.col(base_column).cast(pl.Float64, strict=False) * sign)
+            .otherwise(None)
+        )
+
+    def _resolved(keys: Sequence[str], sign: float) -> pl.Expr:
+        own = _directional(keys, sign)
+        if not propagate:
+            return own.fill_null(0.0)
+        # The direction's final value in this cycle, and the datapoint it sat
+        # on. `forward_fill().last()` is the last non-null, i.e. the final
+        # value the direction reached; null when the direction never occurs.
+        last_value = own.forward_fill().last().over(cycle_column)
+        last_datapoint = (
+            pl.when(pl.col(state_column).is_in(list(keys)))
+            .then(pl.col(datapoint_column))
+            .otherwise(None)
+            .max()
+            .over(cycle_column)
+        )
+        return (
+            pl.when(pl.col(state_column).is_in(list(keys)))
+            .then(own)
+            .when(pl.col(datapoint_column) > last_datapoint)
+            .then(last_value)
+            .otherwise(0.0)
+            .fill_null(0.0)
+        )
+
+    def hook(frame: pl.DataFrame) -> pl.DataFrame:
+        required = {base_column, state_column, cycle_column, datapoint_column}
+        missing = sorted(required - set(frame.columns))
+        if missing:
+            raise LoaderError(
+                f"state splitting needs vendor column(s) {missing}, which the "
+                f"parsed frame does not have; it has {sorted(frame.columns)}"
+            )
+
+        if combined:
+            # One output: charge positive, discharge negated, rest zero.
+            expression = (
+                pl.when(pl.col(state_column).is_in(list(charge_keys)))
+                .then(pl.col(base_column).cast(pl.Float64, strict=False) * n_charge)
+                .when(pl.col(state_column).is_in(list(discharge_keys)))
+                .then(pl.col(base_column).cast(pl.Float64, strict=False) * n_discharge)
+                .otherwise(0.0)
+                .fill_null(0.0)
+                .alias(charge_output)
+            )
+            return frame.with_columns(expression)
+
+        return frame.with_columns(
+            _resolved(charge_keys, n_charge).alias(charge_output),
+            _resolved(discharge_keys, n_discharge).alias(discharge_output),
+        )
+
+    hook.__name__ = f"state_splitter[{base_column}]"
+    return hook

--- a/cellpy/readers/instruments/maccor_txt_native.py
+++ b/cellpy/readers/instruments/maccor_txt_native.py
@@ -40,6 +40,7 @@ from cellpy.readers.instruments.declarations import (
     ResetGranularity,
 )
 from cellpy.readers.instruments.harmonize import harmonize
+from cellpy.readers.instruments.hooks import state_splitter
 
 _SCHEMA = default_schema().raw
 
@@ -55,6 +56,7 @@ _DURATION = re.compile(
 _VENDOR_CAPACITY = "mAmp-hr"
 _VENDOR_STATE = "State"
 _VENDOR_CYCLE = "Cyc#"
+_VENDOR_DATAPOINT = "Rec#"
 
 # Names the split hook produces; declared in column_map like any other column.
 _CHARGE_CAPACITY = "_charge_capacity"
@@ -75,35 +77,27 @@ def _duration_to_seconds(value: str | None) -> float | None:
     )
 
 
-def split_capacity_by_state(frame: pl.DataFrame) -> pl.DataFrame:
-    """Split the single signed capacity column into charge and discharge.
-
-    Reproduces the legacy ``_state_splitter`` semantics: within a cycle, each
-    direction's column carries the vendor value on that direction's rows, holds
-    the last value for the rest of the cycle (the legacy "propagate"), and is
-    zero before the direction first appears.
-    """
-    if _VENDOR_CAPACITY not in frame.columns or _VENDOR_STATE not in frame.columns:
-        raise LoaderError(
-            f"expected {_VENDOR_CAPACITY!r} and {_VENDOR_STATE!r} columns in the "
-            f"Maccor file; got {frame.columns}"
-        )
-
-    def _directional(states: tuple[str, ...], alias: str) -> pl.Expr:
-        return (
-            pl.when(pl.col(_VENDOR_STATE).is_in(states))
-            .then(pl.col(_VENDOR_CAPACITY))
-            .otherwise(None)
-            .forward_fill()
-            .over(_VENDOR_CYCLE)
-            .fill_null(0.0)
-            .alias(alias)
-        )
-
-    return frame.with_columns(
-        _directional(_CHARGE_STATES, _CHARGE_CAPACITY),
-        _directional(_DISCHARGE_STATES, _DISCHARGE_CAPACITY),
-    )
+#: Split the single signed capacity column into charge and discharge.
+#:
+#: Uses the shared :func:`~cellpy.readers.instruments.hooks.state_splitter`.
+#: This module previously carried its own copy built on ``forward_fill()``,
+#: which was **not** the legacy behaviour it claimed to reproduce: a forward
+#: fill also fills rests *between* two same-direction rows, where
+#: ``_state_splitter`` leaves them at 0 and only propagates after the
+#: direction's last row in the cycle. The in-tree Maccor fixtures happen not to
+#: contain that pattern, so the difference never showed — see
+#: ``tests/test_hooks.py::test_propagate_is_not_a_forward_fill``.
+split_capacity_by_state = state_splitter(
+    base_column=_VENDOR_CAPACITY,
+    state_column=_VENDOR_STATE,
+    cycle_column=_VENDOR_CYCLE,
+    datapoint_column=_VENDOR_DATAPOINT,
+    charge_keys=_CHARGE_STATES,
+    discharge_keys=_DISCHARGE_STATES,
+    charge_output=_CHARGE_CAPACITY,
+    discharge_output=_DISCHARGE_CAPACITY,
+    propagate=True,
+)
 
 
 MACCOR_THREE = LoaderDeclarations(

--- a/cellpy/readers/instruments/processors/pre_processors.py
+++ b/cellpy/readers/instruments/processors/pre_processors.py
@@ -41,8 +41,16 @@ def remove_empty_lines(
         raise IOError(f"Could not find the file ({filename})")
     out_file_name = filename.parent / (str(uuid.uuid4()) + ".txt")
 
-    with open(filename, "r+") as file:
-        with open(out_file_name, "w") as out_file:
+    # Encoding is stated, not left to the platform default. Without it this
+    # read used cp1252 on Windows and UTF-8 on Linux, so a Maccor file carrying
+    # a stray non-UTF-8 byte — 0xFF in maccor_002.txt's Description line, which
+    # is real vendor output — loaded on Windows and raised a bare
+    # UnicodeDecodeError on Linux. `errors="replace"` keeps such a file
+    # loadable: this pre-processor only strips blank lines, so it has no reason
+    # to be the thing that rejects a file over one undecodable byte in a
+    # header comment.
+    with open(filename, "r", encoding="utf-8", errors="replace") as file:
+        with open(out_file_name, "w", encoding="utf-8") as out_file:
             for line in file.readlines():
                 if line.strip():
                     out_file.write(f"{line.strip()}\n")

--- a/tests/test_derived_declarations.py
+++ b/tests/test_derived_declarations.py
@@ -305,3 +305,98 @@ def test_maccor_txt_one_watt_hr_is_energy():
     # cellpy-core#139), so it is a real mapping, not a passthrough.
     assert column_map["Watt-hr"] == "cumulative_charge_energy"
     assert "Watt-hr" not in passthrough
+
+
+# -- granularity and durations read from the post-processors (#560) ------------
+
+
+@pytest.mark.essential
+def test_cumulate_capacity_within_cycle_derives_per_step():
+    """A configuration running that post-processor is declaring PER_STEP.
+
+    The post-processor offsets each step by the running total of the cycle's
+    completed steps, which is precisely what PER_STEP normalization undoes.
+    Reading it beats defaulting: with the PER_CYCLE default, neware capacities
+    came out wrong by up to 8 mAh against the legacy frame.
+    """
+    from cellpy.readers.instruments.declarations import ResetGranularity
+
+    config = _config("neware_txt_one")
+    assert config.post_processors.get("cumulate_capacity_within_cycle"), (
+        "fixture assumption broken: neware_txt_one no longer cumulates"
+    )
+
+    declarations = declarations_from_configuration(config)
+
+    for column in ("cumulative_charge_capacity", "cumulative_discharge_capacity"):
+        assert declarations.reset_granularity[column] is ResetGranularity.PER_STEP
+
+
+@pytest.mark.essential
+def test_energies_keep_the_per_cycle_default_when_capacities_are_per_step():
+    """``cumulate_capacity_within_cycle`` touches capacities only."""
+    from cellpy.readers.instruments.declarations import ResetGranularity
+
+    declarations = declarations_from_configuration(_config("neware_txt_one"))
+
+    for column in ("cumulative_charge_energy", "cumulative_discharge_energy"):
+        assert declarations.reset_granularity[column] is ResetGranularity.PER_CYCLE
+
+
+@pytest.mark.essential
+def test_a_configuration_without_the_post_processor_stays_per_cycle():
+    from cellpy.readers.instruments.declarations import ResetGranularity
+
+    config = _config("maccor_txt_one")
+    assert not config.post_processors.get("cumulate_capacity_within_cycle")
+
+    declarations = declarations_from_configuration(config)
+
+    assert (
+        declarations.reset_granularity["cumulative_charge_capacity"]
+        is ResetGranularity.PER_CYCLE
+    )
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", ["neware_txt_one", "maccor_txt_one"])
+def test_timedelta_post_processors_derive_duration_columns(name):
+    """Both shipped families write elapsed times as strings."""
+    config = _config(name)
+    declarations = declarations_from_configuration(config)
+
+    for processor, column in (
+        ("convert_test_time_to_timedelta", "test_time"),
+        ("convert_step_time_to_timedelta", "step_time"),
+    ):
+        if config.post_processors.get(processor):
+            assert column in declarations.duration_columns, (
+                f"{name} runs {processor} but {column} was not declared as a "
+                f"duration column - harmonize would cast the strings to null"
+            )
+
+
+@pytest.mark.essential
+def test_declarations_derive_from_a_live_model_parameters_instance():
+    """The port derives from a running loader, not only from a module.
+
+    ``ModelParameters`` and the configuration modules expose the same attribute
+    names; only their *own* name is spelled differently. Locally-defined
+    instruments (YAML) exist only in the instance form.
+    """
+    from cellpy.readers.instruments.configurations import ModelParameters
+
+    module = _config("neware_txt_one")
+    instance = ModelParameters(
+        name="neware_txt_one",
+        normal_headers_renaming_dict=dict(module.normal_headers_renaming_dict),
+        raw_units=dict(module.raw_units),
+        post_processors=dict(module.post_processors),
+    )
+
+    from_module = declarations_from_configuration(module)
+    from_instance = declarations_from_configuration(instance)
+
+    assert from_instance.column_map == from_module.column_map
+    assert from_instance.reset_granularity == from_module.reset_granularity
+    assert from_instance.duration_columns == from_module.duration_columns

--- a/tests/test_derived_declarations.py
+++ b/tests/test_derived_declarations.py
@@ -392,6 +392,11 @@ def test_declarations_derive_from_a_live_model_parameters_instance():
         normal_headers_renaming_dict=dict(module.normal_headers_renaming_dict),
         raw_units=dict(module.raw_units),
         post_processors=dict(module.post_processors),
+        # Required: this configuration spells its vendor columns with
+        # `{{ unit }}` placeholders, and unit_labels is what resolves them.
+        # Omitting it silently produced different vendor names on the two
+        # shapes — which is what this test exists to catch.
+        unit_labels=dict(module.unit_labels),
     )
 
     from_module = declarations_from_configuration(module)

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -502,3 +502,106 @@ def test_a_column_cannot_be_both_declared_and_dropped():
 
     with pytest.raises(LoaderError, match="both declared and dropped"):
         _minimal_declarations(dropped=("V",))
+
+
+# -- duration strings and destructive casts (#560) -----------------------------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("00:00:00", 0.0),
+        ("00:01:00", 60.0),
+        ("01:00:30", 3630.0),
+        ("00:00:01.50", 1.5),
+        ("  0d 00:01:00.00", 60.0),
+        ("2d 01:00:00", 176_400.0),
+    ],
+)
+def test_duration_strings_become_seconds(text, expected):
+    """The elapsed-time spellings the shipped vendors actually write."""
+    frame = _minimal_vendor_frame(T=[text, text])
+    declarations = _minimal_declarations(duration_columns=(SCHEMA.test_time,))
+
+    raw = harmonize(frame, declarations, test_id=1)
+
+    assert raw[SCHEMA.test_time].to_list() == [expected, expected]
+
+
+@pytest.mark.essential
+def test_a_duration_column_that_is_already_numeric_is_left_alone():
+    """Declaring it costs nothing when the vendor already writes seconds.
+
+    This is what lets the declaration be *derived* from the legacy
+    ``convert_*_to_timedelta`` flags without checking each vendor's spelling.
+    """
+    frame = _minimal_vendor_frame(T=[0.0, 90.0])
+    declarations = _minimal_declarations(duration_columns=(SCHEMA.test_time,))
+
+    raw = harmonize(frame, declarations, test_id=1)
+
+    assert raw[SCHEMA.test_time].to_list() == [0.0, 90.0]
+
+
+@pytest.mark.essential
+def test_an_unparseable_duration_raises_rather_than_nulling():
+    frame = _minimal_vendor_frame(T=["not a duration", "00:01:00"])
+    declarations = _minimal_declarations(duration_columns=(SCHEMA.test_time,))
+
+    with pytest.raises(LoaderError, match="could not be parsed as an elapsed time"):
+        harmonize(frame, declarations, test_id=1)
+
+
+@pytest.mark.essential
+def test_duration_columns_must_be_produced_by_column_map():
+    with pytest.raises(LoaderError, match="duration_columns declares"):
+        _minimal_declarations(duration_columns=(SCHEMA.step_time,))
+
+
+@pytest.mark.essential
+def test_a_cast_that_empties_a_column_raises():
+    """The guard that would have caught the neware duration bug.
+
+    A string column cast to the schema's Float64 becomes all-null. Non-strict
+    casting is deliberate — one stray value should not kill a load — but losing
+    values that *were* there is a wrong-dtype bug, and silence is how #580
+    shipped.
+    """
+    frame = _minimal_vendor_frame(T=["00:01:00", "00:02:00"])
+    # ...the same frame, but without declaring the column as a duration.
+    declarations = _minimal_declarations()
+
+    with pytest.raises(LoaderError, match="emptied column"):
+        harmonize(frame, declarations, test_id=1)
+
+
+@pytest.mark.essential
+def test_the_destructive_cast_message_names_the_column_and_the_dtypes():
+    frame = _minimal_vendor_frame(T=["00:01:00", "00:02:00"])
+
+    with pytest.raises(LoaderError) as excinfo:
+        harmonize(frame, _minimal_declarations(), test_id=1)
+
+    message = str(excinfo.value)
+    assert SCHEMA.test_time in message
+    assert "String" in message
+    assert "duration_columns" in message, "the message should name the fix"
+
+
+@pytest.mark.essential
+def test_a_genuinely_stray_value_still_becomes_null_and_warns(caplog):
+    """Non-strict casting is kept for the case it was meant for.
+
+    Real vendor files carry junk rows and the legacy path coerced them to NaN.
+    Refusing the file would be a regression against 1.x, so a partial loss
+    warns instead of raising - the loud case is losing the whole column.
+    """
+    frame = _minimal_vendor_frame(V=[3.0, 3.1], QC=[0.0, 0.1])
+    frame = frame.with_columns(pl.Series("I", ["0.1", "bad"]))
+
+    with caplog.at_level(logging.WARNING):
+        raw = harmonize(frame, _minimal_declarations(), test_id=1)
+
+    assert raw[SCHEMA.current].to_list() == [0.1, None]
+    assert SCHEMA.current in caplog.text, "the partial loss was silent"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,177 @@
+"""State-splitting post hook (#560).
+
+Expectations here are **hand-computed from the legacy `_state_splitter`**, not
+read back from the implementation. A splitter that is subtly wrong does not
+raise; it produces a plausible capacity curve, which is the failure mode this
+whole arc exists to prevent.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.hooks import state_splitter
+
+STATES = dict(charge_keys=("C",), discharge_keys=("D",))
+
+COMMON = dict(
+    state_column="State",
+    cycle_column="Cyc",
+    datapoint_column="Rec",
+    **STATES,
+)
+
+
+def _frame(states, values, cycles=None, datapoints=None):
+    n = len(states)
+    return pl.DataFrame(
+        {
+            "Rec": datapoints or list(range(1, n + 1)),
+            "Cyc": cycles or [1] * n,
+            "State": states,
+            "Q": values,
+        }
+    )
+
+
+def _split_capacity(frame):
+    hook = state_splitter(
+        base_column="Q",
+        charge_output="q_charge",
+        discharge_output="q_discharge",
+        propagate=True,
+        **COMMON,
+    )
+    return hook(frame)
+
+
+@pytest.mark.essential
+def test_each_direction_carries_its_own_rows():
+    frame = _frame(["C", "C", "D", "D"], [1.0, 2.0, 0.5, 1.5])
+
+    out = _split_capacity(frame)
+
+    assert out["q_charge"].to_list() == [1.0, 2.0, 2.0, 2.0]
+    assert out["q_discharge"].to_list() == [0.0, 0.0, 0.5, 1.5]
+
+
+@pytest.mark.essential
+def test_a_direction_reads_zero_before_it_first_appears():
+    """Legacy initialises the column to 0.0, not to the first value."""
+    frame = _frame(["R", "R", "C"], [0.0, 0.0, 3.0])
+
+    out = _split_capacity(frame)
+
+    assert out["q_charge"].to_list() == [0.0, 0.0, 3.0]
+
+
+@pytest.mark.essential
+def test_propagate_is_not_a_forward_fill():
+    """The quirk, pinned deliberately.
+
+    A rest *between* two charge rows reads 0 — not the preceding charge value,
+    which a forward fill would give. Legacy only backfills rows *after* the
+    direction's last row in the cycle. Physically odd, but it is what 1.x
+    produced, and the port must not change numbers. Changing this is a separate
+    decision with a release note.
+
+        Rec  State  Q      -> q_charge
+        1    C      1.0       1.0   own row
+        2    R      1.5       0.0   between charges: NOT 1.0
+        3    C      2.0       2.0   own row
+        4    R      2.5       2.0   after last charge (Rec 3): propagated
+        5    D      0.5       2.0   after last charge: propagated
+    """
+    frame = _frame(["C", "R", "C", "R", "D"], [1.0, 1.5, 2.0, 2.5, 0.5])
+
+    out = _split_capacity(frame)
+
+    assert out["q_charge"].to_list() == [1.0, 0.0, 2.0, 2.0, 2.0]
+    assert out["q_discharge"].to_list() == [0.0, 0.0, 0.0, 0.0, 0.5]
+
+
+@pytest.mark.essential
+def test_propagation_does_not_leak_across_cycles():
+    """Propagation is per cycle — cycle 2 starts from zero again."""
+    frame = _frame(
+        ["C", "R", "D", "R"],
+        [1.0, 1.0, 2.0, 2.0],
+        cycles=[1, 1, 2, 2],
+    )
+
+    out = _split_capacity(frame)
+
+    # Cycle 1 has no discharge; cycle 2 has no charge. Neither borrows.
+    assert out["q_charge"].to_list() == [1.0, 1.0, 0.0, 0.0]
+    assert out["q_discharge"].to_list() == [0.0, 0.0, 2.0, 2.0]
+
+
+@pytest.mark.essential
+def test_a_cycle_without_the_direction_is_all_zero_not_null():
+    frame = _frame(["D", "D"], [1.0, 2.0])
+
+    out = _split_capacity(frame)
+
+    assert out["q_charge"].to_list() == [0.0, 0.0]
+    assert out["q_charge"].null_count() == 0
+
+
+@pytest.mark.essential
+def test_combined_output_negates_discharge_and_zeroes_rest():
+    """``split_current``: one column, charge positive, discharge negated.
+
+    Rest rows become 0 — the legacy behaviour, and a real consequence: a
+    resting cell's measured current is discarded rather than kept.
+    """
+    frame = _frame(["C", "D", "R"], [2.0, 3.0, 0.1])
+    hook = state_splitter(
+        base_column="Q",
+        charge_output="I",
+        discharge_output="I",
+        n_charge=1.0,
+        n_discharge=-1.0,
+        propagate=False,
+        **COMMON,
+    )
+
+    out = hook(frame)
+
+    assert out["I"].to_list() == [2.0, -3.0, 0.0]
+
+
+@pytest.mark.essential
+def test_combined_output_does_not_propagate():
+    frame = _frame(["C", "R", "R"], [2.0, 0.0, 0.0])
+    hook = state_splitter(
+        base_column="Q",
+        charge_output="I",
+        discharge_output="I",
+        n_charge=1.0,
+        n_discharge=-1.0,
+        propagate=False,
+        **COMMON,
+    )
+
+    out = hook(frame)
+
+    assert out["I"].to_list() == [2.0, 0.0, 0.0]
+
+
+@pytest.mark.essential
+def test_a_missing_vendor_column_names_what_is_missing():
+    frame = _frame(["C"], [1.0]).drop("State")
+
+    with pytest.raises(LoaderError, match="State"):
+        _split_capacity(frame)
+
+
+@pytest.mark.essential
+def test_the_hook_does_not_mutate_the_input_frame():
+    frame = _frame(["C", "D"], [1.0, 2.0])
+    before = frame.columns.copy()
+
+    _split_capacity(frame)
+
+    assert frame.columns == before

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,9 +1,15 @@
-"""State-splitting post hook (#560).
+"""Vendor post hooks: state splitting and cycle numbering (#560).
 
-Expectations here are **hand-computed from the legacy `_state_splitter`**, not
+Expectations here are **hand-computed from the legacy post-processors**, not
 read back from the implementation. A splitter that is subtly wrong does not
 raise; it produces a plausible capacity curve, which is the failure mode this
 whole arc exists to prevent.
+
+Several tests pin quirks rather than sensible behaviour — a rest between two
+charge rows reading 0, cycles starting at 2 not being rebased. They are
+deliberate: the port's contract is *no change to users' numbers*, so the
+quirks come across intact and improving them is a separate, release-noted
+decision.
 """
 
 from __future__ import annotations
@@ -12,7 +18,10 @@ import polars as pl
 import pytest
 
 from cellpy.exceptions import LoaderError
-from cellpy.readers.instruments.hooks import state_splitter
+from cellpy.readers.instruments.hooks import (
+    cycle_number_not_zero,
+    state_splitter,
+)
 
 STATES = dict(charge_keys=("C",), discharge_keys=("D",))
 
@@ -175,3 +184,61 @@ def test_the_hook_does_not_mutate_the_input_frame():
     _split_capacity(frame)
 
     assert frame.columns == before
+
+
+# -- cycle numbering (#560) ----------------------------------------------------
+
+
+def _cycles(values):
+    return pl.DataFrame({"Cyc": values})
+
+
+@pytest.mark.essential
+def test_zero_based_cycles_are_shifted_to_start_at_one():
+    out = cycle_number_not_zero(cycle_column="Cyc")(_cycles([0, 0, 1, 2]))
+
+    assert out["Cyc"].to_list() == [1, 1, 2, 3]
+
+
+@pytest.mark.essential
+def test_one_based_cycles_are_left_alone():
+    out = cycle_number_not_zero(cycle_column="Cyc")(_cycles([1, 2, 3]))
+
+    assert out["Cyc"].to_list() == [1, 2, 3]
+
+
+@pytest.mark.essential
+def test_cycles_starting_above_one_are_not_rebased():
+    """The quirk: legacy shifts only when the minimum is exactly 0.
+
+    A file whose cycles start at 2 keeps starting at 2 — it is not pulled down
+    to 1. Reproduced rather than tidied, because tidying it would renumber
+    someone's cycles.
+    """
+    out = cycle_number_not_zero(cycle_column="Cyc")(_cycles([2, 3, 4]))
+
+    assert out["Cyc"].to_list() == [2, 3, 4]
+
+
+@pytest.mark.essential
+def test_a_non_numeric_cycle_column_raises_rather_than_doing_nothing():
+    """Silence here would be an off-by-one with nothing to show for it."""
+    frame = pl.DataFrame({"Cyc": ["0", "1"]})
+
+    with pytest.raises(LoaderError, match="not numeric"):
+        cycle_number_not_zero(cycle_column="Cyc")(frame)
+
+
+@pytest.mark.essential
+def test_a_missing_cycle_column_names_itself():
+    with pytest.raises(LoaderError, match="Cyc"):
+        cycle_number_not_zero(cycle_column="Cyc")(pl.DataFrame({"Other": [1]}))
+
+
+@pytest.mark.essential
+def test_an_empty_frame_is_returned_unchanged():
+    frame = pl.DataFrame({"Cyc": []}, schema={"Cyc": pl.Int64})
+
+    out = cycle_number_not_zero(cycle_column="Cyc")(frame)
+
+    assert out.height == 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,4 +1,4 @@
-"""Vendor post hooks: state splitting and cycle numbering (#560).
+"""Vendor post hooks: state splitting, cycle numbering, bad final rows (#560).
 
 Expectations here are **hand-computed from the legacy post-processors**, not
 read back from the implementation. A splitter that is subtly wrong does not
@@ -20,6 +20,7 @@ import pytest
 from cellpy.exceptions import LoaderError
 from cellpy.readers.instruments.hooks import (
     cycle_number_not_zero,
+    drop_last_row_if_worse,
     state_splitter,
 )
 
@@ -242,3 +243,91 @@ def test_an_empty_frame_is_returned_unchanged():
     out = cycle_number_not_zero(cycle_column="Cyc")(frame)
 
     assert out.height == 0
+
+
+# -- dropping a bad final row (#560) -------------------------------------------
+
+
+def _tail_frame(rows):
+    """Two-or-more rows of (a, b, junk); None means missing."""
+    return pl.DataFrame(
+        {
+            "a": [r[0] for r in rows],
+            "b": [r[1] for r in rows],
+            "junk": [r[2] for r in rows],
+        },
+        schema={"a": pl.Float64, "b": pl.Float64, "junk": pl.Float64},
+    )
+
+
+@pytest.mark.essential
+def test_a_more_incomplete_final_row_is_dropped():
+    frame = _tail_frame([(1.0, 1.0, 1.0), (2.0, 2.0, 2.0), (3.0, None, 3.0)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 2
+
+
+@pytest.mark.essential
+def test_an_equally_incomplete_final_row_is_kept():
+    """The rule is *strictly more*, so uniformly sparse files keep every row."""
+    frame = _tail_frame([(1.0, None, 1.0), (2.0, None, 2.0), (3.0, None, 3.0)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 3
+
+
+@pytest.mark.essential
+def test_a_complete_final_row_is_kept():
+    frame = _tail_frame([(1.0, None, 1.0), (2.0, 2.0, 2.0)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 2
+
+
+@pytest.mark.essential
+def test_nan_counts_as_missing_like_pandas_isna():
+    """Legacy used ``isna()``, which is true for NaN as well as None."""
+    frame = _tail_frame([(1.0, 1.0, 1.0), (2.0, float("nan"), 2.0)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 1
+
+
+@pytest.mark.essential
+def test_undeclared_columns_do_not_decide_whether_a_row_survives():
+    """The denominator matters.
+
+    Legacy ran after ``select_columns_to_keep``, so it counted over the columns
+    cellpy keeps. Here the declared columns are complete in both rows and only
+    the undeclared ``junk`` column degrades — the row must survive. Counting
+    over every vendor column instead would drop a perfectly good measurement
+    because of a column nobody asked for.
+    """
+    frame = _tail_frame([(1.0, 1.0, 1.0), (2.0, 2.0, None)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 2
+
+
+@pytest.mark.essential
+def test_a_single_row_frame_is_left_alone():
+    """Legacy indexes iloc[-2]; there is nothing to compare against."""
+    frame = _tail_frame([(1.0, None, None)])
+
+    out = drop_last_row_if_worse(columns=("a", "b"))(frame)
+
+    assert out.height == 1
+
+
+@pytest.mark.essential
+def test_no_checkable_column_raises_rather_than_silently_keeping_everything():
+    frame = _tail_frame([(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)])
+
+    with pytest.raises(LoaderError, match="no column it could check"):
+        drop_last_row_if_worse(columns=("nope",))(frame)

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -36,6 +36,10 @@ from cellpy.readers.instruments.harmonize import harmonize
 PARITY_CASES = (
     ("maccor_txt", "testdata/data/maccor_001.txt", {"model": "one", "sep": "\t"}),
     ("neware_txt", "testdata/data/neware_uio.csv", {"model": "one"}),
+    # Model two brings `remove_last_if_bad` into range — the only shipped
+    # post-processor that changes the *row count*. maccor_002.txt was already in
+    # testdata but no test loaded it.
+    ("maccor_txt", "testdata/data/maccor_002.txt", {"model": "two"}),
 )
 
 #: Legacy post-processor → native columns it changes, for the ones that have no
@@ -77,8 +81,15 @@ def _numeric(series: pl.Series) -> pl.Series | None:
     """A comparable numeric view, so a change of *representation* is not read as
     a change of *value*.
 
-    The legacy frame spells elapsed times as timedelta and timestamps as
-    datetime; the native schema spells them float seconds and int64 epoch ns.
+    The legacy frame spells elapsed times as timedelta, timestamps as datetime,
+    and — for columns it never converted — numbers as **strings**: maccor model
+    two leaves ``cumulative_charge_energy`` as ``'0.00000000'``. The native
+    schema spells all of those numerically.
+
+    A numeric-looking string column is coerced so the *values* can be compared.
+    A string column that does not fully coerce returns ``None``, so the caller
+    falls back to strict equality and reports the difference rather than
+    papering over it.
     """
     dtype = series.dtype
     if dtype.is_numeric():
@@ -89,6 +100,10 @@ def _numeric(series: pl.Series) -> pl.Series | None:
         if dtype.time_zone is not None:
             series = series.dt.convert_time_zone("UTC")
         return series.dt.epoch("ns").cast(pl.Float64) / 1e9
+    if dtype == pl.String:
+        coerced = series.cast(pl.Float64, strict=False)
+        if coerced.null_count() == series.null_count():
+            return coerced
     return None
 
 
@@ -146,7 +161,12 @@ def test_harmonized_values_match_the_legacy_frame(
         )
         left_n, right_n = _numeric(left), _numeric(right)
         if left_n is None or right_n is None:
-            assert (left == right).all(), f"{instrument}: {column} differs"
+            if left.dtype != right.dtype:
+                mismatched.append(
+                    f"{column} (not comparable: {right.dtype} -> {left.dtype})"
+                )
+            elif not (left == right).all():
+                mismatched.append(f"{column} (values differ)")
             checked.append(column)
             continue
         worst = (left_n - right_n).abs().max()

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -42,9 +42,7 @@ PARITY_CASES = (
 #: ``harmonize()`` equivalent yet. Each needs a vendor post hook (the #559 pilot
 #: shows the shape for Maccor's capacity split). Remove an entry when its hook
 #: lands; the parity assertions then cover those columns automatically.
-UNPORTED_POST_PROCESSORS = {
-    "set_cycle_number_not_zero": ("cycle_num",),
-}
+UNPORTED_POST_PROCESSORS: dict[str, tuple[str, ...]] = {}
 
 #: ``date_time`` survives as a passthrough string while the native schema has no
 #: column for it; the legacy path parses it to datetime. Tracked on the metadata

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -43,11 +43,6 @@ PARITY_CASES = (
 #: shows the shape for Maccor's capacity split). Remove an entry when its hook
 #: lands; the parity assertions then cover those columns automatically.
 UNPORTED_POST_PROCESSORS = {
-    "split_capacity": (
-        "cumulative_charge_capacity",
-        "cumulative_discharge_capacity",
-    ),
-    "split_current": ("current",),
     "set_cycle_number_not_zero": ("cycle_num",),
 }
 

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -1,0 +1,220 @@
+"""Value parity between ``harmonize(parse(...))`` and the legacy path (#560).
+
+``test_derived_declarations`` proves the derivation puts columns under the right
+*names*. That is not enough to switch ingestion over: a wrong reset granularity
+or an unparsed duration string produces a correctly-named column full of wrong
+numbers, which no name check can see. This module compares the **values**.
+
+How it works: one ``cellpy.get()`` per case, with ``query_file`` wrapped so the
+same run yields both the vendor frame (what ``harmonize()`` would be handed) and
+the legacy frame (the oracle). Deriving the declarations from the loader's live
+``config_params`` means the test exercises the configuration that actually
+shipped, not a transcription of it.
+
+**The exception list is derived, not hardcoded.** Post-processors that
+``harmonize()`` cannot yet express are listed in ``UNPORTED_POST_PROCESSORS``
+together with the native columns they change; a case skips exactly those
+columns, and only when its own configuration enables that post-processor. So
+when a post hook lands, deleting its entry here tightens the test everywhere at
+once — and no column is ever excused silently.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+
+from cellpy.readers.instruments.base import AutoLoader, TxtLoader
+from cellpy.readers.instruments.config_declarations import (
+    declarations_from_configuration,
+)
+from cellpy.readers.instruments.harmonize import harmonize
+
+#: instrument, source file, loader kwargs.
+PARITY_CASES = (
+    ("maccor_txt", "testdata/data/maccor_001.txt", {"model": "one", "sep": "\t"}),
+    ("neware_txt", "testdata/data/neware_uio.csv", {"model": "one"}),
+)
+
+#: Legacy post-processor → native columns it changes, for the ones that have no
+#: ``harmonize()`` equivalent yet. Each needs a vendor post hook (the #559 pilot
+#: shows the shape for Maccor's capacity split). Remove an entry when its hook
+#: lands; the parity assertions then cover those columns automatically.
+UNPORTED_POST_PROCESSORS = {
+    "split_capacity": (
+        "cumulative_charge_capacity",
+        "cumulative_discharge_capacity",
+    ),
+    "split_current": ("current",),
+    "set_cycle_number_not_zero": ("cycle_num",),
+}
+
+#: ``date_time`` survives as a passthrough string while the native schema has no
+#: column for it; the legacy path parses it to datetime. Tracked on the metadata
+#: arc (#562/#563), not a capacity-corrupting difference.
+KNOWN_REPRESENTATION_GAPS = ("date_time",)
+
+TOLERANCE = 1e-6
+
+
+@pytest.fixture
+def captured_vendor_frame(monkeypatch):
+    """Capture the vendor frame ``query_file`` produced during a load."""
+    captured: dict = {}
+
+    for cls in (AutoLoader, TxtLoader):
+        original = cls.__dict__.get("query_file")
+        if original is None:
+            continue
+
+        def wrapper(self, name, *args, _original=original, **kwargs):
+            frame = _original(self, name, *args, **kwargs)
+            captured["vendor"] = frame.copy()
+            captured["config_params"] = self.config_params
+            return frame
+
+        monkeypatch.setattr(cls, "query_file", wrapper)
+
+    return captured
+
+
+def _numeric(series: pl.Series) -> pl.Series | None:
+    """A comparable numeric view, so a change of *representation* is not read as
+    a change of *value*.
+
+    The legacy frame spells elapsed times as timedelta and timestamps as
+    datetime; the native schema spells them float seconds and int64 epoch ns.
+    """
+    dtype = series.dtype
+    if dtype.is_numeric():
+        return series.cast(pl.Float64)
+    if dtype == pl.Duration:
+        return series.dt.total_nanoseconds().cast(pl.Float64) / 1e9
+    if dtype == pl.Datetime:
+        if dtype.time_zone is not None:
+            series = series.dt.convert_time_zone("UTC")
+        return series.dt.epoch("ns").cast(pl.Float64) / 1e9
+    return None
+
+
+def _excused(config_params) -> set[str]:
+    """Columns this configuration's unported post-processors are allowed to move."""
+    post_processors = getattr(config_params, "post_processors", None) or {}
+    excused = set(KNOWN_REPRESENTATION_GAPS)
+    for processor, columns in UNPORTED_POST_PROCESSORS.items():
+        if post_processors.get(processor):
+            excused.update(columns)
+    return excused
+
+
+def _harmonized_and_legacy(instrument, source, kwargs, captured):
+    import cellpy
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cell = cellpy.get(
+            source, instrument=instrument, mass=1.0, testing=True, **kwargs
+        )
+
+    assert "vendor" in captured, f"query_file was never called for {instrument}"
+    declarations = declarations_from_configuration(captured["config_params"])
+    harmonized = harmonize(captured["vendor"], declarations, strict=False)
+    legacy = pl.from_pandas(cell.data.raw.reset_index(drop=True))
+    return harmonized, legacy, captured["config_params"]
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, source, kwargs", PARITY_CASES)
+def test_harmonized_values_match_the_legacy_frame(
+    instrument, source, kwargs, captured_vendor_frame
+):
+    """Every shared column agrees in value, bar the named exceptions.
+
+    This is the assertion the flag day rests on. A failure here means routing
+    ``load()`` through ``harmonize()`` would change users' numbers.
+    """
+    harmonized, legacy, config_params = _harmonized_and_legacy(
+        instrument, source, kwargs, captured_vendor_frame
+    )
+    excused = _excused(config_params)
+
+    shared = [c for c in harmonized.columns if c in legacy.columns]
+    assert shared, f"{instrument}: harmonize produced no column the legacy path has"
+
+    checked, mismatched = [], []
+    for column in shared:
+        if column in excused:
+            continue
+        left, right = harmonized[column], legacy[column]
+        assert left.len() == right.len(), (
+            f"{instrument}: {column} has {left.len()} rows, legacy has {right.len()}"
+        )
+        left_n, right_n = _numeric(left), _numeric(right)
+        if left_n is None or right_n is None:
+            assert (left == right).all(), f"{instrument}: {column} differs"
+            checked.append(column)
+            continue
+        worst = (left_n - right_n).abs().max()
+        if worst is None or worst > TOLERANCE:
+            mismatched.append(f"{column} (max abs diff {worst})")
+        checked.append(column)
+
+    assert not mismatched, (
+        f"{instrument}: harmonize() disagrees with the legacy path on "
+        f"{mismatched}. Either the derived declarations are wrong, or this is a "
+        f"deliberate change that belongs in the release notes."
+    )
+    assert checked, f"{instrument}: every shared column was excused - test is vacuous"
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, source, kwargs", PARITY_CASES)
+def test_no_column_is_silently_emptied(
+    instrument, source, kwargs, captured_vendor_frame
+):
+    """No harmonized column is all-null when the legacy path filled it.
+
+    The failure this guards against is specific and was real: neware writes
+    ``Time`` as ``"00:01:00"``, and casting a string column to the schema's
+    Float64 nulled all 9065 rows without raising. Same shape as #580 — the data
+    is gone and nothing says so.
+    """
+    harmonized, legacy, _ = _harmonized_and_legacy(
+        instrument, source, kwargs, captured_vendor_frame
+    )
+    emptied = [
+        column
+        for column in harmonized.columns
+        if column in legacy.columns
+        and harmonized[column].null_count() == harmonized.height
+        and legacy[column].null_count() < legacy.height
+    ]
+    assert not emptied, (
+        f"{instrument}: {emptied} came out entirely null while the legacy path "
+        f"populated them"
+    )
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, source, kwargs", PARITY_CASES)
+def test_elapsed_times_are_seconds_not_nulls(
+    instrument, source, kwargs, captured_vendor_frame
+):
+    """``test_time``/``step_time`` arrive as real float seconds.
+
+    Pinned separately from the parity sweep because both vendors write these as
+    duration strings, and the schema dtype is numeric — the combination that
+    produced the silent null column.
+    """
+    harmonized, _, _ = _harmonized_and_legacy(
+        instrument, source, kwargs, captured_vendor_frame
+    )
+    for column in ("test_time", "step_time"):
+        if column not in harmonized.columns:
+            continue
+        series = harmonized[column]
+        assert series.dtype.is_numeric(), f"{column} is {series.dtype}, not numeric"
+        assert series.null_count() < series.len(), f"{column} is entirely null"
+        assert series.max() > 0, f"{column} never advances"

--- a/tests/test_loader_two_stage.py
+++ b/tests/test_loader_two_stage.py
@@ -1,0 +1,134 @@
+"""The two-stage entry points on the shipped loaders (#560).
+
+``parse()`` exposes the vendor stage and ``declarations()`` the declared stage,
+so ``harmonize(parse(source), declarations())`` can be driven directly rather
+than reconstructed by wrapping ``query_file``. Nothing here changes how
+``loader()`` behaves — the legacy path is still what ingestion runs.
+
+The case worth the most attention is ``declarations()`` being **per file**:
+neware writes its units into its column names, and which units those are comes
+from the file, not the configuration.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers import data_structures as ds
+from cellpy.readers.instruments.harmonize import harmonize
+
+#: instrument, source, loader kwargs — the parity cases, driven the new way.
+CASES = (
+    ("maccor_txt", "testdata/data/maccor_001.txt", {"model": "one", "sep": "\t"}),
+    ("neware_txt", "testdata/data/neware_uio.csv", {"model": "one"}),
+    ("maccor_txt", "testdata/data/maccor_002.txt", {"model": "two"}),
+)
+
+
+def _loader(instrument, **kwargs):
+    return ds.generate_default_factory().create(instrument, **kwargs)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, source, kwargs", CASES)
+def test_parse_then_harmonize_produces_a_native_frame(instrument, source, kwargs):
+    """The two stages compose into the harmonized-raw schema."""
+    model = kwargs.get("model")
+    loader = _loader(instrument, model=model) if model else _loader(instrument)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        vendor = loader.parse(source, **kwargs)
+        raw = harmonize(vendor, loader.declarations(), strict=False)
+
+    assert raw.height == len(vendor)
+    for column in ("cycle_num", "step_num", "current", "potential"):
+        assert column in raw.columns, f"{column} missing from the harmonized frame"
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("instrument, source, kwargs", CASES)
+def test_parse_returns_vendor_names_not_native_ones(instrument, source, kwargs):
+    """``parse()`` is the *vendor* stage — renaming belongs to harmonize."""
+    model = kwargs.get("model")
+    loader = _loader(instrument, model=model) if model else _loader(instrument)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        vendor = loader.parse(source, **kwargs)
+
+    assert "potential" not in vendor.columns
+    assert "cumulative_charge_capacity" not in vendor.columns
+
+
+@pytest.mark.essential
+def test_declarations_reflect_the_units_in_the_file_not_the_config_default():
+    """The reason ``declarations()`` cannot be a class attribute.
+
+    ``neware_txt_one`` defaults to ``mA``/``mAh`` and spells its columns
+    ``Current({{ current }})``. ``neware_uio.csv`` is in ``A``/``Ah``, and the
+    loader corrects the units while parsing. So the vendor column names — the
+    keys of ``column_map`` — depend on the file, and declarations read before
+    the parse would name columns the file does not contain.
+    """
+    loader = _loader("neware_txt", model="one")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        vendor = loader.parse("testdata/data/neware_uio.csv", model="one")
+        declarations = loader.declarations()
+
+    assert "Current(A)" in declarations.column_map, (
+        f"expected the file's own units in the vendor names, got "
+        f"{sorted(declarations.column_map)}"
+    )
+    assert "Current(mA)" not in declarations.column_map, "used the config default"
+    # And the names really are the file's.
+    assert "Current(A)" in vendor.columns
+
+
+@pytest.mark.essential
+def test_declarations_before_parse_raises_instead_of_guessing():
+    """Silence here would mean silently unmapped columns, not an error."""
+    loader = _loader("neware_txt", model="one")
+
+    with pytest.raises(LoaderError, match="before parse"):
+        loader.declarations()
+
+
+@pytest.mark.essential
+def test_the_two_stages_agree_with_the_legacy_frame():
+    """Same value parity as the oracle, reached through the public entry points.
+
+    ``test_loader_port_parity`` gets its vendor frame by wrapping
+    ``query_file``. If ``parse()`` did anything different, that oracle would be
+    testing a path nothing uses.
+    """
+    import cellpy
+
+    loader = _loader("neware_txt", model="one")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        vendor = loader.parse("testdata/data/neware_uio.csv", model="one")
+        raw = harmonize(vendor, loader.declarations(), strict=False)
+        cell = cellpy.get(
+            "testdata/data/neware_uio.csv",
+            instrument="neware_txt",
+            model="one",
+            mass=1.0,
+            testing=True,
+        )
+
+    legacy = pl.from_pandas(cell.data.raw.reset_index(drop=True))
+    for column in ("cumulative_charge_capacity", "cumulative_discharge_capacity"):
+        difference = (
+            raw[column].cast(pl.Float64) - legacy[column].cast(pl.Float64)
+        ).abs().max()
+        assert difference is not None and difference < 1e-9, (
+            f"{column} differs by {difference} between the two-stage path and "
+            f"the legacy path"
+        )

--- a/tests/test_pre_processors.py
+++ b/tests/test_pre_processors.py
@@ -1,0 +1,61 @@
+"""Loader pre-processors (#560).
+
+``remove_empty_lines`` used to open its input with the *platform default*
+encoding. That made a real Maccor file (``maccor_002.txt``, whose Description
+line carries a 0xFF byte) load on Windows and raise a bare
+``UnicodeDecodeError`` on Linux — a class of bug that is invisible to anyone
+developing on one platform, and that no test caught because nothing loaded that
+file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.readers.instruments.processors.pre_processors import remove_empty_lines
+
+
+@pytest.mark.essential
+def test_a_non_utf8_byte_does_not_stop_the_file_from_loading(tmp_path):
+    """The regression: 0xFF is not valid UTF-8 and must not be fatal.
+
+    This pre-processor only strips blank lines. It has no business rejecting a
+    file over one undecodable byte in a header comment.
+    """
+    source = tmp_path / "vendor.txt"
+    source.write_bytes(b"Name:\tcell-1\r\nDescription\ttest \xff\xff\r\n\r\ndata\t1\r\n")
+
+    out = remove_empty_lines(source)
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3, f"expected the blank line dropped, got {lines}"
+    assert lines[0] == "Name:\tcell-1"
+    assert lines[2] == "data\t1"
+
+
+@pytest.mark.essential
+def test_blank_lines_are_removed_and_content_preserved(tmp_path):
+    source = tmp_path / "vendor.txt"
+    source.write_text("a\n\n\nb\n   \nc\n", encoding="utf-8")
+
+    out = remove_empty_lines(source)
+
+    assert out.read_text(encoding="utf-8").splitlines() == ["a", "b", "c"]
+
+
+@pytest.mark.essential
+def test_the_source_file_is_not_modified(tmp_path):
+    """It writes a new file; the vendor's own file must survive untouched."""
+    source = tmp_path / "vendor.txt"
+    original = b"a\r\n\r\nb\r\n"
+    source.write_bytes(original)
+
+    remove_empty_lines(source)
+
+    assert source.read_bytes() == original
+
+
+@pytest.mark.essential
+def test_a_missing_file_is_reported_clearly(tmp_path):
+    with pytest.raises(IOError, match="Could not find the file"):
+        remove_empty_lines(tmp_path / "nope.txt")


### PR DESCRIPTION
Part of #560 (loader port). Additive — no change to how anything loads today.

## Why

[#583](https://github.com/jepegit/cellpy/pull/583) proved the derivation puts columns under the right *names*. That is not enough to switch ingestion over: a wrong reset granularity or an unparsed duration string produces a correctly-named column full of wrong numbers, which no name check can see. The flag day needs **value** parity, and there was none.

## What

`tests/test_loader_port_parity.py` — one `cellpy.get()` per case with `query_file` wrapped, so the same run yields both the vendor frame (what `harmonize()` would be handed) and the legacy frame (the oracle). Declarations are derived from the loader's live `config_params`, so the test exercises the configuration that shipped rather than a transcription of it.

## Two bugs it found

**Neither is on a user's load path** — `declarations_from_configuration` has no production callers and `harmonize()` is reached only by the `maccor_txt_native` pilot, so ingestion still runs the legacy chain, which handles both correctly. The numbers below are diffs against that legacy oracle: **regressions the flag day would have introduced**, caught while the path is still behind a flag. Nothing needs re-loading.

**1. `cumulate_capacity_within_cycle` *is* `ResetGranularity.PER_STEP`.** It offsets each step by the running total of the cycle's completed steps — precisely what `PER_STEP` normalization undoes. Nothing said so, and the derivation defaulted every cumulative column to `PER_CYCLE`, so neware capacities came out off by up to 8 mAh. Now **read from the configuration's `post_processors`** instead of defaulted — the configuration already knew, we were not asking it.

**2. Duration strings silently became null columns.** Neware writes `Time`/`Cumulative Time` as `"00:01:00"`; the schema dtype for `step_time`/`test_time` is Float64; `_cast_to_schema` cast non-strictly, so all 9065 rows became null with no error. Fixed twice over:

- a declared `duration_columns` conversion (also derived, from the `convert_*_to_timedelta` flags);
- a guard in `_cast_to_schema` that **raises when a cast empties a column entirely**.

The guard tolerates *partial* loss with a warning rather than raising. Deliberate: the legacy path used `pd.to_numeric(errors="coerce")`, and making stray values fatal would refuse files 1.x loaded happily. Only total loss is a wrong-dtype bug.

This is the same failure shape as #580, differing only in timing. Proposed as a rule for the rest of the port: **on the ingestion path, a step that can destroy data must not be able to do it quietly.**

## Result

- **`neware_txt`: exact value parity on all 14 comparable columns.**
- **`maccor_txt`:** parity on everything except the three columns owned by hooks not yet ported (`split_capacity`, `split_current`, `set_cycle_number_not_zero`).
- The oracle's exception list is **derived from each configuration's own `post_processors`**, so porting a hook tightens the test automatically — no column is ever excused silently.

## Confidence

Both fixes are **mutation-tested**, not merely green:

- disabling the `PER_STEP` derivation fails the oracle with the exact 8 mAh diff;
- removing the duration conversion trips the cast guard, with a message naming the fix.

Full suite **1148 passed, 0 failed** locally — but that is Windows only, and the neware `Capacity(Ah)` dtype inference has differed between platforms in this exact area before (see the comment in `test_derived_declarations._vendor_header`). CI is the real check.

## Follow-ups (not in this PR)

- The remaining post hooks: `split_capacity`, `split_current`, `remove_last_if_bad`, `update_headers_with_units`. `set_cycle_number_not_zero` needs a *decision* — 0- vs 1-based cycles is a user-visible contract.
- `date_time` survives as a passthrough string where the legacy path parsed it to datetime, and neither tier-1 configuration produces `epoch_time_utc`. Metadata-arc question (#562/#563), but it must be settled before the flag day.

Post-processor map and findings recorded in the loader plan §2.7. Release-note framing on #572 (one loader-author item; explicitly *not* a user-facing data note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
