### PR TITLE
fix: batch plot cycle_index and nested cycle_mode (#668)

### DIFF
--- a/.issueflows/03-solved-issues/issue668_original.md
+++ b/.issueflows/03-solved-issues/issue668_original.md
@@ -1,0 +1,177 @@
+# Issue #668: bugs in batch
+
+Source: https://github.com/jepegit/cellpy/issues/668
+
+## Original issue text
+
+Running the loader notebook (using standard template), several bugs were found:
+
+**Bug in `b.plot`**
+
+```python
+# Plot the charge capacity and the C.E. (and resistance and rate) vs. cycle number (standard plot)
+b.plot(rate=True, ir=True,  direction="discharge")
+```
+
+Get this error report:
+
+```python
+WARNING:py.warnings:[C:\Users\jepe\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\utils\batch_tools\batch_plotters.py:811](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/utils/batch_tools/batch_plotters.py#line=810): PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
+  summaries = summaries.reset_index()
+
+CRITICAL:root:could not get the required summaries (<class 'KeyError'>: "['cycle_index'] not in index")
+---------------------------------------------------------------------------
+AttributeError                            Traceback (most recent call last)
+Cell In[5], line 2
+      1 # Plot the charge capacity and the C.E. (and resistance and rate) vs. cycle number (standard plot)
+----> 2 b.plot(rate=True, ir=True,  direction="discharge")
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\utils\batch.py:1443](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/utils/batch.py#line=1442), in Batch.plot(self, backend, reload_data, **kwargs)
+   1437     # 1: summary_plotting_engine
+   1438     # 2:   _preparing_data_and_plotting_legacy
+   1439     # 3:   _plotting_data_legacy
+   1440     # 4:   plot_cycle_life_summary_[backend]
+   1442 elif backend == "plotly":
+-> 1443     self.plotter.do(**kwargs)
+   1445 elif backend == "seaborn":
+   1446     self.plotter.do(**kwargs)
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\utils\batch_tools\batch_core.py:136](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/utils/batch_tools/batch_core.py#line=135), in Doer.do(self, **kwargs)
+    134 self.empty_the_farms()
+    135 logging.debug(f"running - {str(engine)}")
+--> 136 self.run_engine(engine, **kwargs)
+    138 for dumper in self.dumpers:
+    139     logging.debug(f"exporting - {str(dumper)}")
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\utils\batch_tools\batch_plotters.py:1505](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/utils/batch_tools/batch_plotters.py#line=1504), in CyclingSummaryPlotter.run_engine(self, engine, **kwargs)
+   1503 if self.reset_farms:
+   1504     self.farms = []
+-> 1505 self.farms, self.barn = engine(
+   1506     experiments=self.experiments, farms=self.farms, **kwargs
+   1507 )
+   1509 logging.debug("::engine ended")
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\utils\batch_tools\batch_plotters.py:757](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/utils/batch_tools/batch_plotters.py#line=756), in summary_plotting_engine(**kwargs)
+    755         if backend == "plotly":
+    756             if kwargs.pop("plotly_show", True):
+--> 757                 canvas.show()
+    759 return farms, barn
+
+AttributeError: 'NoneType' object has no attribute 'show'
+```
+**Running custom `update_cell function`**
+
+```python
+def update_cell(c):
+    raw = c.data.raw
+    steps = c.data.steps
+    discharge = steps.query("type=='discharge'")
+    un = set(discharge["step"].unique())
+    for i, g in raw.groupby("cycle_index"):
+        sts = set(g.step_index.unique()) & un
+        dc_max = g.discharge_capacity.max()
+        if sts:
+            lp = g.loc[g.step_index == max(sts), "data_point"].max()
+            raw.loc[(raw.data_point > lp) & (raw.cycle_index == i), "discharge_capacity"] = dc_max
+    c.make_step_table()
+    c.make_summary()
+
+    return c
+```
+
+Running in a loop, getting this error message:
+
+```python
+WARNING:cellpycore.summarizers:found 1:730 non-categorized steps (please, check your raw-limits)
+
+
+---------------------------------------------------------------------------
+AttributeError                            Traceback (most recent call last)
+Cell In[8], line 5
+      1 for label in b.cell_names:
+      2     print(f"processing {label}")
+      3     c = b.experiment.data[label]
+      4     cellpyfilename = b.pages.loc[label, "cellpy_file_name"]
+----> 5     c = update_cell(c)
+      6     c.save(cellpyfilename)
+
+Cell In[7], line 13, in update_cell(c)
+      9         if sts:
+     10             lp = g.loc[g.step_index == max(sts), "data_point"].max()
+     11             raw.loc[(raw.data_point > lp) & (raw.cycle_index == i), "discharge_capacity"] = dc_max
+     12     c.make_step_table()
+---> 13     c.make_summary()
+     14 
+     15     return c
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\readers\cellreader.py:4653](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/readers/cellreader.py#line=4652), in CellpyCell.make_summary(self, find_ir, find_end_voltage, use_cellpy_stat_file, ensure_step_table, remove_duplicates, normalization_cycles, nom_cap, nom_cap_specifics, old, create_copy, exclude_types, exclude_steps, selector_type, selector, **kwargs)
+   4640     self._make_summar_legacy(
+   4641         # find_ocv=find_ocv,
+   4642         find_ir=find_ir,
+   (...)   4649         nom_cap_specifics=nom_cap_specifics,
+   4650     )
+   4651     return self
+-> 4653 data = self._make_summary(
+   4654     find_ir=find_ir,
+   4655     find_end_voltage=find_end_voltage,
+   4656     use_cellpy_stat_file=use_cellpy_stat_file,
+   4657     ensure_step_table=ensure_step_table,
+   4658     remove_duplicates=remove_duplicates,
+   4659     normalization_cycles=normalization_cycles,
+   4660     nom_cap=nom_cap,
+   4661     nom_cap_specifics=nom_cap_specifics,
+   4662     create_copy=create_copy,
+   4663     **kwargs,
+   4664 )
+   4665 if create_copy:
+   4666     other = copy.deepcopy(self)
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpy\readers\cellreader.py:4822](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpy/readers/cellreader.py#line=4821), in CellpyCell._make_summary(self, mass, nom_cap, nom_cap_specifics, update_mass, select_columns, find_ir, find_end_voltage, ensure_step_table, remove_duplicates, sort_my_columns, use_cellpy_stat_file, normalization_cycles, create_copy, **kwargs)
+   4813 current_conversion_factor = core_units.calculate_current_conversion_factor(
+   4814     data.raw_units["current"], to_units=self.cellpy_units
+   4815 )
+   4816 specific_conversion_factors = {
+   4817     mode: self.get_converter_to_specific(
+   4818         dataset=data, mode=mode, to_units=self.cellpy_units
+   4819     )
+   4820     for mode in specifics
+   4821 }
+-> 4822 data = self.core.make_core_summary(
+   4823     data,
+   4824     find_ir=find_ir,
+   4825     find_end_voltage=find_end_voltage,
+   4826     select_columns=select_columns,
+   4827     current_conversion_factor=current_conversion_factor,
+   4828 )
+   4829 data = self.core.add_scaled_summary_columns(
+   4830     data,
+   4831     nom_cap_abs=nom_cap_abs,
+   (...)   4834     specific_conversion_factors=specific_conversion_factors,
+   4835 )
+   4837 if sort_my_columns:
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpycore\cell_core.py:1020](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpycore/cell_core.py#line=1019), in OldCellpyCellCore.make_core_summary(self, data, find_ir, find_end_voltage, select_columns, final_data_points, current_conversion_factor, ir_extractor, exclude_step_types)
+   1015 nd.steps = native_steps
+   1016 # Honor cycle_mode on the bridge exactly as the native path does (issue
+   1017 # #129): without this the bridge summary always ran NORMAL, so anode
+   1018 # half-cells silently got the wrong-direction coulombic_efficiency /
+   1019 # coulombic_difference.
+-> 1020 test_mode = _cycle_mode_to_test_mode(self.cycle_mode)
+   1021 summarizers.make_summary(
+   1022     nd,
+   1023     native_schema,
+   (...)   1026     exclude_step_types=exclude_step_types,
+   1027 )
+   1029 # C-rate / IR are now native-schema columns (issue #21): compute them on the
+   1030 # native polars frame before the single native->legacy rename. Their native
+   1031 # names match the legacy names, so they survive the rename untouched.
+
+File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpycore\cell_core.py:48](file:///C:/Users/jepe/.pixi/envs/cellpy-v1/Lib/site-packages/cellpycore/cell_core.py#line=47), in _cycle_mode_to_test_mode(cycle_mode)
+     46 if cycle_mode is None:
+     47     return config.TestMode.NORMAL
+---> 48 key = cycle_mode.strip().lower()
+     49 if key in _INVERTED_CYCLE_MODES:
+     50     return config.TestMode.INVERTED
+
+AttributeError: 'list' object has no attribute 'strip'
+```

--- a/.issueflows/03-solved-issues/issue668_plan.md
+++ b/.issueflows/03-solved-issues/issue668_plan.md
@@ -1,0 +1,130 @@
+# Issue #668 — Plan
+
+## Goal
+
+Fix two 1.x batch-workflow crashes from the loader notebook: `b.plot(...)`
+failing when the summary cycle index is unnamed, and `make_summary()` failing
+when `cycle_mode` is still list-shaped. Confirm what (if anything) still needs
+work on the v2/`master` line and track that separately.
+
+## Constraints
+
+- **Target branch:** `v1.x` (label `v1x`). PR against `v1.x`, not `master`.
+- **Worktree:** `../cellpy-v1x` on `668-batch-bugs` (main `cellpy` checkout stays on other work).
+- **Fixes-only** on `v1.x` — no refactors, no dependency churn beyond what a fix needs
+  (`cellpycore==0.2.1` pin stays unless a core patch release is required and agreed).
+- Prefer the smallest backport that matches known-good `master` behaviour over a
+  new design.
+- Do not change public batch API surface.
+
+### Prior art
+
+- **`master` #658** — deleted `batch_plotters.py`, moved frame prep to
+  [`cellpy/plotting/batch_summary.py`](../../../../cellpy/cellpy/plotting/batch_summary.py).
+  Explicit fix: name unnamed summary index to `cycle_index` before `reset_index`
+  (see `issue658_status.md`). **Mirror this into v1.x `batch_plotters.py`.**
+- **`master` load unwrap** — [`cellpy/readers/cellpy_file/read.py`](../../../../cellpy/cellpy/readers/cellpy_file/read.py)
+  + recursive `test_meta._unwrap` (and tests in `tests/test_test_meta_collection.py`)
+  for double-nested `cycle_mode` (e.g. `[['anode']]`). **Port a minimal unwrap to v1.x.**
+- **`cellpycore.OldCellpyCellCore.cycle_mode`** — one-level `m[0]` getter; setter
+  keeps lists as lists; `_cycle_mode_to_test_mode` assumes `str` and calls `.strip()`.
+  Shared by both lines; still fragile even when consumer unwraps on load.
+- Toolbox (`00-tools/`): nothing for batch plots / cycle_mode. Graphify: absent in this worktree.
+
+### v2 / master impact check (done during planning)
+
+| Symptom | On `master`? | Action |
+|---------|--------------|--------|
+| A. `b.plot` / `cycle_index` KeyError → `NoneType.show` | **No** — fixed in #658 (`batch_summary.py` names index; old `batch_plotters.py` deleted) | No v2 issue |
+| B. `make_summary` / `cycle_mode` list → `.strip()` | **Partly mitigated** on consumer load path; **still fragile in `cellpycore`** | Opened [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) |
+
+## Approach
+
+### 0. Inform v2 / core (tracking issue)
+
+**Done:** [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) — harden:
+
+1. `OldCellpyCellCore.cycle_mode` getter: recursively unwrap 1-element lists/tuples to a scalar (same semantics as cellpy `test_meta._unwrap`).
+2. Setter: store a **scalar** (unwrap first), not a list of lowered strings.
+3. `_cycle_mode_to_test_mode`: accept list/tuple by unwrapping before `.strip()`; keep current string behaviour.
+4. Tests: nested `[['anode']]`, `['anode']`, scalar `'anode'`, `None`.
+
+Note on the cellpy #668 thread once the core issue number exists. No change required
+to master’s batch plotter path for symptom A.
+
+### 1. Fix A — `b.plot` / summary frame (v1.x only)
+
+In [`cellpy/utils/batch_tools/batch_plotters.py`](../../cellpy/utils/batch_tools/batch_plotters.py)
+`generate_summary_frame_for_plotting`:
+
+- After `pd.concat(...)`, if `summaries.index.name is None`, set it to
+  `hdr_summary["cycle_index"]` (same as master `batch_summary.py`).
+- In `summary_plotting_engine`, only call `canvas.show()` when `canvas is not None`
+  (secondary crash after failed frame prep).
+
+### 2. Fix B — `cycle_mode` list on `make_summary` (v1.x consumer)
+
+Without waiting for a core release:
+
+- Add a tiny recursive `_unwrap` helper on v1.x (either a few lines next to the
+  load site, or a minimal shared helper — prefer one place used by load + property).
+- After `meta_test_dependent.update(as_list=True, ...)` in
+  [`cellpy/readers/cellpy_file/read.py`](../../cellpy/readers/cellpy_file/read.py)
+  (and `legacy_read.py` if it has the same path), assign
+  `cycle_mode = _unwrap(...)`.
+- Harden [`CellpyCell.cycle_mode`](../../cellpy/readers/cellreader.py) getter to
+  recursively unwrap (current code only does one level — insufficient for
+  `[['anode']]`).
+
+Do **not** bump `cellpycore` in this PR unless we decide the consumer-only fix is
+insufficient for the reported notebook path after tests.
+
+### 3. Ordering
+
+1. Core tracking issue (step 0).
+2. Fix A + tests.
+3. Fix B + tests.
+4. Run essential suite on the worktree.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `cellpy/utils/batch_tools/batch_plotters.py` | Name cycle index before `reset_index`; guard `canvas.show()` |
+| `cellpy/readers/cellpy_file/read.py` | Unwrap `cycle_mode` after list-shaped meta load |
+| `cellpy/readers/cellpy_file/legacy_read.py` | Same unwrap if applicable |
+| `cellpy/readers/cellreader.py` | Recursive unwrap in `cycle_mode` getter |
+| `tests/…` (new or extend existing batch / meta tests) | Regression for A + B |
+| `.issueflows/01-current-issues/issue668_status.md` | Status after build |
+
+Out of scope for this PR: deleting `batch_plotters.py`, porting #658 plotting package, core release/pin bump (follow-up via the new core issue).
+
+## Test strategy
+
+In `cellpy-v1x` worktree:
+
+```bash
+uv sync
+uv run pytest -m essential
+```
+
+Plus focused tests:
+
+- **A:** Build a multi-cell summary concat with unnamed index; assert frame prep
+  yields a `cycle_index` column (or call the plot helper with `plotly_show=False`
+  and assert no `AttributeError`). Prefer unit-level frame prep if full batch
+  fixtures are heavy.
+- **B:** Meta / cell with `cycle_mode` as `['anode']` and `[['anode']]`;
+  `make_summary()` must not raise `AttributeError` on `.strip()`.
+
+Mark merge-gate tests `@pytest.mark.essential` only if they stay fast and stable.
+
+## Open questions
+
+1. **Core issue home:** create under `cellpy/cellpy-core` (recommended) vs only a
+   `jepegit/cellpy` `master`/`v2` reminder issue. Default: **core**.
+2. **Pin bump:** if consumer unwrap alone is enough for the notebook, leave
+   `cellpycore==0.2.1` and let the core issue ship later. Agree?
+3. **Scope of B:** unwrap only `cycle_mode`, or also other list-boxed meta fields
+   on load (master unwraps via a helper used more broadly)? Default: **cycle_mode
+   only** on v1.x to keep the PR small.

--- a/.issueflows/03-solved-issues/issue668_status.md
+++ b/.issueflows/03-solved-issues/issue668_status.md
@@ -1,0 +1,20 @@
+# Issue #668 — Status
+
+- [x] Done
+
+## What's done
+
+- Core tracking: [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) (noted on #668).
+- **Fix A** (`batch_plotters.py`): name unnamed summary index to `cycle_index` before `reset_index`; guard `canvas.show()` when `canvas is None`.
+- **Fix B**:
+  - `unwrap_meta_value` in `cellpy/readers/cellpy_file/meta.py`
+  - unwrap `cycle_mode` after list-shaped meta load in `read.py` + `legacy_read.py`
+  - recursive unwrap (+ write-back) in `CellpyCell.cycle_mode` getter/setter
+  - touch `self.cycle_mode` at start of `_make_summary` so the core bridge sees a scalar
+- Tests: `tests/test_issue668_batch_bugs.py` (essential).
+- `uv run pytest -m essential` green on close.
+- HISTORY.md Unreleased bullet added.
+
+## Remaining work
+
+- None for this issue. Follow-up: cellpy-core#142 (optional pin bump later).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ Note! Only v1 related changes are collected here.
 
 ## [Unreleased]
 
+* Fix: batch `b.plot` unnamed cycle index and nested list `cycle_mode` crashing `make_summary`. (#668)
+
 ## 1.1.0.post2 - 2026-07-23
 
 * Fix: lazy config load pushes `.env_cellpy` into `os.environ` so OtherPath SSH auth works again after #453. (#662)

--- a/cellpy/readers/cellpy_file/legacy_read.py
+++ b/cellpy/readers/cellpy_file/legacy_read.py
@@ -64,6 +64,13 @@ def extract_meta_from_old_cellpy_file_max_v7(
     meta_dict = data.meta_common.digest(as_list=False, **meta_dict)
     data.meta_test_dependent.update(as_list=True, **meta_dict)
 
+    # Same nested cycle_mode unwrap as the v8 reader (issue #668).
+    from cellpy.readers.cellpy_file import meta as cellpy_file_meta
+
+    data.meta_test_dependent.cycle_mode = cellpy_file_meta.unwrap_meta_value(
+        data.meta_test_dependent.cycle_mode
+    )
+
 
 def load_v7(filename, selector=None) -> tuple["Data", LoadLimits]:
     logging.debug("--- loading v7")

--- a/cellpy/readers/cellpy_file/meta.py
+++ b/cellpy/readers/cellpy_file/meta.py
@@ -3,10 +3,30 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 from cellpy.readers import externals
 from cellpy.exceptions import WrongFileVersion
 from cellpy.parameters import prms
+
+
+def unwrap_meta_value(value: Any) -> Any:
+    """Normalize a legacy meta value to a plain scalar (or ``None``).
+
+    Cellpy-file loads leave 1-element lists in ``meta_test_dependent`` (the
+    ``update(as_list=True)`` path). Older files can also carry double-nested
+    values such as ``[['anode']]`` for ``cycle_mode``; the summarizer bridge
+    needs a scalar string (issue #668).
+    """
+    if isinstance(value, (list, tuple)):
+        if len(value) == 1:
+            return unwrap_meta_value(value[0])
+        return value
+    if isinstance(value, externals.numpy.generic):
+        value = value.item()
+    if isinstance(value, float) and value != value:  # NaN -> absent
+        return None
+    return value
 
 
 def extract_from_meta_dictionary(

--- a/cellpy/readers/cellpy_file/read.py
+++ b/cellpy/readers/cellpy_file/read.py
@@ -303,6 +303,13 @@ def extract_meta_from_cellpy_file(
     test_dependent_meta_dict = test_dependent_meta_table.to_dict(orient="list")
     data.meta_test_dependent.update(as_list=True, **test_dependent_meta_dict)
 
+    # Older files can carry a double-nested cycle_mode (e.g. [['anode']] when
+    # a list-valued box was saved and re-wrapped by the as_list load above);
+    # the engine needs a scalar (issue #668).
+    data.meta_test_dependent.cycle_mode = cellpy_file_meta.unwrap_meta_value(
+        data.meta_test_dependent.cycle_mode
+    )
+
 
 def _assign_fids_from_table(data: "Data", fid_table, fid_table_selected: bool) -> None:
     if fid_table_selected:

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -887,21 +887,27 @@ class CellpyCell:
     @property
     def cycle_mode(self):
         # TODO: v2.0 edit this from scalar to list
+        from cellpy.readers.cellpy_file.meta import unwrap_meta_value
+
         try:
             data = self.data
             m = data.meta_test_dependent.cycle_mode
             # cellpy saves this as a list (ready for v2.0),
-            # but we want to return a scalar for the moment
-            # Temporary fix to make sure that cycle_mode is a scalar:
-            if isinstance(m, (tuple, list)):
-                return m[0]
-            return m
+            # but we want to return a scalar for the moment.
+            # Recursively unwrap nested 1-element lists (issue #668).
+            unwrapped = unwrap_meta_value(m)
+            if unwrapped is not m:
+                data.meta_test_dependent.cycle_mode = unwrapped
+            return unwrapped
         except NoDataFound:
-            return self._cycle_mode
+            return unwrap_meta_value(self._cycle_mode)
 
     @cycle_mode.setter
     def cycle_mode(self, cycle_mode):
         # TODO: v2.0 edit this from scalar to list
+        from cellpy.readers.cellpy_file.meta import unwrap_meta_value
+
+        cycle_mode = unwrap_meta_value(cycle_mode)
         logging.debug(f"-> cycle_mode: {cycle_mode}")
         try:
             data = self.data
@@ -4810,6 +4816,9 @@ class CellpyCell:
         # cellpy-core takes unit conversions by value: cellpy (the consumer, which
         # owns cellpy_units and pint) computes the factors and passes them in, so
         # the core summary engine needs no pint.
+        # Normalize nested list-boxed cycle_mode into meta before the bridge
+        # reads it (OldCellpyCellCore only unwraps one level; issue #668).
+        _ = self.cycle_mode
         current_conversion_factor = core_units.calculate_current_conversion_factor(
             data.raw_units["current"], to_units=self.cellpy_units
         )

--- a/cellpy/utils/batch_tools/batch_plotters.py
+++ b/cellpy/utils/batch_tools/batch_plotters.py
@@ -753,7 +753,7 @@ def summary_plotting_engine(**kwargs):
                 logging.debug("OH NO! Could not generate canvas")
             farms.append(canvas)
             if backend == "plotly":
-                if kwargs.pop("plotly_show", True):
+                if canvas is not None and kwargs.pop("plotly_show", True):
                     canvas.show()
 
     return farms, barn
@@ -808,10 +808,14 @@ def generate_summary_frame_for_plotting(pages, experiment, **kwargs) -> pd.DataF
         keys.append(df.name)
 
     summaries = pd.concat(summary_frames, keys=keys, axis=1)
+    hdr_cycle = hdr_summary["cycle_index"]
+    # Summary farms often carry an unnamed cycle index after join_summaries;
+    # name it so reset_index() yields a selectable ``cycle_index`` column (#668).
+    if summaries.index.name is None:
+        summaries.index.name = hdr_cycle
     summaries = summaries.reset_index()
     summaries.columns.names = ["variable", "cell"]
 
-    hdr_cycle = hdr_summary["cycle_index"]
     hdr_charge, hdr_discharge = _get_capacity_columns(
         capacity_specifics=capacity_specifics
     )

--- a/tests/test_issue668_batch_bugs.py
+++ b/tests/test_issue668_batch_bugs.py
@@ -1,0 +1,79 @@
+"""Regression tests for issue #668 (v1.x batch plot + nested cycle_mode)."""
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from cellpy.parameters.internal_settings import get_headers_summary
+from cellpy.readers.cellpy_file.meta import unwrap_meta_value
+from cellpy.utils.batch_tools.batch_plotters import generate_summary_frame_for_plotting
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("anode", "anode"),
+        (["anode"], "anode"),
+        ([["anode"]], "anode"),
+        (("anode",), "anode"),
+        (None, None),
+        ([1, 2], [1, 2]),
+    ],
+)
+def test_unwrap_meta_value_variants(value, expected):
+    assert unwrap_meta_value(value) == expected
+
+
+@pytest.mark.essential
+def test_summary_frame_unnamed_cycle_index():
+    """Unnamed summary index becomes selectable ``cycle_index`` (#668 / #658)."""
+    hdr = get_headers_summary()
+    cells = ["cell_a", "cell_b"]
+    cycles = [1, 2, 3]
+
+    def _frame(name, values):
+        df = pd.DataFrame(
+            {cell: values for cell in cells},
+            index=cycles,
+        )
+        df.index.name = None  # reproduce post-join_summaries state
+        df.name = name
+        return df
+
+    charge = f"{hdr.charge_capacity}_gravimetric"
+    discharge = f"{hdr.discharge_capacity}_gravimetric"
+    farms = [
+        _frame(charge, [1.0, 0.9, 0.8]),
+        _frame(discharge, [0.95, 0.85, 0.75]),
+        _frame(hdr.coulombic_efficiency, [95.0, 94.0, 93.0]),
+    ]
+    pages = pd.DataFrame(index=cells)
+    experiment = SimpleNamespace(memory_dumped={"summary_engine": farms})
+
+    out = generate_summary_frame_for_plotting(pages, experiment)
+    assert hdr.cycle_index in out.columns
+    assert set(out[hdr.cycle_index].unique()) == {1, 2, 3}
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("nested_mode", [["anode"], [["anode"]]])
+def test_make_summary_with_nested_cycle_mode(
+    cellpy_data_instance, parameters, nested_mode
+):
+    """Nested list-boxed cycle_mode must not crash make_summary (#668)."""
+    c = cellpy_data_instance
+    c.set_instrument("arbin_res")
+    c.from_raw(parameters.res_file_path)
+    c.mass = 1.0
+    c.make_step_table()
+    # Bypass the setter so meta stays nested (as after a bad cellpy-file load).
+    c.data.meta_test_dependent.cycle_mode = nested_mode
+
+    c.make_summary(find_ir=True, find_end_voltage=True)
+
+    assert c.data.meta_test_dependent.cycle_mode == "anode"
+    assert c.cycle_mode == "anode"
+    assert c.data.summary is not None
+    assert not c.data.summary.empty


### PR DESCRIPTION
## Summary
- Fix `b.plot` when summary farms have an unnamed cycle index (`KeyError: cycle_index` → `NoneType.show`) by naming the index before `reset_index` (backport of #658).
- Fix nested list-boxed `cycle_mode` (e.g. `[['anode']]`) crashing `make_summary` via the core bridge: unwrap on cellpy-file load, harden `CellpyCell.cycle_mode`, normalize before `_make_summary`.
- Add essential regression tests; durable core hardening tracked in cellpy/cellpy-core#142.

## Test plan
- [x] `uv run pytest tests/test_issue668_batch_bugs.py`
- [x] `uv run pytest -m essential`
- [ ] Loader-notebook smoke: `b.plot(rate=True, ir=True, direction="discharge")` and custom `update_cell` → `make_summary` loop

Closes #668


Made with [Cursor](https://cursor.com)