### PR TITLE
ci: include plotting tests in nightly tier-3 matrix (#594)

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -17,6 +17,10 @@ jobs:
   conda-pytest:
     name: conda pytest (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Agg keeps matplotlib headless; summary_plot tests also select Agg themselves.
+    # Do not --ignore that file — the exclusion hid real regressions (#594 / #593).
+    env:
+      MPLBACKEND: Agg
     defaults:
       run:
         shell: bash -l {0}
@@ -26,15 +30,14 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-latest
-            pytest-args: --ignore=tests/test_plotutils_summary_plot.py
+            pytest-args: ""
           - os: macos-14
             runner: macos-14
             pytest-args: >-
-              --ignore=tests/test_plotutils_summary_plot.py
               -m "not slowtest and not smoketest and not unimportant and not unfinished and not onlylocal and not skip_on_macos"
           - os: windows
             runner: windows-latest
-            pytest-args: --ignore=tests/test_plotutils_summary_plot.py
+            pytest-args: ""
     steps:
       - uses: actions/checkout@v6
 
@@ -123,16 +126,20 @@ jobs:
   pip-install:
     name: pip install (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Agg keeps matplotlib headless (#594). Plotly/seaborn cases skipif when the
+    # batch extra is not installed (plain `pip install -e .` here).
+    env:
+      MPLBACKEND: Agg
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: linux
             runner: ubuntu-latest
-            pytest-args: --ignore=tests/test_plotutils_summary_plot.py
+            pytest-args: ""
           - os: macos-14
             runner: macos-14
-            pytest-args: --ignore=tests/test_plotutils_summary_plot.py
+            pytest-args: ""
           - os: windows
             runner: windows-latest
             pytest-args: tests/test_maccor.py

--- a/.issueflows/01-current-issues/issue594_original.md
+++ b/.issueflows/01-current-issues/issue594_original.md
@@ -1,0 +1,24 @@
+# Issue #594: Nightly tier-3 matrix still excludes the plotting tests
+
+Source: https://github.com/jepegit/cellpy/issues/594
+
+## Original issue text
+
+Follow-up from #593 (#567 Phase 0).
+
+`ci.yml` (both required jobs) and `release.yml` now run the plotting tests with `MPLBACKEND=Agg`. `ci-scheduled.yml` still carries the old exclusion in five places:
+
+```
+--ignore=tests/test_plotutils_summary_plot.py
+```
+
+The stated reason — "plotutils summary plot needs a display" — is stale: the file selects the Agg backend itself and runs headless. That exclusion was hiding four real regressions on linux (see #593), and the nightly matrix is exactly where platform-specific plotting breakage would show up.
+
+I left it alone because I could not verify macOS/Windows behaviour from a linux/Windows dev box, and a red nightly is noise if the cause is environmental rather than a real bug.
+
+## Done when
+
+- The `--ignore` is removed from `ci-scheduled.yml` and `MPLBACKEND: Agg` is set.
+- One nightly run is observed across the matrix; anything that fails is either fixed or skipped with a *specific* reason (e.g. `skipif` on the platform), not a blanket file exclusion.
+
+Note that tier-3 jobs may not install the `batch` extra, in which case the plotly/seaborn cases skip cleanly and the run is cheap.

--- a/.issueflows/01-current-issues/issue594_plan.md
+++ b/.issueflows/01-current-issues/issue594_plan.md
@@ -1,0 +1,89 @@
+# Issue #594 — plan
+
+## Goal
+
+Stop excluding `tests/test_plotutils_summary_plot.py` from the scheduled Tier-3
+matrix, and run those jobs with `MPLBACKEND=Agg` so nightly catches platform
+plotting regressions the same way Tier-1 / release already do (#593 / #567 Phase 0).
+
+## Constraints
+
+- Match the pattern already used in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)
+  and [`.github/workflows/release.yml`](../../../.github/workflows/release.yml):
+  no file `--ignore`, `MPLBACKEND: Agg` on the pytest step/job.
+- Do **not** add a blanket file exclusion again. If a platform fails after the
+  first observed run, use a targeted `skipif` (or fix the bug) — not matrix
+  `pytest-args` ignore.
+- Tier-3 may lack the `batch` extra: plotly/seaborn cases already
+  `skipif` when missing; that is acceptable (issue text).
+- Scheduled failures do not block merges ([`ci-tiers.md`](../04-designs-and-guides/ci-tiers.md));
+  still prefer a green first run if cheap to fix.
+- Scope: workflow + stale CI docs only. No plotting redesign (#567).
+
+### Prior art
+
+- [`ci.yml`](../../../.github/workflows/ci.yml) essential + full jobs — comments
+  document why the ignore was removed; `MPLBACKEND: Agg` env. **Mirror.**
+- [`release.yml`](../../../.github/workflows/release.yml) — same Agg env. **Mirror.**
+- [`tests/test_plotutils_summary_plot.py`](../../../tests/test_plotutils_summary_plot.py)
+  — sets `matplotlib.use("Agg")` at import; `skipif` on missing plotly/seaborn.
+  **Coexist** (workflow Agg is belt-and-suspenders for other matplotlib imports).
+- [`ci-tiers.md`](../04-designs-and-guides/ci-tiers.md) — Tier-2 = `ci-scheduled.yml`.
+  **Update** only if wording still implies the old ignore.
+- [`testing-and-coverage.md`](../04-designs-and-guides/testing-and-coverage.md) —
+  still says "CI additionally `--ignore=…summary_plot`". **Update** (stale).
+- Toolbox (`00-tools/`): nothing CI-related. Graphify: absent.
+- `github_actions_environment.yml`: has `matplotlib` + `plotly`, **no** `seaborn`
+  → seaborn classes skip on conda-pytest; plotly runs. Leave as-is unless we
+  decide otherwise in Open questions.
+
+## Approach
+
+1. **Edit [`ci-scheduled.yml`](../../../.github/workflows/ci-scheduled.yml)**
+   - `conda-pytest` matrix (3 rows): drop
+     `--ignore=tests/test_plotutils_summary_plot.py` from every `pytest-args`.
+     Keep the macOS `-m "not slowtest and …"` filter as the sole macos args.
+     Linux/Windows can use empty `pytest-args` (or omit the ignore-only value).
+   - `pip-install` matrix: drop the ignore from linux + macos-14 rows
+     (windows stays `tests/test_maccor.py` only — unchanged).
+   - Set `env: MPLBACKEND: Agg` on `conda-pytest` and `pip-install` jobs
+     (job-level is enough for all pytest steps).
+2. **Docs hygiene (same PR)** — fix the stale ignore claim in
+   `testing-and-coverage.md`; skim `ci-tiers.md` / `tests/README.md` for the
+   same leftover and correct if present.
+3. **Local check** — run
+   `MPLBACKEND=Agg uv run pytest tests/test_plotutils_summary_plot.py -q`
+   (and essential gate) before close. Full OS matrix is GHA-only.
+4. **Post-merge observation** — after merge, dispatch
+   `CI (scheduled)` once (`gh workflow run "CI (scheduled)"` or Actions UI),
+   watch the matrix, and file/fix any real platform failures with targeted
+   skips. That satisfies the issue's "one nightly run observed" acceptance;
+   do not block the PR on a full weekly wait.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `.github/workflows/ci-scheduled.yml` | Remove 5× `--ignore=…summary_plot`; add `MPLBACKEND: Agg` on `conda-pytest` + `pip-install` |
+| `.issueflows/04-designs-and-guides/testing-and-coverage.md` | Drop/replace stale "CI `--ignore=summary_plot`" note |
+| `.issueflows/04-designs-and-guides/ci-tiers.md` | Only if it still implies the ignore (likely no edit) |
+| `tests/README.md` | Only if it still documents the scheduled ignore |
+
+## Test strategy
+
+- Local: `MPLBACKEND=Agg uv run pytest tests/test_plotutils_summary_plot.py -q`
+- Local gate: `uv run pytest -m essential` (ignore known host `pyodbc` collection
+  error on `test_arbin_variants_two_stage` if it still appears)
+- GHA: PR does not run `ci-scheduled.yml` automatically — rely on post-merge
+  `workflow_dispatch` for matrix observation
+
+## Open questions
+
+1. **Seaborn on conda Tier-3?** Env has plotly but not seaborn, so seaborn cases
+   will `skipif` on `conda-pytest`. **Recommended:** leave out of this issue
+   (matches "skip cleanly"); add seaborn in a follow-up if we want those cases
+   on the weekly matrix.
+2. **Dispatch before merge?** We can `gh workflow run` against this branch only
+   if the workflow file on `master` already supports it meaningfully — the
+   ignore removal lives on this branch, so observation is **after merge**.
+   OK?

--- a/.issueflows/01-current-issues/issue594_status.md
+++ b/.issueflows/01-current-issues/issue594_status.md
@@ -5,11 +5,17 @@
 ## What's done
 
 - Plan accepted (2026-07-22).
+- Removed all five `--ignore=tests/test_plotutils_summary_plot.py` entries from
+  `ci-scheduled.yml` (`conda-pytest` ×3, `pip-install` linux/macos).
+- Set job-level `MPLBACKEND: Agg` on `conda-pytest` and `pip-install`.
+- Updated stale ignore notes in `testing-and-coverage.md` and `AGENTS.md`.
+- Local: `MPLBACKEND=Agg uv run pytest tests/test_plotutils_summary_plot.py`
+  → **47 passed** (with `--extra batch`).
+- Local: `uv run pytest -m essential` → **535 passed** (ignored host
+  `test_arbin_variants_two_stage` pyodbc collection error).
 
 ## Remaining work
 
-- Remove `--ignore=tests/test_plotutils_summary_plot.py` from `ci-scheduled.yml` (5 places).
-- Set `MPLBACKEND: Agg` on `conda-pytest` and `pip-install` jobs.
-- Update stale CI docs that still claim the ignore.
-- Local: run summary-plot suite + essential gate.
-- Post-merge: dispatch `CI (scheduled)` once and triage any platform failures.
+- Post-merge: dispatch `CI (scheduled)` once and triage any platform failures
+  with targeted `skipif` (not a blanket file ignore).
+- `/iflow-close`

--- a/.issueflows/01-current-issues/issue594_status.md
+++ b/.issueflows/01-current-issues/issue594_status.md
@@ -1,0 +1,15 @@
+# Issue #594 — status
+
+- [ ] Done
+
+## What's done
+
+- Plan accepted (2026-07-22).
+
+## Remaining work
+
+- Remove `--ignore=tests/test_plotutils_summary_plot.py` from `ci-scheduled.yml` (5 places).
+- Set `MPLBACKEND: Agg` on `conda-pytest` and `pip-install` jobs.
+- Update stale CI docs that still claim the ignore.
+- Local: run summary-plot suite + essential gate.
+- Post-merge: dispatch `CI (scheduled)` once and triage any platform failures.

--- a/.issueflows/04-designs-and-guides/testing-and-coverage.md
+++ b/.issueflows/04-designs-and-guides/testing-and-coverage.md
@@ -60,8 +60,10 @@ uv run pytest tests/test_otherpaths_sftp.py -m onlylocal
 Uses `docker/sftp-test/compose.yml` (`atmoz/sftp` on `127.0.0.1:2223`). The
 session fixture starts/stops compose when the Docker daemon is up; otherwise
 the tests skip.
-- CI additionally `--ignore=tests/test_plotutils_summary_plot.py`; that file runs fine locally once
-  the `[all]` extras (plotly/seaborn/kaleido) are installed.
+- Plotting tests (`tests/test_plotutils_summary_plot.py`) run under `MPLBACKEND=Agg`
+  in Tier 1 (`ci.yml`), release, and the scheduled Tier-3 matrix (`ci-scheduled.yml`).
+  Cases that need plotly/seaborn `skipif` when those extras are missing; install
+  `[batch]` / `[all]` locally to exercise them.
 
 ## Coverage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,9 +289,10 @@ resolves from PyPI). No manual install is normally needed.
 - **Run everything through `uv run`** (e.g. `uv run cellpy ...`, `uv run pytest`,
   `uv run python ...`) so the `.venv` interpreter and deps are used. Standard
   commands are in `CONTRIBUTING.md`, `.github/workflows/ci.yml`, and `pyproject.toml`.
-- **Tests:** `uv run pytest -m essential` is the fast CI merge gate (~70 tests).
-  CI ignores `tests/test_plotutils_summary_plot.py` in the essential run. Full suite
-  is `uv run pytest` (default `addopts` deselects slow/local/unfinished markers).
+- **Tests:** `uv run pytest -m essential` is the fast CI merge gate. Plotting tests
+  run under `MPLBACKEND=Agg` (no file `--ignore` in Tier 1 / scheduled / release).
+  Full suite is `uv run pytest` (default `addopts` deselects slow/local/unfinished
+  markers).
 - **Lint/format:** `uv run flake8 cellpy` and `uv run black --check cellpy` (line
   length 120). These are not wired into the Tier-1 CI gate, and the repo currently
   has pre-existing `black` reformat suggestions and some `flake8 F821` findings —


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #594.

### Summary
Remove the stale `--ignore=tests/test_plotutils_summary_plot.py` exclusions from the scheduled Tier-3 matrix and run those jobs with `MPLBACKEND=Agg`, matching Tier-1 (`ci.yml`) and `release.yml` after #593 / #567 Phase 0.

### Changes
- `.github/workflows/ci-scheduled.yml` — drop ignore from `conda-pytest` (linux/macos/windows) and `pip-install` (linux/macos); job-level `MPLBACKEND: Agg`
- `.issueflows/04-designs-and-guides/testing-and-coverage.md` — replace stale ignore note
- `AGENTS.md` — correct Cloud test guidance (essential no longer ignores the file)

### Verification
- `MPLBACKEND=Agg uv run pytest tests/test_plotutils_summary_plot.py` (with `--extra batch`) → **47 passed**
- `uv run pytest -m essential` → **535 passed** (host ignore for `test_arbin_variants_two_stage` pyodbc collection)

### After merge
Dispatch **CI (scheduled)** once and triage any platform failures with targeted `skipif`, not a blanket file ignore. Conda Tier-3 has plotly but not seaborn — seaborn cases will `skipif` until a follow-up adds it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f89ef-bb2c-7176-a9c5-a226b47aafce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f89ef-bb2c-7176-a9c5-a226b47aafce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

