### PR TITLE
docs: chapter for agents (#682)

### DIFF
--- a/.issueflows/03-solved-issues/issue682_original.md
+++ b/.issueflows/03-solved-issues/issue682_original.md
@@ -1,0 +1,17 @@
+# Issue #682: chapter for agents
+
+Source: https://github.com/jepegit/cellpy/issues/682
+
+## Original issue text
+
+We should provide a chapter for agents on how to use cellpy. 
+
+Tasks:
+
+- Search for examples of how it is done in other projects (web)
+- Decide on a structure and content. 
+  - Remember that the agents need to find it. 
+  - It's probably good to include many examples.
+  - Let us assume that one particular use-case will be researchers who want to build an app/GUI for processing their cell data
+- Implement the documentation
+- Add to developer docs / issueflows folder (this-project.md? or other) information so that the agent docs get also get updated when new development is done

--- a/.issueflows/03-solved-issues/issue682_plan.md
+++ b/.issueflows/03-solved-issues/issue682_plan.md
@@ -1,0 +1,48 @@
+# Issue #682 plan: chapter for agents
+
+## Goal
+
+Give coding agents a discoverable, example-heavy guide for **using cellpy as a library** (primary persona: researcher building a small app/GUI), plus a maintenance hook so future API work updates that guide.
+
+## Constraints
+
+- Keep root `AGENTS.md` lean: do not edit the managed issue-flow block; add a short pointer section after `<!-- END issue-flow (managed) -->`.
+- Prefer progressive disclosure (agents.md convention): essentials + link to a fuller chapter, not a 500-line dump in `AGENTS.md`.
+- Docs-only change; no API / behaviour changes.
+- Match existing MkDocs style under `docs/getting_started/`.
+
+### Prior art
+
+- Root [`AGENTS.md`](../../../AGENTS.md) — issue-flow managed block + Cursor Cloud notes; natural discoverability hook.
+- [`docs/getting_started/basic_usage.md`](../../../docs/getting_started/basic_usage.md) — human-oriented load/inspect examples (reuse patterns, don’t duplicate wholesale).
+- [`docs/fundamentals/data_structure.md`](../../../docs/fundamentals/data_structure.md) — `CellpyCell` / `schema` / frames.
+- [`cellpy/utils/example_data.py`](../../../cellpy/utils/example_data.py) — `raw_file()`, `cellpy_file()` for offline-friendly agent demos.
+- [`.issueflows/04-designs-and-guides/this-project.md`](../04-designs-and-guides/this-project.md) — place for “update agent docs when …” rule.
+- Web convention ([agents.md](https://agents.md/)): root `AGENTS.md`, keep ≤~150 lines of actionable guidance, link out for depth.
+
+## Approach
+
+1. Add `docs/getting_started/agents.md` — agent chapter: product shape, install/run, core objects, load → schema → export recipes, GUI/app skeleton tips, pitfalls, links.
+2. Wire into `docs/getting_started/index.md` (and a one-line mention on developers guide if useful).
+3. Add a short **Using cellpy (for agents)** section in root `AGENTS.md` after the managed block that points at that page and lists 5–10 copy-paste commands / API bullets.
+4. Update `this-project.md` Conventions: when public load/get/save/schema/CLI surface changes, update `docs/getting_started/agents.md` (+ the `AGENTS.md` pointer if commands change).
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `docs/getting_started/agents.md` | **New** — full agent chapter |
+| `docs/getting_started/index.md` | Link the new page |
+| `AGENTS.md` | Short discoverability section after managed block |
+| `.issueflows/04-designs-and-guides/this-project.md` | Maintenance rule for agent docs |
+| `.issueflows/01-current-issues/issue682_status.md` | Status |
+
+## Test strategy
+
+- Docs-only: no new pytest.
+- Preflight already green: `uv run pytest -m essential`.
+- Spot-check that example snippets match current v2 APIs (`cellpy.get`, `c.schema`, `c.data.*`, `example_data`).
+
+## Open questions
+
+- None for yolo scope — fuller Sphinx/MkDocs nav nesting or nested `AGENTS.md` deferred.

--- a/.issueflows/03-solved-issues/issue682_status.md
+++ b/.issueflows/03-solved-issues/issue682_status.md
@@ -1,0 +1,15 @@
+# Issue #682 status
+
+- [x] Done
+
+## Progress
+
+- 2026-07-25: Captured original; yolo plan + build.
+- Added `docs/getting_started/agents.md` (usage chapter for agents / GUI builders).
+- Linked from `docs/getting_started/index.md`.
+- Short discoverability section in root `AGENTS.md` (after managed block).
+- Maintenance rule in `.issueflows/04-designs-and-guides/this-project.md`.
+
+## Remaining
+
+- None.

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -32,6 +32,11 @@ See also [testing-and-coverage.md](testing-and-coverage.md) and [ci-tiers.md](ci
   normalize to **forward slashes** — use `pathlib.Path(...).as_posix()` or
   `path.replace("\\", "/")`, not raw `str(path)` on Windows. Parquet/frame comparisons are
   unaffected; string metadata in JSON is where `\` vs `/` bites (see #433).
+- **Agent usage docs (#682):** When a change alters the public `cellpy.get` /
+  `CellpyCell` / `schema` / CLI surface that app-building agents rely on, update
+  [`docs/getting_started/agents.md`](../../docs/getting_started/agents.md) and the
+  short **Using cellpy (for agents)** section in root `AGENTS.md` in the same PR.
+  Do not put long recipes inside the managed issue-flow block of `AGENTS.md`.
 - TODO: Branch, commit, formatting, typing, or review conventions beyond the above.
 
 ## Entry points

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,24 @@ If a `graphify-out/` folder exists in the project root, the project has the opti
 
 <!-- END issue-flow (managed) -->
 
+## Using cellpy (for agents)
+
+Coding agents that **call cellpy as a library** (e.g. a researcher’s small
+GUI/app around cycling data) should read the usage chapter:
+
+**[`docs/getting_started/agents.md`](docs/getting_started/agents.md)**
+
+Quick facts:
+
+- Product: Python library + `cellpy` CLI — not a hosted GUI server.
+- Entry: `import cellpy` then `c = cellpy.get(path, mass=..., instrument=...)`.
+- Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
+- Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
+- Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
+- Prefer schema-resolved names over hard-coded 1.x header strings.
+- When changing public get/save/schema/CLI surface, update
+  `docs/getting_started/agents.md` and this section in the same PR.
+
 ## Cursor Cloud specific instructions
 
 Environment is already provisioned on cloud VM startup: `uv` (on PATH via

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add agent usage chapter for library/app builders. (#682).
 * Update docs about data structure. (#680).
 * Update docs and batch-loader examples for native step/raw headers (cellpy 2.0). (#676).
 * Pin `cellpycore==0.2.4` (EFC summary columns); sync `HeadersSummary` and pipeline_smoke goldens (#675).

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -1,0 +1,190 @@
+# Using cellpy from an agent
+
+This page is for **coding agents** (and humans directing them) that need to
+**call cellpy as a library** — for example a researcher building a small
+desktop GUI, web app, or notebook pipeline around cell cycling data.
+
+For contributing to the cellpy *codebase*, start at
+[AGENTS.md](https://github.com/jepegit/cellpy/blob/master/AGENTS.md) in the
+repo root and the [developers guide](../contributing/developers_guide/index.md).
+
+!!! tip "Findability"
+    Root `AGENTS.md` points here. Prefer this chapter for usage recipes; keep
+    `AGENTS.md` short (commands + link).
+
+## What cellpy is (and is not)
+
+| Is | Is not |
+| --- | --- |
+| A Python library that loads battery-tester files into a consistent shape | A GUI or web server product |
+| Builds **step** and **summary** tables from raw time-series | A plotting-first dashboard (helpers exist; bring your own UI) |
+| Ships a `cellpy` CLI (`setup`, `info`, `serve` → Jupyter) | Long-running app hosting — `serve` only launches Jupyter |
+
+Primary object: **`CellpyCell`**. Measurement frames live on **`c.data`**
+(`raw`, `steps`, `summary`). Column names for the active schema are on
+**`c.schema`** — prefer that over legacy `headers_*` attributes.
+
+## Install and smoke-check
+
+Consumer install:
+
+```bash
+pip install cellpy
+# or: conda install -c conda-forge cellpy
+```
+
+From a clone of this repo (dev):
+
+```bash
+uv sync
+uv run cellpy setup --silent
+uv run cellpy info --check
+uv run pytest -m essential
+```
+
+Always run Python through the project environment (`uv run …` in this repo,
+or the user's activated venv/conda env). Do not call bare `python` unless the
+user already activated an env that has `cellpy` installed.
+
+## Minimal load → inspect → export
+
+Use bundled example data when the agent has network access (first call may
+download small fixtures from GitHub):
+
+```python
+from cellpy.utils import example_data
+
+c = example_data.raw_file()  # Arbin .res → CellpyCell with steps + summary
+
+# Prefer schema-resolved column names (v2 native headers)
+potential = c.data.raw[c.schema.raw.potential]
+charge_cap = c.data.summary[c.schema.summary.charge_capacity]
+
+print(c.data.summary.head())
+print(c.get_cycle_numbers()[:5])
+```
+
+Load a path the user provides:
+
+```python
+import cellpy
+
+c = cellpy.get(
+    r"C:\data\my_cell_01.res",
+    mass=0.85,  # active material mass in mg (instrument-dependent context)
+    instrument="arbin_res",  # omit to use config default / extension guess
+)
+c.save("out/my_cell.cellpy")  # HDF5 cellpy file — fast reload later
+c.to_csv("out/csv_export")
+```
+
+Reload a `.cellpy` file the same way:
+
+```python
+c = cellpy.get("out/my_cell.cellpy")
+```
+
+## Core mental model for app code
+
+```text
+cellpy.get(path, ...)  →  CellpyCell
+                            ├─ .data.raw      # time-series (pandas DataFrame)
+                            ├─ .data.steps    # per-step stats / types
+                            ├─ .data.summary  # per-cycle summary
+                            └─ .schema        # stable names → actual columns
+```
+
+Useful methods on `CellpyCell` (non-exhaustive):
+
+- `get_cycle_numbers()` — list of cycle indices
+- `get_cap(...)` / capacity–voltage style extracts (see API / examples)
+- `make_step_table()` / `make_summary()` — usually already run by `get`
+- `save` / `to_csv` / Excel helpers — persist for the user's workflow
+
+Deeper shape docs: [Data structure](../fundamentals/data_structure.md).
+Human tutorial path: [Basic usage](basic_usage.md),
+[Examples](../examples/index.md).
+
+## Recipe: researcher GUI / app around cellpy
+
+Typical agent task: “build a small app that loads my tester files and shows
+capacities.” Keep **cellpy in the data layer**; keep UI (Streamlit, Qt,
+Panel, FastAPI, …) thin.
+
+Suggested layering:
+
+1. **Load** — `cellpy.get(path, mass=..., instrument=...)` in a worker thread
+   or async job so the UI stays responsive on large files.
+2. **Resolve columns** — always via `c.schema.*`, never hard-coded legacy
+   strings, so v1→v2 and instrument differences hurt less.
+3. **Present** — pass pandas frames or simple dicts to the UI
+   (`summary` for cycle tables; slices of `raw` for plots).
+4. **Export** — offer `.cellpy` (canonical) plus CSV/Excel for the user.
+
+Skeleton (UI-agnostic):
+
+```python
+from dataclasses import dataclass
+from pathlib import Path
+
+import cellpy
+
+
+@dataclass
+class LoadRequest:
+    path: Path
+    mass_mg: float
+    instrument: str | None = None
+
+
+def load_cell(req: LoadRequest):
+    kwargs = {"filename": str(req.path), "mass": req.mass_mg}
+    if req.instrument:
+        kwargs["instrument"] = req.instrument
+    return cellpy.get(**kwargs)
+
+
+def cycle_table(c):
+    s = c.schema.summary
+    df = c.data.summary
+    cols = [s.charge_capacity, s.discharge_capacity]
+    cols = [col for col in cols if col in df.columns]
+    return df[cols].copy()
+```
+
+Instrument strings and formats: see
+[Loading different formats](../examples/06_loading_different_formats.md) and
+the instruments API. Coming from cellpy 1.x:
+[migration guide](migration_v1_to_v2.md).
+
+## Pitfalls agents hit
+
+- **Hard-coded column names** — use `c.schema.raw.potential` (etc.), not
+  remembered 1.x header strings.
+- **Blocking the UI thread** — `get` on large `.res` / SQL dumps can take
+  seconds; load off the main thread.
+- **Missing mass / instrument** — wrong capacities or wrong loader; surface
+  these as required inputs in the GUI.
+- **Writing into the install tree** — treat user data dirs as read/write;
+  never assume repo `testdata/` exists for end users.
+- **Committing secrets / local config** — `cellpy setup` writes
+  `.env_cellpy` and `~/.cellpy_prms_*.conf`; do not commit those.
+- **Plot backends in headless CI** — set `MPLBACKEND=Agg` when running tests
+  or batch plot export without a display.
+
+## Where to read next
+
+| Need | Page |
+| --- | --- |
+| Install / config / CLI checkup | [Installation](installation.md), [Configuration](configuration.md), [Checkup](checkup.md) |
+| Frames and `schema` | [Data structure](../fundamentals/data_structure.md) |
+| Tutorials | [Examples](../examples/index.md) |
+| API signatures | [API reference](../api/index.md) |
+| Contribute to cellpy itself | [Developers guide](../contributing/developers_guide/index.md) |
+
+## Maintaining this page
+
+When you change the public `cellpy.get` / `CellpyCell` / `schema` / CLI
+surface, update **this file** and the short pointer section in root
+`AGENTS.md` in the same PR. That rule is also recorded in
+`.issueflows/04-designs-and-guides/this-project.md`.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -10,5 +10,7 @@ through these pages in order, or jump to what you need.
 - [Check your installation](checkup.md) — version, paths, and useful CLI
   checks
 - [Basic usage](basic_usage.md) — load a cell and inspect the main tables
+- [Using cellpy from an agent](agents.md) — recipes for coding agents and
+  app/GUI builders
 - [Coming from cellpy 1.x](migration_v1_to_v2.md) — what changed in 2.x and
   how to migrate


### PR DESCRIPTION
## Summary
- Add `docs/getting_started/agents.md` — example-heavy guide for coding agents using cellpy as a library (researcher GUI/app persona).
- Point to it from root `AGENTS.md` (after the managed issue-flow block) and the getting-started index.
- Record a maintenance rule in `this-project.md` so public get/schema/CLI changes update the agent docs in the same PR.

Closes #682

## Test plan
- [x] `uv run pytest -m essential` (preflight)
- [ ] Skim `docs/getting_started/agents.md` and `AGENTS.md` pointer for accuracy against v2 APIs

Made with [Cursor](https://cursor.com)