### PR TITLE
fix: rate-limit noisy collector warnings (#669)

### DIFF
--- a/.issueflows/03-solved-issues/issue669_original.md
+++ b/.issueflows/03-solved-issues/issue669_original.md
@@ -1,0 +1,124 @@
+# Issue #669: bad warnings in v1 collectors
+
+Source: https://github.com/jepegit/cellpy/issues/669
+
+## Original issue text
+
+## Batch cycles collector
+
+When running this in a Jupyter Lab notebook:
+
+```python
+cells_collected = collectors.BatchCyclesCollector(
+    b,
+    # cycles_to_plot=range(1, 11),  # plot the first 10 cycles, but collect all (e.g. for exports to csv)
+    # collector_type="forth-and-forth",
+)
+```
+
+We receive all these warnings (way too much):
+
+```
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1370 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 217 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1832 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 423 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1940 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 356 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1232 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1415 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 141 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1816 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 429 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1945 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 337 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1103 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1387 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 282 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1832 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 414 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1779 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 271 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 768 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1419 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 144 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1822 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 491 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1954 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 273 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1349 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3024 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1035 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 987 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3106 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1086 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1084 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 454 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3399 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 465 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1770 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 444 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1697 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 110 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 149 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 126 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 394 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3255 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 389 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1685 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 380 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1517 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 117 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 501 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3157 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 402 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1759 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 402 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1607 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 130 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3040 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1120 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1019 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 2888 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 998 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1032 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3201 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1135 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1031 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 3289 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1189 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 1136 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+WARNING:root:interpolate_y_on_x_per_monotonic_segments: 149 segments exceeds max_segments=100; returning dataframe unchanged (likely noisy x-data).
+```
+
+Same problem when running the collector with `plot_type="fig_pr_cycle"`
+
+## Batch ICA collector
+
+Running for example `cells_collected = collectors.BatchICACollector(b, plot_type="fig_pr_cell")`
+
+We get some warnings without error message:
+
+```
+WARNING:root:Error in dqdv_cycle - first half-cycle
+WARNING:root: - error-message: ''
+WARNING:root:Error in dqdv_cycle - last half-cycle
+WARNING:root: - error-message: 'voltage is empty'
+WARNING:root:Error in dqdv_cycle - first half-cycle
+WARNING:root: - error-message: ''
+WARNING:root:Error in dqdv_cycle - first half-cycle
+WARNING:root: - error-message: ''
+WARNING:root:Error in dqdv_cycle - first half-cycle
+WARNING:root: - error-message: ''
+WARNING:root:Error in dqdv_cycle - last half-cycle
+WARNING:root: - error-message: 'voltage is empty'
+WARNING:root:Error in dqdv_cycle - last half-cycle
+WARNING:root: - error-message: 'voltage is empty'
+```
+
+## Comments (curated summary)
+
+- **Clarifications / constraints**:
+  - Also reproduces on `v2.0.0rc1` (not v1-only).
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-24._

--- a/.issueflows/03-solved-issues/issue669_plan.md
+++ b/.issueflows/03-solved-issues/issue669_plan.md
@@ -1,0 +1,38 @@
+# Issue #669 plan
+
+## Goal
+
+Stop collector notebooks from flooding with per-cycle `WARNING:root` spam when
+noisy voltage curves hit the max-segments fallback or half-cycle ICA fails —
+keep one visible signal, demote repeats.
+
+## Constraints
+
+- Do not change interpolation / ICA numeric behaviour (still skip / empty arrays).
+- Keep backport-friendly (`v1 and v2` / `v1x` labels): small logging change only.
+- ### Prior art
+  - `interpolate_y_on_x_per_monotonic_segments` in `cellpy/readers/data_structures.py` (emits the segment spam via bare `logging.warning`).
+  - `_dqdv_cycle_impl` in `cellpy/ica.py` (per half-cycle `logging.warning`).
+  - Module loggers already used elsewhere (`getLogger(__name__)`); deprecation `warn_once` is wrong tool (DeprecationWarning API).
+
+## Approach
+
+1. Switch both call sites to `logging.getLogger(__name__)`.
+2. Process-level once-flag: first hit → `warning` (with note that further hits are DEBUG); later hits → `debug`.
+3. ICA: collapse the two-line warning into one message; same once-per-process pattern for first/last half-cycle failures.
+
+## Files to touch
+
+- `cellpy/readers/data_structures.py` — module logger + once-flag for max_segments.
+- `cellpy/ica.py` — module logger + once-flag for half-cycle failures.
+- `tests/test_cell_readers.py` (or small new assertion) — assert at most one WARNING from repeated max_segments fallbacks.
+- `.issueflows/01-current-issues/issue669_*` — tracking.
+
+## Test strategy
+
+- `uv run pytest tests/test_cell_readers.py::test_interpolate_y_on_x_per_monotonic_segments_max_segments_fallback -q` plus a new warn-once test.
+- `MPLBACKEND=Agg uv run pytest -m essential` before close.
+
+## Open questions
+
+- None (yolo auto-confirm).

--- a/.issueflows/03-solved-issues/issue669_status.md
+++ b/.issueflows/03-solved-issues/issue669_status.md
@@ -1,0 +1,17 @@
+# Issue #669 status
+
+- [x] Done
+
+## What's done
+
+- Init + plan (yolo auto-confirm).
+- Branch: `669-collector-warnings`.
+- Warn-once (then DEBUG) for `interpolate_y_on_x_per_monotonic_segments` max_segments fallback.
+- Warn-once (then DEBUG) for `_dqdv_cycle_impl` half-cycle failures; module loggers (no more `WARNING:root`).
+- Essential test asserts a single WARNING across two fallback calls.
+- HISTORY Unreleased bullet added.
+- `MPLBACKEND=Agg uv run pytest -m essential` → 628 passed, 1 skipped.
+
+## Remaining work
+
+- None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Rate-limit noisy collector warnings from max_segments interpolation fallback and dqdv half-cycle failures. (#669).
+
 * Fix BatchICACollector fig_pr_cycle KeyError on cycle_num (use ICA cycle column). (#679).
 * Add agent usage chapter for library/app builders. (#682).
 

--- a/cellpy/ica.py
+++ b/cellpy/ica.py
@@ -55,6 +55,11 @@ from cellpycore.config import CurveCols
 from cellpy._deprecation import warn_once
 from cellpy.exceptions import NullData
 
+logger = logging.getLogger(__name__)
+
+# Process-level: BatchICACollector can hit empty half-cycles many times.
+_dqdv_half_cycle_warned = False
+
 __all__ = [
     "BOTH",
     "CHARGE",
@@ -1325,6 +1330,21 @@ def dqdv_cycle(cycle_df, splitter=True, label_direction=False, **kwargs):
     )
 
 
+def _warn_dqdv_half_cycle(which: str, exc: BaseException) -> None:
+    """Log a half-cycle failure once at WARNING; later hits at DEBUG."""
+    global _dqdv_half_cycle_warned
+    msg = "Error in dqdv_cycle - %s half-cycle: %s"
+    if not _dqdv_half_cycle_warned:
+        logger.warning(
+            msg + " Further occurrences in this process are logged at DEBUG.",
+            which,
+            exc,
+        )
+        _dqdv_half_cycle_warned = True
+    else:
+        logger.debug(msg, which, exc)
+
+
 def _dqdv_cycle_impl(cycle_df, splitter=True, label_direction=False, **kwargs):
     if cycle_df.empty:
         raise NullData(f"The cycle (type={type(cycle_df)}) is empty.")
@@ -1337,8 +1357,7 @@ def _dqdv_cycle_impl(cycle_df, splitter=True, label_direction=False, **kwargs):
             voltage_first = np.append(voltage_first, np.nan)
             incremental_first = np.append(incremental_first, np.nan)
     except Exception as e:  # noqa: BLE001 - 1.x behaviour, preserved
-        logging.warning("Error in dqdv_cycle - first half-cycle")
-        logging.warning(f" - error-message: '{e}'")
+        _warn_dqdv_half_cycle("first", e)
         voltage_first = np.array([])
         incremental_first = np.array([])
 
@@ -1347,8 +1366,7 @@ def _dqdv_cycle_impl(cycle_df, splitter=True, label_direction=False, **kwargs):
         voltage_last = voltage_last[::-1]
         incremental_last = incremental_last[::-1]
     except Exception as e:  # noqa: BLE001 - 1.x behaviour, preserved
-        logging.warning("Error in dqdv_cycle - last half-cycle")
-        logging.warning(f" - error-message: '{e}'")
+        _warn_dqdv_half_cycle("last", e)
         voltage_last = np.array([])
         incremental_last = np.array([])
 

--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -35,6 +35,11 @@ from cellpy.parameters.internal_settings import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+# Process-level: max_segments fallback can fire once per cycle in collectors.
+_max_segments_warned = False
+
 LOADERS_NOT_READY_FOR_PROD = [
     "ext_nda_reader"
 ]  # used by the instruments_configurations helper function (move?)
@@ -1423,12 +1428,20 @@ def interpolate_y_on_x_per_monotonic_segments(
 
     n_segments = int(segment_start.sum())
     if max_segments is not None and n_segments > max_segments:
-        logging.warning(
-            "interpolate_y_on_x_per_monotonic_segments: %d segments exceeds max_segments=%s; "
-            "returning dataframe unchanged (likely noisy x-data).",
-            n_segments,
-            max_segments,
+        global _max_segments_warned
+        msg = (
+            "interpolate_y_on_x_per_monotonic_segments: %d segments exceeds "
+            "max_segments=%s; returning dataframe unchanged (likely noisy x-data)."
         )
+        if not _max_segments_warned:
+            logger.warning(
+                msg + " Further occurrences in this process are logged at DEBUG.",
+                n_segments,
+                max_segments,
+            )
+            _max_segments_warned = True
+        else:
+            logger.debug(msg, n_segments, max_segments)
         return df
 
     segment_id = externals.numpy.cumsum(segment_start) - 1

--- a/tests/test_cell_readers.py
+++ b/tests/test_cell_readers.py
@@ -1052,20 +1052,36 @@ def test_interpolate_y_on_x_per_monotonic_segments_preserves_taper_steps():
     assert out["capacity"].max() >= 150.0
 
 
-def test_interpolate_y_on_x_per_monotonic_segments_max_segments_fallback():
+@pytest.mark.essential
+def test_interpolate_y_on_x_per_monotonic_segments_max_segments_fallback(caplog):
     """When segment count exceeds max_segments, return df unchanged (avoid slow/noisy path)."""
+    import logging
+
     import pandas as pd
+
+    import cellpy.readers.data_structures as ds
 
     # Noisy x: many small reversals -> many segments
     df = pd.DataFrame({
         "voltage": [3.0, 3.1, 3.05, 3.15, 3.1, 3.2] * 20,  # 120 points, many segments
         "capacity": range(120),
     })
-    out = cellpy.readers.data_structures.interpolate_y_on_x_per_monotonic_segments(
-        df, x="voltage", y="capacity", number_of_points=5, direction=1, max_segments=10
-    )
+    ds._max_segments_warned = False
+    with caplog.at_level(logging.WARNING, logger="cellpy.readers.data_structures"):
+        out = ds.interpolate_y_on_x_per_monotonic_segments(
+            df, x="voltage", y="capacity", number_of_points=5, direction=1, max_segments=10
+        )
+        out2 = ds.interpolate_y_on_x_per_monotonic_segments(
+            df, x="voltage", y="capacity", number_of_points=5, direction=1, max_segments=10
+        )
     # Should return unchanged (same length as input)
     assert out is df or (out.shape == df.shape and (out.values == df.values).all())
+    assert out2 is df or (out2.shape == df.shape and (out2.values == df.values).all())
+    # Collector spam fix (#669): one WARNING, not one per call
+    warnings_logged = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "max_segments" in r.getMessage()
+    ]
+    assert len(warnings_logged) == 1
 
 
 def test_group_by_interpolate(dataset):


### PR DESCRIPTION
## Summary
- Warn once (then DEBUG) when `interpolate_y_on_x_per_monotonic_segments` hits the max_segments fallback.
- Same pattern for legacy `dqdv_cycle` half-cycle failures in `cellpy.ica`.
- Use module loggers so messages are not `WARNING:root`.

## Test plan
- [x] `uv run pytest tests/test_cell_readers.py::test_interpolate_y_on_x_per_monotonic_segments_max_segments_fallback`
- [x] `MPLBACKEND=Agg uv run pytest -m essential` (628 passed, 1 skipped)

Closes #669


Made with [Cursor](https://cursor.com)