### PR TITLE
#560 Phase B: harmonized-raw flip behind an opt-in flag (default off)

### DIFF
--- a/cellpy/config/models.py
+++ b/cellpy/config/models.py
@@ -67,6 +67,14 @@ class ReaderConfig(BaseModel):
     auto_dirs: bool = True
     max_raw_files_to_merge: int = 20
     jupyter_executable: str = "jupyter"
+    # Phase B / #560 flag day: opt-in to producing the native raw from the
+    # two-stage harmonize(parse()) pipeline rather than the legacy
+    # loader()+to_native rename. Default OFF: the flip currently drops aux
+    # columns not in aux_map and renumbers data_point, and applies to loaders
+    # whose two-stage path is unverified, so it is not yet safe as the default.
+    # Turn on per session once a loader is hardened. Single-file loads only;
+    # multi-file merges and parse failures keep the legacy path regardless.
+    use_harmonized_raw: bool = False
 
 
 class DbConfig(BaseModel):

--- a/cellpy/parameters/prms.py
+++ b/cellpy/parameters/prms.py
@@ -146,6 +146,12 @@ class ReaderClass(CellPyConfig):
     )
     max_raw_files_to_merge: int = 20  # guard against accidentally passing too many files
     jupyter_executable: str = "jupyter"
+    # Phase B / #560 flag day: opt-in to producing the native raw from the
+    # two-stage harmonize(parse()) pipeline instead of the legacy
+    # loader()+to_native rename. Default OFF — see cellpy.config.models for why
+    # it is not yet safe as the default. Single-file loads only; multi-file
+    # merges and parse failures keep the legacy path regardless.
+    use_harmonized_raw: bool = False
 
 
 @dataclass

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1366,10 +1366,67 @@ class CellpyCell:
             from cellpy.readers.cellpy_file import translate as cellpy_file_translate
 
             cellpy_file_translate.to_native(self.data)
+            # Phase B / #560 flag day: prefer the two-stage
+            # harmonize(parse()) native raw over the loader()+to_native rename
+            # just applied. It is the declarative pipeline the parity oracle
+            # checks, and it fills native columns the rename cannot
+            # (epoch_time_utc, mask). The to_native'd frame above stays as the
+            # fallback (kept when harmonize is unavailable), so the legacy path
+            # remains the safety net.
+            self._maybe_use_harmonized_raw()
         self._invent_a_cell_name(self.file_names)  # TODO (v1.0.0): fix me
         self.last_uploaded_from = "raw"
         self.last_uploaded_at = datetime.datetime.now()
         return self
+
+    def _maybe_use_harmonized_raw(self):
+        """Phase B (#560): replace the just-translated raw with the two-stage
+        ``harmonize(parse())`` native frame, when that path is available.
+
+        Kept deliberately conservative — it only acts on a **single-file** load
+        with a loader whose ``parse()``/``declarations()`` succeed, and any
+        failure falls back to the ``to_native``'d legacy frame left in place by
+        the caller. Multi-file merges still run through the legacy ``_append``
+        path (its native port is a follow-up), so they are skipped here.
+
+        Turn the whole flip off with ``prms.Reader.use_harmonized_raw = False``.
+        """
+        if not getattr(config.reader, "use_harmonized_raw", True):
+            return
+        if not self.file_names or len(self.file_names) != 1:
+            # multi-file loads are merged by the legacy _append; leave as-is.
+            return
+        loader = self.loader_class
+        if loader is None or not hasattr(loader, "parse"):
+            return
+
+        source = self.file_names[0]
+        try:
+            from cellpy.readers.instruments.harmonize import harmonize
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                vendor = loader.parse(source)
+                declarations = loader.declarations()
+                native = harmonize(vendor, declarations, strict=False)
+        except Exception as exc:  # noqa: BLE001 — any failure -> legacy fallback
+            logging.info(
+                f"harmonized raw unavailable for {source} ({exc}); "
+                f"keeping the legacy loader()+to_native frame"
+            )
+            return
+
+        native_pd = native.to_pandas()
+        # The grouping-key authority is the pipeline's, not harmonize's identity
+        # stamp: keep the active_test_id the loader assigned (0 for a single,
+        # unmerged test; a tester id when provenance carried one).
+        from cellpy.readers.cellpy_file.translate import _TEST_ID
+
+        native_pd[_TEST_ID] = self.data.active_test_id
+        self.data.raw = native_pd
+        logging.debug(
+            f"using harmonized native raw ({len(native_pd.columns)} columns)"
+        )
 
     def _validate_cell(self, level=0):
         logging.debug("validating test")

--- a/docs/getting_started/configuration_reference.md
+++ b/docs/getting_started/configuration_reference.md
@@ -73,6 +73,7 @@ Settings for reading data.
 | `auto_dirs` | `bool` | `True` |
 | `max_raw_files_to_merge` | `int` | `20` |
 | `jupyter_executable` | `str` | `jupyter` |
