### PR TITLE
auto-delimiter detection: fix IndexError on short files, raise a typed error

### DIFF
--- a/cellpy/readers/instruments/base.py
+++ b/cellpy/readers/instruments/base.py
@@ -15,7 +15,7 @@ from typing import List, Union
 
 import pandas as pd
 
-from cellpy.exceptions import WrongFileVersion
+from cellpy.exceptions import LoaderError, WrongFileVersion
 import cellpy.internals.connections
 import cellpy.readers.data_structures as core
 from cellpy.parameters.internal_settings import headers_normal, merge_raw_units
@@ -53,10 +53,16 @@ def find_delimiter_and_start(
 ):
     """Function to automatically detect the delimiter and what line the first data appears on.
 
-    This function is fairly stupid. It splits the data into two parts, the (possible) header part
-    (using the number of lines defined in ``checking_length_header``) and the rest of the data.
-    Then it counts the appearances of the different possible delimiters in the rest of
-    the data part, and then selects a delimiter if it has unique counts for all the lines.
+    This function is fairly stupid. It reads a window of up to
+    ``checking_length_whole`` non-empty lines and treats up to
+    ``checking_length_header`` of the leading ones as a possible header. It
+    counts the appearances of the different possible delimiters in the data
+    rows past that header and selects a delimiter if its per-row count is both
+    uniform and positive.
+
+    The header window is clamped to the actual number of lines read, so a short
+    file - down to a header line and a single data row - is inspected correctly
+    rather than running off the end of the sample.
 
     The first line is defined as where the delimiter is used same number of times (probably a header line).
 
@@ -71,6 +77,10 @@ def find_delimiter_and_start(
         separator: the delimiter.
         first_index: the index of the first line with data.
         encoding: the encoding (None if not found or checked).
+
+    Raises:
+        LoaderError: if the file has no inspectable content, no candidate
+            delimiter fits the data rows, or the header row cannot be located.
     """
 
     if separators is None:
