### PR TITLE
#560 switchover Phase A: derive epoch_time_utc from the vendor datetime

### DIFF
--- a/cellpy/readers/instruments/arbin_res.py
+++ b/cellpy/readers/instruments/arbin_res.py
@@ -888,6 +888,10 @@ class DataLoader(BaseLoader):
             column_map=column_map,
             raw_units=CellpyUnits(**raw_units),
             passthrough=passthrough,
+            # Arbin stores DateTime as an Excel serial (days since 1899-12-30);
+            # harmonize() derives epoch_time_utc from it. This replaces the
+            # xldate conversion the legacy _post_process ran on the same column.
+            datetime_kind="excel_serial",
         )
 
     def loader(

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -474,6 +474,20 @@ def declarations_from_configuration(
         if post_processors.get(processor) and column in targets
     )
 
+    # A configuration that runs ``convert_date_time_to_datetime`` writes its
+    # absolute timestamp as a wall-clock *string* (the post-processor is
+    # ``pd.to_datetime``). Declaring it lets ``harmonize()`` derive the required
+    # ``epoch_time_utc`` from the ``date_time`` passthrough. Keyed on the
+    # passthrough carrying the datetime column, so it is a no-op for a
+    # configuration that has no datetime.
+    date_time_header = _legacy_column_name("datetime_txt")
+    datetime_kind = None
+    if (
+        post_processors.get("convert_date_time_to_datetime")
+        and date_time_header in passthrough.values()
+    ):
+        datetime_kind = "string"
+
     return LoaderDeclarations(
         column_map=column_map,
         raw_units=_units_from_configuration(config),
@@ -483,4 +497,5 @@ def declarations_from_configuration(
         passthrough=passthrough,
         post_hooks=hooks,
         dropped=dropped,
+        datetime_kind=datetime_kind,
     )

--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -26,6 +26,9 @@ from cellpy.exceptions import LoaderError
 #: ``aux_<quantity>_<name>`` — the harmonized-raw auxiliary naming scheme.
 _AUX_PATTERN = re.compile(r"^aux_(temperature|potential|pressure|resistance)_\w+$")
 
+#: The forms a ``date_time`` passthrough can take; see ``datetime_kind``.
+DATETIME_KINDS = frozenset({"datetime", "string", "epoch_seconds", "excel_serial"})
+
 
 class ResetGranularity(StrEnum):
     """How often a vendor's cumulative column resets to zero.
@@ -105,6 +108,18 @@ class LoaderDeclarations:
     #: no error. Neware and Maccor both ship such columns, which is why it is a
     #: framework feature rather than a per-loader post hook.
     duration_columns: tuple[str, ...] = ()
+    #: How the ``date_time`` passthrough encodes its absolute timestamp, so
+    #: ``harmonize()`` can parse it and derive the required ``epoch_time_utc``
+    #: (int64 ns UTC). ``None`` means the loader carries no absolute timestamp.
+    #: One of :data:`DATETIME_KINDS`:
+    #:
+    #: - ``"datetime"``  — already a polars ``Datetime`` (pec).
+    #: - ``"string"``    — a wall-clock string; parsed with ``pandas.to_datetime``
+    #:   to match the legacy ``convert_date_time_to_datetime`` exactly (maccor's
+    #:   US ``MM/DD/YYYY`` and neware's ISO both go through the same parser).
+    #: - ``"epoch_seconds"`` — float seconds since the Unix epoch.
+    #: - ``"excel_serial"``  — Excel serial days (arbin ``.res``).
+    datetime_kind: str | None = None
 
     def __post_init__(self) -> None:
         self._validate()
@@ -181,6 +196,12 @@ class LoaderDeclarations:
             raise LoaderError(
                 f"duration_columns declares {bad_durations}, which column_map "
                 f"never produces; the declaration would have no effect."
+            )
+
+        if self.datetime_kind is not None and self.datetime_kind not in DATETIME_KINDS:
+            raise LoaderError(
+                f"datetime_kind {self.datetime_kind!r} is not one of "
+                f"{sorted(DATETIME_KINDS)}."
             )
 
         bad_aux = sorted(

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Any
 
 import polars as pl
@@ -133,6 +133,88 @@ def normalize_reset_granularity(
         raise LoaderError(f"unknown reset granularity {granularity!r} for {column!r}")
 
     return out
+
+
+#: Excel serials count days from 1899-12-30 (the Lotus-1900 epoch Excel uses).
+_EXCEL_EPOCH = datetime(1899, 12, 30, tzinfo=dt_timezone.utc)
+
+
+def _parse_datetime_column(series: pl.Series, kind: str) -> pl.Series:
+    """A vendor ``date_time`` column, in whatever form, → a polars ``Datetime``.
+
+    Parsing is per *kind* because the forms are genuinely different and
+    ``harmonize()`` cannot sniff them safely: ``"12/11/2020"`` is December to
+    Maccor (US) but a serial-looking string elsewhere, and Arbin's ``42587.68``
+    is Excel *days*, not epoch seconds. The loader states which it is.
+    """
+    if kind == "datetime":
+        return series
+
+    if kind == "string":
+        # pandas.to_datetime, to match the legacy convert_date_time_to_datetime
+        # exactly (same US-first interpretation of MM/DD/YYYY, same inference).
+        import pandas as pd
+
+        parsed = pd.to_datetime(series.to_pandas(), errors="coerce")
+        return pl.from_pandas(parsed).cast(pl.Datetime("us"))
+
+    if kind == "epoch_seconds":
+        return (series.cast(pl.Float64) * _NS_PER_SECOND).cast(pl.Int64).cast(
+            pl.Datetime("ns")
+        )
+
+    if kind == "excel_serial":
+        # Serial days (may be fractional) from the Excel epoch. Done exactly as
+        # the legacy ``xldate_as_datetime``: ``datetime(1899,12,30) +
+        # timedelta(days=serial)``. Reproduced element-wise rather than
+        # vectorised because ``timedelta``'s own microsecond rounding does not
+        # match a ``round(serial * ...)`` in float — the two disagree by 1 µs on
+        # about half the rows, which is a real parity miss on ``epoch_time_utc``.
+        base = datetime(1899, 12, 30)
+
+        def _from_serial(value: float | None):
+            if value is None:
+                return None
+            return base + timedelta(days=float(value))
+
+        return series.cast(pl.Float64).map_elements(
+            _from_serial, return_dtype=pl.Datetime("us")
+        )
+
+    raise LoaderError(f"unknown datetime_kind {kind!r}")
+
+
+def _derive_epoch_time_utc(
+    raw: pl.DataFrame, declarations: LoaderDeclarations
+) -> pl.DataFrame:
+    """Parse the ``date_time`` passthrough and derive ``epoch_time_utc``.
+
+    ``epoch_time_utc`` is a **required** native column, but no vendor writes it;
+    it is derived from the absolute wall-clock timestamp the file *does* carry.
+    A loader declares that column's form with ``datetime_kind``; here it becomes
+    a proper polars ``Datetime`` (so the ``date_time`` passthrough kept for the
+    one-release window is a real datetime, not a raw string), and a copy is
+    placed in ``epoch_time_utc`` for :func:`_convert_timestamps` to turn into
+    int64 ns UTC — so the naive-timezone rule lives in one place, not two.
+    """
+    schema = default_schema().raw
+    kind = declarations.datetime_kind
+    if kind is None:
+        return raw
+
+    # The passthrough keeps the legacy header name for the datetime column.
+    from cellpy.parameters.internal_settings import get_headers_normal
+
+    date_time = get_headers_normal().datetime_txt
+    if date_time not in raw.columns:
+        # Declared but this file did not carry it; nothing to derive from.
+        return raw
+
+    parsed = _parse_datetime_column(raw[date_time], kind)
+    return raw.with_columns(
+        parsed.alias(date_time),
+        parsed.alias(schema.epoch_time_utc),
+    )
 
 
 def _convert_timestamps(
@@ -382,6 +464,7 @@ def harmonize(
     present = {vendor: native for vendor, native in mapping.items() if vendor in raw.columns}
     raw = raw.select(list(present)).rename(present)
 
+    raw = _derive_epoch_time_utc(raw, declarations)
     raw = _convert_timestamps(raw, declarations)
     raw = _convert_durations(raw, declarations)
     raw = _cast_to_schema(raw)

--- a/cellpy/readers/instruments/pec_csv.py
+++ b/cellpy/readers/instruments/pec_csv.py
@@ -362,6 +362,9 @@ class DataLoader(BaseLoader):
             column_map=column_map,
             raw_units=CellpyUnits(**raw_units),
             passthrough=passthrough,
+            # parse() already converts the vendor date_time to a datetime, so
+            # harmonize() only has to derive epoch_time_utc from it.
+            datetime_kind="datetime",
         )
 
     def _rename_to_canonical(self, df, pec_columns):

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -643,3 +643,100 @@ def test_a_declared_timezone_shifts_naive_timestamps_to_utc():
     raw = harmonize(frame, _minimal_declarations(timezone="Etc/GMT-1"), test_id=1)
 
     assert raw[SCHEMA.epoch_time_utc].to_list() == [0, 3_600_000_000_000]
+
+
+# -- epoch_time_utc derivation from date_time (#560, switchover Phase A) --------
+
+
+def _vendor_frame_with_date_time(values, dtype=None):
+    """A minimal vendor frame carrying a date_time column of a given form."""
+    import polars as pl
+
+    base = _minimal_vendor_frame()
+    series = pl.Series("date_time", values, dtype=dtype) if dtype else pl.Series("date_time", values)
+    return base.with_columns(series)
+
+
+def _declarations_with_date_time(kind):
+    from cellpycore.units import CellpyUnits
+
+    from cellpy.readers.instruments.declarations import LoaderDeclarations
+
+    schema = default_schema().raw
+    return LoaderDeclarations(
+        column_map={
+            "Rec": schema.datapoint_num,
+            "Cyc": schema.cycle_num,
+            "Step": schema.step_num,
+            "T": schema.test_time,
+            "Epoch": schema.epoch_time_utc,
+            "I": schema.current,
+            "V": schema.potential,
+            "QC": schema.cumulative_charge_capacity,
+            "QD": schema.cumulative_discharge_capacity,
+        },
+        raw_units=CellpyUnits(),
+        passthrough={"date_time": "date_time"},
+        datetime_kind=kind,
+    )
+
+
+@pytest.mark.essential
+def test_epoch_time_utc_derived_from_an_iso_string():
+    frame = _vendor_frame_with_date_time(
+        ["2022-05-18 16:27:52", "2022-05-18 16:28:52"]
+    )
+    # Overwrite the numeric Epoch with nulls so the derivation is the only source.
+    frame = frame.with_columns(pl.Series("Epoch", [None, None], dtype=pl.Float64))
+
+    raw = harmonize(frame, _declarations_with_date_time("string"), test_id=1)
+
+    assert raw[SCHEMA.epoch_time_utc].to_list() == [1652891272_000_000_000, 1652891332_000_000_000]
+    # date_time is now a real datetime, not the raw string.
+    assert raw["date_time"].dtype == pl.Datetime
+
+
+@pytest.mark.essential
+def test_epoch_time_utc_from_a_us_format_string_is_month_first():
+    """``12/11/2020`` is December (US), matching legacy pd.to_datetime."""
+    frame = _vendor_frame_with_date_time(["12/11/2020 00:00:00", "12/11/2020 00:00:01"])
+    frame = frame.with_columns(pl.Series("Epoch", [None, None], dtype=pl.Float64))
+
+    raw = harmonize(frame, _declarations_with_date_time("string"), test_id=1)
+
+    import datetime as dt
+
+    got = dt.datetime.utcfromtimestamp(raw[SCHEMA.epoch_time_utc][0] / 1e9)
+    assert (got.month, got.day) == (12, 11)
+
+
+@pytest.mark.essential
+def test_epoch_time_utc_from_an_excel_serial_matches_the_xldate_conversion():
+    """Excel serial 42587.68... → the same instant the legacy xldate produced."""
+    import datetime as dt
+
+    serial = 42587.6815162037
+    frame = _vendor_frame_with_date_time([serial, serial], dtype=pl.Float64)
+    frame = frame.with_columns(pl.Series("Epoch", [None, None], dtype=pl.Float64))
+
+    raw = harmonize(frame, _declarations_with_date_time("excel_serial"), test_id=1)
+
+    expected = dt.datetime(1899, 12, 30) + dt.timedelta(days=serial)
+    expected_ns = int(expected.replace(tzinfo=dt.timezone.utc).timestamp() * 1e9)
+    assert abs(raw[SCHEMA.epoch_time_utc][0] - expected_ns) == 0
+
+
+@pytest.mark.essential
+def test_a_bad_datetime_kind_is_rejected_at_construction():
+    with pytest.raises(LoaderError, match="datetime_kind"):
+        _declarations_with_date_time("clock")
+
+
+@pytest.mark.essential
+def test_no_datetime_kind_means_no_epoch_derivation():
+    """A loader without an absolute timestamp derives nothing and does not error."""
+    frame = _minimal_vendor_frame()
+    # Epoch column carries real epoch-seconds, converted the ordinary way.
+    raw = harmonize(frame, _minimal_declarations(), test_id=1)
+
+    assert raw[SCHEMA.epoch_time_utc].dtype == pl.Int64

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -67,10 +67,13 @@ PARITY_CASES = (
 #: lands; the parity assertions then cover those columns automatically.
 UNPORTED_POST_PROCESSORS: dict[str, tuple[str, ...]] = {}
 
-#: ``date_time`` survives as a passthrough string while the native schema has no
-#: column for it; the legacy path parses it to datetime. Tracked on the metadata
-#: arc (#562/#563), not a capacity-corrupting difference.
-KNOWN_REPRESENTATION_GAPS = ("date_time",)
+#: Columns still excused from the shared-column sweep. Was ``date_time`` — now
+#: that ``harmonize()`` parses it and derives ``epoch_time_utc`` (via
+#: ``datetime_kind``), ``date_time`` is a real datetime that matches the legacy
+#: frame and is checked like any other. ``epoch_time_utc`` is not a *shared*
+#: column (the legacy raw carries only ``date_time``), so it gets an explicit
+#: check of its own — see ``_assert_epoch_time_utc``.
+KNOWN_REPRESENTATION_GAPS: tuple[str, ...] = ()
 
 TOLERANCE = 1e-6
 
@@ -216,6 +219,15 @@ def test_harmonized_values_match_the_legacy_frame(
     for column in shared:
         if column in excused:
             continue
+        # A loader that does not yet declare ``datetime_kind`` carries
+        # ``date_time`` as an unparsed passthrough (raw string / vendor number),
+        # while the legacy path parses it to a datetime — so they cannot be
+        # compared. Skip it *only* in that case; a loader that does parse it
+        # (its harmonized ``date_time`` is a real Datetime) is held to parity
+        # like any other column. arbin_sql_h5 is the current pre-epoch loader;
+        # it gets ``datetime_kind`` in a follow-up (loader plan §8.2).
+        if column == "date_time" and harmonized[column].dtype != pl.Datetime:
+            continue
         left, right = harmonized[column], legacy[column]
         assert left.len() == right.len(), (
             f"{instrument}: {column} has {left.len()} rows, legacy has {right.len()}"
@@ -251,6 +263,45 @@ def test_harmonized_values_match_the_legacy_frame(
         f"deliberate change that belongs in the release notes."
     )
     assert checked, f"{instrument}: every shared column was excused - test is vacuous"
+
+    _assert_epoch_time_utc(instrument, harmonized, legacy)
+
+
+#: Loaders exempt from the *exact* epoch check, with the reason. ``custom`` is
+#: the only one: its test fixture declares ``date_stamp`` as an Excel serial
+#: (≈2018) but the config runs ``convert_date_time_to_datetime`` =
+#: ``pd.to_datetime``, which reads the *number* as nanoseconds → a degenerate
+#: ``1970-01-01 00:00:00.000043``. Both the legacy path and harmonize() produce
+#: that same garbage; they differ only by ~376 ns of float round-trip noise on a
+#: timestamp that means nothing. Reproducing that noise is not worth it, and a
+#: blanket tolerance would have hidden the real 1 µs Excel-serial bug caught on
+#: arbin. This is a synthetic-fixture artifact, not a loader defect.
+_EPOCH_EXACT_SKIP = {"custom"}
+
+
+def _assert_epoch_time_utc(instrument, harmonized, legacy):
+    """``epoch_time_utc`` equals the legacy ``date_time`` as int64 ns UTC.
+
+    This is the switchover's required timestamp column, and it is *not* a shared
+    column — the legacy raw frame carries only ``date_time`` — so it needs its
+    own assertion. A loader with no absolute timestamp declares no
+    ``datetime_kind`` and produces no ``epoch_time_utc``; that is fine, and this
+    check is skipped for it rather than demanded.
+    """
+    if "epoch_time_utc" not in harmonized.columns:
+        return
+    if instrument in _EPOCH_EXACT_SKIP:
+        return
+    assert "date_time" in legacy.columns, (
+        f"{instrument}: harmonize derived epoch_time_utc but the legacy frame "
+        f"has no date_time to check it against"
+    )
+    reference = legacy["date_time"].dt.replace_time_zone("UTC").dt.epoch("ns")
+    worst = (harmonized["epoch_time_utc"] - reference).abs().max()
+    assert worst == 0, (
+        f"{instrument}: epoch_time_utc differs from the legacy date_time by "
+        f"{worst} ns"
+    )
 
 
 @pytest.mark.essential


### PR DESCRIPTION
Part of #560, the switchover's **hard prerequisite** (loader plan §8.2). Off master, independent.

## Why

`epoch_time_utc` is a *required* native column, but no vendor writes it — so today no loader produces it and "missing required column epoch_time_utc" prints on every load. Routing `load()` through `harmonize()` at the flag day needs this column populated first.

## How

A new `LoaderDeclarations.datetime_kind` tells `harmonize()` how the `date_time` passthrough is encoded:

| kind | source | loaders |
|---|---|---|
| `datetime` | already a polars Datetime | pec |
| `string` | wall-clock string, via `pandas.to_datetime` (matches legacy exactly) | maccor (US `MM/DD/YYYY`), neware (ISO) |
| `excel_serial` | Excel serial days | arbin_res |
| `epoch_seconds` | float seconds | (available) |

`harmonize()` parses that column into a real `Datetime` — so the `date_time` passthrough kept for the one-release window is a datetime, not a raw string — and copies it into `epoch_time_utc`, which the existing `_convert_timestamps` turns into int64 ns UTC. The naive=UTC rule stays in one place. The config derivation sets `datetime_kind="string"` automatically from `convert_date_time_to_datetime`; pec/arbin_res set theirs by hand.

## Result

**Exact (0 ns) epoch parity** for the four merged loaders that carry a timestamp: neware, maccor, pec, arbin_res.

## Two findings worth the reviewer's eye

- **Excel serial is done element-wise** (`datetime(1899,12,30)+timedelta(days=s)`, the exact legacy `xldate`). A vectorised `round(serial*…)` disagreed with `timedelta`'s own microsecond rounding by **1 µs on ~half the rows** — a real `epoch_time_utc` parity miss the tightened oracle caught. (A blanket tolerance would have hidden it — which is why `custom` is *skipped*, not tolerated.)
- **`custom` is skipped from the exact check** (documented). Its fixture declares `date_stamp` as an Excel serial (≈2018), but the config feeds the *number* to `pd.to_datetime`, read as nanoseconds → a degenerate `1970-01-01 00:00:00.000043`. Both paths produce that garbage; they differ only by ~376 ns of float noise. A synthetic-fixture artifact, not a loader defect.

## Oracle

`date_time` is no longer excused (it now matches as a real datetime); `epoch_time_utc` gets an explicit assertion since it isn't a *shared* column (legacy raw carries only `date_time`).

## Scope

Phase A, not the flag day. `arbin_sql_h5` gets `datetime_kind` on #609; the fixture-less loaders acquire it as they're ported/parked. The `load()` routing and `to_native()` deletion are Phase B.

Full suite under `PYTHONUTF8=1`: **1256 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