+| `use_harmonized_raw` | `bool` | `False` |
 
 
 ## db

--- a/tests/prms_support.py
+++ b/tests/prms_support.py
@@ -104,6 +104,7 @@ EXPECTED_PRMS_INVENTORY: list[tuple[str, str, object]] = [
     ("Reader", "sorted_data", True),
     ("Reader", "time_interpolation_step", 10.0),
     ("Reader", "use_cellpy_stat_file", False),
+    ("Reader", "use_harmonized_raw", False),
     ("Reader", "voltage_interpolation_step", 0.01),
     ("Materials", "cell_class", "Li-Ion"),
     ("Materials", "default_mass", 1.0),

--- a/tests/test_harmonized_raw_flip.py
+++ b/tests/test_harmonized_raw_flip.py
@@ -1,0 +1,61 @@
+"""The opt-in harmonized-raw flip (Phase B / #560).
+
+``prms.Reader.use_harmonized_raw`` routes single-file raw loading through the
+two-stage ``harmonize(parse())`` pipeline instead of the legacy
+``loader()+to_native`` rename. It ships **off** — the flip still drops aux
+columns and renumbers ``data_point`` on some loaders, so it is not yet a safe
+default (see the loader plan) — but the mechanism is wired and reversible, and
+this module keeps it covered so it does not rot before it is hardened.
+
+biologics_mpr is used because its flip is clean end-to-end (no aux columns, no
+data_point renumbering divergence); the fixture is in-repo.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import cellpy
+import cellpy.config as config
+
+SOURCE = "testdata/data/biol.mpr"
+
+
+def _get():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return cellpy.get(SOURCE, instrument="biologics_mpr", mass=1.0, testing=True)
+
+
+@pytest.fixture
+def harmonized_raw_on():
+    previous = getattr(config.reader, "use_harmonized_raw", False)
+    config.reader.use_harmonized_raw = True
+    try:
+        yield
+    finally:
+        config.reader.use_harmonized_raw = previous
+
+
+@pytest.mark.essential
+def test_default_is_off_so_raw_has_no_epoch_time_utc():
+    """The legacy loader()+to_native path carries date_time, not epoch_time_utc."""
+    assert getattr(config.reader, "use_harmonized_raw", False) is False
+    c = _get()
+    assert "epoch_time_utc" not in c.data.raw.columns
+
+
+@pytest.mark.essential
+def test_flip_on_produces_the_harmonized_native_raw(harmonized_raw_on):
+    """With the flip on, raw comes from harmonize(parse()) and carries the
+    native epoch_time_utc/mask columns the rename path omits."""
+    c = _get()
+    assert "epoch_time_utc" in c.data.raw.columns
+    assert "mask" in c.data.raw.columns
+    # and it is still a usable cell: the summary builds.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        c.make_summary()
+    assert len(c.data.summary) >= 1


### PR DESCRIPTION
Wires the **switchover mechanism** for routing single-file raw loading through the two-stage `harmonize(parse())` pipeline instead of the legacy `loader()+to_native` rename, gated by `prms.Reader.use_harmonized_raw`. **It ships OFF** — nothing changes for users — but the infrastructure is in place and reversible.

## How it works
`_maybe_use_harmonized_raw()` runs after the existing `to_native` boundary in `from_raw`: for a single-file load with a working two-stage loader it replaces the just-translated raw with the harmonized native frame (which fills the `epoch_time_utc` and `mask` native columns the rename path omits), keeping the pipeline's `active_test_id`. Any failure, multi-file merges, and the flag being off all fall back to the legacy `to_native`'d frame — the legacy path stays the safety net.

## Why default-off
I ran the full suite with the flip **on** to characterize the blast radius. It regresses real behavior:

| Regression | Detail |
|---|---|
| **aux column loss** | columns not declared in `aux_map` are dropped (`arbin_res`: `aux_0_u_C` gone) |
| **data_point renumbering** | harmonize renumbers from 1 instead of preserving the vendor value (`10000`) |
| **unverified loaders misconvert** | `batmo_bdf` (inherits `parse()`, never hardened) gets `test_time` wrong |
| **dedup change** | `arbin_sql_h5` keeps 47 raw rows vs 34 — summary values identical, extra rows are genuinely distinct measurements |

The parity oracle only ever checked *shared numeric* columns, so aux, `data_point` and dedup were never covered. Hardening those per loader (declare `aux_map`, preserve `data_point`, fix batmo's declarations, restrict to verified loaders) is the follow-up **before this can become the default**.

## Coverage
`test_harmonized_raw_flip.py` keeps the opt-in path alive: off by default (raw carries `date_time`, not `epoch_time_utc`); on → produces `epoch_time_utc`/`mask` and a usable summary. So the dormant mechanism cannot silently rot.

Full suite: **1299 passed**, under `PYTHONUTF8=1`.

Part of #560. The flag day itself (making this the default) needs the per-loader hardening above first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)