### PR TITLE
#560: port neware_nda to two-stage (declaration-level)

### DIFF
--- a/cellpy/readers/instruments/neware_nda.py
+++ b/cellpy/readers/instruments/neware_nda.py
@@ -169,6 +169,48 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def parse(self, source, **kwargs):
+        """Vendor stage (#560): read the nda/ndax file into a fastnda-named frame.
+
+        Taps the same ``_run_fastnda`` read as :meth:`loader` — including its
+        charge/discharge split of the signed capacity/energy/power columns, which
+        is vendor decoding rather than a declarative rename — and stops before
+        ``_post_process`` (the rename, the Unix-time datetime conversion). The
+        ``drop_duplicates`` is vendor cleanup, kept here as in the legacy path.
+
+        Needs the ``fastnda`` backend and an ``.nda*`` file, neither shipped as an
+        in-repo fixture, so the port is exercised at the declaration level. The
+        ``unix_time_s`` column is Unix epoch seconds (``datetime_kind`` =
+        ``"epoch_seconds"``), decoded as absolute UTC, which is what the legacy
+        ``unix_time_s_to_datetime(..., utc=True)`` also produces.
+        """
+        import polars as pl
+        from pathlib import Path
+
+        self.name = source if isinstance(source, Path) else Path(source)
+        self.copy_to_temporary()
+        raw_data = self._run_fastnda().drop_duplicates()
+        self._parsed = True
+        return pl.from_pandas(raw_data.reset_index(drop=True))
+
+    def declarations(self):
+        """Declarations for Neware nda/ndax via fastnda (#560).
+
+        ``datetime_kind="epoch_seconds"`` — the vendor ``unix_time_s`` is float
+        seconds since the Unix epoch.
+        """
+        from cellpy.readers.instruments.config_declarations import (
+            declarations_from_renaming,
+        )
+
+        return declarations_from_renaming(
+            self.get_raw_units(),
+            normal_headers_renaming_dict,
+            "epoch_seconds",
+            getattr(self, "_parsed", False),
+            "neware_nda",
+        )
+
     # TODO: rename this (for all instruments) to e.g. load
     # TODO: implement more options (bad_cycles, ...)
     def loader(self, name, **kwargs):

--- a/tests/test_neware_nda_two_stage.py
+++ b/tests/test_neware_nda_two_stage.py
@@ -1,0 +1,53 @@
+"""neware_nda's two-stage declarations (#560).
+
+The real fastnda-based Neware loader (the parked zombie is ``ext_nda_reader``).
+It needs the ``fastnda`` backend and an ``.nda*`` file, neither of which is an
+in-repo fixture, so — like the fixture-less Arbin variants — it is checked at
+the declaration level: vendor→native mapping, ``Test_ID`` dropped as provenance,
+and ``datetime_kind="epoch_seconds"`` for its ``unix_time_s`` column.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.exceptions import LoaderError
+from cellpy.readers.instruments import neware_nda
+
+
+def _declarations():
+    """declarations() needs only the static renaming dict, not parsed data (which
+    would require fastnda), so we set the parsed flag directly."""
+    loader = neware_nda.DataLoader()
+    loader._parsed = True
+    return loader.declarations()
+
+
+@pytest.mark.essential
+def test_declarations_map_fastnda_columns_to_native():
+    column_map = _declarations().column_map
+    assert column_map["voltage_V"] == "potential"
+    assert column_map["current_mA"] == "current"
+    assert column_map["charge_capacity_mAh"] == "cumulative_charge_capacity"
+    assert column_map["discharge_capacity_mAh"] == "cumulative_discharge_capacity"
+    assert column_map["internal_resistance_mOhm"] == "internal_resistance"
+
+
+@pytest.mark.essential
+def test_test_id_is_dropped_as_provenance():
+    assert "Test_ID" not in _declarations().column_map
+
+
+@pytest.mark.essential
+def test_unix_time_is_declared_epoch_seconds():
+    declarations = _declarations()
+    assert declarations.datetime_kind == "epoch_seconds"
+    # unix_time_s is kept as the date_time passthrough for harmonize to parse.
+    assert declarations.passthrough.get("unix_time_s") == "date_time"
+
+
+@pytest.mark.essential
+def test_declarations_before_parse_raises():
+    loader = neware_nda.DataLoader()
+    with pytest.raises(LoaderError, match="before parse"):
+        loader.declarations()


### PR DESCRIPTION
Adds `parse()`/`declarations()` to the **real** fastnda-based Neware loader (the parked zombie is `ext_nda_reader`). `parse()` taps the same `_run_fastnda` read — including its charge/discharge split of the signed capacity/energy/power columns (vendor decoding, not a declarative rename) — and stops before the rename and the Unix-time datetime conversion.

`datetime_kind="epoch_seconds"`: `unix_time_s` is float seconds since the Unix epoch, decoded as absolute UTC — matching the legacy `unix_time_s_to_datetime(..., utc=True)`, and host-independent (no `fromtimestamp`-local). declarations reuse the shared `declarations_from_renaming` helper.

Needs the `fastnda` backend and an `.nda*` file, neither shipped as an in-repo fixture, so the port is checked at the **declaration level** (`test_neware_nda_two_stage.py`): vendor→native mapping, `Test_ID` dropped as provenance, `datetime_kind`.

**This completes the six-loader port (#560 plan §8.1)** — every loader now has two-stage `parse()`/`declarations()`.

Full suite: **1297 passed** (4 new tests), under `PYTHONUTF8=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)