### PR TITLE
Lock file-format compatibility matrix (pre-v8 freeze)

### DIFF
--- a/.issueflows/03-solved-issues/issue573_original.md
+++ b/.issueflows/03-solved-issues/issue573_original.md
@@ -1,0 +1,34 @@
+# Issue #573: Stage 3.16: lock the file-format compatibility matrix (v8 read/write, v9, convert)
+
+Source: https://github.com/jepegit/cellpy/issues/573
+
+## Original issue text
+
+## Goal
+
+Verify and lock the 2.0 file-format compatibility matrix end to end.
+
+## Why
+
+The support matrix is a promise made in the release notes; it needs a test, not a
+sentence. v9 write and v8 write both exist today (`save(cellpy_file_format="v8")`), but
+there is no single suite asserting the whole matrix, and `cellpy convert --to v9` does
+not exist yet â€” `convert` still only takes `old_h5 new_h5`.
+
+Plan: `architecture-plan/cellpy2-release-and-branching-plan.md` Â§1; architecture plan
+Â§2 and Â§6 row 3.1.
+
+## Scope
+
+- [ ] Test matrix: read v8 âœ“, read v9 âœ“, write v9 (default) âœ“,
+      write v8 via `save(cellpy_file_format="v8")` âœ“, read v<8 â†’ typed error naming
+      `cellpy convert` on 1.x âœ“.
+- [ ] `cellpy convert --to v9` (and `--to v8`) implemented and tested.
+- [ ] v8 round-trip through 2.0 preserves values (parity oracle, not byte equality).
+- [ ] The v<8 freeze message is what the 1.x deprecation warnings promised.
+- [ ] Matrix runs on every CI job that touches file IO.
+
+## Acceptance
+
+- One parametrized suite covers every cell of the matrix.
+- Converting a v8 golden to v9 and back gives value parity on raw, steps and summary.

