### PR TITLE
Add ica_plot / dva_plot families on the new pipeline

### DIFF
--- a/.issueflows/03-solved-issues/issue648_original.md
+++ b/.issueflows/03-solved-issues/issue648_original.md
@@ -1,0 +1,25 @@
+# Issue #648: Add ica_plot / dva_plot families on the new pipeline
+
+Source: https://github.com/jepegit/cellpy/issues/648
+
+## Original issue text
+
+## Context
+
+Part of epic #567 (Stage 2 â€” Other plot families on the same skeleton). Plan of record: `architecture-plan/cellpy2-plotting-redesign-plan.md`. ICA redesign: #566 / migration notes.
+
+## Scope
+
+Register ICA/DVA figure families that consume the specced long frames from `cellpy.ica` (`dqdv` / `dvdq`). Implement prepare modules that do not re-invent the math. Public entry points `ica_plot` / `dva_plot` (names may live as `cellpy.plotting` exports and re-exports). Add corresponding cases to the figure-spec snapshot.
+
+## Acceptance
+
+- New oracle cases committed and green.
+- Plots honour cell-centric `direction`.
+- No dependency on deleted `Converter` / wide-frame helpers.
+
+## Depends on
+
+#647
+
+Part of epic #567.

--- a/.issueflows/03-solved-issues/issue648_plan.md
+++ b/.issueflows/03-solved-issues/issue648_plan.md
@@ -1,0 +1,104 @@
+# Issue #648 — Plan: `ica_plot` / `dva_plot` on prepare→spec→render
+
+## Goal
+
+Register ICA/DVA figure families that consume the specced long frames from [`cellpy.ica`](cellpy/ica.py) (`dqdv` / `dvdq`), add prepare + backend `kind` branches, and expose public `ica_plot` / `dva_plot` (plotutils + re-exports). New figure-spec oracle cases green. Honour cell-centric `direction`. No use of deprecated `Converter` / wide-frame helpers.
+
+## Constraints
+
+- Plan of record: [`architecture-plan/cellpy2-plotting-redesign-plan.md`](../architecture-plan/cellpy2-plotting-redesign-plan.md) Phase 3; epic [`.issueflows/05-epics/epic567_plan.md`](.issueflows/05-epics/epic567_plan.md) Stage 2 (Published: #648). ICA data contract: [`cellpy2-ica-redesign-plan.md`](../architecture-plan/cellpy2-ica-redesign-plan.md) + migration notes (#566 / #591).
+- Depends on #647 (merged): prepare/`kind` dispatch pattern.
+- Design notes: [`plotting-prepare.md`](.issueflows/04-designs-and-guides/plotting-prepare.md), [`plotting-backends.md`](.issueflows/04-designs-and-guides/plotting-backends.md), [`plotting-registry.md`](.issueflows/04-designs-and-guides/plotting-registry.md).
+- **Direction display (locked):** when `direction="both"`, plot **both halves in one figure**. Same line/marker style for charge and discharge (no dash/solid split). Plotly hover includes `direction` (and cycle). Matplotlib: identical props; reader infers half from curve shape.
+- **Trace identity:** one series per `(cycle, direction)` so half-cycles are **not** connected end-to-end; color scale still keyed by `cycle` (both halves of a cycle share color).
+- Math stays in `cellpy.ica` — prepare only calls `dqdv` / `dvdq` and builds `FigureSpec`.
+- Collectors’ `ica_plotter` / film layouts stay out of scope (Stage 3).
+- Oracle: add cases and **commit** updated `tests/data/figure_specs.json` in the same PR.
+
+### Prior art
+
+- Mirror `#647` / `#646`: [`prepare/raw.py`](cellpy/plotting/prepare/raw.py), [`prepare/curves.py`](cellpy/plotting/prepare/curves.py), registry families with `extras={"entry_point", "kind"}`, backend `kind` branches in [`plotly.py`](cellpy/plotting/backends/plotly.py) / [`mpl.py`](cellpy/plotting/backends/mpl.py), thin orchestrators in [`plotutils.py`](cellpy/utils/plotutils.py).
+- Data: [`cellpy.ica.dqdv`](cellpy/ica.py) / `dvdq` → columns via `ICA_COLS` (`cycle`, `direction`, `voltage`, `capacity`, `dqdv` / `dvdq`). Defaults: `direction="both"`, DVA uses `DVA_DEFAULTS` (normalize=False).
+- Collectors [`ica_plotter`](cellpy/utils/collectors.py) (~2858): single-direction default, x=voltage y=dqdv — **do not** copy its direction clamp; new public API matches `ica.dqdv` defaults.
+- Oracle menu: [`tests/figure_spec_support.py`](tests/figure_spec_support.py) `_other_family_cases()`.
+- Toolbox: none relevant. Graphify: plotting/ICA migration communities only.
+
+## Approach
+
+```mermaid
+flowchart LR
+  entry["ica_plot / dva_plot"] --> ctx["from_source"]
+  ctx --> reg["registry.get ica|dva"]
+  reg --> prep["prepare/ica.py"]
+  prep --> ica["ica.dqdv / dvdq"]
+  ica --> spec["frame + FigureSpec kind=ica|dva"]
+  spec --> be["get_backend.render"]
+```
+
+1. **Register families** in [`registry.py`](cellpy/plotting/registry.py)
+   - `"ica"` — `extras={"entry_point": "ica_plot", "kind": "ica"}`; columns voltage/dqdv (+ cycle, direction).
+   - `"dva"` — `extras={"entry_point": "dva_plot", "kind": "dva"}`; columns capacity/dvdq (+ cycle, direction).
+   - Excluded from summary oracle via `entry_point` filter (same as cycles/raw).
+
+2. **One prepare module** [`cellpy/plotting/prepare/ica.py`](cellpy/plotting/prepare/ica.py)
+   - Shared `IcaPrepareConfig`: `cycles`, `direction` (default `"both"`), `options` / IcaOptions field overrides, title/size/colormap knobs, `backend`, `additional_kwargs`, plus `derivative: "dqdv" | "dvdq"`.
+   - `prepare(ctx, family, config) -> (frame, FigureSpec)`:
+     - Call `ica.dqdv(cell, ...)` or `ica.dvdq(cell, ...)` only (never `Converter`, `to_wide`, or legacy `split`/`tidy` paths).
+     - Drop deprecated duplicate `dq` column from the plotting frame if present (avoid accidental y-column confusion).
+     - Build `FigureSpec` with one panel; axis labels via `plotting.labels` / `units_label` where units are known; stash render knobs in `extras` (`kind`, x/y columns, color=`cycle`, hover fields including `direction`, colormap, ranges, title).
+   - Export from [`prepare/__init__.py`](cellpy/plotting/prepare/__init__.py).
+
+3. **Backend branches** (`kind == "ica"` | `"dva"`)
+   - Plotly: multi-trace lines colored by cycle; hovertemplate / `hover_data` includes `direction` (and cycle). Do **not** vary dash by direction. Prefer grouping that yields one trace per `(cycle, direction)` with color mapped from cycle.
+   - Matplotlib: same; legend by cycle; no direction linestyle. Accept visual overlap of styles.
+   - Keep branches small; share a private helper if ica/dva differ only by x/y column names from extras.
+
+4. **Public entry points** in [`plotutils.py`](cellpy/utils/plotutils.py)
+   - `ica_plot(cell, cycles=None, direction="both", backend=None, interactive=None, **kwargs)` and `dva_plot(...)` — same `backend=` / deprecated `interactive=` `warn_once` pattern as `raw_plot`.
+   - Orchestrate: resolve backend → `from_source` → `registry.get` → prepare → `get_backend(...).render`.
+   - Re-export from [`cellpy.plotting`](cellpy/plotting/__init__.py) and keep plotutils as the permanent import path (existing convention).
+   - Seed `interactive=` deprecations in [`_deprecation.py`](cellpy/_deprecation.py) + `DEPRECATIONS.md` if that pattern is registered for peer entry points.
+
+5. **Oracle + tests**
+   - Add to `_other_family_cases()`: `ica_plot` × both backends, `dva_plot` × both backends (defaults enough for structural snapshot; golden cell already used by figure specs / ICA goldens).
+   - Focused unit tests: prepare returns correct `kind` + frame columns; `direction="both"` keeps both labels; no `Converter` import in prepare; `interactive=` warns+maps.
+   - Regenerate `tests/data/figure_specs.json` in the same commit.
+
+6. **Design notes** — update `plotting-prepare.md`, `plotting-backends.md`, `plotting-registry.md` for ica/dva.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `cellpy/plotting/prepare/ica.py` | **new** — dqdv/dvdq prepare + FigureSpec |
+| `cellpy/plotting/prepare/__init__.py` | export prepare_ica (and alias if useful) |
+| `cellpy/plotting/registry.py` | register `"ica"`, `"dva"` |
+| `cellpy/plotting/backends/plotly.py` | `kind` ica/dva render |
+| `cellpy/plotting/backends/mpl.py` | same |
+| `cellpy/utils/plotutils.py` | `ica_plot` / `dva_plot` orchestrators |
+| `cellpy/plotting/__init__.py` | re-export entry points if peers are exported |
+| `cellpy/_deprecation.py` + `DEPRECATIONS.md` | `interactive=` for new entry points |
+| `tests/figure_spec_support.py` | four new FigureCases |
+| `tests/data/figure_specs.json` | regenerate |
+| `tests/test_ica_plot_prepare.py` (name flexible) | prepare / direction / deprecation |
+| `.issueflows/04-designs-and-guides/plotting-*.md` | document |
+| `.issueflows/01-current-issues/issue648_plan.md` | persist this plan (on Accept) |
+| `.issueflows/01-current-issues/issue648_status.md` | start status on build |
+
+## Test strategy
+
+```bash
+uv sync --extra batch
+MPLBACKEND=Agg uv run pytest tests/test_ica_plot_prepare.py tests/test_figure_specs.py -q
+MPLBACKEND=Agg uv run pytest -m essential --ignore=tests/test_arbin_variants_two_stage.py
+```
+
+(Conda `cellpy_dev_313` acceptable per project rules if preferred locally.)
+
+## Open questions
+
+None remaining for coding — direction overlay + shared styling + plotly hover decided.
+
+## Scope check
+
+Single coherent deliverable (two entry points, one prepare module, two registry families). Fits one PR. Collectors rebase stays Stage 3.

--- a/.issueflows/03-solved-issues/issue648_status.md
+++ b/.issueflows/03-solved-issues/issue648_status.md
@@ -1,0 +1,22 @@
+# Issue #648 — Status
+
+- [x] Done
+
+## What's done
+
+- Plan confirmed (direction overlay + shared styling + plotly hover).
+- `cellpy/plotting/prepare/ica.py` — `dqdv` / `dvdq` prepare + FigureSpec.
+- Registry families `"ica"` / `"dva"`.
+- Backend `kind` branches (plotly + matplotlib): one series per `(cycle, direction)`,
+  cycle colour, shared linestyle, plotly hover includes direction.
+- Public `ica_plot` / `dva_plot` in `plotutils` with `backend=` / deprecated `interactive=`.
+- Shared cycle legend policy: `cellpy/plotting/cycle_legend.py`
+  (legend if ≤8 cycles, else colorbar; overridable). Wired into ICA/DVA backends.
+- Oracle cases + regenerated `figure_specs.json`; `tests/test_ica_plot_prepare.py`,
+  `tests/test_cycle_legend.py`.
+- Design notes + manual `dev/preview_*.py` scripts.
+- Related discovery filed separately: #654 (CV-split summary dead `selector_type`).
+
+## Remaining
+
+- None for #648.

--- a/.issueflows/04-designs-and-guides/plotting-backends.md
+++ b/.issueflows/04-designs-and-guides/plotting-backends.md
@@ -4,8 +4,8 @@
 
 Epic #567 Stage 1 needs one layout engine and prepare→spec→render for
 `summary_plot`, with two public backends (`plotly` | `matplotlib`). Stage 2
-adds further render branches for `cycles_plot` (#646) and `raw_plot` /
-`cycle_info_plot` (#647).
+adds further render branches for `cycles_plot` (#646), `raw_plot` /
+`cycle_info_plot` (#647), and `ica_plot` / `dva_plot` (#648).
 
 ## Decision
 
@@ -19,15 +19,22 @@ adds further render branches for `cycles_plot` (#646) and `raw_plot` /
   public backend name. `SeabornPlotBuilder` is deleted.
 - **Public switch:** `summary_plot(..., backend="plotly"|"matplotlib")`,
   `cycles_plot(..., backend=...)`, `raw_plot(..., backend=...)`,
-  `cycle_info_plot(..., backend=...)`. `interactive=` is a `warn_once` alias
+  `cycle_info_plot(..., backend=...)`, `ica_plot(..., backend=...)`,
+  `dva_plot(..., backend=...)`. `interactive=` is a `warn_once` alias
   (removal 2.1) on all of them.
 - **Family dispatch:** `spec.extras.get("kind")` selects the render branch:
   - `"cycles"` — voltage–capacity (#646)
   - `"raw"` — raw time-series (#647)
   - `"cycle_info"` — raw + step annotations (#647; matplotlib single-cycle)
+  - `"ica"` / `"dva"` — dQ/dV vs V / dV/dQ vs capacity (#648); one trace per
+    `(cycle, direction)`, cycle colour, shared linestyle; plotly hover shows
+    direction. Cycle colour key uses
+    `cellpy.plotting.cycle_legend.resolve_cycle_legend_mode` (legend if
+    ≤8 cycles, else colorbar; overridable via `legend_cycle_limit` /
+    `force_colorbar` / `force_legend`).
   - otherwise — summary path
 
 ## Links
 
-- Issues #647, #646, #639, #638, #637, #636; epic #567
+- Issues #648, #647, #646, #639, #638, #637, #636; epic #567
 - Plan of record: `architecture-plan/cellpy2-plotting-redesign-plan.md` §3.1

--- a/.issueflows/04-designs-and-guides/plotting-cycle-legend.md
+++ b/.issueflows/04-designs-and-guides/plotting-cycle-legend.md
@@ -1,0 +1,22 @@
+# Cycle legend vs colorbar
+
+## Context
+
+Multi-cycle figures (ICA/DVA #648, and likely `cycles_plot` later) colour by
+cycle. A discrete legend overflows once there are many cycles.
+
+## Decision
+
+Shared policy in `cellpy/plotting/cycle_legend.py`:
+
+- `resolve_cycle_legend_mode(n)` → `"legend"` if `n ≤ 8`, else `"colorbar"`
+- Overrides: `legend_cycle_limit`, `force_colorbar`, `force_legend`
+  (`force_nonbar` alias)
+- Backend helpers: `add_matplotlib_cycle_colorbar`, `add_plotly_cycle_colorbar`
+
+First consumer: `ica_plot` / `dva_plot` render branches. `cycles_plot` still
+has its own threshold constant; can migrate later.
+
+## Links
+
+- Issue #648, epic #567

--- a/.issueflows/04-designs-and-guides/plotting-prepare.md
+++ b/.issueflows/04-designs-and-guides/plotting-prepare.md
@@ -1,11 +1,12 @@
-# Plotting prepare (summary + curves + raw + cycle_info)
+# Plotting prepare (summary + curves + raw + cycle_info + ica/dva)
 
 ## Context
 
 `SummaryPlotDataPreparer` lived in `cellpy/utils/plotutils.py` and fed both
 plotly and seaborn builders. Epic #567 Stage 1 needs prepare → `FigureSpec` →
 backend.render as the only summary path. Stage 2 extends the same contract to
-`cycles_plot` (#646), then `raw_plot` / `cycle_info_plot` (#647).
+`cycles_plot` (#646), `raw_plot` / `cycle_info_plot` (#647), then `ica_plot` /
+`dva_plot` (#648).
 
 ## Decision
 
@@ -30,15 +31,21 @@ backend.render as the only summary path. Stage 2 extends the same contract to
   `spec.extras["kind"] == "cycle_info"`. Plotly path emits a merged scaled
   frame; matplotlib keeps the single-cycle asymmetry and stashes the step
   table on `extras["steps"]`.
+- **ICA/DVA prepare** lives in `cellpy/plotting/prepare/ica.py` (#648).
+  Calls `cellpy.ica.dqdv` / `dvdq` only (never `Converter` / `to_wide`).
+  `kind` is `"ica"` or `"dva"`; drops deprecated `dq` column from the plotting
+  frame. When `direction="both"`, both halves stay on one figure; backends draw
+  one series per `(cycle, direction)` with cycle-keyed colour and shared line
+  style (plotly hover carries `direction`).
 - **`LiveHeaders`** lives in `cellpy/plotting/headers.py` (re-exported as
   `plotutils._LiveHeaders`).
 - **`CellContext`** in `cellpy/plotting/context.py` is the thin cell adapter;
   BatchContext waits for collectors rebase.
-- Public `summary_plot` / `cycles_plot` / `raw_plot` / `cycle_info_plot` stay
-  in `plotutils` and orchestrate context → registry → prepare →
-  `get_backend(backend).render`.
+- Public `summary_plot` / `cycles_plot` / `raw_plot` / `cycle_info_plot` /
+  `ica_plot` / `dva_plot` stay in `plotutils` and orchestrate context →
+  registry → prepare → `get_backend(backend).render`.
 
 ## Links
 
-- Issues #647, #646, #639, #638; epic #567
+- Issues #648, #647, #646, #639, #638; epic #567
 - Related: `plotting-registry.md`, `plotting-backends.md`

--- a/.issueflows/04-designs-and-guides/plotting-registry.md
+++ b/.issueflows/04-designs-and-guides/plotting-registry.md
@@ -21,7 +21,8 @@ moves selection into `cellpy.plotting.registry`.
   `families(entry_point="summary_plot")` so the snapshot menu cannot drift
   from the runtime menu. Non-summary families register with
   `extras={"entry_point": "..."}` and are excluded from the summary oracle:
-  `"cycles"` (`cycles_plot`, #646), `"raw"` / `"cycle_info"` (#647).
+  `"cycles"` (`cycles_plot`, #646), `"raw"` / `"cycle_info"` (#647),
+  `"ica"` / `"dva"` (#648).
 
 ## Alternatives considered
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -12,6 +12,7 @@ uv run python -m cellpy._deprecation
 | `cycles_plot(interactive=...)` | `backend="plotly"|"matplotlib"` | 2.0 | 2.1 |
 | `cycles_plot(xlim=...)` | `cycles_plot(x_range=...)` | 2.0 | 2.1 |
 | `cycles_plot(ylim=...)` | `cycles_plot(y_range=...)` | 2.0 | 2.1 |
+| `dva_plot(interactive=...)` | `backend="plotly"|"matplotlib"` | 2.0 | 2.1 |
 | `ica.Converter` | `cellpy.ica.transform_half_cycle with IcaOptions` | 2.0 | 2.1 |
 | `ica.dqdv(cycle=...)` | `cellpy.ica.dqdv(cycles=...)` | 2.0 | 2.1 |
 | `ica.dqdv(label_direction=...)` | `the direction column, which the specced frame always carries` | 2.0 | 2.1 |
@@ -19,6 +20,7 @@ uv run python -m cellpy._deprecation
 | `ica.dqdv_cycle` | `cellpy.ica.dqdv (returns the specced long frame)` | 2.0 | 2.1 |
 | `ica.dqdv_cycles` | `cellpy.ica.dqdv (returns the specced long frame)` | 2.0 | 2.1 |
 | `ica.dqdv_np` | `cellpy.ica.transform_half_cycle with IcaOptions` | 2.0 | 2.1 |
+| `ica_plot(interactive=...)` | `backend="plotly"|"matplotlib"` | 2.0 | 2.1 |
 | `legacy header attribute access (headers_normal / _summary / _step_table)` | `c.schema.raw / c.schema.steps / c.schema.summary` | 2.0 | 2.1 |
 | `make_new_cell` | `CellpyCell.vacant` | 2.0 | 2.1 |
 | `plotutils.summary_plot_legacy` | `cellpy.utils.plotutils.summary_plot (same figures, same options)` | 2.0 | 2.1 |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Add ica_plot / dva_plot families on the new pipeline (#648).
+
 * Port raw_plot and cycle_info_plot to prepare→spec→render (#647).
 
 * Port cycles_plot to prepare→spec→render (#646).

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -188,6 +188,17 @@ def _seed_known_deprecations() -> None:
         'backend="plotly"|"matplotlib"',
         removal="2.1",
     )
+    # Stage 2 (#648): ica_plot / dva_plot backend=.
+    _register(
+        "ica_plot(interactive=...)",
+        'backend="plotly"|"matplotlib"',
+        removal="2.1",
+    )
+    _register(
+        "dva_plot(interactive=...)",
+        'backend="plotly"|"matplotlib"',
+        removal="2.1",
+    )
 
 
 if __name__ == "__main__":

--- a/cellpy/plotting/__init__.py
+++ b/cellpy/plotting/__init__.py
@@ -11,6 +11,7 @@ live; the plan is `architecture-plan/cellpy2-plotting-redesign-plan.md`.
 | [`figures`][cellpy.plotting.figures] | loading and saving figures |
 | [`labels`][cellpy.plotting.labels] | legend and marker post-processing |
 | [`theme`][cellpy.plotting.theme] | plotly templates and colour/marker cycles |
+| [`cycle_legend`][cellpy.plotting.cycle_legend] | shared legend-vs-colorbar policy for cycle colouring |
 | [`spec`][cellpy.plotting.spec] | ``FigureSpec`` / ``PanelSpec`` / ``AxisSpec`` |
 | [`registry`][cellpy.plotting.registry] | named ``PlotFamily`` records for ``summary_plot`` |
 | [`backends`][cellpy.plotting.backends] | render protocol + plotly formation layout (#637) |
@@ -31,6 +32,10 @@ from cellpy.plotting.backends import (
     get_backend,
 )
 from cellpy.plotting.context import CellContext, from_source
+from cellpy.plotting.cycle_legend import (
+    DEFAULT_LEGEND_CYCLE_LIMIT,
+    resolve_cycle_legend_mode,
+)
 from cellpy.plotting.figures import (
     load_figure,
     load_matplotlib_figure,
@@ -58,6 +63,7 @@ __all__ = [
     "AxisSpec",
     "Backend",
     "CellContext",
+    "DEFAULT_LEGEND_CYCLE_LIMIT",
     "FigureSpec",
     "MatplotlibBackend",
     "PanelSpec",
@@ -77,6 +83,7 @@ __all__ = [
     "prepare_summary",
     "quantity_label",
     "remove_markers",
+    "resolve_cycle_legend_mode",
     "save_matplotlib_figure",
     "units_quantity_label",
 ]

--- a/cellpy/plotting/backends/mpl.py
+++ b/cellpy/plotting/backends/mpl.py
@@ -70,6 +70,8 @@ class MatplotlibBackend:
             return self._render_raw(frame, spec)
         if kind == "cycle_info":
             return self._render_cycle_info(frame, spec)
+        if kind in ("ica", "dva"):
+            return self._render_ica_dva(frame, spec)
 
         config = extras.get("config")
         c = extras.get("cell")
@@ -1217,6 +1219,81 @@ class MatplotlibBackend:
 
         if get_axes:
             return ax1, ax2, ax2, ax4
+        return fig
+
+    def _render_ica_dva(self, frame: Any, spec: FigureSpec) -> Any:
+        """Render ICA (dQ/dV) or DVA (dV/dQ) figures (#648).
+
+        One series per ``(cycle, direction)``; shared line style for charge and
+        discharge. Cycle legend vs colorbar via
+        :mod:`cellpy.plotting.cycle_legend`.
+        """
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import Normalize
+
+        from cellpy.ica import ICA_COLS
+        from cellpy.plotting.cycle_legend import (
+            add_matplotlib_cycle_colorbar,
+            pop_cycle_legend_options,
+            resolve_cycle_legend_mode,
+        )
+
+        extras = dict(spec.extras or {})
+        kwargs = dict(extras.get("additional_kwargs") or {})
+        x_col = extras.get("x") or ICA_COLS.voltage
+        y_col = extras.get("y") or ICA_COLS.dqdv
+        x_label = extras.get("x_label") or (spec.x_axis.label or x_col)
+        y_label = extras.get("y_label") or y_col
+        colormap = extras.get("colormap") or "viridis"
+        figsize = extras.get("figsize") or (6, 4)
+        x_range = extras.get("x_range")
+        y_range = extras.get("y_range")
+        legend_opts = pop_cycle_legend_options(extras, kwargs)
+
+        fig, ax = plt.subplots(1, 1, figsize=figsize)
+        cycles = sorted(frame[ICA_COLS.cycle].unique())
+        n_cycles = len(cycles)
+        cmap = plt.get_cmap(colormap)
+        if n_cycles == 1:
+            norm = Normalize(vmin=cycles[0] - 0.5, vmax=cycles[0] + 0.5)
+            cycle_to_color = {cycles[0]: cmap(0.5)}
+        else:
+            norm = Normalize(vmin=min(cycles), vmax=max(cycles))
+            cycle_to_color = {cycle: cmap(norm(cycle)) for cycle in cycles}
+
+        mode = resolve_cycle_legend_mode(n_cycles, **legend_opts)
+        use_legend = mode == "legend"
+
+        shown_cycles: set[Any] = set()
+        for (cycle, _direction), group in frame.groupby(
+            [ICA_COLS.cycle, ICA_COLS.direction], sort=True
+        ):
+            label = None
+            if use_legend and cycle not in shown_cycles:
+                label = str(cycle)
+                shown_cycles.add(cycle)
+            ax.plot(
+                group[x_col],
+                group[y_col],
+                color=cycle_to_color[cycle],
+                label=label,
+                linewidth=1.5,
+            )
+
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
+        ax.set_title(spec.title)
+        if x_range is not None:
+            ax.set_xlim(x_range)
+        if y_range is not None:
+            ax.set_ylim(y_range)
+
+        if use_legend and shown_cycles:
+            ax.legend(title="cycle")
+        elif n_cycles:
+            add_matplotlib_cycle_colorbar(fig, ax, cmap=cmap, norm=norm)
+
+        fig.tight_layout()
         return fig
 
 

--- a/cellpy/plotting/backends/plotly.py
+++ b/cellpy/plotting/backends/plotly.py
@@ -303,6 +303,8 @@ class PlotlyBackend:
             return self._render_raw(frame, spec)
         if kind == "cycle_info":
             return self._render_cycle_info(frame, spec)
+        if kind in ("ica", "dva"):
+            return self._render_ica_dva(frame, spec)
 
         import plotly.express as px
 
@@ -849,4 +851,100 @@ class PlotlyBackend:
             width=width,
             height=height,
         )
+        return fig
+
+    def _render_ica_dva(self, frame: Any, spec: FigureSpec) -> Any:
+        """Render ICA (dQ/dV) or DVA (dV/dQ) figures (#648).
+
+        One trace per ``(cycle, direction)`` so half-cycles are not connected;
+        color is keyed by cycle. Hover includes direction. Line style is shared
+        across charge and discharge. Cycle legend vs colorbar via
+        :mod:`cellpy.plotting.cycle_legend`.
+        """
+        import plotly.express as px
+        import plotly.graph_objects as go
+
+        from cellpy.ica import ICA_COLS
+        from cellpy.plotting.cycle_legend import (
+            add_plotly_cycle_colorbar,
+            pop_cycle_legend_options,
+            resolve_cycle_legend_mode,
+        )
+        from cellpy.utils.plotutils import set_plotly_template
+
+        extras = dict(spec.extras or {})
+        kwargs = dict(extras.get("additional_kwargs") or {})
+        set_plotly_template(extras.get("plotly_template"))
+        legend_opts = pop_cycle_legend_options(extras, kwargs)
+
+        x_col = extras.get("x") or ICA_COLS.voltage
+        y_col = extras.get("y") or ICA_COLS.dqdv
+        x_label = extras.get("x_label") or (spec.x_axis.label or x_col)
+        y_label = extras.get("y_label") or y_col
+        colormap = extras.get("colormap") or "viridis"
+        color_scales = px.colors.named_colorscales()
+        if colormap not in color_scales:
+            colormap = "viridis"
+
+        marker_size = extras.get("marker_size", 5)
+        width = extras.get("width", 800)
+        height = extras.get("height", 600)
+        x_range = extras.get("x_range")
+        y_range = extras.get("y_range")
+
+        cycles = sorted(frame[ICA_COLS.cycle].unique())
+        n_cycles = len(cycles)
+        mode = resolve_cycle_legend_mode(n_cycles, **legend_opts)
+        use_legend = mode == "legend"
+
+        sample_n = max(n_cycles, 1)
+        samplepoints = [
+            0.0 if sample_n == 1 else i / (sample_n - 1) for i in range(sample_n)
+        ]
+        colors = px.colors.sample_colorscale(colormap, samplepoints=samplepoints)
+        cycle_to_color = {cycle: colors[i] for i, cycle in enumerate(cycles)}
+
+        fig = go.Figure()
+        shown_cycles: set[Any] = set()
+        group_cols = [ICA_COLS.cycle, ICA_COLS.direction]
+        for (cycle, direction), group in frame.groupby(group_cols, sort=True):
+            color = cycle_to_color[cycle]
+            show_legend = use_legend and cycle not in shown_cycles
+            if show_legend:
+                shown_cycles.add(cycle)
+            fig.add_trace(
+                go.Scatter(
+                    x=group[x_col],
+                    y=group[y_col],
+                    mode="lines",
+                    name=str(cycle),
+                    legendgroup=str(cycle),
+                    showlegend=show_legend,
+                    line=dict(color=color, width=1.5),
+                    customdata=group[[ICA_COLS.cycle, ICA_COLS.direction]],
+                    hovertemplate=(
+                        f"{x_label}: %{{x}}<br>"
+                        f"{y_label}: %{{y}}<br>"
+                        "cycle: %{customdata[0]}<br>"
+                        "direction: %{customdata[1]}<extra></extra>"
+                    ),
+                )
+            )
+
+        if not use_legend and cycles:
+            add_plotly_cycle_colorbar(fig, cycles=list(cycles), colormap=colormap)
+
+        layout_kwargs: dict[str, Any] = {
+            "title": spec.title,
+            "width": width,
+            "height": height,
+        }
+        if use_legend:
+            layout_kwargs["legend_title_text"] = "cycle"
+        else:
+            layout_kwargs["showlegend"] = False
+        fig.update_layout(**layout_kwargs)
+        fig.update_xaxes(title_text=x_label, range=x_range)
+        fig.update_yaxes(title_text=y_label, range=y_range)
+        _ = marker_size
         return fig

--- a/cellpy/plotting/cycle_legend.py
+++ b/cellpy/plotting/cycle_legend.py
@@ -1,0 +1,163 @@
+"""Shared cycle legend vs colorbar policy for multi-cycle plots (#648).
+
+Several figure families colour traces by cycle number. A discrete legend
+works for a handful of cycles and overflows once the list grows. This
+module owns the **decision** (and small apply helpers) so matplotlib /
+plotly backends — and future families — share one rule.
+
+Default threshold matches ``cycles_plot``'s
+``plotly_max_individual_traces_for_lines`` (8).
+
+Override knobs (accepted from ``FigureSpec.extras`` or
+``additional_kwargs``):
+
+- ``legend_cycle_limit`` — max cycles that still get a discrete legend
+- ``force_colorbar`` — always use a colorbar
+- ``force_legend`` / ``force_nonbar`` — always use a discrete legend
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Mapping, MutableMapping
+
+CycleLegendMode = Literal["legend", "colorbar"]
+
+#: Max number of cycles for which a discrete legend is preferred.
+DEFAULT_LEGEND_CYCLE_LIMIT = 8
+
+
+def resolve_cycle_legend_mode(
+    n_cycles: int,
+    *,
+    legend_cycle_limit: int = DEFAULT_LEGEND_CYCLE_LIMIT,
+    force_colorbar: bool = False,
+    force_legend: bool = False,
+) -> CycleLegendMode:
+    """Choose discrete legend vs colorbar for a cycle-coloured figure.
+
+    Args:
+        n_cycles: Number of distinct cycle values being drawn.
+        legend_cycle_limit: Prefer a legend when ``n_cycles`` is at most this.
+        force_colorbar: Always return ``"colorbar"``.
+        force_legend: Always return ``"legend"`` (wins over ``force_colorbar``,
+            matching the ``force_nonbar`` escape hatch on ``cycles_plot``).
+
+    Returns:
+        ``"legend"`` or ``"colorbar"``.
+    """
+    if force_legend:
+        return "legend"
+    if force_colorbar:
+        return "colorbar"
+    if n_cycles <= legend_cycle_limit:
+        return "legend"
+    return "colorbar"
+
+
+def pop_cycle_legend_options(
+    extras: Mapping[str, Any] | None = None,
+    kwargs: MutableMapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Pull shared cycle-legend knobs from extras / kwargs.
+
+    Values in *kwargs* win over *extras*. Consumed keys are removed from
+    *kwargs* when it is a mutable mapping.
+
+    Returns:
+        Dict with ``legend_cycle_limit``, ``force_colorbar``, ``force_legend``
+        ready to splat into :func:`resolve_cycle_legend_mode`.
+    """
+    extras = dict(extras or {})
+    source = dict(kwargs) if kwargs is not None else {}
+
+    def _take(key: str, default: Any) -> Any:
+        if kwargs is not None and key in kwargs:
+            return kwargs.pop(key)
+        if key in source:
+            return source[key]
+        return extras.get(key, default)
+
+    force_legend = bool(_take("force_legend", False))
+    if not force_legend:
+        # Alias used by cycles_plot today.
+        force_legend = bool(_take("force_nonbar", False))
+
+    return {
+        "legend_cycle_limit": int(
+            _take("legend_cycle_limit", DEFAULT_LEGEND_CYCLE_LIMIT)
+        ),
+        "force_colorbar": bool(_take("force_colorbar", False)),
+        "force_legend": force_legend,
+    }
+
+
+def add_matplotlib_cycle_colorbar(
+    fig: Any,
+    ax: Any,
+    *,
+    cmap: Any,
+    norm: Any,
+    label: str = "cycle",
+    aspect: int = 30,
+) -> Any:
+    """Attach a cycle colorbar to a matplotlib axes.
+
+    Args:
+        fig: Matplotlib figure.
+        ax: Axes that owns the cycle-coloured lines.
+        cmap: Matplotlib colormap.
+        norm: Normalize spanning the cycle range.
+        label: Colorbar label.
+        aspect: Colorbar aspect ratio.
+
+    Returns:
+        The colorbar instance.
+    """
+    from matplotlib.cm import ScalarMappable
+
+    mappable = ScalarMappable(norm=norm, cmap=cmap)
+    mappable.set_array([])
+    cbar = fig.colorbar(mappable, ax=ax, aspect=aspect, location="right")
+    cbar.set_label(label, rotation=270, labelpad=12)
+    return cbar
+
+
+def add_plotly_cycle_colorbar(
+    fig: Any,
+    *,
+    cycles: list[Any],
+    colormap: str = "viridis",
+    title: str = "cycle",
+) -> None:
+    """Attach a cycle colorbar to a plotly figure via a hidden scale trace.
+
+    Line traces keep explicit colours; this only adds the scale widget so the
+    figure does not also need a long discrete legend.
+    """
+    import plotly.graph_objects as go
+
+    if not cycles:
+        return
+    cmin = float(min(cycles))
+    cmax = float(max(cycles))
+    if cmin == cmax:
+        cmin -= 0.5
+        cmax += 0.5
+    fig.add_trace(
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="markers",
+            marker=dict(
+                size=0.1,
+                color=[cmin],
+                colorscale=colormap,
+                cmin=cmin,
+                cmax=cmax,
+                showscale=True,
+                colorbar=dict(title=title),
+            ),
+            hoverinfo="skip",
+            showlegend=False,
+        )
+    )

--- a/cellpy/plotting/prepare/__init__.py
+++ b/cellpy/plotting/prepare/__init__.py
@@ -1,10 +1,17 @@
-"""Prepare stages for the prepare → spec → render pipeline (#638 / #646 / #647)."""
+"""Prepare stages for the prepare → spec → render pipeline (#638–#648)."""
 
 from __future__ import annotations
 
 from cellpy.plotting.prepare.curves import prepare as prepare_curves
+from cellpy.plotting.prepare.ica import prepare as prepare_ica
 from cellpy.plotting.prepare.raw import prepare as prepare_raw
 from cellpy.plotting.prepare.steps import prepare as prepare_cycle_info
 from cellpy.plotting.prepare.summary import prepare as prepare_summary
 
-__all__ = ["prepare_curves", "prepare_cycle_info", "prepare_raw", "prepare_summary"]
+__all__ = [
+    "prepare_curves",
+    "prepare_cycle_info",
+    "prepare_ica",
+    "prepare_raw",
+    "prepare_summary",
+]

--- a/cellpy/plotting/prepare/ica.py
+++ b/cellpy/plotting/prepare/ica.py
@@ -1,0 +1,158 @@
+"""ICA/DVA prepare path: long frames from ``cellpy.ica`` + FigureSpec (#648).
+
+Public ``ica_plot`` / ``dva_plot`` call :func:`prepare` then hand
+``(frame, FigureSpec)`` to a backend renderer (``spec.extras['kind']`` is
+``'ica'`` or ``'dva'``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+import pandas as pd
+
+from cellpy.exceptions import UnitsError
+from cellpy.ica import BOTH, ICA_COLS, dqdv, dvdq
+from cellpy.plotting.labels import quantity_label
+from cellpy.plotting.spec import AxisSpec, FigureSpec, PanelSpec
+from cellpy.units import units_label, with_cellpy_unit
+
+Derivative = Literal["dqdv", "dvdq"]
+
+
+@dataclass
+class IcaPrepareConfig:
+    """Input knobs for :func:`prepare` (mirrors public ``ica_plot`` / ``dva_plot``)."""
+
+    derivative: Derivative = "dqdv"
+    cycles: Optional[Any] = None
+    direction: str = BOTH
+    options: Any = None
+    strict: bool = False
+    cycle_mode: Optional[str] = None
+    number_of_points: Optional[int] = None
+    title: Optional[str] = None
+    colormap: str = "viridis"
+    width: int = 800
+    height: int = 600
+    figsize: tuple = (6, 4)
+    x_range: Optional[list] = None
+    y_range: Optional[list] = None
+    marker_size: int = 5
+    plotly_template: Optional[str] = None
+    backend: str = "plotly"
+    option_overrides: dict = field(default_factory=dict)
+    additional_kwargs: dict = field(default_factory=dict)
+
+
+def _range_tuple(value: Any) -> Optional[tuple[float, float]]:
+    if value is None:
+        return None
+    return (float(value[0]), float(value[1]))
+
+
+def _capacity_unit(c: Any) -> str:
+    try:
+        return units_label("charge", "gravimetric", units=c.cellpy_units)
+    except UnitsError:
+        return "-"
+
+
+def _default_title(c: Any, *, kind: str, backend: str) -> str:
+    use_plotly = backend == "plotly"
+    bold_o = "<b>" if use_plotly else "'"
+    bold_c = "</b>" if use_plotly else "'"
+    label = "Incremental capacity (dQ/dV)" if kind == "ica" else "Differential voltage (dV/dQ)"
+    return f"{label} for {bold_o}{c.cell_name}{bold_c}"
+
+
+def prepare(
+    ctx: Any,
+    family: Any,
+    config: IcaPrepareConfig,
+) -> tuple[pd.DataFrame, FigureSpec]:
+    """Prepare an ICA or DVA frame and :class:`FigureSpec`.
+
+    Args:
+        ctx: :class:`~cellpy.plotting.context.CellContext` (or compatible).
+        family: registered :class:`~cellpy.plotting.registry.PlotFamily`
+            (``ica`` or ``dva``).
+        config: :class:`IcaPrepareConfig` built by the public entry point.
+
+    Returns:
+        ``(frame, spec)`` where ``spec.extras['kind']`` is ``'ica'`` or ``'dva'``.
+    """
+    c = ctx.cell
+    family_name = getattr(family, "name", config.derivative)
+    kind = "dva" if config.derivative == "dvdq" else "ica"
+
+    transform = dvdq if config.derivative == "dvdq" else dqdv
+    frame = transform(
+        c,
+        cycles=config.cycles,
+        direction=config.direction,
+        options=config.options,
+        strict=config.strict,
+        cycle_mode=config.cycle_mode,
+        number_of_points=config.number_of_points,
+        **dict(config.option_overrides or {}),
+    )
+    frame = frame.copy()
+    if ICA_COLS.legacy_dqdv in frame.columns:
+        frame = frame.drop(columns=[ICA_COLS.legacy_dqdv])
+
+    if config.derivative == "dvdq":
+        x_col = ICA_COLS.capacity
+        y_col = ICA_COLS.dvdq
+        capacity_unit = _capacity_unit(c)
+        x_label = quantity_label("Capacity", capacity_unit)
+        y_label = quantity_label("dV/dQ", f"V/({capacity_unit})")
+    else:
+        x_col = ICA_COLS.voltage
+        y_col = ICA_COLS.dqdv
+        x_label = with_cellpy_unit("Voltage", "voltage", units=c.cellpy_units)
+        capacity_unit = _capacity_unit(c)
+        y_label = quantity_label("dQ/dV", f"{capacity_unit}/V")
+
+    title = config.title
+    if title is None:
+        title = _default_title(c, kind=kind, backend=config.backend)
+
+    x_range = _range_tuple(config.x_range)
+    y_range = _range_tuple(config.y_range)
+
+    spec = FigureSpec(
+        panels=(
+            PanelSpec(
+                columns=(x_col, y_col),
+                kind="line",
+                y_axis=AxisSpec(label=y_label, range=y_range),
+            ),
+        ),
+        x_axis=AxisSpec(label=x_label, range=x_range),
+        title=title,
+        supports_formation=False,
+        extras={
+            "kind": kind,
+            "family": family_name,
+            "derivative": config.derivative,
+            "x": x_col,
+            "y": y_col,
+            "x_label": x_label,
+            "y_label": y_label,
+            "color": ICA_COLS.cycle,
+            "hover": [ICA_COLS.cycle, ICA_COLS.direction],
+            "colormap": config.colormap,
+            "width": config.width,
+            "height": config.height,
+            "figsize": config.figsize,
+            "marker_size": config.marker_size,
+            "plotly_template": config.plotly_template,
+            "x_range": list(config.x_range) if config.x_range is not None else None,
+            "y_range": list(config.y_range) if config.y_range is not None else None,
+            "additional_kwargs": dict(config.additional_kwargs or {}),
+            "cell": c,
+        },
+    )
+    return frame, spec

--- a/cellpy/plotting/registry.py
+++ b/cellpy/plotting/registry.py
@@ -309,6 +309,21 @@ def _register_builtin_families() -> None:
             supports_formation=False,
             extras={"entry_point": "cycle_info_plot", "kind": "cycle_info"},
         ),
+        # Stage 2 (#648): ICA / DVA from cellpy.ica long frames.
+        PlotFamily(
+            name="ica",
+            description="Incremental capacity (dQ/dV vs voltage)",
+            column_builder=lambda hdr: ["voltage", "dqdv", "cycle", "direction"],
+            supports_formation=False,
+            extras={"entry_point": "ica_plot", "kind": "ica"},
+        ),
+        PlotFamily(
+            name="dva",
+            description="Differential voltage (dV/dQ vs capacity)",
+            column_builder=lambda hdr: ["capacity", "dvdq", "cycle", "direction"],
+            supports_formation=False,
+            extras={"entry_point": "dva_plot", "kind": "dva"},
+        ),
     ]
     for family in builtins:
         _register_family(family)

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -1724,6 +1724,245 @@ def cycles_plot(
     return None
 
 
+def _resolve_plot_backend(
+    *,
+    backend: Optional[str],
+    interactive: Optional[bool],
+    deprecation_site: str,
+) -> str:
+    """Resolve ``backend=`` vs deprecated ``interactive=`` for plot entry points."""
+    resolved = backend
+    if interactive is not None:
+        warn_once(
+            deprecation_site,
+            'backend="plotly"|"matplotlib"',
+            removal="2.1",
+        )
+        if resolved is None:
+            resolved = "plotly" if interactive else "matplotlib"
+    if resolved is None:
+        resolved = "plotly"
+    if resolved == "plotly" and not plotly_available:
+        warnings.warn("Can not perform interactive plotting. Plotly is not available.")
+        resolved = "matplotlib"
+    return resolved
+
+
+def ica_plot(
+    cell,
+    cycles=None,
+    direction="both",
+    options=None,
+    *,
+    backend: Optional[str] = None,
+    interactive: Optional[bool] = None,
+    title=None,
+    colormap="viridis",
+    width=800,
+    height=600,
+    figsize=(6, 4),
+    x_range=None,
+    y_range=None,
+    plotly_template=None,
+    return_data=False,
+    **kwargs,
+):
+    """Plot incremental capacity (dQ/dV vs voltage).
+
+    Draws through prepare → spec → render (#648). Data come from
+    [`cellpy.ica.dqdv`][cellpy.ica.dqdv]; both half-cycles are overlaid when
+    ``direction="both"`` (plotly hover shows charge/discharge).
+
+    Args:
+        cell: cellpy object.
+        cycles: Cycle number or list (``None`` = all).
+        direction: ``"charge"``, ``"discharge"``, or ``"both"``.
+        options: Optional [`IcaOptions`][cellpy.ica.IcaOptions].
+        backend: ``"plotly"`` (default) or ``"matplotlib"``.
+        interactive: Deprecated alias for backend selection (removal 2.1).
+        title: Figure title.
+        colormap: Cycle colour map.
+        width, height: Plotly figure size.
+        figsize: Matplotlib figure size.
+        x_range, y_range: Optional axis ranges.
+        plotly_template: Optional plotly template name.
+        return_data: If True, return ``(figure, frame)``.
+        **kwargs: Extra knobs (``strict``, ``cycle_mode``, ``number_of_points``,
+            and individual ``IcaOptions`` field overrides).
+
+    Returns:
+        Plotly or matplotlib figure (or ``(figure, frame)`` when ``return_data``).
+    """
+    from cellpy.plotting.backends import get_backend
+    from cellpy.plotting.context import from_source
+    from cellpy.plotting.prepare.ica import IcaPrepareConfig, prepare as prepare_ica
+
+    resolved_backend = _resolve_plot_backend(
+        backend=backend,
+        interactive=interactive,
+        deprecation_site="ica_plot(interactive=...)",
+    )
+
+    option_keys = {
+        "voltage_resolution",
+        "capacity_resolution",
+        "pre_smoothing",
+        "diff_smoothing",
+        "post_smoothing",
+        "savgol_window_divisor",
+        "savgol_order",
+        "voltage_fwhm",
+        "capacity_fwhm",
+        "gaussian",
+        "normalize",
+        "normalizing_factor",
+        "normalizing_roof",
+        "increment_method",
+    }
+    option_overrides = {k: kwargs.pop(k) for k in list(kwargs) if k in option_keys}
+    strict = kwargs.pop("strict", False)
+    cycle_mode = kwargs.pop("cycle_mode", None)
+    number_of_points = kwargs.pop("number_of_points", None)
+
+    prep_config = IcaPrepareConfig(
+        derivative="dqdv",
+        cycles=cycles,
+        direction=direction,
+        options=options,
+        strict=strict,
+        cycle_mode=cycle_mode,
+        number_of_points=number_of_points,
+        title=title,
+        colormap=colormap,
+        width=width,
+        height=height,
+        figsize=figsize,
+        x_range=x_range,
+        y_range=y_range,
+        plotly_template=plotly_template,
+        backend=resolved_backend,
+        option_overrides=option_overrides,
+        additional_kwargs=dict(kwargs),
+    )
+    ctx = from_source(cell)
+    family = plot_registry.get("ica")
+    frame, spec = prepare_ica(ctx, family, prep_config)
+    fig = get_backend(resolved_backend).render(frame, spec)
+    if resolved_backend == "matplotlib" and fig is not None:
+        plt.close(fig)
+    if return_data:
+        return fig, frame
+    return fig
+
+
+def dva_plot(
+    cell,
+    cycles=None,
+    direction="both",
+    options=None,
+    *,
+    backend: Optional[str] = None,
+    interactive: Optional[bool] = None,
+    title=None,
+    colormap="viridis",
+    width=800,
+    height=600,
+    figsize=(6, 4),
+    x_range=None,
+    y_range=None,
+    plotly_template=None,
+    return_data=False,
+    **kwargs,
+):
+    """Plot differential voltage analysis (dV/dQ vs capacity).
+
+    Draws through prepare → spec → render (#648). Data come from
+    [`cellpy.ica.dvdq`][cellpy.ica.dvdq]; both half-cycles are overlaid when
+    ``direction="both"`` (plotly hover shows charge/discharge).
+
+    Args:
+        cell: cellpy object.
+        cycles: Cycle number or list (``None`` = all).
+        direction: ``"charge"``, ``"discharge"``, or ``"both"``.
+        options: Optional [`IcaOptions`][cellpy.ica.IcaOptions] (defaults to
+            DVA-oriented options inside ``dvdq``).
+        backend: ``"plotly"`` (default) or ``"matplotlib"``.
+        interactive: Deprecated alias for backend selection (removal 2.1).
+        title: Figure title.
+        colormap: Cycle colour map.
+        width, height: Plotly figure size.
+        figsize: Matplotlib figure size.
+        x_range, y_range: Optional axis ranges.
+        plotly_template: Optional plotly template name.
+        return_data: If True, return ``(figure, frame)``.
+        **kwargs: Extra knobs (``strict``, ``cycle_mode``, ``number_of_points``,
+            and individual ``IcaOptions`` field overrides).
+
+    Returns:
+        Plotly or matplotlib figure (or ``(figure, frame)`` when ``return_data``).
+    """
+    from cellpy.plotting.backends import get_backend
+    from cellpy.plotting.context import from_source
+    from cellpy.plotting.prepare.ica import IcaPrepareConfig, prepare as prepare_ica
+
+    resolved_backend = _resolve_plot_backend(
+        backend=backend,
+        interactive=interactive,
+        deprecation_site="dva_plot(interactive=...)",
+    )
+
+    option_keys = {
+        "voltage_resolution",
+        "capacity_resolution",
+        "pre_smoothing",
+        "diff_smoothing",
+        "post_smoothing",
+        "savgol_window_divisor",
+        "savgol_order",
+        "voltage_fwhm",
+        "capacity_fwhm",
+        "gaussian",
+        "normalize",
+        "normalizing_factor",
+        "normalizing_roof",
+        "increment_method",
+    }
+    option_overrides = {k: kwargs.pop(k) for k in list(kwargs) if k in option_keys}
+    strict = kwargs.pop("strict", False)
+    cycle_mode = kwargs.pop("cycle_mode", None)
+    number_of_points = kwargs.pop("number_of_points", None)
+
+    prep_config = IcaPrepareConfig(
+        derivative="dvdq",
+        cycles=cycles,
+        direction=direction,
+        options=options,
+        strict=strict,
+        cycle_mode=cycle_mode,
+        number_of_points=number_of_points,
+        title=title,
+        colormap=colormap,
+        width=width,
+        height=height,
+        figsize=figsize,
+        x_range=x_range,
+        y_range=y_range,
+        plotly_template=plotly_template,
+        backend=resolved_backend,
+        option_overrides=option_overrides,
+        additional_kwargs=dict(kwargs),
+    )
+    ctx = from_source(cell)
+    family = plot_registry.get("dva")
+    frame, spec = prepare_ica(ctx, family, prep_config)
+    fig = get_backend(resolved_backend).render(frame, spec)
+    if resolved_backend == "matplotlib" and fig is not None:
+        plt.close(fig)
+    if return_data:
+        return fig, frame
+    return fig
+
+
 def _cell_and_output_path():
     import pathlib
     import cellpy

--- a/dev/plot_preview_common.py
+++ b/dev/plot_preview_common.py
@@ -1,0 +1,206 @@
+"""Shared helpers for manual plot preview scripts under ``dev/``.
+
+These are for human eyeballs — structural oracle coverage stays in
+``tests/test_figure_specs.py`` / ``dev/snapshot_figure_specs.py``.
+
+Typical use::
+
+    uv sync --extra batch
+    uv run python dev/preview_ica_plots.py
+    uv run python dev/preview_plots.py --list
+    uv run python dev/preview_plots.py --function ica_plot --open
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT_ROOT = REPO_ROOT / "tmp" / "plot_previews"
+
+if str(REPO_ROOT / "tests") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "tests"))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from figure_spec_support import (  # noqa: E402
+    FIGURE_CASES,
+    FigureCase,
+    load_figure_cell,
+    plotly_available,
+    seaborn_available,
+)
+
+
+def _safe_name(name: str) -> str:
+    cleaned = re.sub(r"[^\w.\-]+", "_", name)
+    return cleaned.strip("._")
+
+
+def select_cases(
+    *,
+    functions: Sequence[str] | None = None,
+    backends: Sequence[str] | None = None,
+    name_substr: str | None = None,
+) -> list[FigureCase]:
+    """Filter the oracle menu (``FIGURE_CASES``) for a preview run."""
+    selected: list[FigureCase] = []
+    for case in FIGURE_CASES:
+        if functions and case.function not in functions:
+            continue
+        backend = case.kwargs.get("backend")
+        if backends and backend is not None and backend not in backends:
+            continue
+        if name_substr and name_substr not in case.name:
+            continue
+        reason = case.skip_reason()
+        if reason:
+            print(f"skip {case.name}: {reason}")
+            continue
+        selected.append(case)
+    return selected
+
+
+def render_live(case: FigureCase, cell):
+    """Render one case without the oracle's structural describe/close path."""
+    from cellpy.utils import plotutils
+
+    return getattr(plotutils, case.function)(cell, **dict(case.kwargs))
+
+
+def save_figure(figure, out_dir: Path, case_name: str) -> Path | None:
+    """Write a plotly HTML or matplotlib PNG; return the path (or None)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = _safe_name(case_name)
+
+    if figure is None:
+        print(f"skip save {case_name}: no figure returned")
+        return None
+
+    if hasattr(figure, "to_html") and hasattr(figure, "write_html"):
+        path = out_dir / f"{stem}.html"
+        figure.write_html(path, include_plotlyjs="cdn", full_html=True)
+        return path
+
+    if hasattr(figure, "savefig"):
+        path = out_dir / f"{stem}.png"
+        figure.savefig(path, dpi=120, bbox_inches="tight")
+        return path
+
+    print(f"skip save {case_name}: unsupported figure type {type(figure)!r}")
+    return None
+
+
+def preview_cases(
+    cases: Iterable[FigureCase],
+    *,
+    out_dir: Path | None = None,
+    open_files: bool = False,
+) -> list[Path]:
+    """Render *cases*, write artifacts under *out_dir*, optionally open them."""
+    cases = list(cases)
+    if not cases:
+        raise SystemExit("no figure cases matched the selection")
+
+    if out_dir is None:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_dir = DEFAULT_OUT_ROOT / stamp
+
+    print(f"loading golden cell…")
+    cell = load_figure_cell()
+    print(f"writing {len(cases)} figure(s) under {out_dir}")
+
+    written: list[Path] = []
+    for case in cases:
+        print(f"  render {case.name}")
+        figure = render_live(case, cell)
+        path = save_figure(figure, out_dir, case.name)
+        if path is None:
+            continue
+        written.append(path)
+        print(f"    -> {path}")
+        if open_files:
+            webbrowser.open(path.resolve().as_uri())
+
+    print(f"done: {len(written)} file(s) in {out_dir}")
+    return written
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=f"output directory (default: {DEFAULT_OUT_ROOT}/<utc-stamp>/)",
+    )
+    parser.add_argument(
+        "--backend",
+        action="append",
+        choices=("plotly", "matplotlib"),
+        default=None,
+        help="limit to this backend (repeatable); default: both",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="open each written file with the system default handler",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list matching cases and exit",
+    )
+
+
+def run_preview_cli(
+    *,
+    functions: Sequence[str] | None = None,
+    description: str,
+    argv: Sequence[str] | None = None,
+) -> None:
+    """Shared CLI entry used by the thin family scripts and ``preview_plots``."""
+    parser = argparse.ArgumentParser(description=description)
+    add_common_args(parser)
+    parser.add_argument(
+        "--function",
+        action="append",
+        dest="functions",
+        default=None,
+        help="limit to this plotutils function (repeatable)",
+    )
+    parser.add_argument(
+        "--name",
+        default=None,
+        help="substring filter on the oracle case name",
+    )
+    args = parser.parse_args(argv)
+
+    selected_functions = list(functions or [])
+    if args.functions:
+        selected_functions.extend(args.functions)
+    if not selected_functions:
+        selected_functions = None
+
+    cases = select_cases(
+        functions=selected_functions,
+        backends=args.backend,
+        name_substr=args.name,
+    )
+    if args.list:
+        for case in cases:
+            print(case.name)
+        print(f"{len(cases)} case(s)")
+        return
+
+    if not plotly_available:
+        print("note: plotly not installed — plotly cases are skipped")
+    if not seaborn_available:
+        print("note: seaborn not installed — some matplotlib cases may look plain")
+
+    preview_cases(cases, out_dir=args.out, open_files=args.open)

--- a/dev/preview_curve_plots.py
+++ b/dev/preview_curve_plots.py
@@ -1,0 +1,26 @@
+"""Manually preview cycles / raw / cycle_info oracle cases.
+
+```shell
+uv sync --extra batch
+uv run python dev/preview_curve_plots.py
+uv run python dev/preview_curve_plots.py --function cycles_plot --open
+uv run python dev/preview_curve_plots.py --backend matplotlib
+```
+
+Artifacts land under ``tmp/plot_previews/<utc-stamp>/`` (gitignored).
+"""
+
+from __future__ import annotations
+
+from plot_preview_common import run_preview_cli
+
+
+def main() -> None:
+    run_preview_cli(
+        functions=["cycles_plot", "raw_plot", "cycle_info_plot"],
+        description="Preview cycles/raw/cycle_info oracle cases as HTML/PNG.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/preview_ica_plots.py
+++ b/dev/preview_ica_plots.py
@@ -1,0 +1,26 @@
+"""Manually preview ``ica_plot`` / ``dva_plot`` oracle cases (#648).
+
+```shell
+uv sync --extra batch
+uv run python dev/preview_ica_plots.py
+uv run python dev/preview_ica_plots.py --open
+uv run python dev/preview_ica_plots.py --backend plotly
+```
+
+Artifacts land under ``tmp/plot_previews/<utc-stamp>/`` (gitignored).
+"""
+
+from __future__ import annotations
+
+from plot_preview_common import run_preview_cli
+
+
+def main() -> None:
+    run_preview_cli(
+        functions=["ica_plot", "dva_plot"],
+        description="Preview ica_plot / dva_plot oracle cases as HTML/PNG.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/preview_plots.py
+++ b/dev/preview_plots.py
@@ -1,0 +1,26 @@
+"""Manually preview the full figure menu (oracle cases).
+
+```shell
+uv sync --extra batch
+uv run python dev/preview_plots.py --list
+uv run python dev/preview_plots.py --function ica_plot --open
+uv run python dev/preview_plots.py --backend matplotlib --name summary_plot
+```
+
+Artifacts land under ``tmp/plot_previews/<utc-stamp>/`` (gitignored).
+"""
+
+from __future__ import annotations
+
+from plot_preview_common import run_preview_cli
+
+
+def main() -> None:
+    run_preview_cli(
+        functions=None,
+        description="Preview any/all oracle figure cases as HTML/PNG.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/preview_summary_plots.py
+++ b/dev/preview_summary_plots.py
@@ -1,0 +1,26 @@
+"""Manually preview ``summary_plot`` oracle cases.
+
+```shell
+uv sync --extra batch
+uv run python dev/preview_summary_plots.py
+uv run python dev/preview_summary_plots.py --backend plotly --open
+uv run python dev/preview_summary_plots.py --name no_formation
+```
+
+Artifacts land under ``tmp/plot_previews/<utc-stamp>/`` (gitignored).
+"""
+
+from __future__ import annotations
+
+from plot_preview_common import run_preview_cli
+
+
+def main() -> None:
+    run_preview_cli(
+        functions=["summary_plot"],
+        description="Preview summary_plot oracle cases as HTML/PNG.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/figure_specs.json
+++ b/tests/data/figure_specs.json
@@ -277,6 +277,2208 @@
       "backend": null,
       "empty": true
     },
+    "dva_plot[matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 2.2638,
+                "last": 1623.142201,
+                "n": 359
+              },
+              "y": {
+                "first": 0.003115,
+                "last": 0.005945,
+                "n": 359
+              }
+            },
+            {
+              "label": "_child1",
+              "x": {
+                "first": 1.179813,
+                "last": 1753.914031,
+                "n": 744
+              },
+              "y": {
+                "first": -0.169177,
+                "last": -0.000127,
+                "n": 744
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 2.29052,
+                "last": 1697.273182,
+                "n": 371
+              },
+              "y": {
+                "first": 0.003246,
+                "last": 0.006198,
+                "n": 371
+              }
+            },
+            {
+              "label": "_child3",
+              "x": {
+                "first": 2.021289,
+                "last": 1565.45517,
+                "n": 388
+              },
+              "y": {
+                "first": -0.022483,
+                "last": -0.000194,
+                "n": 388
+              }
+            },
+            {
+              "label": "_child4",
+              "x": {
+                "first": 2.297113,
+                "last": 1729.21116,
+                "n": 377
+              },
+              "y": {
+                "first": 0.003506,
+                "last": 0.006183,
+                "n": 377
+              }
+            },
+            {
+              "label": "_child5",
+              "x": {
+                "first": 2.040219,
+                "last": 1583.681518,
+                "n": 389
+              },
+              "y": {
+                "first": -0.022697,
+                "last": -0.00019,
+                "n": 389
+              }
+            },
+            {
+              "label": "_child6",
+              "x": {
+                "first": 3.614628,
+                "last": 1572.362994,
+                "n": 218
+              },
+              "y": {
+                "first": 0.003251,
+                "last": 0.006025,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child7",
+              "x": {
+                "first": 3.214657,
+                "last": 1514.103298,
+                "n": 236
+              },
+              "y": {
+                "first": -0.02235,
+                "last": -0.00022,
+                "n": 236
+              }
+            },
+            {
+              "label": "_child8",
+              "x": {
+                "first": 3.605102,
+                "last": 1531.69924,
+                "n": 213
+              },
+              "y": {
+                "first": 0.00301,
+                "last": 0.005932,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child9",
+              "x": {
+                "first": 3.298624,
+                "last": 1467.88751,
+                "n": 223
+              },
+              "y": {
+                "first": -0.01962,
+                "last": -0.000259,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child10",
+              "x": {
+                "first": 3.59149,
+                "last": 1533.566086,
+                "n": 214
+              },
+              "y": {
+                "first": 0.003034,
+                "last": 0.005975,
+                "n": 214
+              }
+            },
+            {
+              "label": "_child11",
+              "x": {
+                "first": 3.297568,
+                "last": 1467.417869,
+                "n": 223
+              },
+              "y": {
+                "first": -0.019585,
+                "last": -0.000224,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child12",
+              "x": {
+                "first": 3.604932,
+                "last": 1531.62592,
+                "n": 213
+              },
+              "y": {
+                "first": 0.002939,
+                "last": 0.0059,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child13",
+              "x": {
+                "first": 3.312114,
+                "last": 1467.266303,
+                "n": 222
+              },
+              "y": {
+                "first": -0.019516,
+                "last": -0.000199,
+                "n": 222
+              }
+            },
+            {
+              "label": "_child14",
+              "x": {
+                "first": 3.580444,
+                "last": 1528.848381,
+                "n": 214
+              },
+              "y": {
+                "first": 0.003087,
+                "last": 0.005951,
+                "n": 214
+              }
+            },
+            {
+              "label": "_child15",
+              "x": {
+                "first": 3.314813,
+                "last": 1461.832266,
+                "n": 221
+              },
+              "y": {
+                "first": -0.019491,
+                "last": -0.000216,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child16",
+              "x": {
+                "first": 3.612607,
+                "last": 1570.92893,
+                "n": 218
+              },
+              "y": {
+                "first": 0.00304,
+                "last": 0.005907,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child17",
+              "x": {
+                "first": 3.353583,
+                "last": 1505.758716,
+                "n": 225
+              },
+              "y": {
+                "first": -0.019358,
+                "last": -0.000224,
+                "n": 225
+              }
+            },
+            {
+              "label": "_child18",
+              "x": {
+                "first": 3.590966,
+                "last": 1524.536311,
+                "n": 213
+              },
+              "y": {
+                "first": 0.002939,
+                "last": 0.005865,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child19",
+              "x": {
+                "first": 3.310443,
+                "last": 1459.905143,
+                "n": 221
+              },
+              "y": {
+                "first": -0.019417,
+                "last": -0.000278,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child20",
+              "x": {
+                "first": 3.588555,
+                "last": 1538.906905,
+                "n": 215
+              },
+              "y": {
+                "first": 0.003025,
+                "last": 0.005832,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child21",
+              "x": {
+                "first": 3.344725,
+                "last": 1474.466769,
+                "n": 221
+              },
+              "y": {
+                "first": -0.019069,
+                "last": -0.000218,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child22",
+              "x": {
+                "first": 3.581916,
+                "last": 1536.168764,
+                "n": 215
+              },
+              "y": {
+                "first": 0.003138,
+                "last": 0.005782,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child23",
+              "x": {
+                "first": 3.338723,
+                "last": 1472.376847,
+                "n": 221
+              },
+              "y": {
+                "first": -0.019122,
+                "last": -0.000231,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child24",
+              "x": {
+                "first": 3.573933,
+                "last": 1568.956624,
+                "n": 220
+              },
+              "y": {
+                "first": 0.003387,
+                "last": 0.005746,
+                "n": 220
+              }
+            },
+            {
+              "label": "_child25",
+              "x": {
+                "first": 3.364825,
+                "last": 1504.076732,
+                "n": 224
+              },
+              "y": {
+                "first": -0.018993,
+                "last": -0.000203,
+                "n": 224
+              }
+            },
+            {
+              "label": "_child26",
+              "x": {
+                "first": 3.591083,
+                "last": 1561.160159,
+                "n": 218
+              },
+              "y": {
+                "first": 0.003177,
+                "last": 0.005642,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child27",
+              "x": {
+                "first": 3.370835,
+                "last": 1499.497541,
+                "n": 223
+              },
+              "y": {
+                "first": -0.01882,
+                "last": -0.000225,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child28",
+              "x": {
+                "first": 3.566889,
+                "last": 1551.596759,
+                "n": 218
+              },
+              "y": {
+                "first": 0.003276,
+                "last": 0.005623,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child29",
+              "x": {
+                "first": 3.376044,
+                "last": 1488.353748,
+                "n": 221
+              },
+              "y": {
+                "first": -0.018903,
+                "last": -0.000201,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child30",
+              "x": {
+                "first": 3.573344,
+                "last": 1582.01468,
+                "n": 222
+              },
+              "y": {
+                "first": 0.003359,
+                "last": 0.005541,
+                "n": 222
+              }
+            },
+            {
+              "label": "_child31",
+              "x": {
+                "first": 3.4067,
+                "last": 1522.794742,
+                "n": 224
+              },
+              "y": {
+                "first": -0.018413,
+                "last": -0.000209,
+                "n": 224
+              }
+            },
+            {
+              "label": "_child32",
+              "x": {
+                "first": 3.549558,
+                "last": 1521.814974,
+                "n": 215
+              },
+              "y": {
+                "first": 0.003153,
+                "last": 0.005501,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child33",
+              "x": {
+                "first": 3.375134,
+                "last": 1461.432685,
+                "n": 217
+              },
+              "y": {
+                "first": -0.018514,
+                "last": -0.000221,
+                "n": 217
+              }
+            },
+            {
+              "label": "_child34",
+              "x": {
+                "first": 1.259543,
+                "last": 238.053613,
+                "n": 95
+              },
+              "y": {
+                "first": -0.030115,
+                "last": -0.000243,
+                "n": 95
+              }
+            }
+          ],
+          "n_collections": 0,
+          "n_lines": 35,
+          "title": "Differential voltage (dV/dQ) for '20160805_test001_45_cc_01'",
+          "xlabel": "Capacity (mAh/g)",
+          "ylabel": "dV/dQ (V/(mAh/g))"
+        },
+        {
+          "lines": [],
+          "n_collections": 2,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "cycle"
+        }
+      ]
+    },
+    "dva_plot[plotly]": {
+      "axis_titles": {
+        "xaxis": "Capacity (mAh/g)",
+        "yaxis": "dV/dQ (V/(mAh/g))"
+      },
+      "backend": "plotly",
+      "n_axes": 2,
+      "n_traces": 36,
+      "traces": [
+        {
+          "mode": "lines",
+          "name": "1",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "1",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "2",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "2",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "3",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "3",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "4",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "4",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "5",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "5",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "6",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "6",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "7",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "7",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "8",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "8",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "9",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "9",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "10",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "10",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "11",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "11",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "12",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "12",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "13",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "13",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "14",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "14",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "15",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "15",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "16",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "16",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "17",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "17",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "18",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "markers",
+          "name": null,
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 1
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 1
+          },
+          "yaxis": "y"
+        }
+      ]
+    },
+    "ica_plot[matplotlib]": {
+      "backend": "matplotlib",
+      "n_panels": 2,
+      "panels": [
+        {
+          "lines": [
+            {
+              "label": "_child0",
+              "x": {
+                "first": 0.111484,
+                "last": 0.998874,
+                "n": 359
+              },
+              "y": {
+                "first": 238.173447,
+                "last": 147.727126,
+                "n": 359
+              }
+            },
+            {
+              "label": "_child1",
+              "x": {
+                "first": 0.051769,
+                "last": 2.838019,
+                "n": 744
+              },
+              "y": {
+                "first": -15658.511436,
+                "last": -1.799207,
+                "n": 744
+              }
+            },
+            {
+              "label": "_child2",
+              "x": {
+                "first": 0.110522,
+                "last": 0.998913,
+                "n": 371
+              },
+              "y": {
+                "first": 217.114558,
+                "last": 139.789138,
+                "n": 371
+              }
+            },
+            {
+              "label": "_child3",
+              "x": {
+                "first": 0.050939,
+                "last": 0.859892,
+                "n": 388
+              },
+              "y": {
+                "first": -7105.643625,
+                "last": -32.121518,
+                "n": 388
+              }
+            },
+            {
+              "label": "_child4",
+              "x": {
+                "first": 0.10835,
+                "last": 0.998929,
+                "n": 377
+              },
+              "y": {
+                "first": 194.06173,
+                "last": 140.447356,
+                "n": 377
+              }
+            },
+            {
+              "label": "_child5",
+              "x": {
+                "first": 0.050915,
+                "last": 0.843288,
+                "n": 389
+              },
+              "y": {
+                "first": -5510.106683,
+                "last": -31.348722,
+                "n": 389
+              }
+            },
+            {
+              "label": "_child6",
+              "x": {
+                "first": 0.141778,
+                "last": 0.99814,
+                "n": 218
+              },
+              "y": {
+                "first": 225.785439,
+                "last": 148.471152,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child7",
+              "x": {
+                "first": 0.051553,
+                "last": 0.831565,
+                "n": 236
+              },
+              "y": {
+                "first": -4732.243189,
+                "last": -35.32372,
+                "n": 236
+              }
+            },
+            {
+              "label": "_child8",
+              "x": {
+                "first": 0.15319,
+                "last": 0.998121,
+                "n": 213
+              },
+              "y": {
+                "first": 245.82527,
+                "last": 151.830864,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child9",
+              "x": {
+                "first": 0.05156,
+                "last": 0.791222,
+                "n": 223
+              },
+              "y": {
+                "first": -3775.819522,
+                "last": -40.075071,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child10",
+              "x": {
+                "first": 0.152259,
+                "last": 0.998128,
+                "n": 214
+              },
+              "y": {
+                "first": 243.900653,
+                "last": 150.232557,
+                "n": 214
+              }
+            },
+            {
+              "label": "_child11",
+              "x": {
+                "first": 0.051548,
+                "last": 0.785999,
+                "n": 223
+              },
+              "y": {
+                "first": -4570.705469,
+                "last": -40.127557,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child12",
+              "x": {
+                "first": 0.153804,
+                "last": 0.998122,
+                "n": 213
+              },
+              "y": {
+                "first": 251.394035,
+                "last": 153.000395,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child13",
+              "x": {
+                "first": 0.051554,
+                "last": 0.785377,
+                "n": 222
+              },
+              "y": {
+                "first": -4738.829127,
+                "last": -40.241962,
+                "n": 222
+              }
+            },
+            {
+              "label": "_child14",
+              "x": {
+                "first": 0.152259,
+                "last": 0.998128,
+                "n": 214
+              },
+              "y": {
+                "first": 239.93641,
+                "last": 151.615967,
+                "n": 214
+              }
+            },
+            {
+              "label": "_child15",
+              "x": {
+                "first": 0.051553,
+                "last": 0.781376,
+                "n": 221
+              },
+              "y": {
+                "first": -4899.865716,
+                "last": -40.228623,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child16",
+              "x": {
+                "first": 0.142699,
+                "last": 0.998142,
+                "n": 218
+              },
+              "y": {
+                "first": 245.341863,
+                "last": 152.514479,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child17",
+              "x": {
+                "first": 0.051526,
+                "last": 0.782942,
+                "n": 225
+              },
+              "y": {
+                "first": -5229.448419,
+                "last": -40.443388,
+                "n": 225
+              }
+            },
+            {
+              "label": "_child18",
+              "x": {
+                "first": 0.154419,
+                "last": 0.998124,
+                "n": 213
+              },
+              "y": {
+                "first": 254.68566,
+                "last": 154.215702,
+                "n": 213
+              }
+            },
+            {
+              "label": "_child19",
+              "x": {
+                "first": 0.051549,
+                "last": 0.77984,
+                "n": 221
+              },
+              "y": {
+                "first": -3913.631893,
+                "last": -40.300883,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child20",
+              "x": {
+                "first": 0.149792,
+                "last": 0.998131,
+                "n": 215
+              },
+              "y": {
+                "first": 246.723846,
+                "last": 155.24848,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child21",
+              "x": {
+                "first": 0.051541,
+                "last": 0.776461,
+                "n": 221
+              },
+              "y": {
+                "first": -5307.4525,
+                "last": -41.097919,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child22",
+              "x": {
+                "first": 0.148564,
+                "last": 0.998129,
+                "n": 215
+              },
+              "y": {
+                "first": 236.212215,
+                "last": 157.419053,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child23",
+              "x": {
+                "first": 0.051538,
+                "last": 0.774925,
+                "n": 221
+              },
+              "y": {
+                "first": -4911.156896,
+                "last": -40.854314,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child24",
+              "x": {
+                "first": 0.138073,
+                "last": 0.99815,
+                "n": 220
+              },
+              "y": {
+                "first": 217.116025,
+                "last": 158.671256,
+                "n": 220
+              }
+            },
+            {
+              "label": "_child25",
+              "x": {
+                "first": 0.051512,
+                "last": 0.773103,
+                "n": 224
+              },
+              "y": {
+                "first": -5541.407055,
+                "last": -41.076373,
+                "n": 224
+              }
+            },
+            {
+              "label": "_child26",
+              "x": {
+                "first": 0.141163,
+                "last": 0.998139,
+                "n": 218
+              },
+              "y": {
+                "first": 234.064453,
+                "last": 162.509902,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child27",
+              "x": {
+                "first": 0.051516,
+                "last": 0.77156,
+                "n": 223
+              },
+              "y": {
+                "first": -5202.306612,
+                "last": -41.411409,
+                "n": 223
+              }
+            },
+            {
+              "label": "_child28",
+              "x": {
+                "first": 0.14147,
+                "last": 0.99814,
+                "n": 218
+              },
+              "y": {
+                "first": 224.991287,
+                "last": 163.33468,
+                "n": 218
+              }
+            },
+            {
+              "label": "_child29",
+              "x": {
+                "first": 0.051525,
+                "last": 0.769088,
+                "n": 221
+              },
+              "y": {
+                "first": -5433.232398,
+                "last": -41.101974,
+                "n": 221
+              }
+            },
+            {
+              "label": "_child30",
+              "x": {
+                "first": 0.132218,
+                "last": 0.998154,
+                "n": 222
+              },
+              "y": {
+                "first": 221.381215,
+                "last": 166.455178,
+                "n": 222
+              }
+            },
+            {
+              "label": "_child31",
+              "x": {
+                "first": 0.051493,
+                "last": 0.764808,
+                "n": 224
+              },
+              "y": {
+                "first": -5524.437282,
+                "last": -42.204436,
+                "n": 224
+              }
+            },
+            {
+              "label": "_child32",
+              "x": {
+                "first": 0.147335,
+                "last": 0.998126,
+                "n": 215
+              },
+              "y": {
+                "first": 236.226145,
+                "last": 168.676828,
+                "n": 215
+              }
+            },
+            {
+              "label": "_child33",
+              "x": {
+                "first": 0.051534,
+                "last": 0.760149,
+                "n": 217
+              },
+              "y": {
+                "first": -5116.907717,
+                "last": -41.870817,
+                "n": 217
+              }
+            },
+            {
+              "label": "_child34",
+              "x": {
+                "first": 0.296506,
+                "last": 0.754733,
+                "n": 95
+              },
+              "y": {
+                "first": -4941.30151,
+                "last": -27.6495,
+                "n": 95
+              }
+            }
+          ],
+          "n_collections": 0,
+          "n_lines": 35,
+          "title": "Incremental capacity (dQ/dV) for '20160805_test001_45_cc_01'",
+          "xlabel": "Voltage (V)",
+          "ylabel": "dQ/dV (mAh/g/V)"
+        },
+        {
+          "lines": [],
+          "n_collections": 2,
+          "n_lines": 0,
+          "title": "",
+          "xlabel": "",
+          "ylabel": "cycle"
+        }
+      ]
+    },
+    "ica_plot[plotly]": {
+      "axis_titles": {
+        "xaxis": "Voltage (V)",
+        "yaxis": "dQ/dV (mAh/g/V)"
+      },
+      "backend": "plotly",
+      "n_axes": 2,
+      "n_traces": 36,
+      "traces": [
+        {
+          "mode": "lines",
+          "name": "1",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "1",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "2",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "2",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "3",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "3",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "4",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "4",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "5",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "5",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "6",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "6",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "7",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "7",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "8",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "8",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "9",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "9",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "10",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "10",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "11",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "11",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "12",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "12",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "13",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "13",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "14",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "14",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "15",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "15",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "16",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "16",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "17",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "17",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "lines",
+          "name": "18",
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 2
+          },
+          "yaxis": "y"
+        },
+        {
+          "mode": "markers",
+          "name": null,
+          "type": "scatter",
+          "x": {
+            "first": null,
+            "last": null,
+            "n": 1
+          },
+          "xaxis": "x",
+          "y": {
+            "first": null,
+            "last": null,
+            "n": 1
+          },
+          "yaxis": "y"
+        }
+      ]
+    },
     "raw_plot[matplotlib]": {
       "backend": "matplotlib",
       "n_panels": 2,

--- a/tests/figure_spec_support.py
+++ b/tests/figure_spec_support.py
@@ -145,7 +145,8 @@ def describe_figure(figure) -> dict[str, Any]:
 
 #: Every predefined y-set `summary_plot` accepts — sourced from the PlotFamily
 #: registry (#636) so the oracle menu cannot drift from the runtime menu.
-#: Non-summary families (e.g. ``cycles`` for ``cycles_plot``, #646) are excluded.
+#: Non-summary families (e.g. ``cycles`` for ``cycles_plot``, #646;
+#: ``raw`` / ``cycle_info``, #647; ``ica`` / ``dva``, #648) are excluded.
 SUMMARY_FAMILIES = tuple(
     name for name, _description in _plot_families(entry_point="summary_plot")
 )
@@ -250,6 +251,28 @@ def _other_family_cases() -> list[FigureCase]:
         FigureCase(
             name="cycles_plot[matplotlib]",
             function="cycles_plot",
+            kwargs={"backend": "matplotlib"},
+        ),
+        FigureCase(
+            name="ica_plot[plotly]",
+            function="ica_plot",
+            kwargs={"backend": "plotly"},
+            needs_plotly=True,
+        ),
+        FigureCase(
+            name="ica_plot[matplotlib]",
+            function="ica_plot",
+            kwargs={"backend": "matplotlib"},
+        ),
+        FigureCase(
+            name="dva_plot[plotly]",
+            function="dva_plot",
+            kwargs={"backend": "plotly"},
+            needs_plotly=True,
+        ),
+        FigureCase(
+            name="dva_plot[matplotlib]",
+            function="dva_plot",
             kwargs={"backend": "matplotlib"},
         ),
     ]

--- a/tests/test_cycle_legend.py
+++ b/tests/test_cycle_legend.py
@@ -1,0 +1,41 @@
+"""Tests for shared cycle legend vs colorbar policy (#648)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.plotting.cycle_legend import (
+    DEFAULT_LEGEND_CYCLE_LIMIT,
+    pop_cycle_legend_options,
+    resolve_cycle_legend_mode,
+)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    ("n", "kwargs", "expected"),
+    [
+        (1, {}, "legend"),
+        (DEFAULT_LEGEND_CYCLE_LIMIT, {}, "legend"),
+        (DEFAULT_LEGEND_CYCLE_LIMIT + 1, {}, "colorbar"),
+        (3, {"force_colorbar": True}, "colorbar"),
+        (20, {"force_legend": True}, "legend"),
+        (20, {"force_colorbar": True, "force_legend": True}, "legend"),
+    ],
+)
+def test_resolve_cycle_legend_mode(n, kwargs, expected):
+    assert resolve_cycle_legend_mode(n, **kwargs) == expected
+
+
+@pytest.mark.essential
+def test_pop_cycle_legend_options_kwargs_win_and_consume():
+    extras = {"legend_cycle_limit": 5, "force_colorbar": True}
+    kwargs = {"legend_cycle_limit": 12, "force_nonbar": True}
+    opts = pop_cycle_legend_options(extras, kwargs)
+    assert opts == {
+        "legend_cycle_limit": 12,
+        "force_colorbar": True,
+        "force_legend": True,
+    }
+    assert "legend_cycle_limit" not in kwargs
+    assert "force_nonbar" not in kwargs

--- a/tests/test_ica_plot_prepare.py
+++ b/tests/test_ica_plot_prepare.py
@@ -1,0 +1,107 @@
+"""Tests for ica_plot / dva_plot prepare → spec → render (#648)."""
+
+from __future__ import annotations
+
+import ast
+import warnings
+from pathlib import Path
+
+import pytest
+
+from cellpy.ica import CHARGE, DISCHARGE, ICA_COLS
+from cellpy.plotting.context import from_source
+from cellpy.plotting.prepare.ica import IcaPrepareConfig, prepare as prepare_ica
+from cellpy.plotting import registry as plot_registry
+from cellpy.utils.plotutils import dva_plot, ica_plot
+
+
+@pytest.mark.essential
+def test_prepare_ica_module_does_not_import_converter():
+    source = Path("cellpy/plotting/prepare/ica.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                imported_names.add(alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_names.add(alias.name.split(".")[-1])
+    assert "Converter" not in imported_names
+    assert "to_wide" not in imported_names
+
+
+@pytest.mark.essential
+def test_prepare_ica_returns_ica_spec(cell):
+    family = plot_registry.get("ica")
+    ctx = from_source(cell)
+    config = IcaPrepareConfig(derivative="dqdv", cycles=1, backend="matplotlib")
+    frame, spec = prepare_ica(ctx, family, config)
+    assert not frame.empty
+    assert spec.extras.get("kind") == "ica"
+    assert ICA_COLS.dqdv in frame.columns
+    assert ICA_COLS.legacy_dqdv not in frame.columns
+    assert {CHARGE, DISCHARGE} <= set(frame[ICA_COLS.direction].unique())
+
+
+@pytest.mark.essential
+def test_prepare_dva_returns_dva_spec(cell):
+    family = plot_registry.get("dva")
+    ctx = from_source(cell)
+    config = IcaPrepareConfig(derivative="dvdq", cycles=1, backend="matplotlib")
+    frame, spec = prepare_ica(ctx, family, config)
+    assert not frame.empty
+    assert spec.extras.get("kind") == "dva"
+    assert ICA_COLS.dvdq in frame.columns
+    assert {CHARGE, DISCHARGE} <= set(frame[ICA_COLS.direction].unique())
+
+
+@pytest.mark.essential
+def test_ica_plot_backend_matplotlib(cell):
+    fig = ica_plot(cell, cycles=1, backend="matplotlib")
+    assert fig is not None
+    assert hasattr(fig, "get_axes")
+
+
+@pytest.mark.essential
+def test_dva_plot_backend_matplotlib(cell):
+    fig = dva_plot(cell, cycles=1, backend="matplotlib")
+    assert fig is not None
+    assert hasattr(fig, "get_axes")
+
+
+@pytest.mark.essential
+def test_ica_plot_interactive_alias_warns(cell):
+    from cellpy import _deprecation
+
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        fig = ica_plot(cell, cycles=1, interactive=False)
+    assert fig is not None
+    messages = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "interactive" in str(w.message)
+    ]
+    assert messages
+    assert "backend=" in messages[0] or "matplotlib" in messages[0]
+
+
+@pytest.mark.essential
+def test_dva_plot_interactive_alias_warns(cell):
+    from cellpy import _deprecation
+
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        fig = dva_plot(cell, cycles=1, interactive=False)
+    assert fig is not None
+    messages = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "interactive" in str(w.message)
+    ]
+    assert messages


### PR DESCRIPTION
## Summary
- Add public `ica_plot` / `dva_plot` through prepare → spec → render, consuming `cellpy.ica.dqdv` / `dvdq` long frames (cell-centric `direction`, shared line style, plotly hover shows charge/discharge).
- Shared cycle legend policy (`cellpy.plotting.cycle_legend`): discrete legend for ≤8 cycles, colorbar otherwise.
- Manual visual preview scripts under `dev/` (`preview_ica_plots.py`, etc.).

Closes #648.

## Test plan
- [x] `MPLBACKEND=Agg uv run pytest tests/test_cycle_legend.py tests/test_ica_plot_prepare.py tests/test_figure_specs.py`
- [x] `MPLBACKEND=Agg uv run pytest -m essential --ignore=tests/test_arbin_variants_two_stage.py`
- [x] Optional: `uv run python dev/preview_ica_plots.py --open`

## Notes
- Related discovery (not fixed here): CV-split summary rows use dead `selector_type` — #654.

Made with [Cursor](https://cursor.com)