### PR TITLE
fix: reuse batch summary cache on soft plot reset (#668)

### DIFF
--- a/.issueflows/03-solved-issues/issue668_original.md
+++ b/.issueflows/03-solved-issues/issue668_original.md
@@ -175,3 +175,17 @@ File [~\.pixi\envs\cellpy-v1\Lib\site-packages\cellpycore\cell_core.py:48](file:
 
 AttributeError: 'list' object has no attribute 'strip'
 ```
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - After PR #670, `b.plot(rate=True, ir=True, direction="discharge")` still fails: `NullData: No summaries available to join` from `join_summaries` when `summary_frames` is empty — find why the summary collector yields nothing and fix that path on `v1.x`.
+  - Durable `cycle_mode` hardening tracked in [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) (not this PR unless a pin bump is required).
+- **Clarifications / constraints**:
+  - Target **`v1.x`** (`v1x` label); do not conflate with master/`cellpy.plotting` (#658 already covers the index-name fix on v2).
+  - Original `KeyError: cycle_index` / `NoneType.show` and list-`cycle_mode` `.strip()` crashes were addressed in #670; remaining scope is the empty-summaries failure.
+- **Superseded / retracted**:
+  - Prior close as fully Done (local status after #670) — reopened: error message improved, underlying plot still broken.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 3, last comment by @jepegit on 2026-07-24._
+

--- a/.issueflows/03-solved-issues/issue668_plan.md
+++ b/.issueflows/03-solved-issues/issue668_plan.md
@@ -1,130 +1,140 @@
-# Issue #668 — Plan
+# Issue #668 — Plan (v2: remaining `NullData` after #670)
+
+Supersedes the #670 plan (cycle_index + nested `cycle_mode`). Those fixes shipped
+in [PR #670](https://github.com/jepegit/cellpy/pull/670). This plan covers the
+**post-merge** failure only.
 
 ## Goal
 
-Fix two 1.x batch-workflow crashes from the loader notebook: `b.plot(...)`
-failing when the summary cycle index is unnamed, and `make_summary()` failing
-when `cycle_mode` is still list-shaped. Confirm what (if anything) still needs
-work on the v2/`master` line and track that separately.
+Make `b.plot(...)` succeed (or fail with an actionable error) on `v1.x` when the
+batch has been loaded via the standard template — specifically eliminate
+`NullData: No summaries available to join` from `summary_collector` /
+`join_summaries`.
 
 ## Constraints
 
-- **Target branch:** `v1.x` (label `v1x`). PR against `v1.x`, not `master`.
-- **Worktree:** `../cellpy-v1x` on `668-batch-bugs` (main `cellpy` checkout stays on other work).
-- **Fixes-only** on `v1.x` — no refactors, no dependency churn beyond what a fix needs
-  (`cellpycore==0.2.1` pin stays unless a core patch release is required and agreed).
-- Prefer the smallest backport that matches known-good `master` behaviour over a
-  new design.
-- Do not change public batch API surface.
+- **Target branch:** `v1.x` (`v1x` label). PR against `v1.x`, not `master`.
+- **Branch:** `668-batch-summaries` (from `origin/v1.x`).
+- Fixes-only on `v1.x` — no batch redesign, no `cellpycore` pin bump unless proven
+  necessary (durable `cycle_mode` hardening stays on
+  [cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142)).
+- Do not change public `Batch.plot` / journal API.
+- Keep #670 regressions green (`tests/test_issue668_batch_bugs.py`).
 
 ### Prior art
 
-- **`master` #658** — deleted `batch_plotters.py`, moved frame prep to
-  [`cellpy/plotting/batch_summary.py`](../../../../cellpy/cellpy/plotting/batch_summary.py).
-  Explicit fix: name unnamed summary index to `cycle_index` before `reset_index`
-  (see `issue658_status.md`). **Mirror this into v1.x `batch_plotters.py`.**
-- **`master` load unwrap** — [`cellpy/readers/cellpy_file/read.py`](../../../../cellpy/cellpy/readers/cellpy_file/read.py)
-  + recursive `test_meta._unwrap` (and tests in `tests/test_test_meta_collection.py`)
-  for double-nested `cycle_mode` (e.g. `[['anode']]`). **Port a minimal unwrap to v1.x.**
-- **`cellpycore.OldCellpyCellCore.cycle_mode`** — one-level `m[0]` getter; setter
-  keeps lists as lists; `_cycle_mode_to_test_mode` assumes `str` and calls `.strip()`.
-  Shared by both lines; still fragile even when consumer unwraps on load.
-- Toolbox (`00-tools/`): nothing for batch plots / cycle_mode. Graphify: absent in this worktree.
-
-### v2 / master impact check (done during planning)
-
-| Symptom | On `master`? | Action |
-|---------|--------------|--------|
-| A. `b.plot` / `cycle_index` KeyError → `NoneType.show` | **No** — fixed in #658 (`batch_summary.py` names index; old `batch_plotters.py` deleted) | No v2 issue |
-| B. `make_summary` / `cycle_mode` list → `.strip()` | **Partly mitigated** on consumer load path; **still fragile in `cellpycore`** | Opened [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) |
+- **`summary_engine` / `_load_summaries`** —
+  [`cellpy/utils/batch_tools/engines.py`](../../cellpy/utils/batch_tools/engines.py):
+  on `reset=True` (always used by `Batch.plot` when `summary_engine` not in
+  `memory_dumped`), **discards** `experiment.summary_frames` and rebuilds from
+  `experiment.data[label].data.summary` for each `cell_names` entry.
+- **`join_summaries`** —
+  [`cellpy/utils/batch_tools/batch_helpers.py`](../../cellpy/utils/batch_tools/batch_helpers.py):
+  `NullData("No summaries available to join")` only when `summary_frames` is
+  falsy (empty dict / None) — **not** when frames exist but are empty DataFrames.
+- **`CyclingExperiment.update`** —
+  [`batch_experiments.py`](../../cellpy/utils/batch_tools/batch_experiments.py):
+  fills `self.summary_frames` with real summaries; with default
+  `all_in_memory=False` stores **stubs** in `cell_data_frames` (steps only).
+  Lazy reload via `Data.__look_up__` needs a readable cellpy file.
+- **`cell_names`** — keys of `cell_data_frames` only (not journal pages). Empty
+  `cell_data_frames` → `_load_summaries` → `{}` → exact `NullData` seen in the
+  issue comment.
+- **#670** — index-name + `cycle_mode` unwrap; did **not** touch engines /
+  summary_collector. Original KeyError path implied collector once succeeded.
+- Toolbox / graphify: nothing specific for this collector path.
 
 ## Approach
 
-### 0. Inform v2 / core (tracking issue)
+### 0. Diagnose (read-only / small repro) before coding the fix
 
-**Done:** [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) — harden:
+Reproduce on `668-batch-summaries` with the loader-notebook sequence (or a minimal
+batch fixture). Record:
 
-1. `OldCellpyCellCore.cycle_mode` getter: recursively unwrap 1-element lists/tuples to a scalar (same semantics as cellpy `test_meta._unwrap`).
-2. Setter: store a **scalar** (unwrap first), not a list of lowered strings.
-3. `_cycle_mode_to_test_mode`: accept list/tuple by unwrapping before `.strip()`; keep current string behaviour.
-4. Tests: nested `[['anode']]`, `['anode']`, scalar `'anode'`, `None`.
+| Probe | Implication if true |
+|-------|---------------------|
+| `b.experiment.cell_names` empty / `cell_data_frames == {}` | Never updated, or all cells failed load → UX / load errors, not plotter |
+| `summary_frames` from `update` non-empty, but `reset=True` reload yields `{}` | Collector discards good cache; stubs + failed look-up |
+| Cells present, summaries empty after look-up | File/link/`save_cellpy` path; improve `_load_summaries` fallback |
+| Plot called before `update` | Clearer error; optional doc note in template |
 
-Note on the cellpy #668 thread once the core issue number exists. No change required
-to master’s batch plotter path for symptom A.
+Primary hypothesis to confirm/falsify: **`plot` → `summary_collector.do(reset=True)`
+throws away `update()`'s `summary_frames` and rebuilds from stub cells; when
+look-up cannot restore summaries (or `cell_names` is empty), join raises
+`NullData`.**
 
-### 1. Fix A — `b.plot` / summary frame (v1.x only)
+### 1. Fix (choose after diagnose; prefer smallest)
 
-In [`cellpy/utils/batch_tools/batch_plotters.py`](../../cellpy/utils/batch_tools/batch_plotters.py)
-`generate_summary_frame_for_plotting`:
+**Likely fix A — prefer cached frames on reset (recommended if hypothesis holds):**
 
-- After `pd.concat(...)`, if `summaries.index.name is None`, set it to
-  `hdr_summary["cycle_index"]` (same as master `batch_summary.py`).
-- In `summary_plotting_engine`, only call `canvas.show()` when `canvas is not None`
-  (secondary crash after failed frame prep).
+In `summary_engine` / `_load_summaries`:
 
-### 2. Fix B — `cycle_mode` list on `make_summary` (v1.x consumer)
+- If `experiment.summary_frames` already has non-empty entries, **reuse** them on
+  `reset` unless an explicit force-reload flag is set (or only rebuild missing
+  labels).
+- Else load from `experiment.data[label].data.summary` as today.
+- If still empty: raise `NullData` with a message that distinguishes
+  “no cells loaded (`cell_names` empty — run `b.update()`)” vs
+  “cells present but no summary tables”.
 
-Without waiting for a core release:
+**Likely fix B — harden `_load_summaries` only:**
 
-- Add a tiny recursive `_unwrap` helper on v1.x (either a few lines next to the
-  load site, or a minimal shared helper — prefer one place used by load + property).
-- After `meta_test_dependent.update(as_list=True, ...)` in
-  [`cellpy/readers/cellpy_file/read.py`](../../cellpy/readers/cellpy_file/read.py)
-  (and `legacy_read.py` if it has the same path), assign
-  `cycle_mode = _unwrap(...)`.
-- Harden [`CellpyCell.cycle_mode`](../../cellpy/readers/cellreader.py) getter to
-  recursively unwrap (current code only does one level — insufficient for
-  `[['anode']]`).
+- Iterate journal page index (or `cell_names`), lazy-load via `.data[label]`,
+  and fall back to `experiment.summary_frames[label]` when the in-memory cell
+  summary is missing/empty.
+- Same clearer `NullData` text.
 
-Do **not** bump `cellpycore` in this PR unless we decide the consumer-only fix is
-insufficient for the reported notebook path after tests.
+Do **not** do both large redesigns; pick A or B after the probe table.
 
-### 3. Ordering
+### 2. Tests
 
-1. Core tracking issue (step 0).
-2. Fix A + tests.
-3. Fix B + tests.
-4. Run essential suite on the worktree.
+Extend `tests/test_issue668_batch_bugs.py` (keep `@pytest.mark.essential`):
+
+- Stub experiment mimicking post-`update` / `all_in_memory=False`:
+  `summary_frames` populated, `cell_data_frames` stubs without summaries →
+  `summary_engine(..., reset=True)` must still produce joinable farms (or the
+  chosen fallback behaviour).
+- Empty `cell_names` → `NullData` message mentions update / no cells (not a
+  vague join failure).
+- Keep existing #670 tests green.
+
+### 3. Out of scope
+
+- cellpy-core#142 bridge hardening.
+- master / `cellpy.plotting` (already on #658 path).
+- Full batch redesign / collectors v3.
 
 ## Files to touch
 
 | Path | Change |
 |------|--------|
-| `cellpy/utils/batch_tools/batch_plotters.py` | Name cycle index before `reset_index`; guard `canvas.show()` |
-| `cellpy/readers/cellpy_file/read.py` | Unwrap `cycle_mode` after list-shaped meta load |
-| `cellpy/readers/cellpy_file/legacy_read.py` | Same unwrap if applicable |
-| `cellpy/readers/cellreader.py` | Recursive unwrap in `cycle_mode` getter |
-| `tests/…` (new or extend existing batch / meta tests) | Regression for A + B |
-| `.issueflows/01-current-issues/issue668_status.md` | Status after build |
-
-Out of scope for this PR: deleting `batch_plotters.py`, porting #658 plotting package, core release/pin bump (follow-up via the new core issue).
+| [`cellpy/utils/batch_tools/engines.py`](../../cellpy/utils/batch_tools/engines.py) | Reuse / fallback summary frames; clearer empty case |
+| [`cellpy/utils/batch_tools/batch_helpers.py`](../../cellpy/utils/batch_tools/batch_helpers.py) | Optional: richer `NullData` message only if raised here |
+| [`tests/test_issue668_batch_bugs.py`](../../tests/test_issue668_batch_bugs.py) | New collector / stub-memory cases |
+| `HISTORY.md` | Unreleased bullet for the follow-up fix |
 
 ## Test strategy
 
-In `cellpy-v1x` worktree:
-
 ```bash
-uv sync
 uv run pytest -m essential
+uv run pytest tests/test_issue668_batch_bugs.py -q
 ```
 
-Plus focused tests:
-
-- **A:** Build a multi-cell summary concat with unnamed index; assert frame prep
-  yields a `cycle_index` column (or call the plot helper with `plotly_show=False`
-  and assert no `AttributeError`). Prefer unit-level frame prep if full batch
-  fixtures are heavy.
-- **B:** Meta / cell with `cycle_mode` as `['anode']` and `[['anode']]`;
-  `make_summary()` must not raise `AttributeError` on `.strip()`.
-
-Mark merge-gate tests `@pytest.mark.essential` only if they stay fast and stable.
+(On this machine, conda `cellpy_dev_313` is also fine if that is the usual v1.x env — match whatever the branch already uses.)
 
 ## Open questions
 
-1. **Core issue home:** create under `cellpy/cellpy-core` (recommended) vs only a
-   `jepegit/cellpy` `master`/`v2` reminder issue. Default: **core**.
-2. **Pin bump:** if consumer unwrap alone is enough for the notebook, leave
-   `cellpycore==0.2.1` and let the core issue ship later. Agree?
-3. **Scope of B:** unwrap only `cycle_mode`, or also other list-boxed meta fields
-   on load (master unwraps via a helper used more broadly)? Default: **cycle_mode
-   only** on v1.x to keep the PR small.
+_All resolved 2026-07-25 — plan **Accepted** with defaults._
+
+1. **Notebook probes:** none provided — diagnose during `/iflow-build` via
+   unit repro (stub `all_in_memory=False` experiment) instead of waiting on
+   a live notebook session.
+2. **Force-reload semantics:** **yes** — `Batch.plot(reload_data=True)` /
+   hard reset rebuilds from cells/files; plain first plot / soft `reset`
+   reuses non-empty cached `experiment.summary_frames` (Fix A).
+3. **Plan file:** replace #670 plan in place — confirmed.
+
+## Status
+
+- **Confirmed:** 2026-07-25
+- **Next:** `/iflow-build` (implement Fix A + tests)

--- a/.issueflows/03-solved-issues/issue668_status.md
+++ b/.issueflows/03-solved-issues/issue668_status.md
@@ -2,19 +2,25 @@
 
 - [x] Done
 
-## What's done
+## What's done (PR #670 on `v1.x`)
 
-- Core tracking: [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142) (noted on #668).
+- Core tracking: [cellpy/cellpy-core#142](https://github.com/cellpy/cellpy-core/issues/142).
 - **Fix A** (`batch_plotters.py`): name unnamed summary index to `cycle_index` before `reset_index`; guard `canvas.show()` when `canvas is None`.
-- **Fix B**:
-  - `unwrap_meta_value` in `cellpy/readers/cellpy_file/meta.py`
-  - unwrap `cycle_mode` after list-shaped meta load in `read.py` + `legacy_read.py`
-  - recursive unwrap (+ write-back) in `CellpyCell.cycle_mode` getter/setter
-  - touch `self.cycle_mode` at start of `_make_summary` so the core bridge sees a scalar
+- **Fix B**: unwrap nested/`list` `cycle_mode` on load + `CellpyCell.cycle_mode`; touch before `_make_summary`.
 - Tests: `tests/test_issue668_batch_bugs.py` (essential).
-- `uv run pytest -m essential` green on close.
-- HISTORY.md Unreleased bullet added.
+- HISTORY.md Unreleased bullet for #670.
+
+## What's done (re-open / Fix A summary cache)
+
+- Plan v2 accepted (defaults).
+- `summary_engine`: soft path reuses non-empty `experiment.summary_frames`; `reset=True` hard-rebuilds from cells.
+- `Batch.plot` / `plot_summaries`: `summary_collector.do(reset=bool(reload_data))`.
+- Actionable `NullData` when no cells vs empty summary tables.
+- Import fix: `NullData` in `batch_helpers.py`.
+- Tests: soft-reset reuse, hard-reset rebuild, empty `cell_names` message.
+- HISTORY.md Unreleased bullet for the follow-up.
+- Essential suite green on close.
 
 ## Remaining work
 
-- None for this issue. Follow-up: cellpy-core#142 (optional pin bump later).
+- None for this issue. Follow-up: cellpy-core#142; optional notebook verify after install from PR.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ Note! Only v1 related changes are collected here.
 
 ## [Unreleased]
 
+* Fix: `b.plot` reuses `update()` summary frames on soft reset so default
+  `all_in_memory=False` batches no longer raise `NullData: No summaries
+  available to join`; `reload_data=True` still force-rebuilds. (#668)
+
 ## 1.1.0.post3 - 2026-07-24
 
 * Fix: batch `b.plot` unnamed cycle index and nested list `cycle_mode` crashing `make_summary`. (#668)

--- a/cellpy/utils/batch.py
+++ b/cellpy/utils/batch.py
@@ -1404,7 +1404,9 @@ class Batch:
 
         if reload_data or ("summary_engine" not in self.experiment.memory_dumped):
             logging.debug("running summary_collector")
-            self.summary_collector.do(reset=True)
+            # Soft reset reuses update()'s summary_frames; reload_data forces
+            # a hard rebuild from cells/files (#668).
+            self.summary_collector.do(reset=bool(reload_data))
 
         if backend is None:
             backend = config.batch.backend
@@ -1465,7 +1467,7 @@ class Batch:
         warnings.warn("Deprecated - use plot instead.", DeprecationWarning)
         if reload_data or ("summary_engine" not in self.experiment.memory_dumped):
             logging.debug("running summary_collector")
-            self.summary_collector.do(reset=True)
+            self.summary_collector.do(reset=bool(reload_data))
 
         if backend is None:
             backend = config.batch.backend

--- a/cellpy/utils/batch_tools/batch_helpers.py
+++ b/cellpy/utils/batch_tools/batch_helpers.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 import cellpy.parameters.internal_settings
 from cellpy import filefinder, prms
+from cellpy.exceptions import NullData
 from cellpy.readers import data_structures as core
 import cellpy.config as config
 

--- a/cellpy/utils/batch_tools/engines.py
+++ b/cellpy/utils/batch_tools/engines.py
@@ -88,6 +88,34 @@ def raw_data_engine(**kwargs):
     raise NotImplementedError
 
 
+def _usable_summary_frames(summary_frames):
+    """True when at least one summary frame is non-empty (issue #668)."""
+    if not summary_frames:
+        return False
+    try:
+        return any(not getattr(frame, "empty", False) for frame in summary_frames.values())
+    except Exception:
+        return True
+
+
+def _ensure_summaries_or_raise(experiment):
+    """Raise ``NullData`` with an actionable message when frames are missing."""
+    from cellpy.exceptions import NullData
+
+    if _usable_summary_frames(experiment.summary_frames):
+        return
+    cell_names = experiment.cell_names or []
+    if not cell_names:
+        raise NullData(
+            "No summaries available to join: no cells loaded in the experiment "
+            "(cell_data_frames is empty). Run b.update() first."
+        )
+    raise NullData(
+        "No summaries available to join: cells are present but summary tables "
+        "are missing or empty."
+    )
+
+
 def summary_engine(**kwargs):
     """engine to extract summary data"""
     logging.debug("summary_engine")
@@ -95,6 +123,9 @@ def summary_engine(**kwargs):
 
     farms = []
     experiments = kwargs.pop("experiments")
+    # reset=True: hard rebuild from cells/files (Batch.plot(reload_data=True)).
+    # reset=False: reuse non-empty experiment.summary_frames from update()
+    # (avoids wiping the cache when cell_data_frames only hold step stubs).
     reset = kwargs.pop("reset", False)
 
     for experiment in experiments:
@@ -103,10 +134,14 @@ def summary_engine(**kwargs):
         else:
             selected_summaries = experiment.selected_summaries
         logging.debug(f"selected summaries: {selected_summaries}")
-        if reset or experiment.summary_frames is None:
+        if reset:
+            logging.debug("Hard-reset: re-loading summary frames from cells")
+            experiment.summary_frames = _load_summaries(experiment)
+        elif not _usable_summary_frames(experiment.summary_frames):
             logging.debug("No summary frames found")
             logging.debug("Re-loading")
             experiment.summary_frames = _load_summaries(experiment)
+        _ensure_summaries_or_raise(experiment)
         farm = helper.join_summaries(experiment.summary_frames, selected_summaries)
         farms.append(farm)
     barn = "batch_dir"
@@ -116,7 +151,8 @@ def summary_engine(**kwargs):
 
 def _load_summaries(experiment):
     summary_frames = {}
-    for label in experiment.cell_names:
+    labels = experiment.cell_names or []
+    for label in labels:
         # TODO: replace this with direct lookup from hdf5?
         summary_frames[label] = experiment.data[label].data.summary
     return summary_frames

--- a/tests/test_issue668_batch_bugs.py
+++ b/tests/test_issue668_batch_bugs.py
@@ -5,9 +5,51 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from cellpy.exceptions import NullData
 from cellpy.parameters.internal_settings import get_headers_summary
 from cellpy.readers.cellpy_file.meta import unwrap_meta_value
 from cellpy.utils.batch_tools.batch_plotters import generate_summary_frame_for_plotting
+from cellpy.utils.batch_tools.engines import summary_engine
+
+
+def _minimal_summary_frame():
+    hdr = get_headers_summary()
+    df = pd.DataFrame(
+        {
+            hdr["discharge_capacity_gravimetric"]: [1.0, 0.9],
+            hdr["charge_capacity_gravimetric"]: [1.05, 0.95],
+            hdr["coulombic_efficiency"]: [95.0, 94.0],
+        },
+        index=[1, 2],
+    )
+    df.index.name = hdr.cycle_index
+    return df
+
+
+def _stub_experiment(*, cached_summary, cell_names=("cell_a",)):
+    """Mimic post-update / ``all_in_memory=False``: cache good, cells empty."""
+
+    class _StubCell:
+        def __init__(self):
+            self.data = SimpleNamespace(summary=pd.DataFrame())
+
+    class _StubData:
+        def __getitem__(self, key):
+            return _StubCell()
+
+    selected = [
+        "discharge_capacity_gravimetric",
+        "charge_capacity_gravimetric",
+        "coulombic_efficiency",
+    ]
+    frames = {name: cached_summary.copy() for name in cell_names} if cached_summary is not None else None
+    return SimpleNamespace(
+        selected_summaries=selected,
+        summary_frames=frames,
+        cell_names=list(cell_names),
+        cell_data_frames={name: _StubCell() for name in cell_names},
+        data=_StubData(),
+    )
 
 
 @pytest.mark.essential
@@ -77,3 +119,36 @@ def test_make_summary_with_nested_cycle_mode(
     assert c.cycle_mode == "anode"
     assert c.data.summary is not None
     assert not c.data.summary.empty
+
+
+@pytest.mark.essential
+def test_summary_engine_reuses_cached_frames_on_soft_reset():
+    """Soft reset must not wipe update() cache when cells are stubs (#668)."""
+    exp = _stub_experiment(cached_summary=_minimal_summary_frame())
+    farms, barn = summary_engine(experiments=[exp], reset=False)
+    assert barn == "batch_dir"
+    assert farms
+    assert len(farms[0]) == 3
+    # Cache must remain the non-empty frames (not replaced by stub empties).
+    assert not exp.summary_frames["cell_a"].empty
+
+
+@pytest.mark.essential
+def test_summary_engine_hard_reset_rebuilds_from_cells():
+    """``reset=True`` rebuilds from cells even when a cache exists (#668)."""
+    exp = _stub_experiment(cached_summary=_minimal_summary_frame())
+    with pytest.raises(NullData, match="summary tables"):
+        summary_engine(experiments=[exp], reset=True)
+
+
+@pytest.mark.essential
+def test_summary_engine_empty_cell_names_message():
+    """Empty cell_data_frames → actionable NullData (#668)."""
+    exp = SimpleNamespace(
+        selected_summaries=["coulombic_efficiency"],
+        summary_frames=None,
+        cell_names=[],
+        data={},
+    )
+    with pytest.raises(NullData, match="no cells loaded"):
+        summary_engine(experiments=[exp], reset=False)


### PR DESCRIPTION
## Summary
- Soft `summary_collector` reset reuses non-empty `experiment.summary_frames` from `update()` so default `all_in_memory=False` batches can `b.plot` without `NullData: No summaries available to join`.
- `Batch.plot(..., reload_data=True)` still hard-rebuilds from cells/files.
- Clearer `NullData` messages (no cells vs empty summaries); missing `NullData` import in `batch_helpers.py`.
- Essential regression tests for soft reuse / hard reset / empty `cell_names`.

## Test plan
- [x] `uv run pytest tests/test_issue668_batch_bugs.py`
- [x] `uv run pytest -m essential`
- [ ] Optional: loader notebook `b.plot(rate=True, ir=True, direction="discharge")` after install from this branch

Closes #668

Made with [Cursor](https://cursor.com)