--- a/.issueflows/03-solved-issues/issue573_plan.md
+++ b/.issueflows/03-solved-issues/issue573_plan.md
@@ -1,0 +1,146 @@
+# Issue #573 — plan
+
+## Goal
+
+Lock the cellpy **2.0 file-format support matrix** in one essential, parametrized
+suite (and align default `load` with that matrix), so #574’s release checklist can
+assert a test — not a sentence.
+
+## Constraints
+
+- **Plan of record:** [architecture-plan/cellpy2-release-and-branching-plan.md](../../../architecture-plan/cellpy2-release-and-branching-plan.md) §1;
+  architecture plan §2 / §6 row 3.1; Stage-3 sequencing: **#573 before #574**.
+- **Promised 2.x matrix:** read **v8 + v9**, write **v9** (default) and **v8** via
+  `save(... cellpy_file_format="v8"|".h5")`; **v&lt;8** → typed error that names
+  `cellpy convert` on **1.x**.
+- **Already shipped (do not re-implement):** `cellpy convert --to v9|v8` and
+  destination inference ([`cli_api.convert`](../../cellpy/cli_api.py), CLI wiring in
+  [`cli.py`](../../cellpy/cli.py), essential coverage in
+  [`tests/test_cli_api.py`](../../tests/test_cli_api.py)) from #569 / #568.
+- **Parity helpers already exist:** reuse
+  [`tests/cellpy_file_support.py`](../../tests/cellpy_file_support.py)
+  (`assert_data_frames_equal`, meta/fid helpers, `snapshot_cell_state`) — do not
+  invent a second oracle.
+- **Fixtures:** `testdata/hdf5/20160805_test001_45_cc_v{0,4,5,6,7,8,8_with_fids}.h5`
+  already cover the versions the matrix needs.
+- **CI:** Tier-1 is `uv run pytest -m essential` ([ci-tiers.md](../04-designs-and-guides/ci-tiers.md)).
+  Matrix cells that guard the release promise get `@pytest.mark.essential`; no new
+  workflow.
+- **Docs drift:** [migration_v1_to_v2.md](../../docs/getting_started/migration_v1_to_v2.md)
+  currently says 2.x still loads v4–v8; freeze must update that table in the same PR.
+- **KISS:** one new test module + small load-path / message change. No new package
+  layer.
+
+### Prior art
+
+| Hit | Module | Convention |
+|---|---|---|
+| `cli_api.convert` / `CONVERT_TARGETS` | [`cellpy/cli_api.py`](../../cellpy/cli_api.py) | **Reuse** — already implements `--to` + suffix inference; convert keeps `accept_old=True`. |
+| v8→v9 value round-trip | [`tests/test_cellpy_file_v9.py`](../../tests/test_cellpy_file_v9.py) | **Mirror** into matrix row (same helpers / fixture). |
+| v8 HDF5 round-trip + legacy v4–v7 shapes | [`tests/test_cellpy_file_roundtrip.py`](../../tests/test_cellpy_file_roundtrip.py) | **Coexist** — leave characterization tests; matrix is the release contract. |
+| Version gate | [`cellpy/readers/cellpy_file/read.py`](../../cellpy/readers/cellpy_file/read.py) | **Migrate** — today’s `accept_old=False` message says `Try loading setting accept_old=True`; freeze message must name convert on 1.x. |
+| `CellpyCell.load(..., accept_old=True)` default | [`cellpy/readers/cellreader.py`](../../cellpy/readers/cellreader.py) | **Migrate** — default still permissive; contradicts release §1. |
+| Parity helpers | [`tests/cellpy_file_support.py`](../../tests/cellpy_file_support.py) | **Reuse**. |
+| Toolbox (`00-tools/`) | — | None relevant. |
+| Graph communities | cellpy_file / convert / WrongFileVersion / CLI | Confirms same hotspots; no extra modules. |
+
+## Approach
+
+### 1. Decide freeze semantics (product)
+
+**Recommended (matches issue + release §1):**
+
+1. Change `CellpyCell.load` default to `accept_old=False`.
+2. On `version < 8` with `accept_old=False`, raise `WrongFileVersion` whose message
+   **names `cellpy convert` on cellpy 1.x** (and, briefly, that 2.x `cellpy convert`
+   can also rewrite if they already upgraded). Drop the
+   `Try loading setting accept_old=True` as the primary instruction — keep
+   `accept_old=True` as a documented escape for tests / advanced use, not the
+   user-facing remedy.
+3. Leave `cli_api.convert(..., accept_old=True)` so 2.0 CLI convert still upgrades
+   v4–v7 → v9/v8 (already covered by `test_convert_really_upgrades_a_legacy_file`).
+4. Update migration guide support-matrix row to: 2.x default `load` = **v8 + v9
+   only**; pre-v8 → convert (1.x preferred; 2.x `cellpy convert` also works).
+
+**Note:** v1.x today still uses the old `accept_old=True` message — the “promised”
+1.x deprecation text was never landed as a distinct string. Craft the 2.0 freeze
+message from release §1 / migration guide; optionally open a small v1.x follow-up
+to warn — **out of scope** unless you want it in this PR (see Open questions).
+
+### 2. One parametrized matrix suite
+
+Add [`tests/test_file_format_compat_matrix.py`](../../tests/test_file_format_compat_matrix.py)
+with one row per matrix cell (all `@pytest.mark.essential` unless a cell is
+fixture-missing → `pytest.skip`):
+
+| Cell | Assert |
+|---|---|
+| read v8 | `load(v8_with_fids)` succeeds; non-empty raw/steps/summary |
+| read v9 | v8 → `save(.cellpy)` → `load`; zip sniff + tables |
+| write v9 (default) | `save(tmp.cellpy)` → `is_zip_cellpy` + `cellpy_file_version == 9` |
+| write v8 | `save(tmp.h5)` or `cellpy_file_format="v8"` → HDF5 keys, not zip |
+| read v&lt;8 (default) | v5 (and optionally v4/v7) → `WrongFileVersion` matching convert/1.x |
+| read v&lt;8 (`accept_old=True`) | still loads (escape; not the user path) |
+| convert → v9 / v8 | thin wrap or import of existing CLI-api real-file test pattern (v5 fixture) |
+| v8 round-trip parity | v8 → v9 → load; raw/steps/summary via `assert_data_frames_equal` (same as `test_v8_to_v9_to_read_roundtrip`) |
+| v8 → save v8 → load parity | optional second parity row if cheap |
+
+Do **not** delete `test_cellpy_file_v9.py` / `test_cellpy_file_roundtrip.py` /
+`test_cli_api.py` convert tests — matrix is the release contract; those stay as
+characterization depth.
+
+### 3. Retarget existing tests that assume permissive default
+
+- [`tests/test_cellpy_file_roundtrip.py`](../../tests/test_cellpy_file_roundtrip.py)
+  legacy parametrize already passes `accept_old=True` — keep.
+- Grep for bare `load(` / `CellpyCell().load(` on v4–v7 fixtures without
+  `accept_old=True` and fix those call sites.
+- Any test expecting the old “Try loading setting accept_old=True” string must
+  match the new freeze message.
+
+### 4. CI
+
+No workflow edits if the new suite is `essential` — Tier 1 already runs it.
+Mention the suite name in `tests/README.md` in one line if that file already
+indexes essential file-IO suites.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `cellpy/readers/cellreader.py` | `load(..., accept_old=False)` default + docstring |
+| `cellpy/readers/cellpy_file/read.py` | Freeze `WrongFileVersion` message for `version < HDF5_FILE_VERSION` when not `accept_old` |
+| `tests/test_file_format_compat_matrix.py` | **New** — parametrized matrix (essential) |
+| `tests/test_cellpy_file_*.py` / other loaders | Only if grep finds callers broken by default flip |
+| `docs/getting_started/migration_v1_to_v2.md` | Support-matrix row aligned with freeze |
+| `tests/README.md` | One-line pointer to the matrix suite (if index exists) |
+
+**Out of scope:** implementing `convert --to` (done); v1.x backport of the warning
+(unless you opt in); #574 release checklist; rewriting characterization suites.
+
+## Test strategy
+
+```bash
+uv run pytest -m essential
+uv run pytest tests/test_file_format_compat_matrix.py tests/test_cli_api.py -k convert tests/test_cellpy_file_v9.py tests/test_cellpy_file_roundtrip.py -q
+```
+
+(Project toolchain: `uv run pytest`; conda `cellpy_dev_313` also fine locally.)
+
+## Open questions
+
+_Resolved on Accept (2026-07-24) — recommended answers locked:_
+
+1. **Freeze default:** flip `accept_old` default to `False` in this PR.
+2. **2.x convert escape:** keep `cli_api.convert` able to rewrite v&lt;8 (`accept_old=True`).
+3. **Freeze message copy:** use
+   `File format too old (v{n}): use cellpy 1.x \`cellpy convert\` to rewrite to v8+, then open in 2.x`
+   (tweak only if wording is awkward in the raise site).
+4. **v1.x warning:** out of scope — follow-up later if needed.
+
+## Scope check
+
+One cohesive PR (matrix + freeze + migration-doc sync). Not an epic. If you reject
+the freeze (Q1 = keep permissive), shrink to tests + docs-only and mark the release
+matrix row as “still reads v4–v7 via accept_old default” — that is a **plan revise**,
+not silent scope cut.

