### PR TITLE
Fix BatchICACollector fig_pr_cycle KeyError on cycle_num

### DIFF
--- a/.issueflows/03-solved-issues/issue679_original.md
+++ b/.issueflows/03-solved-issues/issue679_original.md
@@ -1,0 +1,188 @@
+# Issue #679: bug in BatchICACollector
+
+Source: https://github.com/jepegit/cellpy/issues/679
+
+## Original issue text
+
+Bug in v2.0.0rc1.
+
+Running the following cell in batch loader notebook:
+
+```python
+cycles_collected = collectors.BatchICACollector(
+    b,
+    plot_type="fig_pr_cycle",
+    cycles=[1, 2, 3],
+    palette="Viridis",
+    data_collector_arguments={"voltage_resolution": 0.01},
+)
+```
+
+Error message:
+
+```python
+WARNING:py.warnings:[C:\Users\jepe\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\utils\collectors.py:1698](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/utils/collectors.py#line=1697): RuntimeWarning: dqdv failed for 1 half-cycle(s): cycle 2 discharge
+  curves = ica.dqdv(
+
+---------------------------------------------------------------------------
+KeyError                                  Traceback (most recent call last)
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\pandas\core\indexes\base.py:3641](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/pandas/core/indexes/base.py#line=3640), in Index.get_loc(self, key)
+   3640 try:
+-> 3641     return self._engine.get_loc(casted_key)
+   3642 except KeyError as err:
+
+File pandas/_libs/index.pyx:168, in pandas._libs.index.IndexEngine.get_loc()
+--> 168 'Could not get source, probably due dynamically evaluated source code.'
+
+File pandas/_libs/index.pyx:197, in pandas._libs.index.IndexEngine.get_loc()
+--> 197 'Could not get source, probably due dynamically evaluated source code.'
+
+File pandas/_libs/hashtable_class_helper.pxi:7668, in pandas._libs.hashtable.PyObjectHashTable.get_item()
+-> 7668 'Could not get source, probably due dynamically evaluated source code.'
+
+File pandas/_libs/hashtable_class_helper.pxi:7676, in pandas._libs.hashtable.PyObjectHashTable.get_item()
+-> 7676 'Could not get source, probably due dynamically evaluated source code.'
+
+KeyError: 'cycle_num'
+
+The above exception was the direct cause of the following exception:
+
+KeyError                                  Traceback (most recent call last)
+Cell In[10], line 1
+----> 1 cycles_collected = collectors.BatchICACollector(
+      2     b,
+      3     plot_type="fig_pr_cycle",
+      4     cycles=[1, 2, 3],
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\utils\collectors.py:1286](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/utils/collectors.py#line=1285), in BatchICACollector.__init__(self, b, plot_type, cycles, max_cycle, rate, rate_on, rate_std, rate_agg, inverse, label_mapper, backend, cycles_to_plot, width, palette, show_legend, legend_position, fig_title, cols, group_legend_muting, only_selected, *args, **kwargs)
+   1264 elevated_data_collector_arguments = dict(
+   1265     cycles=cycles,
+   1266     max_cycle=max_cycle,
+   (...)   1273     only_selected=only_selected,
+   1274 )
+   1275 elevated_plotter_arguments = dict(
+   1276     cycles_to_plot=cycles_to_plot,
+   1277     width=width,
+   (...)   1283     group_legend_muting=group_legend_muting,
+   1284 )
+-> 1286 super().__init__(
+   1287     b,
+   1288     family_kind="ica",
+   1289     data_collector=ica_collector,
+   1290     collector_name="ica",
+   1291     backend=backend,
+   1292     elevated_data_collector_arguments=elevated_data_collector_arguments,
+   1293     elevated_plotter_arguments=elevated_plotter_arguments,
+   1294     *args,
+   1295     **kwargs,
+   1296 )
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\utils\collectors.py:295](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/utils/collectors.py#line=294), in BatchCollector.__init__(self, b, data_collector, plotter, collector_name, name, nick, autorun, backend, elevated_data_collector_arguments, elevated_plotter_arguments, data_collector_arguments, plotter_arguments, experimental, family_kind, **kwargs)
+    292 self.parse_units()
+    294 if autorun:
+--> 295     self.update(update_name=False)
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\utils\collectors.py:609](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/utils/collectors.py#line=608), in BatchCollector.update(self, data_collector_arguments, plotter_arguments, reset, update_data, update_name, update_plot)
+    607 if update_plot:
+    608     try:
+--> 609         self.render()
+    610     except TypeError as e:
+    611         print("Type error:", e)
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\utils\collectors.py:451](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/utils/collectors.py#line=450), in BatchCollector.render(self, **kwargs)
+    443     self.figure = self.plotter(
+    444         self.data,
+    445         backend=self.backend,
+   (...)    448         **kwargs,
+    449     )
+    450     return
+--> 451 self.figure = collected_plot(
+    452     self.data,
+    453     family_kind=self.family_kind,
+    454     backend=self.backend,
+    455     journal=self.b.journal,
+    456     units=self.units,
+    457     **kwargs,
+    458 )
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\plotting\collected.py:1474](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/plotting/collected.py#line=1473), in collected_plot(frame, family_kind, layout, kind, backend, method, plot_type, spread, **opts)
+   1469 if backend_key == "seaborn":
+   1470     # Keep the historical seaborn branch without forcing get_backend("matplotlib")
+   1471     # into the single-cell summary path.
+   1472     return render_collected(frame, spec, backend_override="seaborn")
+-> 1474 return get_backend(backend_key).render(frame, spec)
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\plotting\backends\plotly.py:303](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/plotting/backends/plotly.py#line=302), in PlotlyBackend.render(self, frame, spec)
+    300 if kind == "collected":
+    301     from cellpy.plotting.collected import render_collected
+--> 303     return render_collected(frame, spec, backend_override="plotly")
+    304 if kind == "cycles":
+    305     return self._render_cycles(frame, spec)
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\plotting\collected.py:1394](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/plotting/collected.py#line=1393), in render_collected(frame, spec, backend_override)
+   1392     return summary_plotter(frame, backend=backend, **opts)
+   1393 if family_kind == "ica":
+-> 1394     return ica_plotter(frame, backend=backend, method=method, **opts)
+   1395 if family_kind == "cycles":
+   1396     return cycles_plotter(frame, backend=backend, method=method, **opts)
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\plotting\collected.py:1273](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/plotting/collected.py#line=1272), in ica_plotter(collected_curves, cycles_to_plot, backend, method, direction, **kwargs)
+   1270 if method == "film":
+   1271     kwargs["range_y"] = kwargs.pop("range_y", None) or (1, max_cycle)
+-> 1273 return _cycles_plotter(
+   1274     collected_curves,
+   1275     x="voltage",
+   1276     y="dqdv",
+   1277     z="cycle",
+   1278     g="cell",
+   1279     x_label="Voltage",
+   1280     x_unit="V",
+   1281     y_label="dQ/dV",
+   1282     y_unit="mAh/g/V.",
+   1283     default_title=f"Incremental Analysis Plots",
+   1284     direction=direction,
+   1285     backend=backend,
+   1286     method=method,
+   1287     cycles=cycles_to_plot,
+   1288     **kwargs,
+   1289 )
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\cellpy\plotting\collected.py:911](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/cellpy/plotting/collected.py#line=910), in _cycles_plotter(collected_curves, cycles, x, y, z, g, standard_deviation, default_title, backend, method, match_axes, **kwargs)
+    909         number_of_figs = len(cycles)
+    910     else:
+--> 911         number_of_figs = len(collected_curves[_CCOLS.cycle_num].unique())
+    912 elif method == "summary":
+    913     number_of_figs = len(collected_curves["variable"].unique())
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\pandas\core\frame.py:4378](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/pandas/core/frame.py#line=4377), in DataFrame.__getitem__(self, key)
+   4374 
+   4375         if is_single_key:
+   4376             if self.columns.nlevels > 1:
+   4377                 return self._getitem_multilevel(key)
+-> 4378             indexer = self.columns.get_loc(key)
+   4379             if is_integer(indexer):
+   4380                 indexer = [indexer]
+   4381         else:
+
+File [~\.pixi\envs\cellpy-v2\Lib\site-packages\pandas\core\indexes\base.py:3648](file:///C:/Users/jepe/.pixi/envs/cellpy-v2/Lib/site-packages/pandas/core/indexes/base.py#line=3647), in Index.get_loc(self, key)
+   3643     if isinstance(casted_key, slice) or (
+   3644         isinstance(casted_key, abc.Iterable)
+   3645         and any(isinstance(x, slice) for x in casted_key)
+   3646     ):
+   3647         raise InvalidIndexError(key) from err
+-> 3648     raise KeyError(key) from err
+   3649 except TypeError:
+   3650     # If we have a listlike key, _check_indexing_error will raise
+   3651     #  InvalidIndexError. Otherwise we fall through and re-raise
+   3652     #  the TypeError.
+   3653     self._check_indexing_error(key)
+
+KeyError: 'cycle_num'
+```
+
+## Comments (curated summary)
+
+- **Clarifications / constraints**:
+  - Failure is specific to `plot_type="fig_pr_cycle"`; `plot_type="fig_pr_cell"` and `plot_type="film"` did not fail on the same batch.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-24._

