### PR TITLE
Sync conda env YAML files with pyproject.toml (#628)

### DIFF
--- a/.issueflows/03-solved-issues/issue628_original.md
+++ b/.issueflows/03-solved-issues/issue628_original.md
@@ -1,0 +1,9 @@
+# Issue #628: Iterative fixes: update conda yaml files
+
+Source: https://github.com/jepegit/cellpy/issues/628
+
+## Original issue text
+
+Interactive `/iflow-fix` session for syncing conda environment YAML files with `pyproject.toml` / `uv.lock`.
+
+Individual fixes are recorded in the local status markdown and landed together via `/iflow-close`.

--- a/.issueflows/03-solved-issues/issue628_status.md
+++ b/.issueflows/03-solved-issues/issue628_status.md
@@ -1,0 +1,11 @@
+# Issue #628: Iterative fixes — update conda yaml files
+
+Interactive `/iflow-fix` session. Fixes logged below; landed via `/iflow-close`.
+
+- [x] Done
+
+## Iterative fixes log
+
+- **2026-07-22** — Sync conda YAMLs with `pyproject.toml`: bump `cellpycore` `0.2.1`→`0.2.3`; add `pyyaml`, `paramiko >= 5.0.0`, `universal-pathlib >= 0.3.10` to `environment.yml`, `environment_dev.yml`, `github_actions_environment.yml`.
+- **2026-07-22** — Drop obsolete `fabric` from the three conda YAMLs (replaced by `universal-pathlib` + `paramiko`).
+- **2026-07-22** — Move `cellpycore ==0.2.3` from pip to conda-forge deps in all three YAMLs (package now on forge).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@
   (native-projected adapters); `ext_nda_reader` parked; `local_instrument`
   confirmed as warn-only escape hatch (#561).
 
+* Sync conda env files with `pyproject.toml`: pin `cellpycore ==0.2.3` from
+  conda-forge (was PyPI 0.2.1), add `pyyaml` / `paramiko` / `universal-pathlib`,
+  drop obsolete `fabric` (#628).
+
 ## [2.0.0a6] - 2026-07-22
 
 * **Breaking:** `CellpyCell.get_cap` now returns native `cellpycore` curve

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,12 @@ channels:
     - conda-forge
 dependencies:
     - python >= 3.13
+    - cellpycore ==0.2.3
     - charset-normalizer
     - cookiecutter
     - cryptography
     - dateparser
     - defusedxml
-    - fabric
     - hdf5
     - ipykernel
     - ipython
@@ -30,6 +30,9 @@ dependencies:
     - pyodbc
     - pytables
     - python-isal
+    - pyyaml
+    - paramiko >= 5.0.0
+    - universal-pathlib >= 0.3.10
     - requests
     - rich
     - scipy
@@ -41,8 +44,6 @@ dependencies:
     - xlrd
     - xmltodict
     - pip:
-        # PyPI-only (no conda-forge package).
-        - cellpycore==0.2.1
         # Optional external fastnda; cellpy defaults to cellpy.libs.local_fastnda.
         - fastnda
         # Old plotly kaleido 0.1.x (python-kaleido on conda-forge is 1.x).

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -5,12 +5,12 @@ dependencies:
     - python=3.13
     - PyGithub
     - black
+    - cellpycore ==0.2.3
     - cookiecutter
     - coverage
     - cryptography
     - dateparser
     - defusedxml
-    - fabric
     - graphviz
     - hdf5
     - ipykernel
@@ -41,6 +41,9 @@ dependencies:
     - pytest-benchmark
     - pytest-timeout
     - python-isal
+    - pyyaml
+    - paramiko >= 5.0.0
+    - universal-pathlib >= 0.3.10
     - requests
     - rich
     - scipy
@@ -58,8 +61,6 @@ dependencies:
     - xmltodict
     - charset-normalizer
     - pip:
-        # PyPI-only (no conda-forge package).
-        - cellpycore==0.2.1
         # Optional external fastnda; cellpy defaults to cellpy.libs.local_fastnda.
         - fastnda
         # Old plotly kaleido 0.1.x (python-kaleido on conda-forge is 1.x).

--- a/github_actions_environment.yml
+++ b/github_actions_environment.yml
@@ -5,13 +5,13 @@ channels:
 dependencies:
     - python
     - PyGithub
+    - cellpycore ==0.2.3
     - charset-normalizer
     - cookiecutter
     - coverage
     - cryptography
     - dateparser
     - defusedxml
-    - fabric
     - hdf5
     - jinja2-time
     - lmfit
@@ -33,6 +33,9 @@ dependencies:
     - pytest-benchmark
     - pytest-timeout
     - python-isal
+    - pyyaml
+    - paramiko >= 5.0.0
+    - universal-pathlib >= 0.3.10
     - requests
     - rich
     - scipy
@@ -44,7 +47,5 @@ dependencies:
     - xlrd
     - xmltodict
     - pip:
-        # PyPI-only (no conda-forge package).
-        - cellpycore==0.2.1
         # Optional external fastnda; cellpy defaults to cellpy.libs.local_fastnda.
         - fastnda


### PR DESCRIPTION
## Summary
- Pin `cellpycore ==0.2.3` from conda-forge (was PyPI `0.2.1`) in `environment.yml`, `environment_dev.yml`, and `github_actions_environment.yml`
- Add missing runtime deps: `pyyaml`, `paramiko >= 5.0.0`, `universal-pathlib >= 0.3.10`
- Drop obsolete `fabric` (replaced by universal-pathlib + paramiko)

Closes #628

## Test plan
- [x] `uv run pytest -m essential` (552 passed)
- [ ] Optional: `conda env update -f environment_dev.yml` and confirm `cellpycore` resolves from conda-forge

Made with [Cursor](https://cursor.com)