--- a/.issueflows/03-solved-issues/issue573_status.md
+++ b/.issueflows/03-solved-issues/issue573_status.md
@@ -16,4 +16,4 @@
 
 ## Remaining work
 
-- None (close / PR).
+- None (close / PR). Follow-up: CI full fixed by `accept_old=True` on `neware_uio.h5` (v7) fixtures.

--- a/.issueflows/03-solved-issues/issue573_status.md
+++ b/.issueflows/03-solved-issues/issue573_status.md
@@ -1,0 +1,19 @@
+# Issue #573 — status
+
+- [x] Done
+
+## What's done
+
+- Plan accepted (freeze default + convert escape + message copy locked).
+- Flipped `CellpyCell.load` and `cellpy_file.read.load` default to `accept_old=False`.
+- Freeze `WrongFileVersion` message names `cellpy 1.x \`cellpy convert\``.
+- Added essential `tests/test_file_format_compat_matrix.py` (read v8/v9, write v9/v8, reject pre-v8, convert escape, v8→v9 parity).
+- Fixed pre-v8 test call sites (`test_cellpy_method_integrity`, `test_cell_readers`).
+- Synced `docs/getting_started/migration_v1_to_v2.md` and `tests/README.md`.
+- `cli_api.convert` still loads with `accept_old=True` (unchanged).
+- Verified: matrix + v9 + cli_api (41 passed); `uv run pytest -m essential` (624 passed); matrix re-check on close (10 passed).
+- HISTORY.md bullet under `[Unreleased]`.
+
+## Remaining work
+
+- None (close / PR).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Lock the file-format compatibility matrix (v8/v9 read/write, convert, pre-v8 freeze) (#573).
+
 * Complete cli_api extraction for remaining CLI commands (new, serve, setup, …) (#651).
 
 * Fix summary CV-split plots: use exclude_step_types and full−non_cv instead of dead selector_type (#654).

--- a/cellpy/readers/cellpy_file/read.py
+++ b/cellpy/readers/cellpy_file/read.py
@@ -382,13 +382,16 @@ def load_current_version(
 def load(
     filename,
     *,
-    accept_old: bool = True,
+    accept_old: bool = False,
     selector=None,
     parent_level: str | None = None,
 ) -> LoadResult:
     """Load a cellpy-file and return populated ``Data`` with explicit limits.
 
     Dispatches by container sniff: zip (v9 ``.cellpy``) vs HDF5 (v4–v8).
+    Default ``accept_old=False`` freezes pre-v8: raises ``WrongFileVersion``
+    naming ``cellpy convert`` on 1.x. Pass ``accept_old=True`` to load
+    legacy vintages (escape hatch used by ``cli_api.convert``).
     """
     from cellpy.readers.cellpy_file import legacy_read
     from cellpy.readers.cellpy_file import v9 as cellpy_file_v9
@@ -446,8 +449,8 @@ def load(
                 logging.debug(data)
             else:
                 raise WrongFileVersion(
-                    f"File format too old: {filename} :: version: {cellpy_file_version}"
-                    f"Try loading setting accept_old=True"
+                    f"File format too old (v{cellpy_file_version}): {filename}. "
+                    f"Use cellpy 1.x `cellpy convert` to rewrite to v8+, then open in 2.x."
                 )
         else:
             logging.debug(f"Loading {filename} :: v{cellpy_file_version}")

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1509,7 +1509,7 @@ class CellpyCell:
         cellpy_file,
         parent_level=None,
         return_cls=True,
-        accept_old=True,
+        accept_old=False,
         selector=None,
         **kwargs,
     ):
@@ -1519,8 +1519,11 @@ class CellpyCell:
             cellpy_file (OtherPath, str): Full path to the cellpy file.
             parent_level (str, optional): Parent level. Warning! Deprecating this soon!
             return_cls (bool): Return the class.
-            accept_old (bool): Accept loading old cellpy-file versions.
-                Instead of raising WrongFileVersion it only issues a warning.
+            accept_old (bool): Accept loading pre-v8 cellpy-file versions.
+                Default is ``False`` (2.0 freeze): pre-v8 raises
+                ``WrongFileVersion`` naming ``cellpy convert`` on 1.x. Pass
+                ``True`` only as an escape (tests / advanced use). Prefer
+                rewriting with ``cellpy convert`` instead.
             selector (dict): Experimental feature - select specific ranges of data.
 
         Returns:

--- a/docs/getting_started/migration_v1_to_v2.md
+++ b/docs/getting_started/migration_v1_to_v2.md
@@ -12,9 +12,9 @@ the 2.0 release date (decision #438-6). Feature work lands only on 2.x.
 | | 1.x | 2.x (current alphas / intended GA) |
 |---|-----|-------------------------------------|
 | Default `save()` | HDF5 (`.h5` / `.hdf5` / `.cellpy` as HDF5) | **v9** zip-of-parquet + `meta.json` (`.cellpy`) |
-| `load()` | v4–v8 HDF5 | **v4–v8 HDF5 and v9** (sniffs zip vs HDF5) |
+| `load()` | v4–v8 HDF5 | **v8 HDF5 and v9** only (sniffs zip vs HDF5). Pre-v8 raises `WrongFileVersion`. |
 | Write v8 / HDF5 | default | Escape: `save("out.h5")` or `cellpy_file_format="hdf5"` / `"v8"` |
-| Very old (pre-v8) rewrite | `cellpy convert` on **1.x** | Prefer convert on 1.x, then open in 2.x; or `load` + `save` to v9 when 2.x still reads that vintage |
+| Very old (pre-v8) rewrite | `cellpy convert` | Prefer **1.x** `cellpy convert`, then open in 2.x. 2.x `cellpy convert --to v9|v8` also rewrites. Escape: `load(..., accept_old=True)`. |
 
 v9 stores raw / steps / summary (and optional fid) as parquet members inside a
 zip, with typed metadata in `meta.json`. Parquet columns use **native** header
@@ -32,7 +32,7 @@ cellpy convert old.h5 --to v8         # keep HDF5 if you must
 from cellpy.readers.cellreader import CellpyCell
 
 cell = CellpyCell()
-cell.load("legacy_run.h5")          # v4–v8 HDF5
+cell.load("legacy_run.h5")          # v8 HDF5 (or v9 .cellpy)
 cell.save("legacy_run.cellpy")      # v9 zip-of-parquet
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,13 @@ Philosophy (loader-free core vs loaderful cellpy): see
 2. Add tests that read from `tests/data/goldens/my_suite/` (skip if files missing).
 3. Document the suite in [`data/goldens/README.md`](data/goldens/README.md).
 
+## File-format compatibility matrix (Stage 3.16 / #573)
+
+Release-contract suite: [`test_file_format_compat_matrix.py`](test_file_format_compat_matrix.py)
+(all `@pytest.mark.essential`). Asserts read v8/v9, write v9/v8, default reject of
+v&lt;8 (message names `cellpy convert` on 1.x), convert rewrite escape, and v8→v9
+value parity. Deeper HDF5 characterization stays below.
+
 ## Cellpy-file characterization (Stage 0.2)
 
 HDF5 load/save behavior is locked in [`test_cellpy_file_roundtrip.py`](test_cellpy_file_roundtrip.py)

--- a/tests/test_cell_readers.py
+++ b/tests/test_cell_readers.py
@@ -677,7 +677,12 @@ def test_make_summary(cellpy_data_instance, parameters):
 
 def test_v6(parameters):
     # c = cellpy.get(logging_mode="DEBUG", testing=True)
-    c2 = cellpy.get(parameters.cellpy_file_path_v6, logging_mode="DEBUG", testing=True)
+    c2 = cellpy.get(
+        parameters.cellpy_file_path_v6,
+        logging_mode="DEBUG",
+        testing=True,
+        accept_old=True,
+    )
     # c.load(parameters.cellpy_file_path_v6)
 
 
@@ -740,7 +745,7 @@ def test_make_summary_new_version(parameters):
 
     s1 = c_raw.data.summary
     c_h5 = cellpy.get(logging_mode="DEBUG", testing=True)
-    c_h5.load(parameters.cellpy_file_path_v6)
+    c_h5.load(parameters.cellpy_file_path_v6, accept_old=True)
     s2 = c_h5.data.summary
 
     print()

--- a/tests/test_cellpy_method_integrity.py
+++ b/tests/test_cellpy_method_integrity.py
@@ -16,7 +16,10 @@ def cellpy_cell(cellpy_data_instance, parameters):
 
 @pytest.fixture
 def neware_cellpy_cell(cellpy_data_instance, parameters):
-    return cellpy_data_instance.load(parameters.nw_cellpy_file_path)
+    # neware_uio.h5 is still v7; escape the 2.0 pre-v8 freeze (#573).
+    return cellpy_data_instance.load(
+        parameters.nw_cellpy_file_path, accept_old=True
+    )
 
 
 # TODO: this cellpy file is not found - fix it!

--- a/tests/test_cellpy_method_integrity.py
+++ b/tests/test_cellpy_method_integrity.py
@@ -32,12 +32,16 @@ def neware_cellpy_cell(cellpy_data_instance, parameters):
 
 @pytest.fixture
 def cellpy_cell_v5(cellpy_data_instance, parameters):
-    return cellpy_data_instance.load(parameters.cellpy_file_path_v5)
+    return cellpy_data_instance.load(
+        parameters.cellpy_file_path_v5, accept_old=True
+    )
 
 
 @pytest.fixture
 def cellpy_cell_v6(cellpy_data_instance, parameters):
-    return cellpy_data_instance.load(parameters.cellpy_file_path_v6)
+    return cellpy_data_instance.load(
+        parameters.cellpy_file_path_v6, accept_old=True
+    )
 
 
 @pytest.fixture

--- a/tests/test_file_format_compat_matrix.py
+++ b/tests/test_file_format_compat_matrix.py
@@ -1,0 +1,137 @@
+"""2.0 file-format compatibility matrix (issue #573 / release plan §1).
+
+One essential suite covering every promised cell: read v8/v9, write v9/v8,
+reject v<8 by default (naming convert on 1.x), convert escape, and v8→v9
+value parity. Deeper characterization stays in ``test_cellpy_file_*.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from cellpy import cellreader
+from cellpy.exceptions import WrongFileVersion
+from cellpy.readers.cellpy_file import CELLPY_FILE_VERSION, v9 as cellpy_file_v9
+from tests.cellpy_file_support import (
+    assert_data_frames_equal,
+    load_cellpy_file,
+    snapshot_cell_state,
+)
+
+HDF5_DIR = Path(__file__).resolve().parents[1] / "testdata" / "hdf5"
+V8_WITH_FIDS = HDF5_DIR / "20160805_test001_45_cc_v8_with_fids.h5"
+V5 = HDF5_DIR / "20160805_test001_45_cc_v5.h5"
+V7 = HDF5_DIR / "20160805_test001_45_cc_v7.h5"
+
+_FREEZE_MESSAGE = r"Use cellpy 1\.x `cellpy convert`"
+
+
+def _require(path: Path) -> Path:
+    if not path.is_file():
+        pytest.skip(f"missing fixture: {path}")
+    return path
+
+
+@pytest.mark.essential
+def test_matrix_read_v8():
+    cell = load_cellpy_file(_require(V8_WITH_FIDS))
+    assert len(cell.data.raw) > 0
+    assert len(cell.data.steps) > 0
+    assert len(cell.data.summary) > 0
+    assert cell.data.meta_common.cellpy_file_version == 8
+
+
+@pytest.mark.essential
+def test_matrix_write_v9_default_and_read(tmp_path):
+    original = load_cellpy_file(_require(V8_WITH_FIDS))
+    outfile = tmp_path / "out.cellpy"
+    original.save(outfile)
+
+    assert cellpy_file_v9.is_zip_cellpy(outfile)
+    reloaded = load_cellpy_file(outfile)
+    assert reloaded.data.meta_common.cellpy_file_version == CELLPY_FILE_VERSION
+    assert len(reloaded.data.raw) > 0
+
+
+@pytest.mark.essential
+def test_matrix_write_v8_via_h5_suffix(tmp_path):
+    cell = load_cellpy_file(_require(V8_WITH_FIDS))
+    outfile = tmp_path / "legacy.h5"
+    cell.save(outfile)
+
+    assert not cellpy_file_v9.is_zip_cellpy(outfile)
+    with pd.HDFStore(outfile) as store:
+        assert "/CellpyData/raw" in store.keys()
+    reloaded = load_cellpy_file(outfile)
+    assert reloaded.data.meta_common.cellpy_file_version == 8
+
+
+@pytest.mark.essential
+def test_matrix_write_v8_via_format_kwarg(tmp_path):
+    cell = load_cellpy_file(_require(V8_WITH_FIDS))
+    outfile = tmp_path / "explicit.cellpy"
+    cell.save(outfile, cellpy_file_format="v8")
+
+    assert not cellpy_file_v9.is_zip_cellpy(outfile)
+    reloaded = load_cellpy_file(outfile)
+    assert reloaded.data.meta_common.cellpy_file_version == 8
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "legacy, version",
+    [(V5, 5), (V7, 7)],
+)
+def test_matrix_read_pre_v8_raises_naming_convert(legacy, version):
+    path = _require(legacy)
+    cell = cellreader.CellpyCell()
+    with pytest.raises(WrongFileVersion, match=_FREEZE_MESSAGE) as exc_info:
+        cell.load(path)
+    assert f"v{version}" in str(exc_info.value)
+
+
+@pytest.mark.essential
+def test_matrix_read_pre_v8_accept_old_escape():
+    cell = load_cellpy_file(_require(V5), accept_old=True)
+    assert cell.data.meta_common.cellpy_file_version == 5
+    assert len(cell.data.raw) > 0
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("target", ["v9", "v8"])
+def test_matrix_convert_rewrites_pre_v8(tmp_path, target):
+    from cellpy import cli_api
+
+    source = _require(V5)
+    work = tmp_path / source.name
+    shutil.copy(source, work)
+
+    written = cli_api.convert(work, to=target)
+    assert written.is_file()
+    reloaded = cellreader.CellpyCell().load(written)
+    assert len(reloaded.get_cycle_numbers()) > 0
+    assert len(reloaded.data.raw) > 0
+    if target == "v9":
+        assert cellpy_file_v9.is_zip_cellpy(written)
+        assert reloaded.data.meta_common.cellpy_file_version == CELLPY_FILE_VERSION
+    else:
+        assert written.suffix == ".h5"
+        assert reloaded.data.meta_common.cellpy_file_version == 8
+
+
+@pytest.mark.essential
+def test_matrix_v8_to_v9_value_parity(tmp_path):
+    original = load_cellpy_file(_require(V8_WITH_FIDS))
+    expected = snapshot_cell_state(original)
+
+    outfile = tmp_path / "parity.cellpy"
+    original.save(outfile)
+    reloaded = load_cellpy_file(outfile)
+
+    assert_data_frames_equal(reloaded.data.raw, expected["raw"])
+    assert_data_frames_equal(reloaded.data.steps, expected["steps"])
+    assert_data_frames_equal(reloaded.data.summary, expected["summary"])

--- a/tests/test_neware.py
+++ b/tests/test_neware.py
@@ -11,7 +11,10 @@ log.setup_logging(default_level=logging.DEBUG, testing=True)
 
 @pytest.fixture
 def neware_cell(cellpy_data_instance, parameters):
-    return cellpy_data_instance.load(parameters.nw_cellpy_file_path)
+    # neware_uio.h5 is still v7; escape the 2.0 pre-v8 freeze (#573).
+    return cellpy_data_instance.load(
+        parameters.nw_cellpy_file_path, accept_old=True
+    )
 
 
 def test_get_neware_from_csv(parameters):


### PR DESCRIPTION
## Summary
- Freeze default `load` so pre-v8 cellpy-files raise `WrongFileVersion` naming `cellpy convert` on 1.x (`accept_old` defaults to `False`).
- Keep `cli_api.convert` able to rewrite v<8 (`accept_old=True`).
- Add essential `tests/test_file_format_compat_matrix.py` covering read v8/v9, write v9/v8, reject/escape, convert, and v8→v9 value parity.
- Sync migration guide support matrix and tests README.

Closes #573

## Test plan
- [x] `uv run pytest tests/test_file_format_compat_matrix.py`
- [x] `uv run pytest tests/test_cellpy_file_v9.py tests/test_cli_api.py`
- [x] `uv run pytest -m essential`
- [x] CI essential (linux / uv) green on the PR


Made with [Cursor](https://cursor.com)