### PR TITLE
#560: port biologics_mpr to two-stage (parse runs the mpr derivations)

### DIFF
--- a/cellpy/readers/instruments/biologics_mpr.py
+++ b/cellpy/readers/instruments/biologics_mpr.py
@@ -169,6 +169,77 @@ class DataLoader(BaseLoader):
         """
         raise NotImplementedError
 
+    def parse(self, source, bad_steps=None, **kwargs):
+        """Vendor stage (#560): read the mpr file into a cellpy-named frame.
+
+        The two-stage counterpart to :meth:`loader`, tapping the same
+        ``_load_mpr_data`` + ``_rename_headers`` the legacy path uses, and
+        stopping before the (empty) summary. Unlike the Arbin/PEC loaders,
+        biologics' ``_rename_headers`` is not a plain rename: it *derives*
+        columns the file does not store directly — the cycle index from
+        ``half_cycle``, the charge/discharge split from the signed capacity, and
+        the wall-clock ``date_time`` from the log's start plus elapsed seconds.
+        Those derivations are genuine mpr decoding, not declarative renames or
+        post hooks, so they stay in ``parse()``. The frame it returns therefore
+        already carries cellpy header *names*; ``declarations()`` maps those to
+        native and ``harmonize()`` casts and validates.
+        """
+        import polars as pl
+        from pathlib import Path
+
+        self.name = source if isinstance(source, Path) else Path(source)
+        self.copy_to_temporary()
+        self.mpr_data = None
+        self.mpr_log = None
+        self.mpr_settings = None
+        self._load_mpr_data(self.temp_file_path, bad_steps)
+        self._rename_headers()
+        self._parsed = True
+        return pl.from_pandas(self.mpr_data.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for Bio-Logic mpr (#560).
+
+        The parsed frame already uses cellpy header names, so the map is
+        ``derive_column_maps`` over the identity ``{legacy_attr -> its own header
+        name}``, restricted to the columns this file actually produced. The many
+        raw mpr columns that are not cellpy headers (``flags``, ``Ns``, the EIS
+        impedance channels …) are neither mapped nor kept — the same columns the
+        native runtime drops from the legacy frame — so they warn-and-drop.
+
+        ``datetime_kind="datetime"``: ``_generate_datetime`` already built a real
+        datetime (log start + elapsed seconds), and — unlike Arbin — via plain
+        arithmetic, not host-local ``fromtimestamp``, so ``epoch_time_utc``
+        derives with exact parity against the legacy frame.
+        """
+        from cellpycore.units import CellpyUnits
+
+        from cellpy.exceptions import LoaderError
+        from cellpy.readers.instruments.config_declarations import derive_column_maps
+        from cellpy.readers.instruments.declarations import LoaderDeclarations
+
+        if not getattr(self, "_parsed", False):
+            raise LoaderError("biologics_mpr.declarations() was called before parse().")
+
+        produced = set(self.mpr_data.columns)
+        renaming = {
+            attr: name
+            for attr, name in get_headers_normal().items()
+            if name in produced
+        }
+        column_map, passthrough, _ = derive_column_maps(renaming)
+        raw_units = {
+            key: value
+            for key, value in self.get_raw_units().items()
+            if hasattr(CellpyUnits(), key)
+        }
+        return LoaderDeclarations(
+            column_map=column_map,
+            raw_units=CellpyUnits(**raw_units),
+            passthrough=passthrough,
+            datetime_kind="datetime",
+        )
+
     def loader(self, file_name, bad_steps=None, **kwargs):
         """Loads data from BioLogics mpr files.
 

--- a/tests/test_biologics_two_stage.py
+++ b/tests/test_biologics_two_stage.py
@@ -1,0 +1,58 @@
+"""biologics_mpr's two-stage entry points (#560).
+
+Value parity is covered end-to-end in ``test_loader_port_parity.py`` (the mpr
+fixture is in-repo). This module pins the parts specific to the biologics port:
+that ``parse()`` runs the mpr *derivations* — not a plain rename — so the vendor
+frame already carries cellpy names and a real datetime, and that
+``declarations()`` refuses to run before ``parse()``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers import data_structures as ds
+
+SOURCE = "testdata/data/biol.mpr"
+
+
+def _loader():
+    return ds.generate_default_factory().create("biologics_mpr")
+
+
+def _parsed():
+    loader = _loader()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        vendor = loader.parse(SOURCE)
+    return loader, vendor
+
+
+@pytest.mark.essential
+def test_parse_derives_cellpy_columns_the_file_does_not_store():
+    """cycle_index, the capacity split and date_time are all *derived* in parse."""
+    _, vendor = _parsed()
+    for derived in ("cycle_index", "charge_capacity", "discharge_capacity", "date_time"):
+        assert derived in vendor.columns
+    # date_time is a real datetime, built from the log start plus elapsed seconds.
+    assert vendor["date_time"].dtype == pl.Datetime
+
+
+@pytest.mark.essential
+def test_declarations_map_to_native_and_pick_datetime():
+    loader, _ = _parsed()
+    declarations = loader.declarations()
+    assert declarations.column_map["voltage"] == "potential"
+    assert declarations.column_map["current"] == "current"
+    assert declarations.datetime_kind == "datetime"
+
+
+@pytest.mark.essential
+def test_declarations_before_parse_raises():
+    loader = _loader()
+    with pytest.raises(LoaderError, match="before parse"):
+        loader.declarations()

--- a/tests/test_loader_port_parity.py
+++ b/tests/test_loader_port_parity.py
@@ -59,6 +59,10 @@ PARITY_CASES = (
     # arbin_sql_h5: the one arbin_sql variant with an in-repo fixture. Its
     # internal-resistance forward fill is a declared post hook (plan §2.6c).
     ("arbin_sql_h5", "testdata/data/20200624_test001_cc_01.h5", {}),
+    # biologics_mpr: parse() runs the legacy mpr derivations (cycle from
+    # half_cycle, signed-capacity split, datetime from log start), so the vendor
+    # frame already carries cellpy names; declarations() maps them to native.
+    ("biologics_mpr", "testdata/data/biol.mpr", {}),
 )
 
 #: Legacy post-processor → native columns it changes, for the ones that have no


### PR DESCRIPTION
Adds `parse()`/`declarations()` to the Bio-Logic mpr loader.

Unlike the Arbin and PEC loaders, biologics' `_rename_headers` is **not a plain rename** — it *derives* columns the file does not store: the cycle index from `half_cycle`, the charge/discharge split from the signed capacity, and the wall-clock `date_time` from the log start plus elapsed seconds. Those are genuine mpr decoding, not declarative renames or post hooks, so `parse()` runs them and returns a frame already carrying cellpy header names. `declarations()` then maps those to native via `derive_column_maps` over the identity dict, restricted to the columns the file actually produced (the raw EIS/impedance channels that are not cellpy headers warn-and-drop, the same columns the native runtime drops from the legacy frame).

biologics has an in-repo fixture (`biol.mpr`), so it **joins the parity oracle with full value coverage** — including the exact `epoch_time_utc` check, which passes because its `date_time` comes from plain arithmetic (`ole2datetime + timedelta`), not host-local `datetime.fromtimestamp` like Arbin.

Full suite: **1293 passed** (6 new tests), under `PYTHONUTF8=1`.

Part of #560. Last of the six-loader port remaining: `neware_nda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)