### PR TITLE
Complete cli_api extraction for remaining CLI commands

### DIFF
--- a/.issueflows/03-solved-issues/issue651_original.md
+++ b/.issueflows/03-solved-issues/issue651_original.md
@@ -1,0 +1,82 @@
+# Issue #651: Complete cli_api extraction for remaining CLI commands (new, serve, setup, â€¦)
+
+Source: https://github.com/jepegit/cellpy/issues/651
+
+## Original issue text
+
+## Goal
+
+Finish the library-first `cli_api` extraction that #568 started. Remaining command logic still lives in `cellpy/cli.py` and is not callable from scripts without shelling out.
+
+Plan of record: [`architecture-plan/cellpy2-cli-redesign-plan.md`](https://github.com/jepegit/cellpy/blob/master/../architecture-plan) Phase 1 (command-by-command). Parent extraction: #568 / PR #586.
+
+## Why
+
+#568 explicitly left these in `cli.py`:
+
+- `setup` (+ `setup migrate`)
+- `info`
+- `edit`
+- `pull`
+- `new`
+- `serve`
+
+Several are interactive (prompts, cookiecutter, Jupyter). That is fine for a CLI wrapper, but the **core behaviour** should still be reachable as ordinary typed functions with a quiet default â€” same contract as today's `cli_api.convert` / `run_journal`.
+
+## Pattern (especially for `_new`-shaped commands)
+
+Do **not** call `typer.echo` (or `print`) inside the library function. Inject output:
+
+```python
+def create_project(..., echo: Echo | None = None) -> Path | None:
+    say = _resolve_echo(echo)   # None â†’ silent
+    say("Template: â€¦")
+```
+
+CLI stays thin:
+
+```python
+@cli.command()
+def new(...):
+    cli_api.create_project(..., echo=typer.echo)
+```
+
+When moving a function like `_new`, move its helpers with it (or leave thin CLI-only wrappers):
+
+| Helper | Notes |
+|--------|--------|
+| `_get_default_template` / `_read_local_templates` | template discovery |
+| `_get_author_name` | may echo on failure |
+| `_serve` | shared by `serve` and `new --serve` |
+| `_run_project` | already delegates to `cli_api.run_project` |
+
+Also align with existing `cli_api` conventions:
+
+- `echo: Optional[Echo] = None` + `_resolve_echo` (quiet by default â€” **not** `echo=print`)
+- Prefer returning useful values (`Path` to created project, list of templates, â€¦) instead of only printing
+- Interactive pieces (`cookiecutter.prompt.*`, bare `input(...)`, `os.chdir`) either stay documented as interactive-only, get injected (`prompt=` / `confirm=`), or stay in `cli.py` while a non-interactive core moves first
+
+Known footgun while touching `_new`: cookiecutter `ModuleNotFoundError` currently echoes and **continues** (no `return`) â†’ later `NameError`. Fix on the way through.
+
+## Suggested order (from the CLI plan)
+
+1. `info` / `serve` / `edit` â€” small; prove the pattern again
+2. `pull` â€” download helpers
+3. `new` â€” template registry + cookiecutter (`_new` + helpers)
+4. `setup` (+ `migrate`) â€” hardest; coordinate with config Step 5 if still relevant
+
+Each PR: move logic â†’ CLI calls it â†’ tests hit both `cli_api` and the Typer command. No user-visible CLI change.
+
+## Acceptance
+
+- [ ] Each remaining command's logic is importable from `cellpy.cli_api` (or a domain package re-exported there) without a Typer context
+- [ ] Library functions are quiet by default; CLI passes `typer.echo` for identical terminal output
+- [ ] Helpers needed by moved functions live with them (not stranded as private CLI-only deps)
+- [ ] Existing CLI tests still pass; add/extend `tests/test_cli_api.py` for the new surfaces
+- [ ] Optional stretch: non-interactive path for `new` when `project` + `experiment` + `no_input` are provided
+
+## Out of scope
+
+- Redesigning templates / replacing cookiecutter
+- New CLI flags or UX changes
+- Docs "Automating cellpy" recipes (CLI plan Phase 3) â€” follow-up after the moves

--- a/.issueflows/03-solved-issues/issue651_plan.md
+++ b/.issueflows/03-solved-issues/issue651_plan.md
@@ -1,0 +1,112 @@
+# Plan: Issue #651 — Complete `cli_api` extraction
+
+## Goal
+
+Move the remaining CLI command logic (`info`, `serve`, `edit`, `pull`, `new`,
+`setup` + `migrate`) out of [`cellpy/cli.py`](cellpy/cli.py) into
+[`cellpy/cli_api.py`](cellpy/cli_api.py) so scripts can call the same behaviour
+without a Typer context. CLI stays a thin adapter (`echo=typer.echo`). No
+user-visible flag/UX changes.
+
+## Constraints
+
+- Behaviour-preserving move (CLI plan Phase 1). Exception already named in the
+  issue: fix `_new`'s cookiecutter `ModuleNotFoundError` path (echo-then-continue
+  → `NameError`); early `return` after the install hint.
+- Quiet by default: `echo: Optional[Echo] = None` + `_resolve_echo`. Never
+  hard-code `typer.echo` / `print` as the library default (clean
+  `_create_dir` when setup moves — it still calls `typer.echo` today).
+- Keep Typer annotations and command registration in `cli.py`. Do **not** split
+  into `cellpy/cli/` package or `cli_api/` package in this issue (that is a
+  later layout step in the CLI plan).
+- Out of scope: template redesign, new flags, "Automating cellpy" docs (Phase 3).
+- Existing CLI smoke in [`tests/test_cellpy_cmd.py`](tests/test_cellpy_cmd.py)
+  and surface snapshot in [`tests/test_cli_surface.py`](tests/test_cli_surface.py)
+  must stay green.
+
+### Prior art
+
+- [`cellpy/cli_api.py`](cellpy/cli_api.py) — pattern to **mirror**: `Echo`,
+  `_resolve_echo`, `convert`, `run_journal` / `run_journals` / `run_from_db` /
+  `run_project`, `list_journals`, `open_db_editor` (#568 / PR #586).
+- [`tests/test_cli_api.py`](tests/test_cli_api.py) — assert importability,
+  quiet-by-default, return values; CliRunner smoke that CLI still speaks.
+- [`architecture-plan/cellpy2-cli-redesign-plan.md`](../architecture-plan/cellpy2-cli-redesign-plan.md)
+  § Phase 1 order (easy → hard). `run` / `convert` already done.
+- Toolbox: nothing CLI-related in `.issueflows/00-tools/`.
+- Graph: no `cli_api` hits in `GRAPH_REPORT.md` — grep-only was enough.
+
+## Approach
+
+Extract in this order (same as the issue / CLI plan), committing per command
+so review stays readable:
+
+1. **`info`** — move `_version`, `_configloc`, `_envloc`, `_dump_params`,
+   `_dump_config_resolved`, and the `_check*` stack used by `--check` into
+   `cli_api` (names like `show_version`, `config_path`, `diagnose` / keep
+   private helpers with `_` if they are only for info). Public facade returns
+   useful values where cheap (e.g. config `Path`); diagnose may keep echo-driven
+   reporting like today.
+2. **`serve`** — `start_jupyter(lab=…, directory=…, executable=…, echo=…)`.
+   Keep `os.chdir` behaviour documented; resolve `home` / `here` / default
+   notebookdir in the library function (CLI only passes argv).
+3. **`edit`** — resolve target file + launch editor via subprocess; reuse
+   `open_db_editor` for `db`. Guard `name is None` before `.lower()` if the
+   current path can NPE (fix only if the move would otherwise preserve a
+   crash on `cellpy edit` with no args — verify against existing tests first).
+4. **`pull`** — move `_pull`, download/clone helpers
+   (`_download_g_blob`, `_parse_g_*`, `_pull_tests`, `_pull_examples`, …).
+   Stay in `cli_api` for this issue (do not invent `example_data` relocation).
+5. **`new`** — move `_new` + `_get_default_template`, `_read_local_templates`,
+   `_get_author_name`. Share `_serve` / `run_project` with serve/run. Inject
+   `echo=`. Cookiecutter prompts may remain interactive inside the library for
+   now (document); stretch: when `project` + `experiment` + `no_input` are set,
+   take the non-interactive path without prompts. **Fix** the missing-cookiecutter
+   early return.
+6. **`setup` (+ `migrate`)** — largest block. Move write/migrate/folder helpers
+   and silent/dry-run paths first; interactive `_ask_about_*` either:
+   - stay callable from library with injected `prompt=` / `confirm=` defaults
+     that use `input`, or
+   - remain in `cli.py` while silent `setup_config(...)` / `migrate_config(...)`
+     live in `cli_api`.
+   Prefer the second only if the first blows the diff; default attempt is
+   **full move with `echo` + optional prompt callables**, matching the CLI plan's
+   SilentPrompt idea without introducing a new protocol module unless needed.
+
+After each move: Typer command body becomes parse → `cli_api.*(…, echo=typer.echo)`.
+
+Extend `test_every_extracted_command_is_importable` and add focused
+`test_cli_api` cases (quiet default + one return-value or spy per command).
+Rely on existing `test_cellpy_cmd` for CLI parity.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| [`cellpy/cli_api.py`](cellpy/cli_api.py) | Add `info` / `serve` / `edit` / `pull` / `new` / `setup` (+ helpers); fix `_create_dir` echo |
+| [`cellpy/cli.py`](cellpy/cli.py) | Thin each command to call `cli_api`; drop moved helpers |
+| [`tests/test_cli_api.py`](tests/test_cli_api.py) | Importability list + new unit coverage |
+| [`tests/test_cellpy_cmd.py`](tests/test_cellpy_cmd.py) | Only if a move breaks an assumption; prefer keep as-is |
+
+No new modules unless a single file becomes unreadable (>~1.5k lines of *new*
+logic); prefer one `cli_api.py` growth matching #568.
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_cli_api.py tests/test_cli_surface.py tests/test_cellpy_cmd.py -m essential
+uv run pytest tests/test_cli_api.py tests/test_cellpy_cmd.py   # broader CLI if needed
+```
+
+New tests: quiet-by-default for at least one function per extracted command;
+`new` missing-cookiecutter returns without raising; setup silent/dry-run still
+creates expected files (existing tests already cover much of this via CLI).
+
+## Open questions
+
+Resolved 2026-07-24 (plan accepted):
+
+1. **PR shape — A.** One PR, ordered commits (info → serve → edit → pull → new → setup).
+2. **Interactive prompts — keep in library.** `input` / `cookiecutter.prompt`
+   stay inside `cli_api` for parity; inject `echo` only. Injectable
+   `prompt=`/`confirm=` only where silent paths or existing tests already need them.

--- a/.issueflows/03-solved-issues/issue651_status.md
+++ b/.issueflows/03-solved-issues/issue651_status.md
@@ -1,0 +1,22 @@
+# Status: Issue #651 — Complete cli_api extraction
+
+- [x] Done
+
+## What's done
+
+- Plan accepted (one PR; prompts stay in library; inject `echo` only).
+- Branch `651-complete-cli-api-extraction`.
+- Moved remaining command logic into `cellpy/cli_api.py`:
+  `setup_config`, `migrate_config`, `show_info`, `start_jupyter`, `edit_file`,
+  `pull_resources`, `create_project` (+ helpers).
+- `cellpy/cli.py` is thin Typer adapters (`echo=typer.echo`).
+- Echo binder (`_using_echo` / `_say`) documented in
+  `.issueflows/04-designs-and-guides/cli-api-echo-binder.md`.
+- Fixed cookiecutter `ModuleNotFoundError` early `return` in `_new`.
+- Guarded `edit` against `name is None` before `.lower()`.
+- Ruff clean; CLI suites green (`test_cli_api` + `test_cli_surface` +
+  `test_cellpy_cmd` → 69 passed).
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/cli-api-echo-binder.md
+++ b/.issueflows/04-designs-and-guides/cli-api-echo-binder.md
@@ -1,0 +1,20 @@
+# CLI API echo binder (`_using_echo` / `_say`)
+
+**Issue:** #651  
+**Context:** Finishing the Phase-1 move of remaining CLI command bodies into
+`cellpy.cli_api` without threading an `echo` callable through every private
+helper (`_check_import_pyodbc`, `_update_paths`, `_new`, …).
+
+**Decision:** Public facades still take `echo: Optional[Echo] = None` and are
+quiet by default (same as `convert` / `run_journal`). Inside a call they bind
+the resolved echo on a `contextvars.ContextVar` via `_using_echo`; private
+helpers report with `_say(...)`.
+
+**Alternatives considered:**
+
+- Thread `echo=` / `say=` through every helper — correct but a huge, noisy
+  mechanical diff for setup/pull/new.
+- Keep `typer.echo` in library code — breaks the quiet-by-default contract.
+
+**Note:** Colour kwargs formerly passed to `typer.echo(..., color="red")` are
+ignored by `_say` (Typer colour was already optional decoration).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Complete cli_api extraction for remaining CLI commands (new, serve, setup, …) (#651).
+
 * Fix summary CV-split plots: use exclude_step_types and full−non_cv instead of dead selector_type (#654).
 
 * Wire Batch.plot to plotting and delete batch_plotters.py (#658).

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -1,141 +1,14 @@
-import getpass
-import logging
-import os
-import pathlib
-import platform
-import subprocess
+"""Typer CLI adapters — thin wrappers around ``cellpy.cli_api`` (#568, #651)."""
+
+from __future__ import annotations
+
 import sys
-import time
-from typing import Annotated, Optional, Union
 from pathlib import Path
+from typing import Annotated, Optional
 
 import typer
 
-import cellpy._version
-from cellpy.exceptions import ConfigFileNotWritten
-from cellpy.parameters import prmreader
-from cellpy.parameters.internal_settings import OTHERPATHS
-from cellpy.internals.connections import OtherPath
-from cellpy.utils.template_registry import REGISTERED_TEMPLATES
-import cellpy.config as config
 from cellpy import cli_api
-from cellpy.cli_api import _create_dir
-
-DIFFICULT_MISSING_MODULES = {}
-
-try:
-    import cookiecutter.exceptions
-    import cookiecutter.main
-    import cookiecutter.prompt
-
-except ModuleNotFoundError:
-    _txt = (
-        "Could not import cookiecutter (used by cellpy new). Try installing it, for example by writing:"
-        "\n\n         python -m pip install cookiecutter\n"
-    )
-    DIFFICULT_MISSING_MODULES["cookiecutter"] = _txt
-
-try:
-    import github
-    from github import Github
-
-except ModuleNotFoundError:
-    _txt = (
-        "Could not import the github library (used by cellpy pull). Try installing it, for example by writing:"
-        "\n\n         python -m pip install github\n"
-    )
-    DIFFICULT_MISSING_MODULES["github"] = _txt
-
-
-try:
-    import sqlalchemy_access
-
-except ModuleNotFoundError:
-    _txt = (
-        "Could not import the sqlalchemy_access library (usually used by when reading arbin .res files "
-        "on windows). If you need it, try installing it by writing:"
-        "\n\n         python -m pip install sqlalchemy-access\n"
-    )
-    DIFFICULT_MISSING_MODULES["sqlalchemy-access"] = _txt
-
-
-try:
-    import lmfit
-
-except ModuleNotFoundError:
-    _txt = (
-        "Could not import the lmfit library (used when fitting ocv rlx data)."
-        " If you think you will need it, try installing it for example by writing:"
-        "\n\n         python -m pip install lmfit\n"
-    )
-    DIFFICULT_MISSING_MODULES["lmfit"] = _txt
-
-
-try:
-    import jinja2_time
-
-except ModuleNotFoundError:
-    _txt = (
-        "Could not import the jinja2_time library (used by cellpy new)."
-        " Try installing it, for example by writing:"
-        "\n\n         python -m pip install jinja2_time\n"
-    )
-    DIFFICULT_MISSING_MODULES["jinja2_time"] = _txt
-
-VERSION = cellpy._version.__version__
-REPO = "jepegit/cellpy"
-USER = "jepegit"
-GITHUB_PWD_VAR_NAME = "GD_PWD"
-DEFAULT_EDITOR = "vim"
-EDITORS = {"Windows": "notepad"}
-
-
-def save_prm_file(prm_filename):
-    """saves (writes) the prms to file"""
-    prmreader._write_prm_file(prm_filename)
-
-
-def dump_env_file(env_filename):
-    """saves (writes) the env to file"""
-    typer.echo(f" dumping env file to {env_filename}")
-    prmreader._write_env_file(env_filename)
-
-
-def get_package_prm_dir():
-    """gets the folder where the cellpy package lives"""
-    return pathlib.Path(cellpy.parameters.__file__).parent
-
-
-def get_default_config_file_path(init_filename=None):
-    """gets the path to the default config-file"""
-    prm_dir = get_package_prm_dir()
-    if not init_filename:
-        init_filename = prmreader.DEFAULT_FILENAME
-    src = prm_dir / init_filename
-    return src
-
-
-def get_dst_file(user_dir, init_filename):
-    """gets the destination path for the config-file"""
-    user_dir = pathlib.Path(user_dir)
-    dst_file = user_dir / init_filename
-    return dst_file
-
-
-def echo_missing_modules():
-    """prints out the missing modules"""
-    for m in DIFFICULT_MISSING_MODULES:
-        print(f"missing module: {m}")
-        print(f"message: {DIFFICULT_MISSING_MODULES[m]}")
-
-
-def _modify_config_file():
-    pass
-
-
-def _create_cellpy_folders():
-    pass
-
 
 cli = typer.Typer(
     name="cellpy",
@@ -144,9 +17,10 @@ cli = typer.Typer(
     add_completion=False,
 )
 
+setup_app = typer.Typer()
+
 
 # ----------------------- setup --------------------------------------
-setup_app = typer.Typer()
 
 
 @setup_app.callback(invoke_without_command=True)
@@ -221,127 +95,20 @@ def setup(
     ] = False,
 ):
     """This will help you to set up cellpy."""
-
     if ctx.invoked_subcommand is not None:
-        # a subcommand (e.g. ``cellpy setup migrate``) runs instead
         return
-
-    typer.echo("[cellpy] (setup)")
-    typer.echo(f"[cellpy] root-dir: {root_dir}")
-
-    # notify of missing 'difficult' or optional modules
-    if not no_deps:
-        typer.echo("[cellpy] checking dependencies")
-        for m in DIFFICULT_MISSING_MODULES:
-            typer.echo(" [cellpy] WARNING! ".center(80, "-"))
-            typer.echo("[cellpy] missing dependencies:")
-            typer.echo(f"[cellpy] - {m}")
-            typer.echo(f"[cellpy] {DIFFICULT_MISSING_MODULES[m]}")
-            typer.echo(
-                "[cellpy] (you can skip this check by using the --no-deps option)"
-            )
-            typer.echo(80 * "-")
-
-    # generate variables
-    init_filename = prmreader.create_custom_init_filename()
-    user_dir, dst_file = prmreader.get_user_dir_and_dst(init_filename)
-    env_file = prmreader.get_env_file_name()
-
-    if dry_run:
-        typer.echo("Create custom init filename and get user_dir and destination")
-        typer.echo("Got the following parameters:")
-        typer.echo(f" - init_filename: {init_filename}")
-        typer.echo(f" - user_dir: {user_dir}")
-        typer.echo(f" - dst_file: {dst_file}")
-        typer.echo(f" - not_relative: {not_relative}")
-
-    if root_dir and not interactive:
-        typer.echo("[cellpy] custom root-dir can only be used in interactive mode")
-        typer.echo("[cellpy] -> setting interactive mode")
-        interactive = True
-
-    if not root_dir:
-        root_dir = user_dir
-        # root_dir = pathlib.Path(os.getcwd())
-    root_dir = pathlib.Path(root_dir)
-
-    if dry_run:
-        typer.echo(f" - root_dir: {root_dir}")
-
-    if test_user:
-        typer.echo(f"[cellpy] (setup) DEV-MODE test_user: {test_user}")
-        init_filename = prmreader.create_custom_init_filename(test_user)
-        user_dir = root_dir
-        dst_file = get_dst_file(user_dir, init_filename)
-        typer.echo(f"[cellpy] (setup) DEV-MODE user_dir: {user_dir}")
-        typer.echo(f"[cellpy] (setup) DEV-MODE dst_file: {dst_file}")
-
-    if not pathlib.Path(dst_file).is_file():
-        typer.echo(f"[cellpy] {dst_file} not found -> I will make one for you")
-        reset = True
-
-    if not pathlib.Path(env_file).is_file():
-        typer.echo(
-            f"[cellpy] {env_file} not found -> I will make one (but you must edit it yourself)"
-        )
-
-    if interactive:
-        typer.echo(" interactive mode ".center(80, "-"))
-        _update_paths(
-            custom_dir=root_dir,
-            relative_home=not not_relative,
-            default_dir=folder_name,
-            dry_run=dry_run,
-            reset=reset,
-            interactive=True,
-        )
-        _write_config_file(user_dir, dst_file, init_filename, dry_run)
-        _write_toml_config_file(dst_file, dry_run, test_user=test_user)
-        _write_env_file(user_dir, env_file, dry_run)
-        _check(dry_run=dry_run)
-
-    else:
-        if reset:
-            _update_paths(
-                user_dir,
-                False,
-                default_dir=folder_name,
-                dry_run=dry_run,
-                reset=True,
-                interactive=False,
-                silent=silent,
-            )
-        _write_config_file(user_dir, dst_file, init_filename, dry_run)
-        _write_toml_config_file(dst_file, dry_run, test_user=test_user)
-        _write_env_file(user_dir, env_file, dry_run)
-        _check(dry_run=dry_run, full_check=False)
-
-
-def _write_toml_config_file(dst_file, dry_run, test_user=None):
-    """Write the ``cellpy.toml`` twin generated from the config models (#454).
-
-    The TOML is the single source of truth going forward (config plan Step 5):
-    it is *generated* from the resolved ``CellpyConfig`` models (secrets
-    excluded), so adding a field is a one-file change in the models. In
-    test-user (DEV) mode the file lands next to the legacy conf instead of the
-    real platform config dir.
-    """
-    from cellpy import config as cellpy_config
-    from cellpy.config import loader as config_loader
-
-    if test_user:
-        toml_path = pathlib.Path(dst_file).with_name("cellpy.toml")
-    else:
-        toml_path = config_loader.user_config_path()
-
-    if dry_run:
-        typer.echo(f"[cellpy] (setup) dry-run: would write {toml_path}")
-        return
-
-    data = cellpy_config.get_config().model_dump_for_file()
-    toml_path.parent.mkdir(parents=True, exist_ok=True)
-    config_loader.write_toml(toml_path, data)
-    typer.echo(f"[cellpy] (setup) wrote {toml_path}")
+    cli_api.setup_config(
+        interactive=interactive,
+        not_relative=not_relative,
+        dry_run=dry_run,
+        reset=reset,
+        root_dir=root_dir,
+        folder_name=folder_name,
+        test_user=test_user,
+        silent=silent,
+        no_deps=no_deps,
+        echo=typer.echo,
+    )
 
 
 @setup_app.command(
@@ -377,580 +144,24 @@ def setup_migrate(
     The old file is left untouched (it keeps working through the v2.0
     deprecation window); the generated TOML takes precedence once present.
     """
-    from cellpy.config import loader as config_loader
-    from cellpy.config import migrate as config_migrate
-
-    if src is None:
-        try:
-            src = prmreader._get_prm_file()
-        except Exception:
-            src = None
-        if src is None or not pathlib.Path(src).is_file():
-            typer.echo(
-                "[cellpy] (setup migrate) no legacy config file found - "
-                "nothing to migrate (run `cellpy setup` to create a fresh one)."
-            )
-            return
-    src = pathlib.Path(src)
-
-    toml_path = pathlib.Path(dst) if dst else config_loader.user_config_path()
-    if toml_path.is_file() and not force:
-        typer.echo(
-            f"[cellpy] (setup migrate) {toml_path} already exists "
-            "- use --force to overwrite."
-        )
-        return
-
-    typer.echo(f"[cellpy] (setup migrate) source: {src}")
-    typer.echo(f"[cellpy] (setup migrate) target: {toml_path}")
-    if dry_run:
-        typer.echo("[cellpy] (setup migrate) dry-run: not writing anything.")
-        return
-
-    toml_path.parent.mkdir(parents=True, exist_ok=True)
-    config_migrate.convert_yaml_file_to_toml(src, toml_path)
-    typer.echo("[cellpy] (setup migrate) done - the old file is kept untouched.")
-
-
-def _update_paths(
-    custom_dir=None,
-    relative_home=True,
-    reset=False,
-    dry_run=False,
-    default_dir=None,
-    silent=False,
-    interactive=False,
-):
-    # please, refactor me :-(
-
-    h = prmreader.get_user_dir()
-
-    if default_dir is None:
-        default_dir = "cellpy_data"
-
-    if dry_run:
-        typer.echo(f" - default_dir: {default_dir}")
-        typer.echo(f" - custom_dir: {custom_dir}")
-        typer.echo(f" - relative_home: {relative_home}")
-
-    if custom_dir:
-        reset = True
-        if relative_home:
-            h = h / custom_dir
-        if not custom_dir.parts[-1] == default_dir:
-            h = h / default_dir
-
-    if not reset:
-        outdatadir = pathlib.Path(config.paths.outdatadir)
-        rawdatadir = OtherPath(config.paths.rawdatadir)
-        cellpydatadir = OtherPath(config.paths.cellpydatadir)
-        filelogdir = pathlib.Path(config.paths.filelogdir)
-        examplesdir = pathlib.Path(config.paths.examplesdir)
-        db_path = pathlib.Path(config.paths.db_path)
-        db_filename = config.paths.db_filename
-        notebookdir = pathlib.Path(config.paths.notebookdir)
-        batchfiledir = pathlib.Path(config.paths.batchfiledir)
-        templatedir = pathlib.Path(config.paths.templatedir)
-        instrumentdir = pathlib.Path(config.paths.instrumentsdir)
-    else:
-        outdatadir = "out"
-        rawdatadir = "raw"
-        cellpydatadir = "cellpyfiles"
-        filelogdir = "logs"
-        examplesdir = "examples"
-        db_path = "db"
-        db_filename = "cellpy_db.xlsx"
-        notebookdir = "notebooks"
-        batchfiledir = "batchfiles"
-        templatedir = "templates"
-        instrumentdir = "instruments"
-
-    outdatadir = h / outdatadir
-    rawdatadir = h / rawdatadir
-    cellpydatadir = h / cellpydatadir
-    filelogdir = h / filelogdir
-    examplesdir = h / examplesdir
-    db_path = h / db_path
-    notebookdir = h / notebookdir
-    batchfiledir = h / batchfiledir
-    templatedir = h / templatedir
-    instrumentdir = h / instrumentdir
-
-    if dry_run:
-        typer.echo(f" - base (h): {h}")
-
-    if interactive:
-        outdatadir = _ask_about_path(
-            "where to output processed data and results", outdatadir
-        )
-        rawdatadir = _ask_about_otherpath("where your raw data are located", rawdatadir)
-        cellpydatadir = _ask_about_otherpath("where to put cellpy-files", cellpydatadir)
-        filelogdir = _ask_about_path("where to dump the log-files", filelogdir)
-        examplesdir = _ask_about_path(
-            "where to download cellpy examples and tests", examplesdir
-        )
-        db_path = _ask_about_path("what folder your db file lives in", db_path)
-        db_filename = _ask_about_name("the name of your db-file", db_filename)
-        notebookdir = _ask_about_path(
-            "where to put your jupyter notebooks", notebookdir
-        )
-        batchfiledir = _ask_about_path("where to put your batch files", batchfiledir)
-        templatedir = _ask_about_path("where to put your batch files", templatedir)
-        instrumentdir = _ask_about_path("where to put your batch files", instrumentdir)
-
-    # update folders based on suggestions
-    for d in [
-        outdatadir,
-        rawdatadir,
-        cellpydatadir,
-        filelogdir,
-        examplesdir,
-        notebookdir,
-        db_path,
-        batchfiledir,
-        templatedir,
-        instrumentdir,
-    ]:
-        if not dry_run:
-            _create_dir(d, confirm=not silent)
-        else:
-            typer.echo(f"dry run (so I did not create {d})")
-
-    # update config-file based on suggestions
-    config.paths.outdatadir = str(outdatadir)
-    config.paths.rawdatadir = str(rawdatadir)
-    config.paths.cellpydatadir = str(cellpydatadir)
-    config.paths.filelogdir = str(filelogdir)
-    config.paths.examplesdir = str(examplesdir)
-    config.paths.db_path = str(db_path)
-    config.paths.db_filename = str(db_filename)
-    config.paths.notebookdir = str(notebookdir)
-    config.paths.batchfiledir = str(batchfiledir)
-    config.paths.templatedir = str(templatedir)
-    config.paths.instrumentdir = str(instrumentdir)
-
-
-def _ask_about_path(q, p):
-    typer.echo(f"\n[cellpy] (setup) input {q}")
-    typer.echo(f"[cellpy] (setup) current: {p}")
-    new_path = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
-    if not new_path:
-        new_path = p
-    return pathlib.Path(new_path)
-
-
-def _ask_about_otherpath(q, p):
-    typer.echo(f"\n[cellpy] (setup) input {q}")
-    typer.echo(f"[cellpy] (setup) current: {p}")
-    new_path = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
-    if not new_path:
-        new_path = p
-    return OtherPath(new_path)
-
-
-def _ask_about_name(q, n):
-    typer.echo(f"\n[cellpy] (setup) input {q}")
-    typer.echo(f"[cellpy] (setup) current: {n}")
-    new_name = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
-    if not new_name:
-        new_name = n
-    return new_name
-
-
-def _check_import_cellpy():
-    try:
-        import cellpy
-        from cellpy import log
-        from cellpy.readers import cellreader
-
-        return True
-    except:
-        typer.echo(" Failed to import cellpy")
-        typer.echo(" Severity: critical")
-        return False
-
-
-def _check_import_pyodbc():
-    import platform
-
-    from cellpy.parameters import prms
-
-    ODBC = prms._odbc
-    SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver
-
-    use_subprocess = config.instruments.Arbin.use_subprocess
-    detect_subprocess_need = config.instruments.Arbin.detect_subprocess_need
-    typer.echo(" This is needed for loading Arbin .res files")
-    typer.echo(" parsing prms")
-    typer.echo(
-        " (from your configuration file if it exists, otherwise using defaults)"
+    cli_api.migrate_config(
+        src=src, dst=dst, dry_run=dry_run, force=force, echo=typer.echo
     )
-    typer.echo(f" - ODBC: {ODBC}")
-    typer.echo(f" - SEARCH_FOR_ODBC_DRIVERS: {SEARCH_FOR_ODBC_DRIVERS}")
-    typer.echo(f" - use_subprocess: {use_subprocess}")
-    typer.echo(f" - detect_subprocess_need: {detect_subprocess_need}")
-    typer.echo(f" - stated office version: {config.instruments.Arbin.office_version}")
-
-    typer.echo(" checking system")
-    is_posix = False
-    is_macos = False
-    if os.name == "posix":
-        is_posix = True
-        typer.echo(" - running on posix")
-    current_platform = platform.system()
-    if current_platform == "Darwin":
-        is_macos = True
-        typer.echo(" - running on a mac")
-
-    python_version, os_version = platform.architecture()
-    typer.echo(f" - python version: {python_version}")
-    typer.echo(f" - os version: {os_version}")
-
-    if not is_posix:
-        if not config.instruments.Arbin.sub_process_path:
-            sub_process_path = str(prms._sub_process_path)
-        else:
-            sub_process_path = str(config.instruments.Arbin.sub_process_path)
-        typer.echo(f" stated path to sub-process: {sub_process_path}")
-        if not os.path.isfile(sub_process_path):
-            typer.echo(" - OBS! missing")
-
-    if is_posix:
-        typer.echo(" checking existence of mdb-export")
-        sub_process_path = "mdb-export"
-        from subprocess import PIPE, run
-
-        command = ["command", "-v", sub_process_path]
-
-        try:
-            typer.echo(f" - trying to run {command}")
-            result = run(
-                command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True
-            )
-            if result.returncode == 0:
-                typer.echo(" - found it!")
-                return True
-
-            typer.echo(f" - could not find {sub_process_path}")
-
-            if is_macos:
-                driver = "/usr/local/lib/libmdbodbc.dylib"
-                typer.echo(
-                    f" looks like you are on a mac. Searching for suitable driver: {driver})"
-                )
-                if not os.path.isfile(driver):
-                    typer.echo(f" - could not find {driver}")
-                    typer.echo(
-                        " ! If you want to load Arbin .res files you will have to install it manually."
-                    )
-                    typer.echo(" - Try installing it with brew:\n")
-                    typer.echo("   brew install mdbtools")
-                    return False
-                typer.echo(f" - found it: {driver}")
-                return True
-            else:
-                typer.echo(
-                    " ! If you want to load Arbin .res files you will have to install it manually."
-                )
-                typer.echo("   For example (for ubuntu):\n")
-                typer.echo("   sudp apt-get update")
-                typer.echo("   sudp apt-get install -y mdbtools")
-            return False
-
-        except AssertionError:
-            typer.echo(" - could not find any suitable driver")
-            return False
-
-    # not posix - checking for odbc drivers
-    # 1) checking if you have defined one
-    try:
-        driver = config.instruments.Arbin.odbc_driver
-        if not driver:
-            raise AttributeError
-        typer.echo(" You have defined an odbc driver in your config file")
-        typer.echo(f" - driver: {driver}")
-    except AttributeError:
-        typer.echo(" FYI: you have not defined any odbc_driver(s)")
-        typer.echo(
-            " (The name of the driver from the configuration file is "
-            "used as a backup when cellpy cannot locate a driver by itself)"
-        )
-
-    use_ado = False
-
-    if ODBC == "ado":
-        use_ado = True
-        typer.echo(" you stated that you prefer the ado loader")
-        typer.echo(" checking if adodbapi is installed")
-        try:
-            import adodbapi as dbloader
-        except ImportError:
-            use_ado = False
-            typer.echo(" Failed! Try setting pyodbc as your loader or install")
-            typer.echo(" adodbapi (http://adodbapi.sourceforge.net/)")
-
-    if not use_ado:
-        if ODBC == "pyodbc":
-            typer.echo(" you stated that you prefer the pyodbc loader")
-            try:
-                import pyodbc as dbloader
-            except ImportError:
-                typer.echo(" Failed! Could not import it.")
-                typer.echo(" Try 'pip install pyodbc'")
-                dbloader = None
-
-        elif ODBC == "pypyodbc":
-            typer.echo(" you stated that you prefer the pypyodbc loader")
-            try:
-                import pypyodbc as dbloader  # type: ignore
-            except ImportError:
-                typer.echo(" Failed! Could not import it.")
-                typer.echo(" try 'pip install pypyodbc'")
-                typer.echo(" or set pyodbc as your loader in your prm file")
-                typer.echo(" (and install it)")
-                dbloader = None
-
-    typer.echo(" searching for odbc drivers")
-    try:
-        drivers = [
-            driver
-            for driver in dbloader.drivers()
-            if "Microsoft Access Driver" in driver
-        ]
-        typer.echo(f" Found these: {drivers}")
-        driver = drivers[0]
-        typer.echo(f" - odbc driver: {driver}")
-        return True
-
-    except IndexError as e:
-        logging.debug(" Unfortunately, it seems the list of drivers is emtpy.")
-        typer.echo(
-            "\n Could not find any odbc-drivers suitable for .res-type files. "
-            "Check out the homepage of pydobc for info on installing drivers"
-        )
-        typer.echo(
-            " One solution that might work is downloading "
-            "the Microsoft Access database engine "
-            "(in correct bytes (32 or 64)) "
-            "from:\n"
-            "https://www.microsoft.com/en-us/download/details.aspx?id=13255"
-        )
-        typer.echo(
-            " Or install mdbtools and set it up (check the cellpy docs for help)"
-        )
-        typer.echo("\n")
-        return False
 
 
-def _check_config_file():
-    prm_file_name = _configloc()
-    env_file_name = _envloc()
-
-    if env_file_name is None:
-        typer.echo(" FYI! Could not locate the environment file")
-
-    if prm_file_name is None:
-        typer.echo(" Could not find the config file")
-        typer.echo(" You can create one by running 'cellpy setup'")
-        return False
-
-    prm_dict = prmreader._read_prm_file_without_updating(prm_file_name)
-    try:
-        prm_paths = prm_dict["Paths"]
-        required_dirs = [
-            "cellpydatadir",
-            "examplesdir",
-            "filelogdir",
-            "notebookdir",
-            "outdatadir",
-            "rawdatadir",
-            "batchfiledir",
-            "templatedir",
-            "db_path",
-        ]
-        missing = 0
-        for k in required_dirs:
-            value = prm_paths.get(k, None)
-            typer.echo(f" - {k}: {value}")
-            # splitting this into two if-statements to make it easier to debug if OtherPath changes
-            if k in OTHERPATHS:
-                print(f" skipping check for external {k} (for now)")
-                # if not OtherPath(
-                #     value
-                # ).is_dir():  # Assuming OtherPath returns True if it is external.
-                #     missing += 1
-                #     typer.echo("COULD NOT CONNECT!")
-                #     typer.echo(f"({value} is not a directory)")
-            elif value and not pathlib.Path(value).is_dir():
-                missing += 1
-                typer.echo(" COULD NOT CONNECT!")
-                typer.echo(f" ({value} is not a directory)")
-            if not value:
-                missing += 1
-                typer.echo(" MISSING")
-
-        value = prm_paths.get("db_filename", None)
-        typer.echo(f" - db_filename: {value}")
-        if not value:
-            missing += 1
-            typer.echo(" MISSING")
-
-        if missing:
-            return False
-        else:
-            return True
-
-    except Exception as e:
-        typer.echo(" Following error occurred:")
-        typer.echo(e)
-        return False
+# Re-exports used by tests / callers that imported helpers from cellpy.cli
+get_package_prm_dir = cli_api.get_package_prm_dir
 
 
-def _check(dry_run=False, full_check=True):
-    typer.echo(" checking ".center(80, "="))
-    if dry_run:
-        typer.echo("*** dry-run: skipping the test")
-        return
-    failed_checks = 0
-    number_of_checks = 0
-
-    def sub_check(check_type, check_func):
-        failed = 0
-        typer.echo(f"[cellpy] * - Checking {check_type}")
-        if check_func():
-            typer.echo("[cellpy] -> succeeded!")
-        else:
-            typer.echo("f[cellpy] -> failed!!!!")
-            failed = 1
-        typer.echo(80 * "-")
-        return failed
-
-    check_types = [
-        "cellpy imports",
-        "importing pyodbc",
-    ]
-    check_funcs = [
-        _check_import_cellpy,
-        _check_import_pyodbc,
-    ]
-
-    # additional checks that require loading the config file (not a part of setup)
-    additional_types = ["configuration files"]
-    additional_funcs = [_check_config_file]
-    if full_check:
-        check_types.extend(additional_types)
-        check_funcs.extend(additional_funcs)
-
-    for ct, cf in zip(check_types, check_funcs):
-        try:
-            failed_checks += sub_check(ct, cf)
-        except Exception as e:
-            typer.echo(f"[cellpy] check raised an exception ({e})")
-        number_of_checks += 1
-    typer.echo(" results ".center(80, "="))
-    succeeded_checks = number_of_checks - failed_checks
-
-    if failed_checks > 0:
-        typer.echo(
-            "[cellpy] Some of the checks failed! This could potentially be a problem."
-        )
-        typer.echo(f"[cellpy] Failed {failed_checks} out of {number_of_checks} checks.")
-    else:
-        typer.echo(
-            f"[cellpy] Succeeded {succeeded_checks} out of {number_of_checks} checks."
-        )
-    typer.echo(80 * "=")
-
-
-def _write_config_file(user_dir, dst_file, init_filename, dry_run):
-    typer.echo(" update configuration ".center(80, "-"))
-    typer.echo("[cellpy] (setup) Writing configurations to user directory:")
-    typer.echo(f"\n         {user_dir}\n")
-
-    if os.path.isfile(dst_file):
-        typer.echo("[cellpy] (setup) File already exists!")
-        typer.echo("[cellpy] (setup) Keeping most of the old configuration parameters")
-    try:
-        if dry_run:
-            typer.echo(
-                f"*** dry-run: skipping actual saving of {dst_file} ***", color="red"
-            )
-        else:
-            typer.echo(f"[cellpy] (setup) Saving file ({dst_file})")
-            save_prm_file(dst_file)
-
-    except ConfigFileNotWritten:
-        typer.echo("[cellpy] (setup) Something went wrong! Could not write the file")
-        typer.echo(
-            "[cellpy] (setup) Trying to write a file"
-            + f"called {prmreader.DEFAULT_FILENAME} instead"
-        )
-
-        try:
-            user_dir, dst_file = prmreader.get_user_dir_and_dst(init_filename)
-            if dry_run:
-                typer.echo(
-                    f"*** dry-run: skipping actual saving of {dst_file} ***",
-                    color="red",
-                )
-            else:
-                save_prm_file(dst_file)
-
-        except ConfigFileNotWritten:
-            _txt = "[cellpy] (setup) No, that did not work either.\n"
-            _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
-            typer.echo(_txt)
-    else:
-        typer.echo("[cellpy] (setup) Configuration file written!")
-        typer.echo(
-            "[cellpy] (setup) OK! Now you can edit it. For example by "
-            f"issuing \n\n         [your-favourite-editor] {init_filename}\n"
-        )
-
-
-def _write_env_file(user_dir, dst_file, dry_run):
-    typer.echo(" update configuration ".center(80, "-"))
-    typer.echo("[cellpy] (setup) Writing environment file:")
-    typer.echo(f"\n         {dst_file}\n")
-
-    if os.path.isfile(dst_file):
-        typer.echo(f"[cellpy] (setup) Environment file {dst_file} already exists!")
-        if not dry_run:
-            return
-    try:
-        if dry_run:
-            typer.echo(
-                f"*** dry-run: skipping actual saving of {dst_file} ***", color="red"
-            )
-        else:
-            typer.echo(f"[cellpy] (setup) Saving file ({dst_file})")
-            dump_env_file(dst_file)
-
-    except ConfigFileNotWritten:
-        _txt = "[cellpy] (setup) No, that did not work either.\n"
-        _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
-        typer.echo(_txt)
-    else:
-        typer.echo("[cellpy] (setup) Environment file written!")
-        typer.echo(
-            "[cellpy] (setup) OK! Now you can edit it. For example by "
-            f"issuing \n\n         [your-favourite-editor] {dst_file}\n"
-        )
-
-
-def _get_default_editor():
-    """
-    Return the default text editor.
-
-    This code is based on the `editor` library by @rec.
-    """
-
-    return os.environ.get("VISUAL") or (
-        os.environ.get("EDITOR") or EDITORS.get(platform.system(), DEFAULT_EDITOR)
-    )
+def _write_toml_config_file(dst_file, dry_run, test_user=None):
+    """Shim for tests that still call ``cli._write_toml_config_file``."""
+    with cli_api._using_echo(typer.echo):
+        return cli_api._write_toml_config_file(dst_file, dry_run, test_user=test_user)
 
 
 # ----------------------- edit ---------------------------------------
+
+
 @cli.command()
 def edit(
     name: Annotated[Optional[str], typer.Argument()] = None,
@@ -990,44 +201,18 @@ def edit(
             cellpy edit env -e notepad.exe
 
     """
-
-    if name.lower() == "db":
-        _run_db(debug, silent)
-        return
-
-    elif name.lower() not in ["env", "config"] and name is not None:
-        typer.echo("unknown file")
-        return
-
-    if name is None or name.lower() == "config":
-        config_file = _configloc()
-        filename = str(config_file.resolve())
-        if config_file is None:
-            print("could not find the config file")
-            return
-    elif name.lower() == "env":
-        filename = _envloc()
-        if filename is None:
-            print("could not find the env file")
-            return
-    else:
-        filename = name
-
-    if default_editor is None:
-        default_editor = _get_default_editor()
-
-    args = [default_editor, filename]
-    typer.echo(f"[cellpy] (edit) Calling '{default_editor}'")
-    try:
-        subprocess.call(args)
-    except:
-        typer.echo("[cellpy] (edit) Failed!")
-        typer.echo(
-            "[cellpy] (edit) Try 'cellpy edit -e notepad.exe' if you are on Windows"
-        )
+    cli_api.edit_file(
+        name,
+        default_editor=default_editor,
+        debug=debug,
+        silent=silent,
+        echo=typer.echo,
+    )
 
 
 # ----------------------- info ---------------------------------------
+
+
 @cli.command()
 def info(
     version: Annotated[
@@ -1060,51 +245,19 @@ def info(
     ] = False,
 ):
     """This will give you some valuable information about your cellpy."""
-    complete_info = True
-
-    if check:
-        complete_info = False
-        _check()
-
-    if version:
-        complete_info = False
-        _version()
-
-    if configloc:
-        complete_info = False
-        _configloc()
-
-    if params:
-        complete_info = False
-        _dump_params()
-
-    if show_config:
-        complete_info = False
-        _dump_config_resolved()
-
-    if complete_info:
-        _version()
-        _configloc()
-
-
-def _dump_config_resolved():
-    """Print resolved config values with per-field provenance (#454)."""
-    from cellpy import config as cellpy_config
-
-    data = cellpy_config.get_config().model_dump_for_file()
-    provenance = cellpy_config.sources()
-    typer.echo("[cellpy] resolved configuration (value  # source-layer):")
-    for section, fields in data.items():
-        typer.echo(f"\n[{section}]")
-        if not isinstance(fields, dict):
-            typer.echo(f"  {fields!r}")
-            continue
-        for key, value in fields.items():
-            layer = provenance.get(f"{section}.{key}", "default")
-            typer.echo(f"  {key} = {value!r}  # {layer}")
+    cli_api.show_info(
+        version=version,
+        configloc=configloc,
+        params=params,
+        show_config=show_config,
+        check=check,
+        echo=typer.echo,
+    )
 
 
 # ----------------------- run ----------------------------------------
+
+
 @cli.command()
 def run(
     name: Annotated[str, typer.Argument()] = "NONE",
@@ -1183,7 +336,7 @@ def run(
 
     """
     if list_:
-        _run_list(name)
+        cli_api.list_journals(None if name == "NONE" else name, echo=typer.echo)
         return
 
     if name == "NONE":
@@ -1203,101 +356,51 @@ def run(
     typer.echo("[cellpy]\n")
 
     if cellpy_project:
-        _run_project(name)
-
+        cli_api.run_project(name, echo=typer.echo)
     elif journal:
-        _run_journal(name, debug, silent, raw, cellpyfile, minimal, nom_cap)
-
-    elif folder:
-        _run_journals(name, debug, silent, raw, cellpyfile, minimal)
-
-    elif key:
-        _run_from_db(
+        cli_api.run_journal(
             name,
-            debug,
-            silent,
-            raw,
-            cellpyfile,
-            minimal,
-            nom_cap,
-            batch_col,
-            project,
+            debug=debug,
+            silent=silent,
+            raw=raw,
+            cellpyfile=cellpyfile,
+            minimal=minimal,
+            nom_cap=nom_cap,
+            echo=typer.echo,
         )
-
+    elif folder:
+        cli_api.run_journals(
+            name,
+            debug=debug,
+            silent=silent,
+            raw=raw,
+            cellpyfile=cellpyfile,
+            minimal=minimal,
+            echo=typer.echo,
+        )
+    elif key:
+        cli_api.run_from_db(
+            name,
+            debug=debug,
+            silent=silent,
+            raw=raw,
+            cellpyfile=cellpyfile,
+            minimal=minimal,
+            nom_cap=nom_cap,
+            batch_col=batch_col,
+            project=project,
+            echo=typer.echo,
+        )
     else:
-        _run(name, debug, silent)
-
-
-def _run_from_db(
-    name,
-    debug,
-    silent,
-    raw,
-    cellpyfile,
-    minimal,
-    nom_cap,
-    batch_col,
-    project,
-):
-    cli_api.run_from_db(
-        name,
-        debug=debug,
-        silent=silent,
-        raw=raw,
-        cellpyfile=cellpyfile,
-        minimal=minimal,
-        nom_cap=nom_cap,
-        batch_col=batch_col,
-        project=project,
-        echo=typer.echo,
-    )
-
-
-def _run_journal(file_name, debug, silent, raw, cellpyfile, minimal, nom_cap):
-    cli_api.run_journal(
-        file_name,
-        debug=debug,
-        silent=silent,
-        raw=raw,
-        cellpyfile=cellpyfile,
-        minimal=minimal,
-        nom_cap=nom_cap,
-        echo=typer.echo,
-    )
-
-
-def _run_list(batchfiledir):
-    cli_api.list_journals(batchfiledir, echo=typer.echo)
-
-
-def _run_journals(folder_name, debug, silent, raw, cellpyfile, minimal):
-    cli_api.run_journals(
-        folder_name,
-        debug=debug,
-        silent=silent,
-        raw=raw,
-        cellpyfile=cellpyfile,
-        minimal=minimal,
-        echo=typer.echo,
-    )
-
-
-def _run_project(our_new_project, **kwargs):
-    cli_api.run_project(our_new_project, echo=typer.echo, **kwargs)
-
-
-def _run(name, debug, silent):
-    typer.echo(f"running {name}")
-    typer.echo(f" --debug [{debug}]")
-    typer.echo(f" --silent [{silent}]")
-    typer.echo("[cellpy]: sorry, I am not allowed to run this on my own")
-
-
-def _run_db(debug, silent):
-    cli_api.open_db_editor(debug=debug, silent=silent, echo=typer.echo)
+        typer.echo(f"running {name}")
+        typer.echo(f" --debug [{debug}]")
+        typer.echo(f" --silent [{silent}]")
+        typer.echo("[cellpy]: sorry, I am not allowed to run this on my own")
 
 
 # ----------------------- pull ---------------------------------------
+
+
 @cli.command()
 def pull(
     tests: Annotated[
@@ -1320,207 +423,19 @@ def pull(
     ] = None,
 ):
     """Download examples or tests from the big internet (needs git)."""
-    if directory is not None:
-        typer.echo(f"[cellpy] (pull) custom directory: {directory}")
-    else:
-        directory = pathlib.Path(config.paths.examplesdir)
-
-    if password is not None:
-        typer.echo("DEV MODE: password provided")
-    if clone:
-        _clone_repo(directory, password)
-    else:
-        if tests:
-            _pull_tests(directory, password)
-        if examples:
-            _pull_examples(directory, password)
-        else:
-            typer.echo(
-                "[cellpy] (pull) Nothing selected for pulling. "
-                "Please select an option (--tests,--examples, -clone, ...) "
-            )
-
-
-def _clone_repo(directory, password):
-    directory = pathlib.Path(directory)
-    txt = "[cellpy] The plan is that this "
-    txt += "[cellpy] cmd will pull (clone) the cellpy repo.\n"
-    txt += "[cellpy] For now it only prints the link to the git-hub\n"
-    txt += "[cellpy] repository:\n"
-    txt += "[cellpy]\n"
-    txt += "[cellpy] https://github.com/jepegit/cellpy.git\n"
-    txt += "[cellpy]\n"
-    typer.echo(txt)
-
-
-def _pull_tests(directory, pw=None):
-    txt = (
-        "[cellpy] (pull) Pulling tests from",
-        " https://github.com/jepegit/cellpy.git",
+    cli_api.pull_resources(
+        tests=tests,
+        examples=examples,
+        clone=clone,
+        directory=directory,
+        password=password,
+        echo=typer.echo,
     )
-    typer.echo(txt)
-    _pull(gdirpath="tests", rootpath=directory, pw=pw)
-    _pull(gdirpath="testdata", rootpath=directory, pw=pw)
-
-
-def _pull_examples(directory, pw):
-    txt = (
-        "[cellpy] (pull) Pulling examples from",
-        " https://github.com/jepegit/cellpy.git",
-    )
-    typer.echo(txt)
-    _pull(gdirpath="examples", rootpath=directory, pw=pw)
-
-
-def _version():
-    version_text = "[cellpy] version: " + str(VERSION)
-    typer.echo(version_text)
-
-
-def _configloc():
-    _, config_file_name = prmreader.get_user_dir_and_dst()
-    typer.echo(f"[cellpy] -> {config_file_name}")
-    if not os.path.isfile(config_file_name):
-        typer.echo("[cellpy] File does not exist!")
-    else:
-        return config_file_name
-
-
-def _envloc():
-    env_file_name = prmreader.get_env_file_name()
-    typer.echo(f"[cellpy] (from config) -> {env_file_name}")
-    if not os.path.isfile(env_file_name):
-        return
-    return env_file_name
-
-
-def _dump_params():
-    typer.echo("[cellpy] Running prmreader.info:\n")
-    prmreader.info()
-
-
-def _download_g_blob(name, local_path):
-    import urllib.request
-
-    dirs = local_path.parent
-    if not dirs.is_dir():
-        typer.echo(f"[cellpy] (pull) creating dir: {dirs}")
-        dirs.mkdir(parents=True)
-    print(f"[cellpy] (pull) downloading blob: {name.download_url}")
-    filename, headers = urllib.request.urlretrieve(
-        name.download_url, filename=local_path
-    )
-    typer.echo(f"[cellpy] (pull) downloaded blob: {filename}")
-
-
-def _parse_g_subdir(stuff, repo, gdirpath):
-    """recursive function for parsing repo subdirectories"""
-    for f in repo.get_contents(gdirpath):
-        if f.type != "dir":
-            stuff.append(f)
-        else:
-            _parse_g_subdir(stuff, repo, f.path)
-
-
-def _parse_g_dir(repo, gdirpath):
-    """yields content of repo directory"""
-    stuff = []
-    _parse_g_subdir(stuff, repo, gdirpath)
-    for f in stuff:
-        yield f
-
-
-def _get_user_name():
-    return "jepegit"
-
-
-def _get_pw(method):
-    if method == "ask":
-        return getpass.getpass()
-    elif method == "env":
-        return os.environ.get(GITHUB_PWD_VAR_NAME, None)
-
-    else:
-        return None
-
-
-def _pull(gdirpath="examples", rootpath=None, u=None, pw=None):
-    if rootpath is None:
-        rootpath = config.paths.examplesdir
-
-    rootpath = pathlib.Path(rootpath)
-
-    ndirpath = rootpath / gdirpath
-
-    if pw is not None:
-        typer.echo(" DEV MODE ".center(80, "-"))
-        u = _get_user_name()
-        if pw == "ask":
-            typer.echo("   - ask for password")
-            pw = _get_pw(pw)
-        elif pw == "env":
-            typer.echo("   - check environ for password ")
-            pw = _get_pw(pw)
-            typer.echo("   - got something")
-            if pw is None:
-                typer.echo("   - only None")
-                u = None
-
-    g = Github(u, pw)
-    try:
-        repo = g.get_repo(REPO)
-    except github.RateLimitExceededException:
-        typer.echo("   - rate limit exceeded")
-        typer.echo("   - waiting 60 seconds, and trying only once more")
-        typer.echo(
-            "   - hint! you can check status directly using the github api, e.g. "
-        )
-        typer.echo("     $ curl -i https://api.github.com/users/USERNAME")
-        typer.echo("   - press ctrl-c to abort")
-        time.sleep(60)
-        repo = g.get_repo(REPO)
-
-    typer.echo(f"[cellpy] (pull) pulling {gdirpath}")
-    typer.echo(f"[cellpy] (pull) -> {ndirpath}")
-
-    if not ndirpath.is_dir():
-        typer.echo(f"[cellpy] (pull) creating dir: {ndirpath}")
-        ndirpath.mkdir(parents=True)
-
-    for gfile in _parse_g_dir(repo, gdirpath):
-        gfilename = pathlib.Path(gfile.path)
-        nfilename = rootpath / gfilename
-        try:
-            _download_g_blob(gfile, nfilename)
-        except github.RateLimitExceededException:
-            typer.echo("   - rate limit exceeded")
-            typer.echo("   - waiting 60 seconds, and trying only once more")
-            typer.echo("   - press ctrl-c to abort")
-            time.sleep(60)
-            _download_g_blob(gfile, nfilename)
-
-
-def _get_default_template():
-    template = "standard"
-    try:
-        template = config.batch.template
-    except:
-        logging.debug("You dont have any default template defined in you .conf file")
-    return template
-
-
-def _read_local_templates(local_templates_path=None):
-    if local_templates_path is None:
-        local_templates_path = pathlib.Path(config.paths.templatedir)
-    templates = {}
-    for p in list(local_templates_path.rglob("cellpy_cookie*.zip")):
-        label = p.stem.strip()[len("cellpy_cookie_") :]
-        templates[label] = (str(p), None)
-    logging.debug(f"Found the following templates: {templates}")
-    return templates
 
 
 # ----------------------- new ----------------------------------------
+
+
 @cli.command()
 def new(
     template: Annotated[
@@ -1579,261 +494,24 @@ def new(
     ] = False,
 ):
     """Set up a batch experiment (might need git installed)."""
-    _new(
+    cli_api.create_project(
         template,
         directory=directory,
-        project_dir=project,
-        session_id=experiment,
+        project=project,
+        experiment=experiment,
         local_user_template=local_user_template,
         serve_=serve_,
         run_=run_,
         lab=lab,
-        executable=jupyter_executable,
+        jupyter_executable=jupyter_executable,
         list_=list_,
+        echo=typer.echo,
     )
 
 
-def _new(
-    template: str,
-    directory: Union[Path, str, None] = None,
-    project_dir: Union[str, None] = None,
-    local_user_template: bool = False,
-    serve_: bool = False,
-    run_: bool = False,
-    lab: bool = False,
-    list_: bool = False,
-    executable: Union[str, None] = None,
-    session_id: str = "experiment_001",
-    no_input: bool = False,
-    cookie_directory: str = "",
-    local_templates_with_sub_directories: bool = False,
-):
-    """Set up a batch experiment (might need git installed).
-
-    Args:
-        template: short-name of template.
-        directory: the directory for your cellpy projects.
-        local_user_template: use local template if True.
-        serve_: serve the notebook after creation if True.
-        run_: run the notebooks using papermill if True.
-        lab: use jupyter-lab instead of jupyter notebook if True.
-        executable: path to jupyter executable.
-        list_: list all available templates and return if True.
-        project_dir: your project directory.
-        session_id: the lookup value.
-        no_input: accept defaults if True (only valid when providing project_dir and session_id)
-        cookie_directory: name of the directory for your cookie (inside the repository or zip file).
-        local_templates_with_sub_directories: use sub-directories in local templates if True.
-    Returns:
-        None
-    """
-
-    try:
-        import cookiecutter.exceptions
-        import cookiecutter.main
-        import cookiecutter.prompt
-
-    except ModuleNotFoundError:
-        typer.echo("Could not import cookiecutter.")
-        typer.echo("Try installing it, for example by writing:")
-        typer.echo("\npython -m pip install cookiecutter\n")
-
-    if list_:
-        typer.echo("\n[cellpy] batch templates")
-
-        default_template = _get_default_template()
-        local_templates = _read_local_templates()
-        local_templates_path = config.paths.templatedir
-        registered_templates = REGISTERED_TEMPLATES
-        typer.echo(f"[cellpy] - default: {default_template}")
-        typer.echo("[cellpy] - registered templates (on github):")
-        for label, link in registered_templates.items():
-            typer.echo(f"\t\t{label:18s} {link}")
-
-        if local_templates:
-            typer.echo(f"[cellpy] - local templates ({local_templates_path}):")
-            for label, link in local_templates.items():
-                typer.echo(f"\t\t{label:18s} {link}")
-        else:
-            typer.echo(f"[cellpy] - local templates ({local_templates_path}): none")
-
-        return
-
-    if project_dir is None or session_id is None:
-        no_input = False
-
-    if not template:
-        template = _get_default_template()
-
-    if lab:
-        server = "lab"
-    else:
-        server = "notebook"
-
-    typer.echo(f"Template: {template}")
-    if local_user_template:
-        # forcing using local template
-        templates = _read_local_templates()
-
-        if not templates:
-            typer.echo(
-                "You asked me to use a local template, but you have none. Aborting."
-            )
-            return
-    else:
-        templates = REGISTERED_TEMPLATES
-        if local_templates := _read_local_templates():
-            templates.update(local_templates)
-
-    if not template.lower() in templates.keys():
-        typer.echo("This template does not exist. Aborting.")
-        return
-
-    if directory is None:
-        logging.debug("no dir given")
-        directory = config.paths.notebookdir
-
-    if not os.path.isdir(directory):
-        typer.echo("Sorry. This did not work as expected!")
-        typer.echo(f" - {directory} does not exist")
-        return
-
-    directory = Path(directory)
-    selected_project_dir = None
-
-    if project_dir:
-        selected_project_dir = directory / project_dir
-        if not selected_project_dir.is_dir():
-            if cookiecutter.prompt.read_user_yes_no(
-                f"{project_dir} does not exist. Create?", "yes"
-            ):
-                os.mkdir(selected_project_dir)
-                typer.echo(f"Created {selected_project_dir}")
-
-            else:
-                selected_project_dir = None
-                typer.echo("Select another directory instead")
-    CREATE_NEW_DIR = "Create new project..."
-    if not selected_project_dir:
-        project_dirs = [
-            d.name
-            for d in directory.iterdir()
-            if d.is_dir() and not d.name.startswith(".")
-        ]
-        project_dirs.insert(0, CREATE_NEW_DIR)
-
-        project_dir = cookiecutter.prompt.read_user_choice(
-            "project folder", project_dirs
-        )
-
-        if project_dir == CREATE_NEW_DIR:
-            default_name = "cellpy_project"
-            temp_default_name = default_name
-            for j in range(999):
-                if temp_default_name in project_dirs:
-                    temp_default_name = default_name + str(j + 1).zfill(3)
-                else:
-                    default_name = temp_default_name
-                    break
-
-            project_dir = cookiecutter.prompt.read_user_variable(
-                "New name", default_name
-            )
-            try:
-                os.mkdir(directory / project_dir)
-                typer.echo(f"created {project_dir}")
-            except FileExistsError:
-                typer.echo("OK - but this directory already exists!")
-        selected_project_dir = directory / project_dir
-
-    # get a list of all folders
-    existing_projects = os.listdir(selected_project_dir)
-
-    os.chdir(selected_project_dir)
-    cellpy_version = cellpy.__version__
-
-    try:
-        selected_template, cookie_dir = templates[template.lower()]
-
-        if cookie_directory:
-            cookie_dir = cookie_directory
-        if not cookie_dir:
-            # if cookie_dir is not set, use the template name
-            if not local_user_template:
-                cookie_dir = template.lower()
-            elif local_templates_with_sub_directories:
-                cookie_dir = template.lower()
-
-        author_name = _get_author_name()
-        cookiecutter.main.cookiecutter(
-            selected_template,
-            extra_context={
-                "author_name": author_name,
-                "project_name": project_dir,
-                "cellpy_version": cellpy_version,
-                "session_id": session_id,
-            },
-            no_input=no_input,
-            directory=cookie_dir,
-        )
-    except cookiecutter.exceptions.OutputDirExistsException as e:
-        typer.echo("Sorry. This did not work as expected!")
-        typer.echo(" - cookiecutter refused to create the project")
-        typer.echo(e)
-
-    if serve_:
-        os.chdir(directory)
-        _serve(server, executable)
-
-    elif run_:
-        typer.echo("WARNING - experimental feature - use at your own risk")
-        input("Press Enter to continue...")
-        try:
-            import papermill as pm  # type: ignore
-        except ImportError:
-            typer.echo(
-                "[cellpy]: You need to install papermill for automatically execute the notebooks."
-            )
-            typer.echo("[cellpy]: You can install it using pip like this:")
-            typer.echo(" >> pip install papermill")
-            return
-        new_existing_projects = os.listdir(selected_project_dir)
-        our_new_projects = list(set(new_existing_projects) - set(existing_projects))
-
-        if not len(our_new_projects):
-            typer.echo(
-                "[cellpy]: Sorry, could not deiced what is the new project "
-                "- so I don't dare to try to execute automatically."
-            )
-            return
-        our_new_project = selected_project_dir / our_new_projects[0]
-
-        _run_project(our_new_project)
-
-
-def _get_author_name():
-    """Get the name of the author."""
-    try:
-        import getpass
-
-        author_name = getpass.getuser()
-    except Exception as e:
-        typer.echo("Could not get the author name")
-        typer.echo(e)
-        author_name = "unknown"
-    return author_name
-
-
-def _serve(server, executable=None):
-    typer.echo(f"serving with jupyter {server}")
-    # TODO: search for jupyter and find the right one
-    if executable is None:
-        executable = "jupyter"
-    subprocess.run([executable, server], check=True)
-    typer.echo("Finished serving.")
-
-
 # ----------------------- serve ---------------------------------------
+
+
 @cli.command()
 def serve(
     lab: Annotated[
@@ -1854,26 +532,9 @@ def serve(
     ] = None,
 ):
     """Start a Jupyter server."""
-
-    if directory is None:
-        directory = config.paths.notebookdir
-    elif directory == "home":
-        directory = Path().home()
-    elif directory == "here":
-        directory = Path(os.getcwd())
-
-    if not os.path.isdir(directory):
-        typer.echo("Sorry. This did not work as expected!")
-        typer.echo(f" - {directory} does not exist")
-        return
-
-    if lab:
-        server = "lab"
-    else:
-        server = "notebook"
-
-    os.chdir(directory)
-    _serve(server, executable=executable)
+    cli_api.start_jupyter(
+        lab=lab, directory=directory, executable=executable, echo=typer.echo
+    )
 
 
 # `setup` is the only group; the rest register themselves with @cli.command().
@@ -1901,108 +562,5 @@ def convert(
         raise typer.Exit(code=2)
 
 
-# tests etc
-def _main_pull():
-    if sys.platform == "win32":
-        rootpath = pathlib.Path(r"C:\Temp\cellpy_user")
-    else:
-        rootpath = pathlib.Path("/Users/jepe/scripting/tmp/cellpy_test_user")
-    _pull_examples(rootpath, pw="env")
-    _pull_tests(rootpath, pw="env")
-    # _pull(gdirpath="examples", rootpath=rootpath, u="ask", pw="ask")
-    # _pull(gdirpath="tests", rootpath=rootpath, u="ask", pw="ask")
-    # _pull(gdirpath="testdata", rootpath=rootpath, u="ask", pw="ask")
-
-
-def _main():
-    file_name = prmreader.create_custom_init_filename()
-    typer.echo(file_name)
-    user_directory, destination_file_name = prmreader.get_user_dir_and_dst(file_name)
-    typer.echo(user_directory)
-    typer.echo(destination_file_name)
-    typer.echo("trying to save it")
-    save_prm_file(destination_file_name + "_dummy")
-
-    typer.echo(" Testing setup ".center(80, "="))
-    # `setup` is a plain function under Typer, not a self-invoking Click
-    # command, so drive it through the app the way a user would.
-    from typer.testing import CliRunner
-
-    CliRunner().invoke(cli, ["setup", "--interactive", "--reset"])
-
-
-def _cli_setup_interactive():
-    from typer.testing import CliRunner
-
-    if sys.platform == "win32":
-        root_dir = r"C:\Temp\cellpy_user"
-    else:
-        root_dir = "/Users/jepe/scripting/tmp/cellpy_test_user"
-    testuser = "tester"
-    init_filename = prmreader.create_custom_init_filename(testuser)
-    dst_file = get_dst_file(root_dir, init_filename)
-    init_file = pathlib.Path(dst_file)
-    opts = list()
-    opts.append("setup")
-    opts.append("-i")
-    # opts.append("-nr")
-    opts.append("-r")
-    opts.extend(["-d", root_dir])
-    opts.extend(["-t", testuser])
-
-    input_str = "\n"  # out
-    input_str += "\n"  # rawdatadir
-    input_str += "\n"  # cellpyfiles
-    input_str += "\n"  # log
-    input_str += "\n"  # examples
-    input_str += "\n"  # dbfolder
-    input_str += "\n"  # dbfile
-    runner = CliRunner()
-    result = runner.invoke(cli, opts, input=input_str)
-
-    typer.echo(" out ".center(80, "."))
-    typer.echo(result.output)
-    from pprint import pprint
-
-    pprint(config.paths)
-    typer.echo(" conf-file ".center(80, "."))
-    typer.echo(init_file)
-    typer.echo()
-    with init_file.open() as f:
-        for line in f.readlines():
-            typer.echo(line.strip())
-
-
-def _check_it(var=None):
-    import pathlib
-    import sys
-
-    p_env = pathlib.Path(sys.prefix)
-    print(p_env.name)
-    new(list_=True)
-    u1 = os.getlogin()
-    u2 = os.path.expanduser("~")
-    u3 = os.environ.get("USERNAME")
-    u4 = _get_author_name()
-    u5 = _get_user_name()
-
-    print(u1)
-    print(u2)
-    print(u3)
-    print(u4)
-    print(u5)
-    print(cellpy.parameters.__file__)
-    print(pathlib.Path(cellpy.parameters.__file__).parent)
-    # check_it()
-    # typer.echo("\n\n", " RUNNING MAIN PULL ".center(80, "*"), "\n")
-    _main_pull()
-    # typer.echo("ok")
-
-
-def _check_info_check():
-    """Check your cellpy installation."""
-    _check()
-
-
 if __name__ == "__main__":
-    _check_info_check()
+    cli_api.show_info(check=True, echo=typer.echo)

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1,4 +1,4 @@
-"""Library-first API behind the ``cellpy`` command line (CLI plan Phase 0–1, #568).
+"""Library-first API behind the ``cellpy`` command line (CLI plan Phase 0–1).
 
 What a command *does* and how it is *spelled* were the same code, so anything
 the CLI could do was unreachable from a script: you either shelled out to
@@ -6,34 +6,50 @@ the CLI could do was unreachable from a script: you either shelled out to
 
 The logic lives here as ordinary typed functions, and ``cellpy.cli`` becomes
 argument parsing that calls them. Nothing about the command line changes — this
-is a move, not a redesign — and it makes the eventual Click→Typer cutover (#569)
-a re-spelling rather than a rewrite.
+is a move, not a redesign (#568 for ``convert``/``run``; #651 for the rest).
 
 **Output.** These functions are quiet by default, as a library should be. Each
-takes an ``echo`` callable; the CLI passes ``typer.echo``, so the terminal
-output is byte-identical to before, while a script that calls
-``cli_api.run_journal(...)`` gets silence unless it asks otherwise::
+public entry takes an ``echo`` callable; the CLI passes ``typer.echo``. Larger
+commands bind that echo with ``_using_echo`` so private helpers can call
+``_say`` without threading the callable through every signature::
 
     from cellpy import cli_api
     cli_api.run_journal("my_experiment.json")            # quiet
     cli_api.run_journal("my_experiment.json", echo=print)  # chatty
+    cli_api.setup_config(silent=True, echo=print)
 """
 
 from __future__ import annotations
 
+import getpass
 import logging
+import os
 import pathlib
 import platform
 import subprocess
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Callable, Optional, Union
 
-import typer
-
+import cellpy
+import cellpy._version
 import cellpy.config as config
+from cellpy.exceptions import ConfigFileNotWritten
 from cellpy.internals.otherpath import OtherPath
+from cellpy.parameters import prmreader
+from cellpy.parameters.internal_settings import OTHERPATHS
+from cellpy.utils.template_registry import REGISTERED_TEMPLATES
 
 PathLike = Union[str, pathlib.Path]
 Echo = Callable[[str], None]
+
+VERSION = cellpy._version.__version__
+REPO = "jepegit/cellpy"
+USER = "jepegit"
+GITHUB_PWD_VAR_NAME = "GD_PWD"
+DEFAULT_EDITOR = "vim"
+EDITORS = {"Windows": "notepad"}
 
 
 def _silent(_message: str) -> None:
@@ -381,6 +397,79 @@ def open_db_editor(
     # not tested on any of these
     subprocess.check_call(["open", "-a", "Microsoft Excel", db_path])
 
+# -- echo binder for moved CLI helpers (#651) -----------------------------------
+# Public APIs take ``echo=`` and wrap work in ``_using_echo`` so private helpers
+# can call ``_say`` without threading the callable through every signature.
+# Quiet by default (same contract as ``convert`` / ``run_journal``).
+
+_echo_var: ContextVar[Echo] = ContextVar("cellpy_cli_api_echo", default=_silent)
+
+
+def _say(message: str, **_kwargs) -> None:
+    """Report via the bound echo; colour kwargs from old typer.echo are ignored."""
+    _echo_var.get()(message)
+
+
+@contextmanager
+def _using_echo(echo: Optional[Echo] = None):
+    token = _echo_var.set(_resolve_echo(echo))
+    try:
+        yield
+    finally:
+        _echo_var.reset(token)
+
+
+DIFFICULT_MISSING_MODULES: dict[str, str] = {}
+
+try:
+    import cookiecutter.exceptions
+    import cookiecutter.main
+    import cookiecutter.prompt
+except ModuleNotFoundError:
+    cookiecutter = None  # type: ignore
+    DIFFICULT_MISSING_MODULES["cookiecutter"] = (
+        "Could not import cookiecutter (used by cellpy new). Try installing it, "
+        "for example by writing:\n\n         python -m pip install cookiecutter\n"
+    )
+
+try:
+    import github
+    from github import Github
+except ModuleNotFoundError:
+    github = None  # type: ignore
+    Github = None  # type: ignore
+    DIFFICULT_MISSING_MODULES["github"] = (
+        "Could not import the github library (used by cellpy pull). Try installing "
+        "it, for example by writing:\n\n         python -m pip install github\n"
+    )
+
+try:
+    import sqlalchemy_access  # noqa: F401
+except ModuleNotFoundError:
+    DIFFICULT_MISSING_MODULES["sqlalchemy-access"] = (
+        "Could not import the sqlalchemy_access library (usually used when reading "
+        "arbin .res files on windows). If you need it, try installing it by writing:"
+        "\n\n         python -m pip install sqlalchemy-access\n"
+    )
+
+try:
+    import lmfit  # noqa: F401
+except ModuleNotFoundError:
+    DIFFICULT_MISSING_MODULES["lmfit"] = (
+        "Could not import the lmfit library (used when fitting ocv rlx data)."
+        " If you think you will need it, try installing it for example by writing:"
+        "\n\n         python -m pip install lmfit\n"
+    )
+
+try:
+    import jinja2_time  # noqa: F401
+except ModuleNotFoundError:
+    DIFFICULT_MISSING_MODULES["jinja2_time"] = (
+        "Could not import the jinja2_time library (used by cellpy new)."
+        " Try installing it, for example by writing:"
+        "\n\n         python -m pip install jinja2_time\n"
+    )
+
 
 def _create_dir(path, confirm=True, parents=True, exist_ok=True):
     if isinstance(path, OtherPath):
@@ -405,15 +494,1394 @@ def _create_dir(path, confirm=True, parents=True, exist_ok=True):
         if create_dir:
             try:
                 o.mkdir(parents=parents, exist_ok=exist_ok)
-                typer.echo(f"[cellpy] (setup) Created {o}")
+                _say(f"[cellpy] (setup) Created {o}")
             except FileExistsError:
-                typer.echo(f"[cellpy] (setup) {o} already exists.")
+                _say(f"[cellpy] (setup) {o} already exists.")
             except FileNotFoundError:
-                typer.echo(f"[cellpy] (setup) {o} not available.")
+                _say(f"[cellpy] (setup) {o} not available.")
             except Exception as e:
-                typer.echo(f"[cellpy] (setup) WARNING! Could not create {o}.")
+                _say(f"[cellpy] (setup) WARNING! Could not create {o}.")
                 logging.debug(e)
-                typer.echo(f"[cellpy] (setup) ...continuing anyway.")
+                _say("[cellpy] (setup) ...continuing anyway.")
         else:
-            typer.echo(f"[cellpy] (setup) Could not create {o}")
+            _say(f"[cellpy] (setup) Could not create {o}")
     return o
+
+# -- setup file helpers --
+def save_prm_file(prm_filename):
+    """saves (writes) the prms to file"""
+    prmreader._write_prm_file(prm_filename)
+
+
+def dump_env_file(env_filename):
+    """saves (writes) the env to file"""
+    _say(f" dumping env file to {env_filename}")
+    prmreader._write_env_file(env_filename)
+
+
+def get_package_prm_dir():
+    """gets the folder where the cellpy package lives"""
+    return pathlib.Path(cellpy.parameters.__file__).parent
+
+
+def get_default_config_file_path(init_filename=None):
+    """gets the path to the default config-file"""
+    prm_dir = get_package_prm_dir()
+    if not init_filename:
+        init_filename = prmreader.DEFAULT_FILENAME
+    src = prm_dir / init_filename
+    return src
+
+
+def get_dst_file(user_dir, init_filename):
+    """gets the destination path for the config-file"""
+    user_dir = pathlib.Path(user_dir)
+    dst_file = user_dir / init_filename
+    return dst_file
+
+
+def echo_missing_modules():
+    """prints out the missing modules"""
+    for m in DIFFICULT_MISSING_MODULES:
+        print(f"missing module: {m}")
+        print(f"message: {DIFFICULT_MISSING_MODULES[m]}")
+
+
+# -- write toml --
+def _write_toml_config_file(dst_file, dry_run, test_user=None):
+    """Write the ``cellpy.toml`` twin generated from the config models (#454).
+
+    The TOML is the single source of truth going forward (config plan Step 5):
+    it is *generated* from the resolved ``CellpyConfig`` models (secrets
+    excluded), so adding a field is a one-file change in the models. In
+    test-user (DEV) mode the file lands next to the legacy conf instead of the
+    real platform config dir.
+    """
+    from cellpy import config as cellpy_config
+    from cellpy.config import loader as config_loader
+
+    if test_user:
+        toml_path = pathlib.Path(dst_file).with_name("cellpy.toml")
+    else:
+        toml_path = config_loader.user_config_path()
+
+    if dry_run:
+        _say(f"[cellpy] (setup) dry-run: would write {toml_path}")
+        return
+
+    data = cellpy_config.get_config().model_dump_for_file()
+    toml_path.parent.mkdir(parents=True, exist_ok=True)
+    config_loader.write_toml(toml_path, data)
+    _say(f"[cellpy] (setup) wrote {toml_path}")
+
+# -- migrate --
+def migrate_config(
+    src=None,
+    dst=None,
+    dry_run=False,
+    force=False,
+    *,
+    echo=None,
+):
+    """One-time conversion of the legacy YAML .conf file to cellpy.toml.
+
+    The old file is left untouched (it keeps working through the v2.0
+    deprecation window); the generated TOML takes precedence once present.
+    """
+    with _using_echo(echo):
+        _migrate_config_body(src, dst, dry_run, force)
+
+
+def _migrate_config_body(src, dst, dry_run, force):
+    from cellpy.config import loader as config_loader
+    from cellpy.config import migrate as config_migrate
+
+    if src is None:
+        try:
+            src = prmreader._get_prm_file()
+        except Exception:
+            src = None
+        if src is None or not pathlib.Path(src).is_file():
+            _say(
+                "[cellpy] (setup migrate) no legacy config file found - "
+                "nothing to migrate (run `cellpy setup` to create a fresh one)."
+            )
+            return
+    src = pathlib.Path(src)
+
+    toml_path = pathlib.Path(dst) if dst else config_loader.user_config_path()
+    if toml_path.is_file() and not force:
+        _say(
+            f"[cellpy] (setup migrate) {toml_path} already exists "
+            "- use --force to overwrite."
+        )
+        return
+
+    _say(f"[cellpy] (setup migrate) source: {src}")
+    _say(f"[cellpy] (setup migrate) target: {toml_path}")
+    if dry_run:
+        _say("[cellpy] (setup migrate) dry-run: not writing anything.")
+        return
+
+    toml_path.parent.mkdir(parents=True, exist_ok=True)
+    config_migrate.convert_yaml_file_to_toml(src, toml_path)
+    _say("[cellpy] (setup migrate) done - the old file is kept untouched.")
+
+# -- update_paths through get_default_editor --
+def _update_paths(
+    custom_dir=None,
+    relative_home=True,
+    reset=False,
+    dry_run=False,
+    default_dir=None,
+    silent=False,
+    interactive=False,
+):
+    # please, refactor me :-(
+
+    h = prmreader.get_user_dir()
+
+    if default_dir is None:
+        default_dir = "cellpy_data"
+
+    if dry_run:
+        _say(f" - default_dir: {default_dir}")
+        _say(f" - custom_dir: {custom_dir}")
+        _say(f" - relative_home: {relative_home}")
+
+    if custom_dir:
+        reset = True
+        if relative_home:
+            h = h / custom_dir
+        if not custom_dir.parts[-1] == default_dir:
+            h = h / default_dir
+
+    if not reset:
+        outdatadir = pathlib.Path(config.paths.outdatadir)
+        rawdatadir = OtherPath(config.paths.rawdatadir)
+        cellpydatadir = OtherPath(config.paths.cellpydatadir)
+        filelogdir = pathlib.Path(config.paths.filelogdir)
+        examplesdir = pathlib.Path(config.paths.examplesdir)
+        db_path = pathlib.Path(config.paths.db_path)
+        db_filename = config.paths.db_filename
+        notebookdir = pathlib.Path(config.paths.notebookdir)
+        batchfiledir = pathlib.Path(config.paths.batchfiledir)
+        templatedir = pathlib.Path(config.paths.templatedir)
+        instrumentdir = pathlib.Path(config.paths.instrumentsdir)
+    else:
+        outdatadir = "out"
+        rawdatadir = "raw"
+        cellpydatadir = "cellpyfiles"
+        filelogdir = "logs"
+        examplesdir = "examples"
+        db_path = "db"
+        db_filename = "cellpy_db.xlsx"
+        notebookdir = "notebooks"
+        batchfiledir = "batchfiles"
+        templatedir = "templates"
+        instrumentdir = "instruments"
+
+    outdatadir = h / outdatadir
+    rawdatadir = h / rawdatadir
+    cellpydatadir = h / cellpydatadir
+    filelogdir = h / filelogdir
+    examplesdir = h / examplesdir
+    db_path = h / db_path
+    notebookdir = h / notebookdir
+    batchfiledir = h / batchfiledir
+    templatedir = h / templatedir
+    instrumentdir = h / instrumentdir
+
+    if dry_run:
+        _say(f" - base (h): {h}")
+
+    if interactive:
+        outdatadir = _ask_about_path(
+            "where to output processed data and results", outdatadir
+        )
+        rawdatadir = _ask_about_otherpath("where your raw data are located", rawdatadir)
+        cellpydatadir = _ask_about_otherpath("where to put cellpy-files", cellpydatadir)
+        filelogdir = _ask_about_path("where to dump the log-files", filelogdir)
+        examplesdir = _ask_about_path(
+            "where to download cellpy examples and tests", examplesdir
+        )
+        db_path = _ask_about_path("what folder your db file lives in", db_path)
+        db_filename = _ask_about_name("the name of your db-file", db_filename)
+        notebookdir = _ask_about_path(
+            "where to put your jupyter notebooks", notebookdir
+        )
+        batchfiledir = _ask_about_path("where to put your batch files", batchfiledir)
+        templatedir = _ask_about_path("where to put your batch files", templatedir)
+        instrumentdir = _ask_about_path("where to put your batch files", instrumentdir)
+
+    # update folders based on suggestions
+    for d in [
+        outdatadir,
+        rawdatadir,
+        cellpydatadir,
+        filelogdir,
+        examplesdir,
+        notebookdir,
+        db_path,
+        batchfiledir,
+        templatedir,
+        instrumentdir,
+    ]:
+        if not dry_run:
+            _create_dir(d, confirm=not silent)
+        else:
+            _say(f"dry run (so I did not create {d})")
+
+    # update config-file based on suggestions
+    config.paths.outdatadir = str(outdatadir)
+    config.paths.rawdatadir = str(rawdatadir)
+    config.paths.cellpydatadir = str(cellpydatadir)
+    config.paths.filelogdir = str(filelogdir)
+    config.paths.examplesdir = str(examplesdir)
+    config.paths.db_path = str(db_path)
+    config.paths.db_filename = str(db_filename)
+    config.paths.notebookdir = str(notebookdir)
+    config.paths.batchfiledir = str(batchfiledir)
+    config.paths.templatedir = str(templatedir)
+    config.paths.instrumentdir = str(instrumentdir)
+
+
+def _ask_about_path(q, p):
+    _say(f"\n[cellpy] (setup) input {q}")
+    _say(f"[cellpy] (setup) current: {p}")
+    new_path = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
+    if not new_path:
+        new_path = p
+    return pathlib.Path(new_path)
+
+
+def _ask_about_otherpath(q, p):
+    _say(f"\n[cellpy] (setup) input {q}")
+    _say(f"[cellpy] (setup) current: {p}")
+    new_path = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
+    if not new_path:
+        new_path = p
+    return OtherPath(new_path)
+
+
+def _ask_about_name(q, n):
+    _say(f"\n[cellpy] (setup) input {q}")
+    _say(f"[cellpy] (setup) current: {n}")
+    new_name = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
+    if not new_name:
+        new_name = n
+    return new_name
+
+
+def _check_import_cellpy():
+    try:
+        import cellpy  # noqa: F401
+        from cellpy import log  # noqa: F401
+        from cellpy.readers import cellreader  # noqa: F401
+
+        return True
+    except Exception:
+        _say(" Failed to import cellpy")
+        _say(" Severity: critical")
+        return False
+
+
+def _check_import_pyodbc():
+    import platform
+
+    from cellpy.parameters import prms
+
+    ODBC = prms._odbc
+    SEARCH_FOR_ODBC_DRIVERS = prms._search_for_odbc_driver
+
+    use_subprocess = config.instruments.Arbin.use_subprocess
+    detect_subprocess_need = config.instruments.Arbin.detect_subprocess_need
+    _say(" This is needed for loading Arbin .res files")
+    _say(" parsing prms")
+    _say(
+        " (from your configuration file if it exists, otherwise using defaults)"
+    )
+    _say(f" - ODBC: {ODBC}")
+    _say(f" - SEARCH_FOR_ODBC_DRIVERS: {SEARCH_FOR_ODBC_DRIVERS}")
+    _say(f" - use_subprocess: {use_subprocess}")
+    _say(f" - detect_subprocess_need: {detect_subprocess_need}")
+    _say(f" - stated office version: {config.instruments.Arbin.office_version}")
+
+    _say(" checking system")
+    is_posix = False
+    is_macos = False
+    if os.name == "posix":
+        is_posix = True
+        _say(" - running on posix")
+    current_platform = platform.system()
+    if current_platform == "Darwin":
+        is_macos = True
+        _say(" - running on a mac")
+
+    python_version, os_version = platform.architecture()
+    _say(f" - python version: {python_version}")
+    _say(f" - os version: {os_version}")
+
+    if not is_posix:
+        if not config.instruments.Arbin.sub_process_path:
+            sub_process_path = str(prms._sub_process_path)
+        else:
+            sub_process_path = str(config.instruments.Arbin.sub_process_path)
+        _say(f" stated path to sub-process: {sub_process_path}")
+        if not os.path.isfile(sub_process_path):
+            _say(" - OBS! missing")
+
+    if is_posix:
+        _say(" checking existence of mdb-export")
+        sub_process_path = "mdb-export"
+        from subprocess import PIPE, run
+
+        command = ["command", "-v", sub_process_path]
+
+        try:
+            _say(f" - trying to run {command}")
+            result = run(
+                command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True
+            )
+            if result.returncode == 0:
+                _say(" - found it!")
+                return True
+
+            _say(f" - could not find {sub_process_path}")
+
+            if is_macos:
+                driver = "/usr/local/lib/libmdbodbc.dylib"
+                _say(
+                    f" looks like you are on a mac. Searching for suitable driver: {driver})"
+                )
+                if not os.path.isfile(driver):
+                    _say(f" - could not find {driver}")
+                    _say(
+                        " ! If you want to load Arbin .res files you will have to install it manually."
+                    )
+                    _say(" - Try installing it with brew:\n")
+                    _say("   brew install mdbtools")
+                    return False
+                _say(f" - found it: {driver}")
+                return True
+            else:
+                _say(
+                    " ! If you want to load Arbin .res files you will have to install it manually."
+                )
+                _say("   For example (for ubuntu):\n")
+                _say("   sudp apt-get update")
+                _say("   sudp apt-get install -y mdbtools")
+            return False
+
+        except AssertionError:
+            _say(" - could not find any suitable driver")
+            return False
+
+    # not posix - checking for odbc drivers
+    # 1) checking if you have defined one
+    try:
+        driver = config.instruments.Arbin.odbc_driver
+        if not driver:
+            raise AttributeError
+        _say(" You have defined an odbc driver in your config file")
+        _say(f" - driver: {driver}")
+    except AttributeError:
+        _say(" FYI: you have not defined any odbc_driver(s)")
+        _say(
+            " (The name of the driver from the configuration file is "
+            "used as a backup when cellpy cannot locate a driver by itself)"
+        )
+
+    use_ado = False
+
+    if ODBC == "ado":
+        use_ado = True
+        _say(" you stated that you prefer the ado loader")
+        _say(" checking if adodbapi is installed")
+        try:
+            import adodbapi as dbloader
+        except ImportError:
+            use_ado = False
+            _say(" Failed! Try setting pyodbc as your loader or install")
+            _say(" adodbapi (http://adodbapi.sourceforge.net/)")
+
+    if not use_ado:
+        if ODBC == "pyodbc":
+            _say(" you stated that you prefer the pyodbc loader")
+            try:
+                import pyodbc as dbloader
+            except ImportError:
+                _say(" Failed! Could not import it.")
+                _say(" Try 'pip install pyodbc'")
+                dbloader = None
+
+        elif ODBC == "pypyodbc":
+            _say(" you stated that you prefer the pypyodbc loader")
+            try:
+                import pypyodbc as dbloader  # type: ignore
+            except ImportError:
+                _say(" Failed! Could not import it.")
+                _say(" try 'pip install pypyodbc'")
+                _say(" or set pyodbc as your loader in your prm file")
+                _say(" (and install it)")
+                dbloader = None
+
+    _say(" searching for odbc drivers")
+    try:
+        drivers = [
+            driver
+            for driver in dbloader.drivers()
+            if "Microsoft Access Driver" in driver
+        ]
+        _say(f" Found these: {drivers}")
+        driver = drivers[0]
+        _say(f" - odbc driver: {driver}")
+        return True
+
+    except IndexError:
+        logging.debug(" Unfortunately, it seems the list of drivers is emtpy.")
+        _say(
+            "\n Could not find any odbc-drivers suitable for .res-type files. "
+            "Check out the homepage of pydobc for info on installing drivers"
+        )
+        _say(
+            " One solution that might work is downloading "
+            "the Microsoft Access database engine "
+            "(in correct bytes (32 or 64)) "
+            "from:\n"
+            "https://www.microsoft.com/en-us/download/details.aspx?id=13255"
+        )
+        _say(
+            " Or install mdbtools and set it up (check the cellpy docs for help)"
+        )
+        _say("\n")
+        return False
+
+
+def _check_config_file():
+    prm_file_name = _configloc()
+    env_file_name = _envloc()
+
+    if env_file_name is None:
+        _say(" FYI! Could not locate the environment file")
+
+    if prm_file_name is None:
+        _say(" Could not find the config file")
+        _say(" You can create one by running 'cellpy setup'")
+        return False
+
+    prm_dict = prmreader._read_prm_file_without_updating(prm_file_name)
+    try:
+        prm_paths = prm_dict["Paths"]
+        required_dirs = [
+            "cellpydatadir",
+            "examplesdir",
+            "filelogdir",
+            "notebookdir",
+            "outdatadir",
+            "rawdatadir",
+            "batchfiledir",
+            "templatedir",
+            "db_path",
+        ]
+        missing = 0
+        for k in required_dirs:
+            value = prm_paths.get(k, None)
+            _say(f" - {k}: {value}")
+            # splitting this into two if-statements to make it easier to debug if OtherPath changes
+            if k in OTHERPATHS:
+                print(f" skipping check for external {k} (for now)")
+                # if not OtherPath(
+                #     value
+                # ).is_dir():  # Assuming OtherPath returns True if it is external.
+                #     missing += 1
+                #     _say("COULD NOT CONNECT!")
+                #     _say(f"({value} is not a directory)")
+            elif value and not pathlib.Path(value).is_dir():
+                missing += 1
+                _say(" COULD NOT CONNECT!")
+                _say(f" ({value} is not a directory)")
+            if not value:
+                missing += 1
+                _say(" MISSING")
+
+        value = prm_paths.get("db_filename", None)
+        _say(f" - db_filename: {value}")
+        if not value:
+            missing += 1
+            _say(" MISSING")
+
+        if missing:
+            return False
+        else:
+            return True
+
+    except Exception as e:
+        _say(" Following error occurred:")
+        _say(e)
+        return False
+
+
+def _check(dry_run=False, full_check=True):
+    _say(" checking ".center(80, "="))
+    if dry_run:
+        _say("*** dry-run: skipping the test")
+        return
+    failed_checks = 0
+    number_of_checks = 0
+
+    def sub_check(check_type, check_func):
+        failed = 0
+        _say(f"[cellpy] * - Checking {check_type}")
+        if check_func():
+            _say("[cellpy] -> succeeded!")
+        else:
+            _say("f[cellpy] -> failed!!!!")
+            failed = 1
+        _say(80 * "-")
+        return failed
+
+    check_types = [
+        "cellpy imports",
+        "importing pyodbc",
+    ]
+    check_funcs = [
+        _check_import_cellpy,
+        _check_import_pyodbc,
+    ]
+
+    # additional checks that require loading the config file (not a part of setup)
+    additional_types = ["configuration files"]
+    additional_funcs = [_check_config_file]
+    if full_check:
+        check_types.extend(additional_types)
+        check_funcs.extend(additional_funcs)
+
+    for ct, cf in zip(check_types, check_funcs):
+        try:
+            failed_checks += sub_check(ct, cf)
+        except Exception as e:
+            _say(f"[cellpy] check raised an exception ({e})")
+        number_of_checks += 1
+    _say(" results ".center(80, "="))
+    succeeded_checks = number_of_checks - failed_checks
+
+    if failed_checks > 0:
+        _say(
+            "[cellpy] Some of the checks failed! This could potentially be a problem."
+        )
+        _say(f"[cellpy] Failed {failed_checks} out of {number_of_checks} checks.")
+    else:
+        _say(
+            f"[cellpy] Succeeded {succeeded_checks} out of {number_of_checks} checks."
+        )
+    _say(80 * "=")
+
+
+def _write_config_file(user_dir, dst_file, init_filename, dry_run):
+    _say(" update configuration ".center(80, "-"))
+    _say("[cellpy] (setup) Writing configurations to user directory:")
+    _say(f"\n         {user_dir}\n")
+
+    if os.path.isfile(dst_file):
+        _say("[cellpy] (setup) File already exists!")
+        _say("[cellpy] (setup) Keeping most of the old configuration parameters")
+    try:
+        if dry_run:
+            _say(
+                f"*** dry-run: skipping actual saving of {dst_file} ***")
+        else:
+            _say(f"[cellpy] (setup) Saving file ({dst_file})")
+            save_prm_file(dst_file)
+
+    except ConfigFileNotWritten:
+        _say("[cellpy] (setup) Something went wrong! Could not write the file")
+        _say(
+            "[cellpy] (setup) Trying to write a file"
+            + f"called {prmreader.DEFAULT_FILENAME} instead"
+        )
+
+        try:
+            user_dir, dst_file = prmreader.get_user_dir_and_dst(init_filename)
+            if dry_run:
+                _say(
+                    f"*** dry-run: skipping actual saving of {dst_file} ***",
+                    color="red",
+                )
+            else:
+                save_prm_file(dst_file)
+
+        except ConfigFileNotWritten:
+            _txt = "[cellpy] (setup) No, that did not work either.\n"
+            _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
+            _say(_txt)
+    else:
+        _say("[cellpy] (setup) Configuration file written!")
+        _say(
+            "[cellpy] (setup) OK! Now you can edit it. For example by "
+            f"issuing \n\n         [your-favourite-editor] {init_filename}\n"
+        )
+
+
+def _write_env_file(user_dir, dst_file, dry_run):
+    _say(" update configuration ".center(80, "-"))
+    _say("[cellpy] (setup) Writing environment file:")
+    _say(f"\n         {dst_file}\n")
+
+    if os.path.isfile(dst_file):
+        _say(f"[cellpy] (setup) Environment file {dst_file} already exists!")
+        if not dry_run:
+            return
+    try:
+        if dry_run:
+            _say(
+                f"*** dry-run: skipping actual saving of {dst_file} ***")
+        else:
+            _say(f"[cellpy] (setup) Saving file ({dst_file})")
+            dump_env_file(dst_file)
+
+    except ConfigFileNotWritten:
+        _txt = "[cellpy] (setup) No, that did not work either.\n"
+        _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
+        _say(_txt)
+    else:
+        _say("[cellpy] (setup) Environment file written!")
+        _say(
+            "[cellpy] (setup) OK! Now you can edit it. For example by "
+            f"issuing \n\n         [your-favourite-editor] {dst_file}\n"
+        )
+
+
+def _get_default_editor():
+    """
+    Return the default text editor.
+
+    This code is based on the `editor` library by @rec.
+    """
+
+    return os.environ.get("VISUAL") or (
+        os.environ.get("EDITOR") or EDITORS.get(platform.system(), DEFAULT_EDITOR)
+    )
+
+# -- dump_config_resolved --
+def _dump_config_resolved():
+    """Print resolved config values with per-field provenance (#454)."""
+    from cellpy import config as cellpy_config
+
+    data = cellpy_config.get_config().model_dump_for_file()
+    provenance = cellpy_config.sources()
+    _say("[cellpy] resolved configuration (value  # source-layer):")
+    for section, fields in data.items():
+        _say(f"\n[{section}]")
+        if not isinstance(fields, dict):
+            _say(f"  {fields!r}")
+            continue
+        for key, value in fields.items():
+            layer = provenance.get(f"{section}.{key}", "default")
+            _say(f"  {key} = {value!r}  # {layer}")
+
+# -- pull clone/tests/examples --
+def _clone_repo(directory, password):
+    directory = pathlib.Path(directory)
+    txt = "[cellpy] The plan is that this "
+    txt += "[cellpy] cmd will pull (clone) the cellpy repo.\n"
+    txt += "[cellpy] For now it only prints the link to the git-hub\n"
+    txt += "[cellpy] repository:\n"
+    txt += "[cellpy]\n"
+    txt += "[cellpy] https://github.com/jepegit/cellpy.git\n"
+    txt += "[cellpy]\n"
+    _say(txt)
+
+
+def _pull_tests(directory, pw=None):
+    txt = (
+        "[cellpy] (pull) Pulling tests from",
+        " https://github.com/jepegit/cellpy.git",
+    )
+    _say(txt)
+    _pull(gdirpath="tests", rootpath=directory, pw=pw)
+    _pull(gdirpath="testdata", rootpath=directory, pw=pw)
+
+
+def _pull_examples(directory, pw):
+    txt = (
+        "[cellpy] (pull) Pulling examples from",
+        " https://github.com/jepegit/cellpy.git",
+    )
+    _say(txt)
+    _pull(gdirpath="examples", rootpath=directory, pw=pw)
+
+# -- version/configloc/envloc/dump_params --
+def _version():
+    version_text = "[cellpy] version: " + str(VERSION)
+    _say(version_text)
+
+
+def _configloc():
+    _, config_file_name = prmreader.get_user_dir_and_dst()
+    _say(f"[cellpy] -> {config_file_name}")
+    if not os.path.isfile(config_file_name):
+        _say("[cellpy] File does not exist!")
+    else:
+        return config_file_name
+
+
+def _envloc():
+    env_file_name = prmreader.get_env_file_name()
+    _say(f"[cellpy] (from config) -> {env_file_name}")
+    if not os.path.isfile(env_file_name):
+        return
+    return env_file_name
+
+
+def _dump_params():
+    _say("[cellpy] Running prmreader.info:\n")
+    prmreader.info()
+
+
+# -- github download helpers --
+def _download_g_blob(name, local_path):
+    import urllib.request
+
+    dirs = local_path.parent
+    if not dirs.is_dir():
+        _say(f"[cellpy] (pull) creating dir: {dirs}")
+        dirs.mkdir(parents=True)
+    print(f"[cellpy] (pull) downloading blob: {name.download_url}")
+    filename, headers = urllib.request.urlretrieve(
+        name.download_url, filename=local_path
+    )
+    _say(f"[cellpy] (pull) downloaded blob: {filename}")
+
+
+def _parse_g_subdir(stuff, repo, gdirpath):
+    """recursive function for parsing repo subdirectories"""
+    for f in repo.get_contents(gdirpath):
+        if f.type != "dir":
+            stuff.append(f)
+        else:
+            _parse_g_subdir(stuff, repo, f.path)
+
+
+def _parse_g_dir(repo, gdirpath):
+    """yields content of repo directory"""
+    stuff = []
+    _parse_g_subdir(stuff, repo, gdirpath)
+    for f in stuff:
+        yield f
+
+
+def _get_user_name():
+    return "jepegit"
+
+
+def _get_pw(method):
+    if method == "ask":
+        return getpass.getpass()
+    elif method == "env":
+        return os.environ.get(GITHUB_PWD_VAR_NAME, None)
+
+    else:
+        return None
+
+
+def _pull(gdirpath="examples", rootpath=None, u=None, pw=None):
+    if rootpath is None:
+        rootpath = config.paths.examplesdir
+
+    rootpath = pathlib.Path(rootpath)
+
+    ndirpath = rootpath / gdirpath
+
+    if pw is not None:
+        _say(" DEV MODE ".center(80, "-"))
+        u = _get_user_name()
+        if pw == "ask":
+            _say("   - ask for password")
+            pw = _get_pw(pw)
+        elif pw == "env":
+            _say("   - check environ for password ")
+            pw = _get_pw(pw)
+            _say("   - got something")
+            if pw is None:
+                _say("   - only None")
+                u = None
+
+    g = Github(u, pw)
+    try:
+        repo = g.get_repo(REPO)
+    except github.RateLimitExceededException:
+        _say("   - rate limit exceeded")
+        _say("   - waiting 60 seconds, and trying only once more")
+        _say(
+            "   - hint! you can check status directly using the github api, e.g. "
+        )
+        _say("     $ curl -i https://api.github.com/users/USERNAME")
+        _say("   - press ctrl-c to abort")
+        time.sleep(60)
+        repo = g.get_repo(REPO)
+
+    _say(f"[cellpy] (pull) pulling {gdirpath}")
+    _say(f"[cellpy] (pull) -> {ndirpath}")
+
+    if not ndirpath.is_dir():
+        _say(f"[cellpy] (pull) creating dir: {ndirpath}")
+        ndirpath.mkdir(parents=True)
+
+    for gfile in _parse_g_dir(repo, gdirpath):
+        gfilename = pathlib.Path(gfile.path)
+        nfilename = rootpath / gfilename
+        try:
+            _download_g_blob(gfile, nfilename)
+        except github.RateLimitExceededException:
+            _say("   - rate limit exceeded")
+            _say("   - waiting 60 seconds, and trying only once more")
+            _say("   - press ctrl-c to abort")
+            time.sleep(60)
+            _download_g_blob(gfile, nfilename)
+
+# -- templates --
+def _get_default_template():
+    template = "standard"
+    try:
+        template = config.batch.template
+    except Exception:
+        logging.debug("You dont have any default template defined in you .conf file")
+    return template
+
+
+def _read_local_templates(local_templates_path=None):
+    if local_templates_path is None:
+        local_templates_path = pathlib.Path(config.paths.templatedir)
+    templates = {}
+    for p in list(local_templates_path.rglob("cellpy_cookie*.zip")):
+        label = p.stem.strip()[len("cellpy_cookie_") :]
+        templates[label] = (str(p), None)
+    logging.debug(f"Found the following templates: {templates}")
+    return templates
+
+# -- _new through _serve --
+def _new(
+    template: str,
+    directory: PathLike | None = None,
+    project_dir: Union[str, None] = None,
+    local_user_template: bool = False,
+    serve_: bool = False,
+    run_: bool = False,
+    lab: bool = False,
+    list_: bool = False,
+    executable: Union[str, None] = None,
+    session_id: str = "experiment_001",
+    no_input: bool = False,
+    cookie_directory: str = "",
+    local_templates_with_sub_directories: bool = False,
+):
+    """Set up a batch experiment (might need git installed).
+
+    Args:
+        template: short-name of template.
+        directory: the directory for your cellpy projects.
+        local_user_template: use local template if True.
+        serve_: serve the notebook after creation if True.
+        run_: run the notebooks using papermill if True.
+        lab: use jupyter-lab instead of jupyter notebook if True.
+        executable: path to jupyter executable.
+        list_: list all available templates and return if True.
+        project_dir: your project directory.
+        session_id: the lookup value.
+        no_input: accept defaults if True (only valid when providing project_dir and session_id)
+        cookie_directory: name of the directory for your cookie (inside the repository or zip file).
+        local_templates_with_sub_directories: use sub-directories in local templates if True.
+    Returns:
+        None
+    """
+
+    try:
+        import cookiecutter.exceptions
+        import cookiecutter.main
+        import cookiecutter.prompt
+
+    except ModuleNotFoundError:
+        _say("Could not import cookiecutter.")
+        _say("Try installing it, for example by writing:")
+        _say("\npython -m pip install cookiecutter\n")
+        return
+
+    if list_:
+        _say("\n[cellpy] batch templates")
+
+        default_template = _get_default_template()
+        local_templates = _read_local_templates()
+        local_templates_path = config.paths.templatedir
+        registered_templates = REGISTERED_TEMPLATES
+        _say(f"[cellpy] - default: {default_template}")
+        _say("[cellpy] - registered templates (on github):")
+        for label, link in registered_templates.items():
+            _say(f"\t\t{label:18s} {link}")
+
+        if local_templates:
+            _say(f"[cellpy] - local templates ({local_templates_path}):")
+            for label, link in local_templates.items():
+                _say(f"\t\t{label:18s} {link}")
+        else:
+            _say(f"[cellpy] - local templates ({local_templates_path}): none")
+
+        return
+
+    if project_dir is None or session_id is None:
+        no_input = False
+
+    if not template:
+        template = _get_default_template()
+
+    if lab:
+        server = "lab"
+    else:
+        server = "notebook"
+
+    _say(f"Template: {template}")
+    if local_user_template:
+        # forcing using local template
+        templates = _read_local_templates()
+
+        if not templates:
+            _say(
+                "You asked me to use a local template, but you have none. Aborting."
+            )
+            return
+    else:
+        templates = REGISTERED_TEMPLATES
+        if local_templates := _read_local_templates():
+            templates.update(local_templates)
+
+    if template.lower() not in templates:
+        _say("This template does not exist. Aborting.")
+        return
+
+    if directory is None:
+        logging.debug("no dir given")
+        directory = config.paths.notebookdir
+
+    if not os.path.isdir(directory):
+        _say("Sorry. This did not work as expected!")
+        _say(f" - {directory} does not exist")
+        return
+
+    directory = pathlib.Path(directory)
+    selected_project_dir = None
+
+    if project_dir:
+        selected_project_dir = directory / project_dir
+        if not selected_project_dir.is_dir():
+            if cookiecutter.prompt.read_user_yes_no(
+                f"{project_dir} does not exist. Create?", "yes"
+            ):
+                os.mkdir(selected_project_dir)
+                _say(f"Created {selected_project_dir}")
+
+            else:
+                selected_project_dir = None
+                _say("Select another directory instead")
+    CREATE_NEW_DIR = "Create new project..."
+    if not selected_project_dir:
+        project_dirs = [
+            d.name
+            for d in directory.iterdir()
+            if d.is_dir() and not d.name.startswith(".")
+        ]
+        project_dirs.insert(0, CREATE_NEW_DIR)
+
+        project_dir = cookiecutter.prompt.read_user_choice(
+            "project folder", project_dirs
+        )
+
+        if project_dir == CREATE_NEW_DIR:
+            default_name = "cellpy_project"
+            temp_default_name = default_name
+            for j in range(999):
+                if temp_default_name in project_dirs:
+                    temp_default_name = default_name + str(j + 1).zfill(3)
+                else:
+                    default_name = temp_default_name
+                    break
+
+            project_dir = cookiecutter.prompt.read_user_variable(
+                "New name", default_name
+            )
+            try:
+                os.mkdir(directory / project_dir)
+                _say(f"created {project_dir}")
+            except FileExistsError:
+                _say("OK - but this directory already exists!")
+        selected_project_dir = directory / project_dir
+
+    # get a list of all folders
+    existing_projects = os.listdir(selected_project_dir)
+
+    os.chdir(selected_project_dir)
+    cellpy_version = cellpy.__version__
+
+    try:
+        selected_template, cookie_dir = templates[template.lower()]
+
+        if cookie_directory:
+            cookie_dir = cookie_directory
+        if not cookie_dir:
+            # if cookie_dir is not set, use the template name
+            if not local_user_template:
+                cookie_dir = template.lower()
+            elif local_templates_with_sub_directories:
+                cookie_dir = template.lower()
+
+        author_name = _get_author_name()
+        cookiecutter.main.cookiecutter(
+            selected_template,
+            extra_context={
+                "author_name": author_name,
+                "project_name": project_dir,
+                "cellpy_version": cellpy_version,
+                "session_id": session_id,
+            },
+            no_input=no_input,
+            directory=cookie_dir,
+        )
+    except cookiecutter.exceptions.OutputDirExistsException as e:
+        _say("Sorry. This did not work as expected!")
+        _say(" - cookiecutter refused to create the project")
+        _say(e)
+
+    if serve_:
+        os.chdir(directory)
+        _serve(server, executable)
+
+    elif run_:
+        _say("WARNING - experimental feature - use at your own risk")
+        input("Press Enter to continue...")
+        import importlib.util
+
+        if importlib.util.find_spec("papermill") is None:
+            _say(
+                "[cellpy]: You need to install papermill for automatically execute the notebooks."
+            )
+            _say("[cellpy]: You can install it using pip like this:")
+            _say(" >> pip install papermill")
+            return
+        new_existing_projects = os.listdir(selected_project_dir)
+        our_new_projects = list(set(new_existing_projects) - set(existing_projects))
+
+        if not len(our_new_projects):
+            _say(
+                "[cellpy]: Sorry, could not deiced what is the new project "
+                "- so I don't dare to try to execute automatically."
+            )
+            return
+        our_new_project = selected_project_dir / our_new_projects[0]
+
+        run_project(our_new_project, echo=_echo_var.get())
+
+
+def _get_author_name():
+    """Get the name of the author."""
+    try:
+        import getpass
+
+        author_name = getpass.getuser()
+    except Exception as e:
+        _say("Could not get the author name")
+        _say(e)
+        author_name = "unknown"
+    return author_name
+
+
+def _serve(server, executable=None):
+    _say(f"serving with jupyter {server}")
+    # TODO: search for jupyter and find the right one
+    if executable is None:
+        executable = "jupyter"
+    subprocess.run([executable, server], check=True)
+    _say("Finished serving.")
+
+
+
+def setup_config(
+    *,
+    interactive: bool = False,
+    not_relative: bool = False,
+    dry_run: bool = False,
+    reset: bool = False,
+    root_dir=None,
+    folder_name=None,
+    test_user=None,
+    silent: bool = False,
+    no_deps: bool = False,
+    echo: Optional[Echo] = None,
+):
+    """Write / refresh the user cellpy configuration (library form of ``cellpy setup``)."""
+    with _using_echo(echo):
+        _say("[cellpy] (setup)")
+        _say(f"[cellpy] root-dir: {root_dir}")
+
+        # notify of missing 'difficult' or optional modules
+        if not no_deps:
+            _say("[cellpy] checking dependencies")
+            for m in DIFFICULT_MISSING_MODULES:
+                _say(" [cellpy] WARNING! ".center(80, "-"))
+                _say("[cellpy] missing dependencies:")
+                _say(f"[cellpy] - {m}")
+                _say(f"[cellpy] {DIFFICULT_MISSING_MODULES[m]}")
+                _say(
+                    "[cellpy] (you can skip this check by using the --no-deps option)"
+                )
+                _say(80 * "-")
+
+        # generate variables
+        init_filename = prmreader.create_custom_init_filename()
+        user_dir, dst_file = prmreader.get_user_dir_and_dst(init_filename)
+        env_file = prmreader.get_env_file_name()
+
+        if dry_run:
+            _say("Create custom init filename and get user_dir and destination")
+            _say("Got the following parameters:")
+            _say(f" - init_filename: {init_filename}")
+            _say(f" - user_dir: {user_dir}")
+            _say(f" - dst_file: {dst_file}")
+            _say(f" - not_relative: {not_relative}")
+
+        if root_dir and not interactive:
+            _say("[cellpy] custom root-dir can only be used in interactive mode")
+            _say("[cellpy] -> setting interactive mode")
+            interactive = True
+
+        if not root_dir:
+            root_dir = user_dir
+            # root_dir = pathlib.Path(os.getcwd())
+        root_dir = pathlib.Path(root_dir)
+
+        if dry_run:
+            _say(f" - root_dir: {root_dir}")
+
+        if test_user:
+            _say(f"[cellpy] (setup) DEV-MODE test_user: {test_user}")
+            init_filename = prmreader.create_custom_init_filename(test_user)
+            user_dir = root_dir
+            dst_file = get_dst_file(user_dir, init_filename)
+            _say(f"[cellpy] (setup) DEV-MODE user_dir: {user_dir}")
+            _say(f"[cellpy] (setup) DEV-MODE dst_file: {dst_file}")
+
+        if not pathlib.Path(dst_file).is_file():
+            _say(f"[cellpy] {dst_file} not found -> I will make one for you")
+            reset = True
+
+        if not pathlib.Path(env_file).is_file():
+            _say(
+                f"[cellpy] {env_file} not found -> I will make one (but you must edit it yourself)"
+            )
+
+        if interactive:
+            _say(" interactive mode ".center(80, "-"))
+            _update_paths(
+                custom_dir=root_dir,
+                relative_home=not not_relative,
+                default_dir=folder_name,
+                dry_run=dry_run,
+                reset=reset,
+                interactive=True,
+            )
+            _write_config_file(user_dir, dst_file, init_filename, dry_run)
+            _write_toml_config_file(dst_file, dry_run, test_user=test_user)
+            _write_env_file(user_dir, env_file, dry_run)
+            _check(dry_run=dry_run)
+
+        else:
+            if reset:
+                _update_paths(
+                    user_dir,
+                    False,
+                    default_dir=folder_name,
+                    dry_run=dry_run,
+                    reset=True,
+                    interactive=False,
+                    silent=silent,
+                )
+            _write_config_file(user_dir, dst_file, init_filename, dry_run)
+            _write_toml_config_file(dst_file, dry_run, test_user=test_user)
+            _write_env_file(user_dir, env_file, dry_run)
+            _check(dry_run=dry_run, full_check=False)
+
+
+# -- public facades (#651) ------------------------------------------------------
+
+
+def show_info(
+    *,
+    version: bool = False,
+    configloc: bool = False,
+    params: bool = False,
+    show_config: bool = False,
+    check: bool = False,
+    echo: Optional[Echo] = None,
+) -> None:
+    """Library form of ``cellpy info``."""
+    with _using_echo(echo):
+        complete_info = True
+        if check:
+            complete_info = False
+            _check()
+        if version:
+            complete_info = False
+            _version()
+        if configloc:
+            complete_info = False
+            _configloc()
+        if params:
+            complete_info = False
+            _dump_params()
+        if show_config:
+            complete_info = False
+            _dump_config_resolved()
+        if complete_info:
+            _version()
+            _configloc()
+
+
+def config_path(*, echo: Optional[Echo] = None):
+    """Return the user config file path (also echoes it)."""
+    with _using_echo(echo):
+        return _configloc()
+
+
+def start_jupyter(
+    *,
+    lab: bool = False,
+    directory=None,
+    executable=None,
+    echo: Optional[Echo] = None,
+) -> None:
+    """Library form of ``cellpy serve``."""
+    with _using_echo(echo):
+        if directory is None:
+            directory = config.paths.notebookdir
+        elif directory == "home":
+            directory = pathlib.Path().home()
+        elif directory == "here":
+            directory = pathlib.Path(os.getcwd())
+
+        if not os.path.isdir(directory):
+            _say("Sorry. This did not work as expected!")
+            _say(f" - {directory} does not exist")
+            return
+
+        server = "lab" if lab else "notebook"
+        os.chdir(directory)
+        _serve(server, executable=executable)
+
+
+def edit_file(
+    name=None,
+    *,
+    default_editor=None,
+    debug: bool = False,
+    silent: bool = False,
+    echo: Optional[Echo] = None,
+) -> None:
+    """Library form of ``cellpy edit``."""
+    with _using_echo(echo):
+        key = None if name is None else name.lower()
+        if key == "db":
+            open_db_editor(debug=debug, silent=silent, echo=echo)
+            return
+
+        if key is not None and key not in ("env", "config"):
+            _say("unknown file")
+            return
+
+        if key is None or key == "config":
+            config_file = _configloc()
+            if config_file is None:
+                print("could not find the config file")
+                return
+            filename = str(pathlib.Path(config_file).resolve())
+        elif key == "env":
+            filename = _envloc()
+            if filename is None:
+                print("could not find the env file")
+                return
+        else:
+            filename = name
+
+        if default_editor is None:
+            default_editor = _get_default_editor()
+
+        args = [default_editor, filename]
+        _say(f"[cellpy] (edit) Calling '{default_editor}'")
+        try:
+            subprocess.call(args)
+        except Exception:
+            _say("[cellpy] (edit) Failed!")
+            _say(
+                "[cellpy] (edit) Try 'cellpy edit -e notepad.exe' if you are on Windows"
+            )
+
+
+def pull_resources(
+    *,
+    tests: bool = False,
+    examples: bool = False,
+    clone: bool = False,
+    directory=None,
+    password=None,
+    echo: Optional[Echo] = None,
+) -> None:
+    """Library form of ``cellpy pull``."""
+    with _using_echo(echo):
+        if directory is not None:
+            _say(f"[cellpy] (pull) custom directory: {directory}")
+        else:
+            directory = pathlib.Path(config.paths.examplesdir)
+
+        if password is not None:
+            _say("DEV MODE: password provided")
+        if clone:
+            _clone_repo(directory, password)
+        else:
+            if tests:
+                _pull_tests(directory, password)
+            if examples:
+                _pull_examples(directory, password)
+            elif not tests:
+                _say(
+                    "[cellpy] (pull) Nothing selected for pulling. "
+                    "Please select an option (--tests,--examples, -clone, ...) "
+                )
+
+
+def create_project(
+    template=None,
+    *,
+    directory=None,
+    project=None,
+    experiment=None,
+    local_user_template: bool = False,
+    serve_: bool = False,
+    run_: bool = False,
+    lab: bool = False,
+    jupyter_executable=None,
+    list_: bool = False,
+    echo: Optional[Echo] = None,
+    **kwargs,
+):
+    """Library form of ``cellpy new``."""
+    with _using_echo(echo):
+        return _new(
+            template,
+            directory=directory,
+            project_dir=project,
+            session_id=experiment,
+            local_user_template=local_user_template,
+            serve_=serve_,
+            run_=run_,
+            lab=lab,
+            executable=jupyter_executable,
+            list_=list_,
+            **kwargs,
+        )

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -30,6 +30,13 @@ def test_every_extracted_command_is_importable():
         "run_project",
         "list_journals",
         "open_db_editor",
+        "setup_config",
+        "migrate_config",
+        "show_info",
+        "start_jupyter",
+        "edit_file",
+        "pull_resources",
+        "create_project",
     ):
         assert callable(getattr(cli_api, name)), name
 
@@ -278,3 +285,60 @@ def test_convert_really_upgrades_a_legacy_file(tmp_path, target):
     reloaded = cellreader.CellpyCell().load(written)
     assert len(reloaded.get_cycle_numbers()) > 0
     assert len(reloaded.data.raw) > 0
+
+
+# -- remaining commands (#651) ----------------------------------------------------
+
+
+@pytest.mark.essential
+def test_show_info_is_quiet_by_default(capsys):
+    cli_api.show_info(version=True)
+    assert "version" not in capsys.readouterr().out
+
+
+@pytest.mark.essential
+def test_show_info_echoes_when_asked(capsys):
+    cli_api.show_info(version=True, echo=print)
+    assert "version" in capsys.readouterr().out
+
+
+@pytest.mark.essential
+def test_start_jupyter_reports_missing_directory(tmp_path, capsys):
+    missing = tmp_path / "no_such_notebooks"
+    cli_api.start_jupyter(directory=str(missing), echo=print)
+    out = capsys.readouterr().out
+    assert "does not exist" in out
+
+
+@pytest.mark.essential
+def test_create_project_returns_when_cookiecutter_missing(monkeypatch, capsys):
+    """Missing cookiecutter used to echo and then NameError (#651)."""
+    import builtins
+    import sys
+
+    for mod in [m for m in sys.modules if m.startswith("cookiecutter")]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("cookiecutter"):
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    cli_api.create_project(list_=False, echo=print)
+    out = capsys.readouterr().out
+    assert "Could not import cookiecutter" in out
+
+
+@pytest.mark.essential
+def test_pull_resources_with_nothing_selected_is_quiet_by_default(capsys):
+    cli_api.pull_resources()
+    assert "Nothing selected" not in capsys.readouterr().out
+
+
+@pytest.mark.essential
+def test_config_path_returns_a_path_or_none():
+    result = cli_api.config_path()
+    assert result is None or hasattr(result, "exists") or isinstance(result, str)


### PR DESCRIPTION
## Summary
- Move `setup` / `migrate`, `info`, `edit`, `pull`, `new`, and `serve` logic into `cellpy.cli_api` with quiet-by-default `echo=` (CLI passes `typer.echo`).
- Thin `cellpy.cli` to Typer adapters only; bind echo for helpers via `_using_echo` / `_say`.
- Fix cookiecutter `ModuleNotFoundError` path that previously continued and raised `NameError`.

Closes #651.

## Test plan
- [x] `uv run ruff check cellpy/cli_api.py cellpy/cli.py`
- [x] `uv run pytest tests/test_cli_api.py tests/test_cli_surface.py tests/test_cellpy_cmd.py` (69 passed)
- [ ] Spot-check `cellpy info --version`, `cellpy new --list`, `cellpy setup --dry-run`


Made with [Cursor](https://cursor.com)