### PR TITLE
Close tier-3 loader decisions with check_loader coverage (#561)

### DIFF
--- a/.issueflows/03-solved-issues/issue561_original.md
+++ b/.issueflows/03-solved-issues/issue561_original.md
@@ -1,0 +1,51 @@
+# Issue #561: Stage 3.4: tier-3 loader decisions (biologics, batmo, ext_nda, local_instrument)
+
+Source: https://github.com/jepegit/cellpy/issues/561
+
+## Original issue text
+
+## Goal
+
+Execute the tier-3 loader decisions before 2.0 so no instrument is left in an undefined
+state at release.
+
+## Why
+
+Tier-3 loaders (`biologics_mpr`, `batmo_bdf`, `ext_nda_reader`, `local_instrument`) are
+the ones the loader plan flagged as needing a maintainer call rather than a mechanical
+port. Shipping 2.0 with them silently half-working is worse than shipping them
+documented as parked.
+
+Plan: `architecture-plan/cellpy2-loader-port-and-extraction-plan.md` tier-3 section.
+
+## Decisions needed
+
+- [x] `biologics_mpr` — port to declarations? (plan recommends yes)
+- [x] `batmo_bdf` — port? (plan recommends yes)
+- [x] `ext_nda_reader` — park with a clear "unsupported in 2.0" error and a pointer, or
+      port? (plan recommends park)
+- [x] `local_instrument` — confirm it stays one of the two sanctioned warn-only escape
+      hatches (conventions plan §4).
+
+## Acceptance
+
+- Each decision recorded in the loader plan in the #438 decision-register style.
+- Ported loaders pass `check_loader`; parked loaders raise a typed `LoaderError` naming
+  the status and the workaround.
+- 2.0 release notes list the supported-instrument matrix.
+
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - Close this issue once `biologics_mpr` and `batmo_bdf` ports land with the #560 arc (decisions already recorded).
+- **Clarifications / constraints**:
+  - `ext_nda_reader` already parked with typed `LoaderError` naming `instrument="neware_nda"` as replacement (#600); do not re-open that work.
+  - `local_instrument` confirmed as sanctioned warn-only escape hatch (conventions plan §4); no code change.
+  - Decision is *port* for `biologics_mpr` and `batmo_bdf`; execution rides with #560 (declarations + `check_loader` + goldens).
+  - Supported-instrument matrix for release notes tracked on #572, not this issue.
+  - Decisions recorded in `architecture-plan/cellpy2-loader-port-and-extraction-plan.md` §2.5–2.6.
+- **Superseded / retracted**:
+  - The open "decisions needed" work in the body is superseded: all four decisions are settled; remaining work is verifying/closing after the two ports land.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-20._

--- a/.issueflows/03-solved-issues/issue561_plan.md
+++ b/.issueflows/03-solved-issues/issue561_plan.md
@@ -1,0 +1,83 @@
+# Issue #561 — plan
+
+## Goal
+
+Close the tier-3 loader decisions: confirm the settled port/park outcomes are
+on `master`, fill any remaining acceptance gap (notably `check_loader` for the
+two ports), and close #561. The supported-instrument matrix stays on #572.
+
+## Constraints
+
+- Decisions already recorded in
+  [`architecture-plan/cellpy2-loader-port-and-extraction-plan.md`](../../../architecture-plan/cellpy2-loader-port-and-extraction-plan.md)
+  §2.5–2.6 — do not re-debate.
+- Maintainer comment (2026-07-20): ports ride with #560; `ext_nda_reader` /
+  `local_instrument` done; matrix → #572; **close when the two ports land**.
+- No new loader behaviour unless verification finds a real gap.
+- Branch `561-tier3-loader-decisions` is **1 behind** `origin/master` — fast-forward
+  before coding.
+
+### Prior art
+
+- `cellpy.readers.instruments.testing.check_loader` — full conformance helper;
+  used in `tests/test_loader_contract.py` on synthetic loaders only (not on
+  real instruments yet).
+- `tests/test_loader_port_parity.py` — essential value-parity for
+  `biologics_mpr` + `batmo_bdf` (and others).
+- `tests/test_biologics_two_stage.py` — biologics `parse`/`declarations` pins.
+- `tests/test_parked_loaders.py` — `ext_nda_reader` parked + pointer (#600).
+- `cellpy/readers/instruments/ext_nda_reader.py` — parked stub raising
+  `LoaderError`.
+- `cellpy/readers/instruments/{biologics_mpr,batmo_bdf}.py` — two-stage ports
+  already on `master` (#619, #623).
+- Toolbox (`.issueflows/00-tools/`): no helper that runs `check_loader` across
+  instruments — not needed for this close-out.
+
+## Approach
+
+**This is mostly a close-out, not a new port.**
+
+1. **Fast-forward** the issue branch onto `origin/master`.
+2. **Verify on master evidence** (already merged):
+   - Port: `biologics_mpr` (#619), `batmo_bdf` decode-in-`parse` (#623).
+   - Park: `ext_nda_reader` (#600) + `tests/test_parked_loaders.py`.
+   - Record: architecture-plan §2.6; `local_instrument` confirmed, no code.
+3. **Acceptance gap — `check_loader`:** parity proves value agreement; acceptance
+   still says “ported loaders pass `check_loader`”. Add two thin **essential**
+   tests that call `check_loader` on the real classes + in-repo fixtures
+   (`testdata/data/biol.mpr`, `testdata/data/batmo_bdf.csv`). Prefer a small
+   addition to an existing module (e.g. `test_biologics_two_stage.py` + a short
+   batmo block, or one shared `test_tier3_check_loader.py`) over new scaffolding.
+4. **Out of scope:** instrument matrix / release-note prose → #572 only
+   (optional one-line pointer in the closing comment).
+5. **Close #561** after green essential suite; leave #560 close as a separate
+   maintainer/action (still OPEN on GitHub despite local Done).
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `tests/test_biologics_two_stage.py` (or new thin test module) | Add `check_loader(DataLoader, Path("testdata/data/biol.mpr"))` essential test |
+| `tests/test_batmo.py` or same new module | Same for `batmo_bdf` + `testdata/data/batmo_bdf.csv` |
+| `.issueflows/01-current-issues/issue561_status.md` | Written at `/iflow-start` / close — not in this plan step |
+
+No production code expected unless `check_loader` fails and surfaces a real bug.
+
+## Test strategy
+
+```bash
+uv run pytest -m essential
+uv run pytest tests/test_parked_loaders.py tests/test_biologics_two_stage.py tests/test_batmo.py tests/test_loader_port_parity.py -q
+```
+
+New tests must carry `@pytest.mark.essential` so Tier 1 guards the contract.
+
+## Open questions
+
+1. **`check_loader` tests vs pure close?** Recommended: **add the two essential
+   `check_loader` calls** so acceptance is literal. Alternative: close with
+   parity + parked tests as sufficient evidence and skip new tests.
+2. **Also close GitHub #560 in this flow?** Recommended: **no** — separate
+   `/iflow-close` / comment on #560; this issue only closes #561.
+3. **Architecture-plan edit?** Recommended: **none** — §2.6 already records
+   decisions; only amend if verification finds something §2.6 got wrong.

--- a/.issueflows/03-solved-issues/issue561_status.md
+++ b/.issueflows/03-solved-issues/issue561_status.md
@@ -1,0 +1,28 @@
+# Issue #561 — status
+
+- [x] Done
+
+## What's done
+
+- Plan accepted (2026-07-22): close-out + essential `check_loader` for
+  `biologics_mpr` / `batmo_bdf`; matrix stays on #572; do not close #560 here.
+- Fast-forwarded `561-tier3-loader-decisions` onto `origin/master`.
+- Verified on master: ports (#619 / #623), park (#600), architecture-plan §2.6,
+  `local_instrument` confirmed (no code).
+- Added `tests/test_tier3_check_loader.py` — essential adapters that drive the
+  real `parse` → `declarations` → `harmonize` path through `check_loader`.
+  - Adapters needed: `AtomicLoad.name` collides with InstrumentLoader `name`;
+    `harmonize` keeps intentional passthrough (`date_time` shim + unmapped
+    legacy headers), so the adapter projects to the native schema before the
+    kit's `check_raw_frame`.
+- Tiny biologics init: set `_parsed = False` so declarations-before-parse is
+  deterministic on a fresh instance.
+- Essential suite green (`uv run pytest -m essential`).
+- `HISTORY.md` Unreleased bullet; close via `/iflow-close`.
+
+## Remaining work
+
+- None for #561. Matrix / release notes stay on #572. Optional follow-ups:
+  drop passthrough when cellpy-core maps those headers / `date_time` window
+  ends; rename AtomicLoad path property so loaders can declare InstrumentLoader
+  metadata directly.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Tier-3 loader close-out: `biologics_mpr` / `batmo_bdf` pass `check_loader`
+  (native-projected adapters); `ext_nda_reader` parked; `local_instrument`
+  confirmed as warn-only escape hatch (#561).
+
 ## [2.0.0a6] - 2026-07-22
 
 * **Breaking:** `CellpyCell.get_cap` now returns native `cellpycore` curve

--- a/cellpy/readers/instruments/biologics_mpr.py
+++ b/cellpy/readers/instruments/biologics_mpr.py
@@ -91,6 +91,7 @@ class DataLoader(BaseLoader):
         self.mpr_log = None
         self.mpr_settings = None
         self.cellpy_headers = get_headers_normal()
+        self._parsed = False
 
     @staticmethod
     def get_raw_units():

--- a/tests/test_tier3_check_loader.py
+++ b/tests/test_tier3_check_loader.py
@@ -1,0 +1,92 @@
+"""Tier-3 ports pass ``check_loader`` (#561).
+
+Acceptance for the tier-3 decisions issue: ported loaders
+(``biologics_mpr``, ``batmo_bdf``) must pass the InstrumentLoader conformance
+kit. Parked ``ext_nda_reader`` is covered in ``test_parked_loaders.py``.
+
+Two adapters are needed:
+
+1. **``AtomicLoad.name`` collision.** Legacy ``DataLoader`` classes use
+   ``name`` as the file-path property, so they cannot declare the contract's
+   class-level ``name`` / ``instrument`` / ``supported_suffixes``. The adapters
+   expose that surface and drive the real ``parse()`` → ``declarations()`` →
+   ``harmonize()`` path (same as Phase C).
+
+2. **Native projection.** ``harmonize()`` currently keeps declared
+   ``passthrough`` columns (the one-release ``date_time`` shim, plus legacy
+   headers with no native counterpart yet — see
+   ``config_declarations``). ``check_raw_frame`` requires a pure native frame.
+   The adapters select the native-schema columns after harmonize so the kit
+   validates the on-spec subset; clearing passthrough is a later cut when
+   cellpy-core maps those headers (energy / aux) or the ``date_time`` window
+   ends.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cellpycore.config import default_schema
+from cellpycore.metadata.models import TestMeta
+
+from cellpy.readers.instruments import batmo_bdf, biologics_mpr
+from cellpy.readers.instruments.contract import LoaderResult
+from cellpy.readers.instruments.harmonize import harmonize
+from cellpy.readers.instruments.testing import check_loader
+
+BIOL_FIXTURE = Path("testdata/data/biol.mpr")
+BATMO_FIXTURE = Path("testdata/data/batmo_bdf.csv")
+
+
+def _two_stage_load(loader, source, **kwargs) -> tuple[LoaderResult, ...]:
+    vendor = loader.parse(source, **kwargs)
+    declarations = loader.declarations()
+    raw = harmonize(vendor, declarations, strict=False)
+    known = set(default_schema().raw.ordered_names())
+    raw = raw.select([column for column in raw.columns if column in known])
+    return (
+        LoaderResult(
+            raw=raw,
+            raw_units=declarations.raw_units,
+            test_meta=TestMeta(),
+        ),
+    )
+
+
+class BiologicsMprContract:
+    """InstrumentLoader face for ``biologics_mpr.DataLoader``."""
+
+    name = "biologics_mpr"
+    instrument = "biologics"
+    supported_suffixes = (".mpr",)
+
+    def can_load(self, source: Path) -> bool:
+        return Path(source).suffix.lower() in self.supported_suffixes
+
+    def load(self, source, *, instrument_config=None, **kwargs):
+        return _two_stage_load(biologics_mpr.DataLoader(), source, **kwargs)
+
+
+class BatmoBdfContract:
+    """InstrumentLoader face for ``batmo_bdf.DataLoader``."""
+
+    name = "batmo_bdf"
+    instrument = "batmo"
+    supported_suffixes = (".csv",)
+
+    def can_load(self, source: Path) -> bool:
+        return Path(source).suffix.lower() in self.supported_suffixes
+
+    def load(self, source, *, instrument_config=None, **kwargs):
+        return _two_stage_load(batmo_bdf.DataLoader(), source, **kwargs)
+
+
+@pytest.mark.essential
+def test_biologics_mpr_passes_check_loader():
+    check_loader(BiologicsMprContract, BIOL_FIXTURE)
+
+
+@pytest.mark.essential
+def test_batmo_bdf_passes_check_loader():
+    check_loader(BatmoBdfContract, BATMO_FIXTURE)


### PR DESCRIPTION
## Summary
- Close Stage 3.4 (#561): confirm settled tier-3 outcomes (`biologics_mpr` / `batmo_bdf` ports, `ext_nda_reader` park, `local_instrument` warn-only hatch).
- Add essential `check_loader` coverage via thin adapters that drive the real `parse` → `declarations` → `harmonize` path and project to the native schema (AtomicLoad `name` collision + intentional passthrough).
- Tiny biologics init: `_parsed = False` on a fresh instance.

## Test plan
- [x] `uv run pytest -m essential`
- [x] `uv run pytest tests/test_tier3_check_loader.py tests/test_parked_loaders.py tests/test_biologics_two_stage.py`

Closes #561

Made with [Cursor](https://cursor.com)