--- a/.issueflows/03-solved-issues/issue679_plan.md
+++ b/.issueflows/03-solved-issues/issue679_plan.md
@@ -1,0 +1,76 @@
+# Issue #679 plan — bug in BatchICACollector (`fig_pr_cycle`)
+
+## Goal
+
+Make `BatchICACollector(..., plot_type="fig_pr_cycle")` render without `KeyError: 'cycle_num'`, matching the already-working `fig_pr_cell` / `film` paths on the same ICA frame.
+
+## Constraints
+
+- Specced ICA collected frame columns stay `cycle`, `direction`, `voltage`, `capacity`, `dqdv` (#591 / tests in `tests/test_collectors.py`). Do **not** rename ICA to `cycle_num`.
+- Capacity-curve collectors keep native `CurveCols.cycle_num` (#540).
+- Drawing stays in `cellpy.plotting.collected` (#657); no move of collection logic.
+- Keep the fix small — no plotting redesign, no collector API rewrite.
+- Target branch: `master` / label `v2` (rc1 regression).
+
+### Prior art
+
+- Design: [`.issueflows/04-designs-and-guides/plotting-collected.md`](../04-designs-and-guides/plotting-collected.md) — `fig_pr_cycle` → `layout="per_cycle"`.
+- `ica_plotter` already passes `z="cycle"` into `_cycles_plotter` (`cellpy/plotting/collected.py`).
+- `cycles_plotter` passes `z=_CCOLS.cycle_num` for capacity curves.
+- `sequence_plotter` already uses `curves[z]` for palette sizing on `fig_pr_cell`, but still hardcodes `.cycle` when filtering by `cycles=`.
+- Tests: `test_batch_ica_collector_*` cover default / film / frame shape; **no** `fig_pr_cycle` coverage today.
+- Toolbox: nothing relevant for this bug (`00-tools` checked).
+- Graph: `BatchICACollector` → `collected_plot` / `_cycles_plotter` / `sequence_plotter` (community ~14 / 810).
+
+## Approach
+
+**Root cause.** ICA frames use column `"cycle"`. In `_cycles_plotter`, when `method == "fig_pr_cycle"` and `cycles is None`, the code does:
+
+```python
+number_of_figs = len(collected_curves[_CCOLS.cycle_num].unique())  # KeyError
+```
+
+That path is hit in practice because constructor `cycles=[…]` feeds the **data** collector only; plotter `cycles_to_plot` defaults to `None`, and `ica_plotter` leaves it `None` when unique cycles ≤ 50. `fig_pr_cell` / `film` never touch that line (they count `"cell"`), which matches the issue comment.
+
+**Fix (primary).** In `_cycles_plotter`, count unique cycles via the existing `z` parameter (the cycle column for both families):
+
+```python
+number_of_figs = len(collected_curves[z].unique())
+```
+
+**Fix (same PR, small hardening).** In `sequence_plotter`, stop hardcoding `collected_curves.cycle` for cycle filters:
+
+- `fig_pr_cell` / `film`: filter with `collected_curves[z]` (pre-swap `z` is the cycle column).
+- `fig_pr_cycle`: after `z, g = g, z`, the cycle column is in `g` — filter with `collected_curves[g]` (or filter before the swap with the original `z`). Prefer one clear pattern (filter before swap) so both capacity (`cycle_num`) and ICA (`cycle`) work.
+
+**Out of scope (note only).** `cycles_plotter` still references `collected_curves.cycle` in its “too many cycles” branch despite using `cycle_num` as `z` — separate latent bug; only touch if a one-liner falls out of the same edit. Do not auto-wire constructor `cycles` → `cycles_to_plot` unless we decide that in Open questions.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| [`cellpy/plotting/collected.py`](../../cellpy/plotting/collected.py) | `_cycles_plotter`: use `z` for `fig_pr_cycle` fig count; `sequence_plotter`: filter cycles via the cycle column param, not `.cycle` |
+| [`tests/test_collectors.py`](../../tests/test_collectors.py) | Add `BatchICACollector(..., plot_type="fig_pr_cycle")` smoke (and optionally cycles-collector `fig_pr_cycle` if filter hardening is in) |
+| [`.issueflows/04-designs-and-guides/plotting-collected.md`](../04-designs-and-guides/plotting-collected.md) | One short note: ICA frames use `"cycle"`; plotters must use `z` / the cycle column arg, not hardcode `cycle_num` |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_collectors.py -q
+uv run pytest -m essential   # before close
+```
+
+New test(s):
+
+1. `BatchICACollector(populated_batch, plot_type="fig_pr_cycle")` runs (`_assert_ran`) — reproduces #679.
+2. Optional: same with `cycles=[1, 2]` on the constructor (collection filter) still renders.
+3. If filter hardening lands: `BatchCyclesCollector(..., plot_type="fig_pr_cycle", cycles_to_plot=[1])` (or equivalent) does not `KeyError` on `.cycle`.
+
+Mark the new ICA regression `@pytest.mark.essential` only if it stays fast on the existing `populated_batch` fixture (prefer yes — this is an rc1 plot regression).
+
+## Open questions
+
+1. **Wire `cycles` → `cycles_to_plot`?** When the user passes `cycles=[1,2,3]` to `BatchICACollector`, should that also become the plotter’s `cycles_to_plot` default?  
+   - **Recommended: no** for this PR — constructor already documents separate elevated args; the `z`-based count fix is enough for the crash. Can be a follow-up UX issue.
+2. **Include capacity-curve filter hardening in this PR?**  
+   - **Recommended: yes** — same hardcoded `.cycle` footgun, tiny diff, prevents the next KeyError on `BatchCyclesCollector` + `fig_pr_cycle` / filtered `fig_pr_cell`.

--- a/.issueflows/03-solved-issues/issue679_status.md
+++ b/.issueflows/03-solved-issues/issue679_status.md
@@ -1,0 +1,19 @@
+# Issue #679 status
+
+- [x] Done
+
+## What's done
+
+- Plan confirmed (Accept).
+- Fixed `_cycles_plotter` to count unique cycles via `z` (ICA `cycle` / capacity `cycle_num`).
+- Fixed `sequence_plotter` curve/ICA cycle filters to use `z` (filter before `z`/`g` swap on `fig_pr_cycle`).
+- Fixed `cycles_plotter` “too many cycles” branch to use `_CCOLS.cycle_num`.
+- Tests: `test_batch_ica_collector_fig_pr_cycle`, `_with_cycles_arg`, `test_batch_cycles_collector_fig_pr_cycle` (`@pytest.mark.essential`).
+- Design note in `plotting-collected.md`.
+- `MPLBACKEND=Agg uv run pytest tests/test_collectors.py` → 12 passed.
+- `MPLBACKEND=Agg uv run pytest -m essential` → 627 passed, 1 skipped.
+- HISTORY Unreleased bullet added.
+
+## Remaining work
+
+- None (PR + `/iflow-cleanup` after merge).

--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -25,6 +25,9 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   `collected_plot`; custom `plotter=` callables still work if provided.
 - Collector plotly templates remain in `cellpy.plotting.theme`
   (`make_collector_templates`).
+- **Cycle column:** capacity-curve frames use native `cycle_num`; ICA frames
+  use `cycle`. Plotters must use the `z` (cycle-column) argument for counts and
+  filters — never hardcode `cycle_num` or `.cycle` on the curve/ICA paths (#679).
 
 ## Links
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
+* Fix BatchICACollector fig_pr_cycle KeyError on cycle_num (use ICA cycle column). (#679).
 * Add agent usage chapter for library/app builders. (#682).
+
 * Update docs about data structure. (#680).
 * Update docs and batch-loader examples for native step/raw headers (cellpy 2.0). (#676).
 * Pin `cellpycore==0.2.4` (EFC summary columns); sync `HeadersSummary` and pipeline_smoke goldens (#675).

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -446,8 +446,10 @@ def sequence_plotter(
         else:
             plotly_arguments["facet_col"] = g
 
+        # Filter on ``z`` (cycle column) — capacity curves use ``cycle_num``,
+        # ICA uses ``cycle`` (#679). Do not hardcode ``.cycle``.
         if cycles is not None:
-            curves = collected_curves.loc[collected_curves.cycle.isin(cycles), :]
+            curves = collected_curves.loc[collected_curves[z].isin(cycles), :]
         else:
             curves = collected_curves
         logging.debug(f"filtered_curves:\n{curves}")
@@ -463,14 +465,15 @@ def sequence_plotter(
                 curves[y] = curves[y].apply(np.abs)
 
     elif method == "fig_pr_cycle":
+        # Filter before swapping ``z``/``g`` so ``z`` is still the cycle column.
+        if cycles is not None:
+            curves = collected_curves.loc[collected_curves[z].isin(cycles), :]
+        else:
+            curves = collected_curves
+
         z, g = g, z
         plotly_arguments["facet_col"] = g
         seaborn_arguments["col"] = g
-
-        if cycles is not None:
-            curves = collected_curves.loc[collected_curves.cycle.isin(cycles), :]
-        else:
-            curves = collected_curves
 
         if group_cells:
             plotly_arguments["color"] = group
@@ -484,6 +487,7 @@ def sequence_plotter(
             seaborn_arguments["style"] = z
 
     elif method == "summary":
+        # Summary collectors label the cycle column ``cycle``.
         if cycles is not None:
             curves = collected_curves.loc[collected_curves.cycle.isin(cycles), :]
         else:
@@ -908,7 +912,9 @@ def _cycles_plotter(
         if cycles is not None:
             number_of_figs = len(cycles)
         else:
-            number_of_figs = len(collected_curves[_CCOLS.cycle_num].unique())
+            # ``z`` is the cycle column: ``cycle_num`` for capacity curves,
+            # ``cycle`` for the specced ICA frame (#679).
+            number_of_figs = len(collected_curves[z].unique())
     elif method == "summary":
         number_of_figs = len(collected_curves["variable"].unique())
         sub_fig_min_height = 300
@@ -1211,7 +1217,7 @@ def cycles_plotter(
     """
 
     if cycles_to_plot is not None:
-        unique_cycles = list(collected_curves.cycle.unique())
+        unique_cycles = list(collected_curves[_CCOLS.cycle_num].unique())
         if len(unique_cycles) > 50:
             print(f"Too many cycles - setting it to default {DEFAULT_CYCLES}")
             cycles_to_plot = DEFAULT_CYCLES

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -97,6 +97,31 @@ def test_batch_ica_collector_film_mode(populated_batch):
     _assert_ran(collector)
 
 
+@pytest.mark.essential
+def test_batch_ica_collector_fig_pr_cycle(populated_batch):
+    """Per-cycle ICA layout must use the ICA ``cycle`` column, not ``cycle_num`` (#679)."""
+    collector = BatchICACollector(populated_batch, plot_type="fig_pr_cycle")
+    _assert_ran(collector)
+
+
+@pytest.mark.essential
+def test_batch_ica_collector_fig_pr_cycle_with_cycles_arg(populated_batch):
+    """Constructor ``cycles=`` filters collection; plotter still renders (#679)."""
+    collector = BatchICACollector(
+        populated_batch, plot_type="fig_pr_cycle", cycles=[1, 2]
+    )
+    _assert_ran(collector)
+
+
+@pytest.mark.essential
+def test_batch_cycles_collector_fig_pr_cycle(populated_batch):
+    """Capacity-curve ``fig_pr_cycle`` filters via ``cycle_num`` (#679 hardening)."""
+    collector = BatchCyclesCollector(
+        populated_batch, plot_type="fig_pr_cycle", cycles_to_plot=[1]
+    )
+    _assert_ran(collector)
+
+
 def test_select_direction_handles_both_encodings():
     """The plotters see specced string frames and raw ±1 get_cap frames."""
     import pandas as pd


### PR DESCRIPTION
## Summary
- ICA collected frames use `cycle`; `_cycles_plotter` / `sequence_plotter` were hardcoding `cycle_num` / `.cycle`, so `BatchICACollector(..., plot_type="fig_pr_cycle")` crashed with `KeyError: 'cycle_num'` on v2.0.0rc1.
- Count and filter via the cycle-column argument (`z`); filter before the `fig_pr_cycle` `z`/`g` swap. Also fix `cycles_plotter`'s too-many-cycles branch for capacity frames.
- Add essential collector tests for ICA and capacity-curve `fig_pr_cycle`.

## Test plan
- [x] `MPLBACKEND=Agg uv run pytest tests/test_collectors.py`
- [x] `MPLBACKEND=Agg uv run pytest -m essential`
- [ ] Smoke: `BatchICACollector(b, plot_type="fig_pr_cycle", cycles=[1, 2, 3])` (issue repro)

Closes #679

Made with [Cursor](https://cursor.com)