@@ -91,7 +101,6 @@ def find_delimiter_and_start(
             r = results.best()
             encoding = r.encoding
 
-    empty_lines = 0
     with open(file_name, "r") as fin:
         lines = []
         for j in range(checking_length_whole):
@@ -100,18 +109,24 @@ def find_delimiter_and_start(
                 break
             if len(line.strip()):
                 lines.append(line)
-            else:
-                empty_lines += 1
 
-    checking_length_whole -= empty_lines
-    if checking_length_header - empty_lines < 1:
-        checking_length_header = checking_length_whole // 2
+    if not lines:
+        raise LoaderError(
+            f"could not detect a delimiter in {file_name}: "
+            "the file has no non-empty lines to inspect"
+        )
+
     separator, number_of_hits = _find_separator(
-        checking_length_whole - checking_length_header, lines, separators
+        lines, separators, checking_length_header
     )
 
     if separator is None:
-        raise IOError(f"could not decide delimiter in {file_name}")
+        candidates = ", ".join(repr(s) for s in separators)
+        raise LoaderError(
+            f"could not detect a delimiter in {file_name}: none of the "
+            f"candidate delimiters ({candidates}) appears a consistent, "
+            "positive number of times across the data rows"
+        )
 
     if separator == "\t":
         logging.debug("seperator = TAB")
@@ -123,6 +138,12 @@ def find_delimiter_and_start(
     first_index = _find_first_line_whit_delimiter(
         checking_length_header, lines, number_of_hits, separator
     )
+    if first_index is None:
+        raise LoaderError(
+            f"detected delimiter {separator!r} in {file_name} but could not "
+            f"locate the header row within the first {checking_length_header} "
+            "lines"
+        )
     logging.debug(f"First line with delimiter: {first_index}")
     return separator, first_index, encoding
 
@@ -130,40 +151,51 @@ def find_delimiter_and_start(
 def _find_first_line_whit_delimiter(
     checking_length_header, lines, number_of_hits, separator
 ):
+    """Return the index of the first line that carries the data-row delimiter count.
+
+    Only the first ``checking_length_header`` lines are searched (the header is
+    assumed to live there). Returns ``None`` if no line matches, so the caller
+    can raise a delimiter error that names the file.
+    """
     first_part = lines[:checking_length_header]
-    if number_of_hits is None:
-        # remark! if number of hits (i.e. how many separators pr line) is not given, we set it to the amount of
-        # separators we find in the third last line.
-        number_of_hits = lines[-3].count(separator)
-    return [
-        line_number
-        for line_number, line in enumerate(first_part)
-        if line.count(separator) == number_of_hits
-    ][0]
+    for line_number, line in enumerate(first_part):
+        if line.count(separator) == number_of_hits:
+            return line_number
+    return None
 
 
-def _find_separator(checking_length, lines, separators):
+def _find_separator(lines, separators, checking_length_header):
+    """Pick the delimiter from the data rows that follow a possible header.
+
+    The header may be up to ``checking_length_header`` lines, but a short file
+    cannot hold that many header lines - so the header window is clamped to the
+    number of lines actually read, always leaving at least one data row to
+    inspect. The delimiter is the highest-priority candidate whose per-row
+    count is both uniform and positive across those data rows.
+
+    Returns ``(None, None)`` when no candidate qualifies.
+    """
     logging.debug("searching for separators")
-    separator = None
-    number_of_hits = None
-    last_part = lines[
-        checking_length:-1
-    ]  # don't include last line since it might be corrupted
-    check_sep = dict()
+    n = len(lines)
 
-    for i, v in enumerate(separators):
-        check_sep[i] = [line.count(v) for line in last_part]
+    # reserve up to checking_length_header leading lines as a possible header,
+    # but never so many that no data row is left to inspect.
+    header_window = min(checking_length_header, n - 1) if n > 1 else 0
+    data_lines = lines[header_window:]
 
-    unique_sep_counts = {i: set(v) for i, v in check_sep.items()}
+    # the final line can be truncated mid-write, so drop it - but only when a
+    # data row can still be spared (a header + single data row must keep it).
+    if len(data_lines) > 1:
+        data_lines = data_lines[:-1]
 
-    for index, value in unique_sep_counts.items():
-        value_as_list = list(value)
-        number_of_hits = value_as_list[0]
-        if len(value_as_list) == 1 and number_of_hits > 0:
-            separator = separators[index]
-            break
+    for candidate in separators:
+        counts = {line.count(candidate) for line in data_lines}
+        if len(counts) == 1:
+            number_of_hits = counts.pop()
+            if number_of_hits > 0:
+                return candidate, number_of_hits
 
-    return separator, number_of_hits
+    return None, None
 
 
 def query_csv(

--- a/tests/test_find_delimiter_and_start.py
+++ b/tests/test_find_delimiter_and_start.py
@@ -1,0 +1,108 @@
+"""Auto delimiter detection has to cope with short files.
+
+``find_delimiter_and_start`` samples a window of lines and splits it into a
+possible-header part and a data part. The old arithmetic tied the split point
+to the *nominal* window size (``checking_length_whole - checking_length_header``)
+rather than the number of lines actually read, so any file shorter than that
+window left the data slice empty and detection died with a bare
+``IndexError: list index out of range`` - naming neither the file nor the
+cause.
+
+A short vendor file is normal: a truncated run, a quick sanity export, a small
+test fixture. These tests pin that a header line plus a single data row is
+enough to detect the delimiter, and that a file where detection genuinely
+cannot succeed raises a typed :class:`~cellpy.exceptions.LoaderError` that names
+the file. Regression for the synthetic-parity fixtures that had to be 300 rows
+to dodge the bug (#560 / PR #602).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments.base import find_delimiter_and_start
+
+# the parameters the AutoLoader (base.py / custom.py) actually calls with; this
+# pairing (header 100, whole 200) is where the reported failure lived.
+AUTO_HEADER, AUTO_WHOLE = 100, 200
+
+
+def _write_delimited(path, n_rows, sep=";", n_cols=6, preamble=0):
+    """A header row plus ``n_rows`` data rows, optionally behind a preamble."""
+    lines = [f"# preamble line {k}" for k in range(preamble)]
+    lines.append(sep.join(f"col{c}" for c in range(n_cols)))
+    for r in range(n_rows):
+        lines.append(sep.join(str(r * n_cols + c) for c in range(n_cols)))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# 1 is the floor the fix promises (header + one data row); 100/150 straddle the
+# old header=100 threshold that failed at 101 total lines.
+@pytest.mark.parametrize("n_rows", [1, 2, 5, 20, 100, 101, 150])
+@pytest.mark.parametrize("sep", [";", "\t", ",", "|"])
+def test_short_files_detect_the_delimiter(tmp_path, n_rows, sep):
+    source = _write_delimited(tmp_path / "short.csv", n_rows, sep=sep)
+
+    separator, first_index, _ = find_delimiter_and_start(
+        source,
+        checking_length_header=AUTO_HEADER,
+        checking_length_whole=AUTO_WHOLE,
+        check_encoding=False,
+    )
+
+    assert separator == sep
+    # the header row carries the same delimiter count as the data rows here, so
+    # it is the first matching line.
+    assert first_index == 0
+
+
+@pytest.mark.parametrize("n_rows", [1, 2, 5, 20])
+def test_short_files_with_a_preamble_locate_the_header(tmp_path, n_rows):
+    source = _write_delimited(tmp_path / "preamble.csv", n_rows, preamble=3)
+
+    separator, first_index, _ = find_delimiter_and_start(
+        source,
+        checking_length_header=AUTO_HEADER,
+        checking_length_whole=AUTO_WHOLE,
+        check_encoding=False,
+    )
+
+    assert separator == ";"
+    # the three preamble lines carry no delimiters, so the header row - the
+    # first line whose count matches the data - sits at index 3.
+    assert first_index == 3
+
+
+def test_single_header_and_data_line_is_enough(tmp_path):
+    """The floor the fix promises: one header line, one data line."""
+    source = tmp_path / "minimal.csv"
+    source.write_text("a;b;c\n1;2;3\n", encoding="utf-8")
+
+    separator, first_index, _ = find_delimiter_and_start(
+        source, checking_length_header=AUTO_HEADER, check_encoding=False
+    )
+
+    assert separator == ";"
+    assert first_index == 0
+
+
+def test_empty_file_raises_typed_error_naming_the_file(tmp_path):
+    source = tmp_path / "empty.csv"
+    source.write_text("", encoding="utf-8")
+
+    with pytest.raises(LoaderError) as excinfo:
+        find_delimiter_and_start(source, check_encoding=False)
+
+    assert str(source) in str(excinfo.value)
+
+
+def test_file_without_a_delimiter_raises_typed_error_naming_the_file(tmp_path):
+    source = tmp_path / "single_column.csv"
+    source.write_text("voltage\n3.1\n3.2\n3.3\n", encoding="utf-8")
+
+    with pytest.raises(LoaderError) as excinfo:
+        find_delimiter_and_start(source, check_encoding=False)
+
+    assert str(source) in str(excinfo.value)


### PR DESCRIPTION
## What

`find_delimiter_and_start` (`cellpy/readers/instruments/base.py`) failed to load short files with a bare `IndexError: list index out of range` — an error naming neither the file nor the cause. A short vendor file (a truncated run, a quick sanity export, a small fixture) is perfectly normal.

## Root cause

The function split its sample window into a header part and a data part, but computed the data-part start from the **nominal** window size rather than the lines actually read:

```python
_find_separator(checking_length_whole - checking_length_header, lines, separators)
# → last_part = lines[checking_length_whole - checking_length_header : -1]
```

When the file was shorter than that offset, `last_part` was empty and `_find_separator` ran `list({})[0]` → `IndexError`.

## Threshold (bisected, not assumed)

The real callers (`AutoLoader._auto_formatter`, and the same in `custom.py`) use `checking_length_header=100, checking_length_whole=200`, putting the split at line 100 — so **any file under 102 lines failed**. For `neware_txt_zero` (1 header + D data rows): D=100 → 101 lines crashes, D=101 → 102 lines works, which is exactly the reported "100 fails / 150 works" bracket. (The module default `header=30` puts the boundary at 171 rows; both confirmed by bisection.)

## Fix

- `_find_separator` clamps the header window to the actual line count — `min(checking_length_header, n-1)` — always leaving ≥1 data row, and drops the possibly-truncated last line **only** when a data row can still be spared. For any file that already worked (n ≥ 102 at header=100), the inspected window `lines[100:-1]` is **byte-identical** → zero behavior change on existing files.
- A header line + one data line is now enough (verified to the 2-line floor).
- Genuine failures raise a typed `LoaderError` **naming the file** — empty/blank-only files, no consistent delimiter, or an unlocatable header — replacing both the `IndexError` and the old untyped `IOError`.

## Verification

- End-to-end through the real `neware_txt` loader: **D = 1, 2, 5, 20, 100, 300 all load** (previously 1–100 crashed).
- New `tests/test_find_delimiter_and_start.py` — 35 tests: sizes 1/2/5/20/100/101/150 across four delimiters, preamble handling, the minimal 2-line file, and both typed-error paths.
- No regressions: real `neware_uio.csv` parity tests and the `loader_custom` golden (both exercise auto-detection) stay green.

## Context

Found while extending the #560 loader-port parity coverage (PR #602); split out to keep that branch scoped. This also removes the reason the synthetic-parity fixtures had to be 300 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)