### PR TITLE
#560: port the four remaining Arbin SQL loaders to two-stage; add arbin_epoch

### DIFF
--- a/cellpy/readers/instruments/arbin_sql.py
+++ b/cellpy/readers/instruments/arbin_sql.py
@@ -234,6 +234,47 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def parse(self, source, **kwargs):
+        """Vendor stage (#560): query the SQL Server into an Arbin-named frame.
+
+        The two-stage counterpart to :meth:`loader`, tapping the same
+        ``_query_sql`` read. It stops before ``_post_process`` — the rename, the
+        Arbin-integer datetime decode and the dtype coercion are declared and
+        handled by ``harmonize()``. No in-repo fixture exists (this needs a live
+        SQL Server), so the port is exercised at the declaration level; the
+        column map and ``datetime_kind`` mirror the parity-verified
+        ``arbin_sql_h5``, which shares the vendor's integer-tick timestamp.
+        """
+        import polars as pl
+
+        self.name = source
+        self.is_db = True
+        data_df, _ = self._query_sql(self.name)
+        self._parsed = True
+        return pl.from_pandas(data_df.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for Arbin SQL Server (#560).
+
+        Derived from the module ``normal_headers_renaming_dict`` restricted to
+        real cellpy headers — the same set the legacy ``_post_process`` renames
+        by iterating ``arbin_headers_normal`` — so ``derive_column_maps`` gives
+        Arbin → native with ``Test_ID`` dropped as provenance. ``datetime_kind``
+        is ``"arbin_epoch"``: the vendor ``Date_Time`` is integer 100 ns ticks
+        since the Unix epoch.
+        """
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_renaming,
+        )
+
+        return declarations_from_renaming(
+            self.get_raw_units(),
+            normal_headers_renaming_dict,
+            "arbin_epoch",
+            getattr(self, "_parsed", False),
+            "arbin_sql",
+        )
+
     # TODO: rename this (for all instruments) to e.g. load
     # TODO: implement more options (bad_cycles, ...)
     def loader(self, name, **kwargs):

--- a/cellpy/readers/instruments/arbin_sql_7.py
+++ b/cellpy/readers/instruments/arbin_sql_7.py
@@ -235,6 +235,42 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def parse(self, source, **kwargs):
+        """Vendor stage (#560): query MITS 7.0 SQL Server into an Arbin frame.
+
+        Taps the same ``_query_sql`` read as :meth:`loader`. Note this loader is
+        still under development upstream — ``_query_sql`` pivots the raw table to
+        integer ``Data_Type`` column names it never renames to ``Voltage`` etc.,
+        so the vendor frame is incomplete regardless of stage. The two-stage
+        entry points are added for switchover uniformity (no in-repo fixture);
+        the ``Date_Time`` tick format matches the parity-verified
+        ``arbin_sql_h5``, so ``datetime_kind="arbin_epoch"``.
+        """
+        import polars as pl
+
+        self.name = source
+        data_df, _ = self._query_sql()
+        self._parsed = True
+        return pl.from_pandas(data_df.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for Arbin MITS 7.0 SQL Server (#560).
+
+        ``datetime_kind="arbin_epoch"`` — the vendor ``Date_Time`` is integer
+        100 ns ticks since the Unix epoch, as in the other Arbin variants.
+        """
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_renaming,
+        )
+
+        return declarations_from_renaming(
+            self.get_raw_units(),
+            normal_headers_renaming_dict,
+            "arbin_epoch",
+            getattr(self, "_parsed", False),
+            "arbin_sql_7",
+        )
+
     def loader(self, name, **kwargs):
         """returns a Data object with loaded data.
 

--- a/cellpy/readers/instruments/arbin_sql_csv.py
+++ b/cellpy/readers/instruments/arbin_sql_csv.py
@@ -141,6 +141,43 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def parse(self, source, **kwargs):
+        """Vendor stage (#560): read the CSV export into an Arbin-named frame.
+
+        Taps the same ``_query_csv`` read as :meth:`loader`, stopping before the
+        rename. The vendor ``Date_Time`` here is a wall-clock **string** (the
+        legacy path never converts the column, only parses the first value for
+        ``start_datetime``), so ``declarations`` sets ``datetime_kind="string"``.
+        No in-repo CSV fixture exists, so the port is exercised at the
+        declaration level.
+        """
+        import polars as pl
+        from pathlib import Path
+
+        self.name = source if isinstance(source, Path) else Path(source)
+        self.copy_to_temporary()
+        data_df = self._query_csv(self.temp_file_path)
+        self._parsed = True
+        return pl.from_pandas(data_df.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for the Arbin SQL Server CSV export (#560).
+
+        ``datetime_kind="string"``: the CSV ``Date_Time`` is a wall-clock string,
+        read as UTC by ``harmonize()`` (the naive-timestamp rule, #560).
+        """
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_renaming,
+        )
+
+        return declarations_from_renaming(
+            self.get_raw_units(),
+            normal_headers_renaming_dict,
+            "string",
+            getattr(self, "_parsed", False),
+            "arbin_sql_csv",
+        )
+
     # TODO: rename this (for all instruments) to e.g. load
     # TODO: implement more options (bad_cycles, ...)
     def loader(self, name, **kwargs):

--- a/cellpy/readers/instruments/arbin_sql_h5.py
+++ b/cellpy/readers/instruments/arbin_sql_h5.py
@@ -162,6 +162,7 @@ class DataLoader(BaseLoader):
             raw_units=CellpyUnits(**raw_units),
             passthrough=passthrough,
             post_hooks=(forward_fill(columns=("Internal_Resistance",)),),
+            datetime_kind="arbin_epoch",
         )
 
     # TODO: rename this (for all instruments) to e.g. load

--- a/cellpy/readers/instruments/arbin_sql_xlsx.py
+++ b/cellpy/readers/instruments/arbin_sql_xlsx.py
@@ -148,6 +148,42 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def parse(self, source, **kwargs):
+        """Vendor stage (#560): read the xlsx export into an Arbin-named frame.
+
+        Taps the same ``_parse_xlsx_data`` read as :meth:`loader`, stopping
+        before the rename. ``_parse_xlsx_data`` passes ``parse_dates=[Date_Time]``
+        to pandas, so the vendor ``Date_Time`` is already a real datetime — hence
+        ``declarations`` sets ``datetime_kind="datetime"``. No in-repo xlsx
+        fixture exists, so the port is exercised at the declaration level.
+        """
+        import polars as pl
+        from pathlib import Path
+
+        self.name = source if isinstance(source, Path) else Path(source)
+        self.copy_to_temporary()
+        data_df = self._parse_xlsx_data()
+        self._parsed = True
+        return pl.from_pandas(data_df.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for the Arbin SQL Server xlsx export (#560).
+
+        ``datetime_kind="datetime"``: ``_parse_xlsx_data`` already parsed
+        ``Date_Time`` into a datetime, so ``harmonize()`` passes it through.
+        """
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_renaming,
+        )
+
+        return declarations_from_renaming(
+            self.get_raw_units(),
+            normal_headers_renaming_dict,
+            "datetime",
+            getattr(self, "_parsed", False),
+            "arbin_sql_xlsx",
+        )
+
     # TODO: rename this (for all instruments) to e.g. load
     # TODO: implement more options (bad_cycles, ...)
     def loader(self, name, **kwargs):

--- a/cellpy/readers/instruments/config_declarations.py
+++ b/cellpy/readers/instruments/config_declarations.py
@@ -141,6 +141,51 @@ def derive_column_maps(
     return column_map, passthrough, unknown
 
 
+def declarations_from_renaming(
+    raw_units: dict[str, str],
+    renaming: dict[str, str],
+    datetime_kind: str | None,
+    parsed: bool,
+    loader_name: str,
+    *,
+    post_hooks: tuple = (),
+) -> LoaderDeclarations:
+    """Build hand-written loaders' declarations from their module renaming dict.
+
+    Shared by the Arbin SQL variants (``arbin_sql``, ``arbin_sql_csv``,
+    ``arbin_sql_xlsx``, ``arbin_sql_7``), which each carry a
+    ``{legacy_attr -> vendor}`` dict just like a configuration but resolve it in
+    code rather than through a ``configurations/*`` module.
+
+    The dict is first **restricted to real cellpy headers**, reproducing what the
+    legacy ``_post_process`` does when it renames by iterating
+    ``arbin_headers_normal``: the Arbin dicts also carry non-header aliases (e.g.
+    ``acr_txt``, which is *not* a header) that collide with a real header on the
+    same vendor column — ``acr_txt`` and ``internal_resistance_txt`` both name
+    ``Internal_Resistance(Ohm)``. Deriving from the unfiltered dict would let the
+    first-declared non-header alias win and mis-route the column; the legacy path
+    never sees the alias at all, so neither should the derivation.
+    """
+    if not parsed:
+        raise LoaderError(f"{loader_name}.declarations() was called before parse().")
+
+    header_keys = set(get_headers_normal().keys())
+    filtered = {key: value for key, value in renaming.items() if key in header_keys}
+    column_map, passthrough, _ = derive_column_maps(filtered)
+    units = {
+        key: value
+        for key, value in raw_units.items()
+        if hasattr(CellpyUnits(), key)
+    }
+    return LoaderDeclarations(
+        column_map=column_map,
+        raw_units=CellpyUnits(**units),
+        passthrough=passthrough,
+        post_hooks=tuple(post_hooks),
+        datetime_kind=datetime_kind,
+    )
+
+
 def substitute_unit_templates(renaming: dict[str, str], config: Any) -> dict[str, str]:
     """Resolve ``{{ unit }}`` placeholders in vendor column names.
 

--- a/cellpy/readers/instruments/declarations.py
+++ b/cellpy/readers/instruments/declarations.py
@@ -27,7 +27,9 @@ from cellpy.exceptions import LoaderError
 _AUX_PATTERN = re.compile(r"^aux_(temperature|potential|pressure|resistance)_\w+$")
 
 #: The forms a ``date_time`` passthrough can take; see ``datetime_kind``.
-DATETIME_KINDS = frozenset({"datetime", "string", "epoch_seconds", "excel_serial"})
+DATETIME_KINDS = frozenset(
+    {"datetime", "string", "epoch_seconds", "excel_serial", "arbin_epoch"}
+)
 
 
 class ResetGranularity(StrEnum):
@@ -119,6 +121,8 @@ class LoaderDeclarations:
     #:   US ``MM/DD/YYYY`` and neware's ISO both go through the same parser).
     #: - ``"epoch_seconds"`` — float seconds since the Unix epoch.
     #: - ``"excel_serial"``  — Excel serial days (arbin ``.res``).
+    #: - ``"arbin_epoch"``   — integer 100 ns ticks since the Unix epoch, the
+    #:   form the Arbin SQL Server / h5 exports use (``epoch seconds x 1e7``).
     datetime_kind: str | None = None
 
     def __post_init__(self) -> None:

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -163,6 +163,19 @@ def _parse_datetime_column(series: pl.Series, kind: str) -> pl.Series:
             pl.Datetime("ns")
         )
 
+    if kind == "arbin_epoch":
+        # Arbin's SQL/h5 exports store the wall-clock instant as an integer of
+        # 100 ns ticks since the Unix epoch — the legacy ``from_arbin_to_datetime``
+        # splits the last 7 digits off as the fractional second (value = epoch
+        # seconds x 1e7). One tick is therefore exactly 100 ns, so ``value * 100``
+        # is epoch nanoseconds with no float rounding at all — unlike a
+        # ``/ 1e7`` in float64, where 1.6e16-scale integers already exceed the
+        # 2**53 exact range and would lose resolution near 2026. The legacy
+        # decoder went via ``datetime.fromtimestamp`` (host-local); here the
+        # value is treated as the absolute UTC instant Unix time already is,
+        # which is what ``epoch_time_utc`` means.
+        return (series.cast(pl.Int64) * 100).cast(pl.Datetime("ns"))
+
     if kind == "excel_serial":
         # Serial days (may be fractional) from the Excel epoch. Done exactly as
         # the legacy ``xldate_as_datetime``: ``datetime(1899,12,30) +

--- a/tests/test_arbin_sql_h5_two_stage.py
+++ b/tests/test_arbin_sql_h5_two_stage.py
@@ -76,6 +76,27 @@ def test_declarations_before_parse_raises():
 
 
 @pytest.mark.essential
+def test_epoch_time_utc_is_the_vendor_ticks_as_absolute_utc():
+    """``epoch_time_utc`` = Arbin's integer Date_Time ticks x 100, exactly.
+
+    Arbin stores the wall-clock instant as an integer of 100 ns ticks since the
+    Unix epoch (``epoch seconds x 1e7``). The native column is that instant as
+    absolute int64 ns UTC, so ``ticks x 100`` is the whole derivation — checked
+    against the vendor frame rather than the legacy ``date_time``, which the
+    legacy path decodes host-local (``datetime.fromtimestamp``) and so differs by
+    the host offset off-UTC. This assertion is host-independent and exact.
+    """
+    from cellpy.readers.instruments.harmonize import harmonize
+
+    loader, vendor = _parsed()
+    raw = harmonize(vendor, loader.declarations(), strict=False)
+
+    ticks = vendor["Date_Time"].cast(pl.Int64) * 100
+    difference = (raw["epoch_time_utc"] - ticks).abs().max()
+    assert difference == 0, f"epoch_time_utc is not the vendor ticks: off by {difference}"
+
+
+@pytest.mark.essential
 def test_two_stage_capacities_match_the_legacy_loader_stage_frame():
     import cellpy
     from cellpy.readers.instruments.harmonize import harmonize

--- a/tests/test_arbin_variants_two_stage.py
+++ b/tests/test_arbin_variants_two_stage.py
@@ -1,0 +1,101 @@
+"""Two-stage declarations for the four fixture-less Arbin variants (#560).
+
+``arbin_sql`` and ``arbin_sql_7`` need a live SQL Server; ``arbin_sql_csv`` and
+``arbin_sql_xlsx`` read exports for which there is no in-repo fixture. So unlike
+``arbin_sql_h5`` (see ``test_arbin_sql_h5_two_stage.py``) these cannot be checked
+against a golden frame end-to-end. What *is* checkable — and is the part most
+likely to be wrong — is that ``declarations()`` maps the vendor columns to the
+right native columns, drops ``Test_ID`` as provenance, and picks the correct
+``datetime_kind``. That is what this module pins, no backend required.
+
+The ``arbin_epoch`` decode itself (shared with ``arbin_sql_h5``) is checked
+here directly and, end-to-end on a real fixture, in ``test_arbin_sql_h5``.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments import (
+    arbin_sql,
+    arbin_sql_7,
+    arbin_sql_csv,
+    arbin_sql_xlsx,
+)
+
+# module, bare-or-suffixed vendor names, expected datetime_kind.
+_VARIANTS = {
+    "arbin_sql": (arbin_sql, "Voltage", "Current", "Internal_Resistance",
+                  "Charge_Capacity", "Discharge_Capacity", "arbin_epoch"),
+    "arbin_sql_7": (arbin_sql_7, "Voltage", "Current", "Internal_Resistance",
+                    "Charge_Capacity", "Discharge_Capacity", "arbin_epoch"),
+    "arbin_sql_csv": (arbin_sql_csv, "Voltage(V)", "Current(A)",
+                      "Internal_Resistance(Ohm)", "Charge_Capacity(Ah)",
+                      "Discharge_Capacity(Ah)", "string"),
+    "arbin_sql_xlsx": (arbin_sql_xlsx, "Voltage(V)", "Current(A)",
+                       "Internal_Resistance(Ohm)", "Charge_Capacity(Ah)",
+                       "Discharge_Capacity(Ah)", "datetime"),
+}
+
+
+def _declarations(module):
+    """declarations() without a backend: the mapping needs no parsed data, only
+    the loader's static renaming dict, so we set the parsed flag directly."""
+    loader = module.DataLoader()
+    loader._parsed = True
+    return loader.declarations()
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", sorted(_VARIANTS))
+def test_declarations_map_vendor_columns_to_native(name):
+    module, voltage, current, ir, q_ch, q_dch, kind = _VARIANTS[name]
+    column_map = _declarations(module).column_map
+
+    assert column_map[voltage] == "potential"
+    assert column_map[current] == "current"
+    # The acr_txt/internal_resistance_txt collision must resolve to the real
+    # header (internal_resistance), not the non-header alias that would drop it.
+    assert column_map[ir] == "internal_resistance"
+    assert column_map[q_ch] == "cumulative_charge_capacity"
+    assert column_map[q_dch] == "cumulative_discharge_capacity"
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", sorted(_VARIANTS))
+def test_test_id_is_dropped_as_provenance(name):
+    column_map = _declarations(_VARIANTS[name][0]).column_map
+    assert "Test_ID" not in column_map
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", sorted(_VARIANTS))
+def test_datetime_kind_matches_the_vendor_form(name):
+    assert _declarations(_VARIANTS[name][0]).datetime_kind == _VARIANTS[name][6]
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("name", sorted(_VARIANTS))
+def test_declarations_before_parse_raises(name):
+    loader = _VARIANTS[name][0].DataLoader()
+    with pytest.raises(LoaderError, match="before parse"):
+        loader.declarations()
+
+
+@pytest.mark.essential
+def test_arbin_epoch_decode_is_exact_hundred_ns_ticks():
+    """``arbin_epoch`` turns integer 100 ns ticks into the right UTC instant.
+
+    2020-06-24T09:45:33.4602Z is 1_593_596_733.4602 s -> 15_935_967_334_602_000
+    ticks; harmonize must read that back as exactly that instant in ns UTC, with
+    no float rounding (the reason the decode is integer ``x 100``, not ``/ 1e7``
+    in float64).
+    """
+    from cellpy.readers.instruments.harmonize import _parse_datetime_column
+
+    ticks = 15_935_967_334_602_000
+    parsed = _parse_datetime_column(pl.Series([ticks]), "arbin_epoch")
+    # naive Datetime carrying the UTC wall clock; epoch("ns") = ticks x 100.
+    assert parsed.dt.replace_time_zone("UTC").dt.epoch("ns")[0] == ticks * 100

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -75,6 +75,19 @@ UNPORTED_POST_PROCESSORS: dict[str, tuple[str, ...]] = {}
 #: check of its own — see ``_assert_epoch_time_utc``.
 KNOWN_REPRESENTATION_GAPS: tuple[str, ...] = ()
 
+#: Loaders whose legacy path decodes the timestamp in the analysis host's
+#: **local** zone. Arbin stores the instant as integer 100 ns ticks since the
+#: Unix epoch and the legacy ``from_arbin_to_datetime`` decodes it with
+#: ``datetime.fromtimestamp`` — host-local. The native path derives
+#: ``epoch_time_utc`` as absolute UTC (what the column *means*), so the two agree
+#: only on a UTC host and differ by exactly the host offset otherwise (7200 s on
+#: a CEST laptop). The host-local legacy value is therefore not a valid oracle
+#: for an absolute-UTC column: ``date_time`` is excused from the value sweep and
+#: the UTC epoch-exact check is skipped for these. The derivation is instead
+#: pinned host-independently against the vendor ticks in
+#: ``tests/test_arbin_sql_h5_two_stage.py``.
+_LEGACY_DATETIME_IS_HOST_LOCAL = {"arbin_sql_h5", "arbin_sql", "arbin_sql_7"}
+
 TOLERANCE = 1e-6
 
 
@@ -224,9 +237,13 @@ def test_harmonized_values_match_the_legacy_frame(
         # while the legacy path parses it to a datetime — so they cannot be
         # compared. Skip it *only* in that case; a loader that does parse it
         # (its harmonized ``date_time`` is a real Datetime) is held to parity
-        # like any other column. arbin_sql_h5 is the current pre-epoch loader;
-        # it gets ``datetime_kind`` in a follow-up (loader plan §8.2).
-        if column == "date_time" and harmonized[column].dtype != pl.Datetime:
+        # like any other column — unless its legacy path is host-local (Arbin),
+        # where the two legitimately differ by the host offset and the legacy
+        # value is not a valid oracle (see ``_LEGACY_DATETIME_IS_HOST_LOCAL``).
+        if column == "date_time" and (
+            harmonized[column].dtype != pl.Datetime
+            or instrument in _LEGACY_DATETIME_IS_HOST_LOCAL
+        ):
             continue
         left, right = harmonized[column], legacy[column]
         assert left.len() == right.len(), (
@@ -291,6 +308,11 @@ def _assert_epoch_time_utc(instrument, harmonized, legacy):
     if "epoch_time_utc" not in harmonized.columns:
         return
     if instrument in _EPOCH_EXACT_SKIP:
+        return
+    if instrument in _LEGACY_DATETIME_IS_HOST_LOCAL:
+        # Legacy date_time is host-local here; comparing an absolute-UTC column
+        # to it would fail by the host offset off-UTC. Pinned against the vendor
+        # ticks instead (test_arbin_sql_h5_two_stage.py).
         return
     assert "date_time" in legacy.columns, (
         f"{instrument}: harmonize derived epoch_time_utc but the legacy frame "


### PR DESCRIPTION
Ports the four Arbin SQL variants without `parse()` yet — `arbin_sql`, `arbin_sql_7`, `arbin_sql_csv`, `arbin_sql_xlsx` — to the two-stage `parse()`/`declarations()` design, and adds the `arbin_epoch` `datetime_kind` they all need. That mechanism also **closes the Phase A gap** left open for the already-merged `arbin_sql_h5` (the follow-up flagged in loader plan §8.2).

## `arbin_epoch`
Arbin stores `Date_Time` as an integer of 100 ns ticks since the Unix epoch (`epoch seconds × 1e7`). The decode is exact integer math (`value × 100` ns), so `epoch_time_utc` carries no float rounding near 2026 — unlike a `/1e7` in float64, whose 1.6e16-scale integers already exceed the 2**53 exact range. It is read as **absolute UTC**, which is what `epoch_time_utc` means; the legacy `from_arbin_to_datetime` went via host-local `datetime.fromtimestamp`.

## Why the parity oracle can't pin Arbin's timestamp against the legacy frame
Because the legacy value is **host-local** and the native one is absolute UTC, they agree only on a UTC host — and differ by exactly the host offset otherwise (proved locally: `date_time (max abs diff 7200.0)` on a CEST laptop). The oracle now excuses the host-local-legacy Arbin loaders from the UTC `date_time`/epoch sweep; `arbin_sql_h5`'s epoch is instead pinned **host-independently** against the vendor ticks (`epoch_time_utc == Date_Time × 100`, exact) in `test_arbin_sql_h5_two_stage.py`.

## Testing the fixture-less four
Two need a live SQL Server; two read exports we ship no sample of. So they're checked at the **declaration level** (`test_arbin_variants_two_stage.py`): vendor→native mapping, `Test_ID` dropped as provenance, correct `datetime_kind`. A shared `declarations_from_renaming()` restricts each renaming dict to real cellpy headers before deriving — reproducing the legacy `_post_process` selection and resolving the `acr_txt` / `internal_resistance_txt` collision to the real header instead of dropping IR.

`arbin_sql_7` is still upstream under-development (its `_query_sql` pivots to unrenamed integer columns); ported thinly for switchover uniformity and documented as such in the code.

## Result
Full suite: **1287 passed** (18 new tests), 0 failures, under `PYTHONUTF8=1` (the Windows-dev / Linux-CI encoding proxy).

Part of #560. Remaining in the six-loader port: `biologics_mpr` (real fixture, complex derivations) and `neware_nda` next, as separate branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)