### PR TITLE
Fix unit_labels override writing to raw_limits in TxtLoader

### DIFF
--- a/cellpy/readers/instruments/base.py
+++ b/cellpy/readers/instruments/base.py
@@ -851,7 +851,7 @@ class TxtLoader(AutoLoader, ABC):
 
         if unit_labels := kwargs.get("unit_labels", None):
             logging.critical(f"overriding unit_labels: {unit_labels}")
-            self.config_params.raw_limits.update(unit_labels)
+            self.config_params.unit_labels.update(unit_labels)
 
         if raw_limits := kwargs.get("raw_limits", None):
             logging.critical(f"overriding raw_limits: {raw_limits}")

--- a/tests/test_loader_two_stage.py
+++ b/tests/test_loader_two_stage.py
@@ -132,3 +132,29 @@ def test_the_two_stages_agree_with_the_legacy_frame():
             f"{column} differs by {difference} between the two-stage path and "
             f"the legacy path"
         )
+
+
+@pytest.mark.essential
+def test_unit_labels_override_lands_in_unit_labels_not_raw_limits():
+    """A ``unit_labels=`` override must reach ``config_params.unit_labels``.
+
+    Regression for a copy-paste slip where the ``unit_labels`` branch of
+    ``parse_loader_parameters`` updated ``raw_limits`` instead. The symptom was
+    that vendor column-name templates (neware spells its columns
+    ``Current({{ current }})``) could not be overridden this way, while the
+    unit-label strings silently polluted ``raw_limits``.
+    """
+    loader = _loader("neware_txt", model="one")
+    raw_limits_before = dict(loader.config_params.raw_limits)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # sep is given so the branch runs without touching the auto-formatter.
+        loader.parse_loader_parameters(sep="\t", unit_labels={"current": "A"})
+
+    assert loader.config_params.unit_labels["current"] == "A", (
+        "unit_labels override did not reach config_params.unit_labels"
+    )
+    assert dict(loader.config_params.raw_limits) == raw_limits_before, (
+        "unit_labels override leaked into config_params.raw_limits"
+    )


### PR DESCRIPTION
## What

`TxtLoader.parse_loader_parameters` had a copy-paste slip in its override handling: the `unit_labels=` branch updated `config_params.raw_limits` instead of `config_params.unit_labels`.

```python
if unit_labels := kwargs.get("unit_labels", None):
    logging.critical(f"overriding unit_labels: {unit_labels}")
-   self.config_params.raw_limits.update(unit_labels)
+   self.config_params.unit_labels.update(unit_labels)
```

## Why

- Passing `unit_labels=` to a loader had **no effect** on unit labels, so vendor column-name templates (e.g. neware's `Current({{ current }})`) could not be overridden this way.
- The unit-label strings silently **polluted `raw_limits`** instead.

The bug is bracketed by a correct `raw_units` branch above and a correct `raw_limits` branch immediately below, which is what makes it a copy-paste slip rather than intent. `git blame` traces it to `a9de15c4` — *"implement renaming original headers based on unit labels"* — whose stated purpose was to wire `unit_labels`.

## Test

Adds `test_unit_labels_override_lands_in_unit_labels_not_raw_limits` in `tests/test_loader_two_stage.py`: passes `unit_labels={"current": "A"}` to a neware loader and asserts it lands in `config_params.unit_labels` while `raw_limits` is unchanged. Verified it fails on the pre-fix code and passes after; the surrounding two-stage and port-parity suites stay green.

## Notes for reviewer

Found while porting loader post-processors for #560 (PR #601); kept out of that PR to keep it scoped to the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)