### PR TITLE
Add Dependabot auto-merge for patch and minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@
 # .issueflows/04-designs-and-guides/release-procedure.md.
 # Do not add [tool.uv.sources] path overrides to pyproject.toml; Dependabot
 # cannot resolve sibling checkouts when regenerating the lockfile.
+# Patch/minor PRs are auto-merged via .github/workflows/dependabot-auto-merge.yml
+# once required checks pass (majors stay manual).
 version: 2
 
 updates:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+# Enable GitHub auto-merge for Dependabot patch/minor PRs.
+# Requires repo setting "Allow auto-merge" (already on for this repo).
+# Merge still waits for required status checks / branch protection.
+# Majors are left for manual review. cellpycore stays ignored in dependabot.yml.
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a GitHub Actions workflow that enables auto-merge on Dependabot PRs for **patch and minor** updates (squash), so weekly `uv` lock bumps can land without manual clicking once checks pass. Major updates stay manual. `cellpycore` remains ignored in `dependabot.yml`.

## Details
- New workflow: `.github/workflows/dependabot-auto-merge.yml`
- Uses `dependabot/fetch-metadata` and `gh pr merge --auto --squash`
- Repo already has **Allow auto-merge** enabled
- Auto-merge still respects required status checks / branch protection — worth confirming the CI `full` (or intended merge-gate) job is required on `master` so updates do not merge without tests

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next Dependabot patch/minor PR (or trigger a Dependabot update)
- [ ] Confirm the workflow runs, enables auto-merge, and the PR merges after CI is green
- [ ] Confirm a major-version Dependabot PR (if any) is *not* auto-merged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f884c-87e4-735d-91bc-c75afc253f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f884c-87e4-735d-91bc-c75afc253f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

