### PR TITLE
fix: correct setup dry-run messages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Report dry-run setup destinations without claiming that files were written (#666).
+
 * Align 2.0 release guides for a `v2.0.0rc1` soak and record the Stage 3.17 gate audit (#574).
 
 * Lock the file-format compatibility matrix (v8/v9 read/write, convert, pre-v8 freeze) (#573).

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1116,6 +1116,12 @@ def _write_config_file(user_dir, dst_file, init_filename, dry_run):
             _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
             _say(_txt)
     else:
+        if dry_run:
+            _say(
+                "[cellpy] (setup) dry-run: would write "
+                f"{dst_file} (not written)"
+            )
+            return
         _say("[cellpy] (setup) Configuration file written!")
         _say(
             "[cellpy] (setup) OK! Now you can edit it. For example by "
@@ -1145,6 +1151,12 @@ def _write_env_file(user_dir, dst_file, dry_run):
         _txt += "[cellpy] (setup) Well, guess you have to talk to the developers."
         _say(_txt)
     else:
+        if dry_run:
+            _say(
+                "[cellpy] (setup) dry-run: would write "
+                f"{dst_file} (not written)"
+            )
+            return
         _say("[cellpy] (setup) Environment file written!")
         _say(
             "[cellpy] (setup) OK! Now you can edit it. For example by "

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -255,6 +255,9 @@ def test_cli_setup():
         result = runner.invoke(cli.cli, ["setup", "--dry-run"])
         print(result.output)
         assert result.exit_code == 0
+        assert "Configuration file written!" not in result.output
+        assert "Environment file written!" not in result.output
+        assert result.output.count("dry-run: would write") == 3
 
 
 def test_cli_setup_interactive():


### PR DESCRIPTION
Closes #666

## Summary
- Report configuration and environment destinations as planned writes during `setup --dry-run`.
- Keep the existing success messages unchanged for live setup runs.
- Assert that dry-run output lists all three destinations without claiming success.

## Test plan
- [x] Regression test fails on the original implementation and passes with the fix.
- [x] `python -m pytest tests/test_cellpy_cmd.py::test_cli_setup tests/test_cellpy_cmd.py::test_cli_setup_interactive tests/test_cellpy_cmd.py::test_cli_setup_custom_dir -q`
