### PR TITLE
Import in-tree loaders by package path, not bare name (#560 follow-up)

### DIFF
--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -907,16 +907,56 @@ class InstrumentFactory:
         if not module_name:
             raise ValueError(key)
 
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        loader_module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = loader_module  # noqa
-        spec.loader.exec_module(loader_module)
+        loader_module = self._import_loader_module(module_name, module_path)
         cls = getattr(loader_module, instrument_class)
 
         # TODO: get stored kwargs from self.__kwargs and merge them with the supplied kwargs
         #  (supplied should have preference)
 
         return cls(**kwargs)
+
+    @staticmethod
+    def _import_loader_module(module_name: str, module_path):
+        """Import a loader module, preferring the package path for in-tree ones.
+
+        In-tree loaders live inside ``cellpy.readers.instruments``. Loading them
+        by file path (``spec_from_file_location``) creates a *second* module
+        object - e.g. a bare ``custom`` distinct from
+        ``cellpy.readers.instruments.custom`` - so one source file yields two
+        ``DataLoader`` classes. That breaks ``isinstance``/``issubclass`` against
+        the package-path class, duplicates any class-level state, and makes
+        monkeypatching the package-path class silently miss the instantiated one.
+        Importing by dotted name instead lets Python's module cache hand back the
+        one canonical module (and class).
+
+        User-supplied / local loader files legitimately live outside the package
+        and are still loaded from their path, unchanged.
+        """
+        package = "cellpy.readers.instruments"
+        instruments_dir = pathlib.Path(
+            importlib.import_module(package).__file__
+        ).resolve().parent
+
+        in_tree = False
+        if module_path is not None:
+            try:
+                in_tree = (
+                    pathlib.Path(module_path).resolve().parent == instruments_dir
+                )
+            except OSError:
+                in_tree = False
+
+        if in_tree:
+            # Derive the dotted name from the file itself so a stale registered
+            # module_name cannot point us at the wrong (or a missing) module.
+            dotted = f"{package}.{pathlib.Path(module_path).stem}"
+            return importlib.import_module(dotted)
+
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        loader_module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = loader_module  # noqa
+        spec.loader.exec_module(loader_module)
+        return loader_module
 
     def query(self, key: str, variable: str) -> Any:
         """performs a get_params lookup for the instrument loader.

--- a/tests/test_instrument_registering.py
+++ b/tests/test_instrument_registering.py
@@ -158,3 +158,28 @@ def test_query_instrument(parameter, loader, expected):
         instrument_factory.register_builder(instrument_id, instrument)
 
     assert instrument_factory.query(loader, parameter) == expected
+
+
+@pytest.mark.parametrize("instrument", ["custom", "local_instrument"])
+def test_factory_loader_is_package_path_class(parameters, instrument):
+    """A registry-created loader must be the *same class object* as the one
+    imported by package path.
+
+    Loading in-tree loaders by file path used to create a duplicate module
+    (e.g. a bare ``custom`` alongside ``cellpy.readers.instruments.custom``),
+    so ``isinstance`` checks failed, class-level state existed twice, and
+    monkeypatching the package-path class silently missed the instantiated one.
+    """
+    import importlib
+
+    module = importlib.import_module(f"cellpy.readers.instruments.{instrument}")
+
+    factory = core.generate_default_factory()
+    loader = factory.create(
+        instrument,
+        instrument_file=parameters.custom_instrument_definitions_file,
+    )
+
+    assert type(loader).__module__ == f"cellpy.readers.instruments.{instrument}"
+    assert type(loader) is module.DataLoader
+    assert isinstance(loader, module.DataLoader)


### PR DESCRIPTION
## What & why

`InstrumentFactory.create()` loaded every instrument module by **file path** (`importlib.util.spec_from_file_location`) and cached it in `sys.modules` under the **bare** module name (e.g. `custom`). For in-tree loaders that produced a module object distinct from the one Python already had cached as `cellpy.readers.instruments.custom` — so **one source file yielded two `DataLoader` classes**.

Reproduce (before this PR):

```python
import importlib
from cellpy.readers import data_structures as ds
m = importlib.import_module("cellpy.readers.instruments.custom")
loader = ds.generate_default_factory().create(
    "custom", instrument_file="testdata/data/custom_instrument_001.yml"
)
print(type(loader).__module__)        # -> "custom"
print(m.DataLoader.__module__)        # -> "cellpy.readers.instruments.custom"
print(type(loader) is m.DataLoader)   # -> False
```

Consequences of the duplicate class:

- `isinstance` / `issubclass` against the package-path class fail for registry-created loaders.
- Any class-level state (caches, registries, counters) exists twice.
- Monkeypatching the package-path class has no effect on the instantiated one. That last one is how this was found — a test patched `cellpy.readers.instruments.custom.DataLoader.query_file` and the patch silently did nothing, so the test captured nothing instead of failing loudly.

## The fix

Module import now goes through a new `InstrumentFactory._import_loader_module` helper:

- **In-tree loaders** (file lives under `cellpy/readers/instruments/`) are imported by **dotted package path** (`importlib.import_module("cellpy.readers.instruments." + stem)`), so Python's module cache hands back the one canonical module/class.
- **User-supplied / local loader files** outside the package keep the file-path load unchanged — that escape hatch is why the path-based approach existed in the first place.

The dotted name is derived from the file **stem**, so a stale registered `module_name` cannot mispoint the import.

## Tests

Adds `test_factory_loader_is_package_path_class` (parametrized over the in-tree `custom` and `local_instrument` loaders), asserting a registry-created loader is the **same class object** as the package-path import.

Verified:

- The new test **fails** against the pre-fix source and **passes** with the fix (confirmed by stashing just the source change).
- Loader suite green: 78 passed, 2 xfailed (pre-existing) across the instrument/loader test files.
- An out-of-tree loader registered with a path outside the package still loads by file path, unchanged.

## Reviewer notes

- Found while extending the #560 loader-port parity oracle (PR #601 follow-up); kept out of that branch to keep it scoped.
- Separately spotted (not fixed here): `find_all_instruments()` uses `module_path.name.rstrip(".py")`, which strips a *character set* rather than the suffix — it mangles e.g. `registry.py` → `registr` and registers non-loader modules as bogus instruments. This PR's fix is unaffected (it uses `.stem`); the registration-side bug is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
