### PR TITLE
#560: settle the naive-timestamp rule (UTC), fixing a comment that lied

### DIFF
--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -56,8 +56,10 @@ class LoaderDeclarations:
             columns not mentioned here are dropped; native names must exist.
         raw_units: the units the *file* is in, as a validated ``CellpyUnits``.
         timezone: IANA zone for naive vendor timestamps. ``None`` means "treat
-            naive timestamps as local time", the shared D3 rule — recorded on
-            ``TestMeta.time_zone`` so the assumption is visible later.
+            naive timestamps as **UTC**" (decision 2026-07-21, #560, aligning
+            with ``cellpycore.timestamps``) — recorded on ``TestMeta.time_zone``
+            so the assumption is visible later. Set it when the cycler's local
+            zone is known, so absolute times are correct rather than assumed.
         reset_granularity: native cumulative column → its granularity in the
             vendor file. Columns not listed are assumed already cycle-
             cumulative, which is the common case and the target convention.

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -152,11 +152,18 @@ def _convert_timestamps(
         series = raw[column]
         if series.dtype.time_zone is None:
             if declarations.timezone is None:
-                # The shared D3 rule: naive means local. Say so, because it is
-                # an assumption about someone else's data.
+                # Decision (2026-07-21, #560): a naive timestamp is read as
+                # **UTC**, not the host's local zone. This matches
+                # ``cellpycore.timestamps`` (the canonical-timestamp authority)
+                # and keeps the result reproducible wherever analysis runs —
+                # interpreting naive time as the *analysis* host's zone would
+                # give the same file different absolute times on a lab laptop
+                # and a CI runner. Still a warning, because it is an assumption
+                # about someone else's data; silence a loader that knows better
+                # by declaring ``timezone``.
                 logging.warning(
-                    "naive timestamps interpreted as local time; declare a "
-                    "timezone in the loader declarations to be explicit"
+                    "naive timestamps interpreted as UTC; declare a timezone in "
+                    "the loader declarations if the cycler's local zone is known"
                 )
                 series = series.dt.replace_time_zone("UTC")
             else:

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -605,3 +605,41 @@ def test_a_genuinely_stray_value_still_becomes_null_and_warns(caplog):
 
     assert raw[SCHEMA.current].to_list() == [0.1, None]
     assert SCHEMA.current in caplog.text, "the partial loss was silent"
+
+
+# -- naive timestamps are read as UTC (#560 decision, 2026-07-21) ---------------
+
+
+@pytest.mark.essential
+def test_a_naive_datetime_epoch_column_is_read_as_utc():
+    """Decision (#560): a naive vendor timestamp is UTC, not the host's zone.
+
+    Stamping UTC onto the wall-clock value (rather than shifting from some
+    assumed local zone) is what keeps the result reproducible wherever analysis
+    runs. Pinned so the decision cannot drift back to "local time".
+    """
+    import datetime as dt
+
+    frame = _minimal_vendor_frame()
+    # A naive datetime at 1970-01-01 00:00:01 UTC → 1_000_000_000 ns.
+    naive = [dt.datetime(1970, 1, 1, 0, 0, 1), dt.datetime(1970, 1, 1, 0, 0, 2)]
+    frame = frame.with_columns(pl.Series("Epoch", naive))
+
+    raw = harmonize(frame, _minimal_declarations(), test_id=1)
+
+    assert raw[SCHEMA.epoch_time_utc].to_list() == [1_000_000_000, 2_000_000_000]
+
+
+@pytest.mark.essential
+def test_a_declared_timezone_shifts_naive_timestamps_to_utc():
+    """A loader that knows the cycler's zone declares it, and it is honoured."""
+    import datetime as dt
+
+    frame = _minimal_vendor_frame()
+    naive = [dt.datetime(1970, 1, 1, 1, 0, 0), dt.datetime(1970, 1, 1, 2, 0, 0)]
+    frame = frame.with_columns(pl.Series("Epoch", naive))
+
+    # UTC+1: 01:00 local is 00:00 UTC → 0 ns; 02:00 local → 1h = 3.6e12 ns.
+    raw = harmonize(frame, _minimal_declarations(timezone="Etc/GMT-1"), test_id=1)
+
+    assert raw[SCHEMA.epoch_time_utc].to_list() == [0, 3_600_000_000_000]


### PR DESCRIPTION
Part of #560. Settles the last open piece of the `date_time`/`epoch_time_utc` question before the switchover. Text + tests only — **no behaviour change**.

## What was actually open

The big decision was already recorded in the native-headers plan: `epoch_time_utc` canonical (int64 ns UTC), `date_time` a passthrough for 2.0 then dropped in 2.1. `cellpycore/timestamps.py` grounds *why* — float epoch-seconds lose resolution near 2026, int64-ns doesn't.

What was **not** settled — and actively contradicted itself — was how a **naive** (timezone-less) vendor timestamp is read:

| Source | Says naive → |
|---|---|
| `cellpycore/timestamps.py` (authority) | UTC |
| `harmonize()` code | UTC (`replace_time_zone("UTC")`) |
| `harmonize()` comment + warning, `declarations` docstring | "local time" |

So the code already did UTC; only the words disagreed — and the **warning told users the wrong thing** ("interpreted as local time").

## Decision (2026-07-21): naive = UTC

Matches core and the shipped code, and keeps a file's absolute times reproducible wherever analysis runs. Rejected "local TZ of the conversion host" (the plan's old wording): it couples a file's meaning to *where analysis happens* — same file, different absolute times on a lab laptop vs a CI runner — and the analysis host is usually not the lab.

## Changes

- Corrected the `harmonize()` comment + warning and the `declarations` docstring to say UTC.
- Two enforcing tests: naive → UTC; a declared `timezone` shifts correctly (UTC+1 case).
- Native-headers plan updated (lines 83 and 242): the old #438 "naive = local" note is superseded and was never implemented anyway.

## Not in scope (rides with the switchover)

Actually *deriving* `epoch_time_utc` for every loader. The derivation has no `datetime_txt → epoch_time_utc` mapping yet, so no loader produces the column — that's why "missing required column epoch_time_utc" prints on loads. Wiring it in, with each vendor's datetime format (maccor/neware strings, arbin Excel-serial, arbin_sql_h5 format) converted in `parse()`, is the switchover's work. This PR settles the rule that work will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
