### PR TITLE
fix: follow symlink project dirs in remote OtherPath.rglob

### DIFF
--- a/.issueflows/03-solved-issues/issue688_original.md
+++ b/.issueflows/03-solved-issues/issue688_original.md
@@ -1,0 +1,98 @@
+# Issue #688: Deal-breaker: remote OtherPath rglob / auto_use_file_list skips symlink project dirs under rawdatadir
+
+Source: https://github.com/jepegit/cellpy/issues/688
+
+## Original issue text
+
+## Summary
+
+After the switch from the self-built / Fabric-based `OtherPath` to `universal-pathlib` (`UPath` + fsspec/Paramiko), **recursive remote file search no longer follows symlink directories** under `rawdatadir`.
+
+This breaks the normal batch workflow when project folders under the raw root are symlinks (common on our IFE `odin` layout, e.g. `projects/LongLife` → real storage). Journal creation then finds **zero matching raw files**, so `raw_file_names` stay empty and nothing loads.
+
+**Severity:** deal-breaker for remote batch use. Needs a fix before we can rely on UPath-based remotes in production.
+
+Related: #687 (SSH-config Host aliases / credentials) — separate problem; even with a DNS-resolvable host and working auth, this symlink/recursion bug still blocks loading.
+
+## Observed behaviour (2.0.0rc2)
+
+Config (after #687 workaround — full hostname):
+
+```yaml
+Paths:
+  rawdatadir: scp://d1-odin-01.ad.ife.no/home/jepe@ad.ife.no/projects
+Batch:
+  auto_use_file_list: true
+```
+
+Log:
+
+```text
+Authentication (publickey) successful!
+find_in_raw_file_directory: Found 70 files
+...
+raw_file_names: [None, None, ...]   # all cells
+Raw file(s) not given in the journal.pages ...
+```
+
+Those “70 files” are **top-level project entries only** (directory/symlink names), not the `.h5` files inside them.
+
+Per-cell match against that list (`*20250709_lol079_01_cc*.h5`) finds nothing.
+
+## Evidence
+
+From the parent `projects` listing, `LongLife` is a **symlink**:
+
+```text
+fs.ls(..., detail=True) → LongLife type=link
+fs.info(.../LongLife)   → type=directory   # follows when opened directly
+```
+
+UPath/fsspec SFTP recursion from the parent does **not** descend into that link:
+
+| Call | Result |
+| --- | --- |
+| `OtherPath(.../projects).rglob("*.h5")` | **0** |
+| `OtherPath(.../projects).rglob("*")` | ~70 top-level names only |
+| `filefinder.search_for_files(..., raw_file_dir=.../projects)` | **[]** |
+| `OtherPath(.../projects/LongLife).rglob("*.h5")` / `search_for_files` | **works** (files found) |
+| `fs.find(.../projects, maxdepth=2)` | lists `LongLife` as a leaf; **no** files under it |
+| `fs.find(.../projects/LongLife, maxdepth=1)` | 332 files |
+
+So both paths are broken when `rawdatadir` is the shared projects root:
+
+1. `auto_use_file_list=True` → `filefinder.find_in_raw_file_directory` → `OtherPath.rglob("*")` → useless top-level list
+2. `auto_use_file_list=False` → `search_for_files` → `OtherPath.rglob("<run>*.<ext>")` from the same root → still empty (no symlink follow)
+
+This used to work with the pre-UPath OtherPath (Fabric / remote shell listing that followed links).
+
+## Current workaround
+
+Point `rawdatadir` at the concrete project path (the symlink path is OK if it is the search root):
+
+```yaml
+Paths:
+  rawdatadir: scp://d1-odin-01.ad.ife.no/home/jepe@ad.ife.no/projects/LongLife
+```
+
+That is not acceptable as the long-term default: users keep a shared projects root and expect subfolder / symlink discovery.
+
+## Expected behaviour
+
+- Recursive remote discovery from `rawdatadir` **follows directory symlinks** the same way the old OtherPath did (at least one level of project-dir symlinks; ideally consistent with `find -L` / pathlib-on-local behaviour).
+- `filefinder.find_in_raw_file_directory` and `search_for_files(..., sub_folders=True)` both find files under symlink project dirs.
+- Prefer fixing in `OtherPath.rglob` / `glob` / listing so all callers benefit; if fsspec cannot follow links, implement an explicit follow-symlinks walk (e.g. `ls` + recurse into `type in {directory, link}` that resolve to dirs).
+
+## Acceptance criteria
+
+- [ ] With `rawdatadir` = remote `.../projects` and a symlink project dir (e.g. `LongLife`), `search_for_files("20250709_lol079_01_cc", raw_extension="h5", sub_folders=True)` returns the expected remote `.h5` path(s).
+- [ ] `find_in_raw_file_directory()` / `auto_use_file_list=True` journal creation populates non-null `raw_file_names` for those cells.
+- [ ] Regression test with a mocked SFTP (or local symlink fixture if equivalent) covering symlink project dirs.
+- [ ] Docs note symlink-following behaviour for remotes.
+- [ ] No silent “Found N files” where N is only top-level dirs when the intent was a recursive file dump (consider filtering to files only and/or warning when zero files match under symlink-heavy trees).
+
+## Environment
+
+- cellpy `2.0.0rc2` (UPath-based `OtherPath`)
+- Remote: IFE odin SFTP (`d1-odin-01.ad.ife.no`)
+- Instrument files: `arbin_sql_h5` under `projects/LongLife/` (symlink)

--- a/.issueflows/03-solved-issues/issue688_plan.md
+++ b/.issueflows/03-solved-issues/issue688_plan.md
@@ -1,0 +1,120 @@
+# Issue #688 — Plan
+
+## Goal
+
+Restore remote recursive discovery under a shared `rawdatadir` when project
+folders are **symlinks** (UPath/fsspec currently skips them), so batch
+`auto_use_file_list` / `search_for_files` populate `raw_file_names` again. Also
+stop `find_in_raw_file_directory` from counting directories as “files”, and fix the
+secondary `NullData` NameError in empty-summary joins.
+
+## Constraints
+
+- Keep the UPath-based `OtherPath` (do not bring Fabric back).
+- Prefer fixing listing in `OtherPath` so all callers benefit (not filefinder-only).
+- Shallow `glob` / `listdir(levels≤1)` stay on UPath; only `rglob` and deep
+  `listdir` get the symlink-following walk.
+- Follow directory symlinks with a **cycle guard** (visited set of resolved paths).
+- `#687` (SSH Host aliases / credentials) is **out of scope**.
+- Back-compat: `rglob` may still yield directory matches for patterns like `*`;
+  file-only filtering belongs in `find_in_raw_file_directory`.
+
+### Prior art
+
+- `OtherPath.rglob` / `listdir` — [`cellpy/internals/otherpath.py`](cellpy/internals/otherpath.py)
+  (thin UPath wrappers; no symlink follow today).
+- Design: [`.issueflows/04-designs-and-guides/otherpath-upath.md`](.issueflows/04-designs-and-guides/otherpath-upath.md).
+- Callers: [`cellpy/readers/filefinder.py`](cellpy/readers/filefinder.py)
+  (`find_in_raw_file_directory`, `search_for_files` → `rglob`).
+- Live SFTP fixture: [`tests/test_otherpaths_sftp.py`](tests/test_otherpaths_sftp.py)
+  + [`docker/sftp-test/`](docker/sftp-test/) (`onlylocal`).
+- Unit OtherPath tests: [`tests/test_otherpaths.py`](tests/test_otherpaths.py).
+- Filefinder tests: [`tests/test_filefinder.py`](tests/test_filefinder.py).
+- `join_summaries` raises `NullData` without importing it —
+  [`cellpy/utils/batch_tools/batch_helpers.py`](cellpy/utils/batch_tools/batch_helpers.py).
+- Toolbox: none relevant.
+- Graph: `OtherPath` god-node / SFTP test community — confirms touch points above.
+
+## Approach
+
+Agreed in grill-me:
+
+1. **Custom remote walk for `OtherPath.rglob`** (and deep `listdir` that already
+   uses `rglob`):
+   - `fs.ls(path, detail=True)` recursively.
+   - `type=directory` → recurse.
+   - `type=link` → if target is a directory (`info` / `isdir`), recurse; if file,
+     treat as a file candidate.
+   - `type=file` → candidate for pattern match (`fnmatch` on name / relative path
+     consistent with current `rglob` semantics).
+   - Cycle guard: track resolved absolute remote paths already visited.
+2. **`find_in_raw_file_directory`**: after `rglob`, keep only `is_file()` matches;
+   if zero files, `critical`/warn clearly (do not claim “Found N files” for dirs).
+3. **`NullData`**: add `from cellpy.exceptions import NullData` in `batch_helpers.py`.
+4. **Tests**:
+   - CI unit test: mock fsspec-like `ls(detail=True)` where a child is `type=link`
+     resolving to a dir that holds a matching file; assert `rglob` finds it;
+     assert cycle does not loop.
+   - `onlylocal` Docker: add symlink project dir under `docker/sftp-test` data
+     (or create via SFTP in test setup) and assert `rglob` / `search_for_files`
+     from the parent root finds the file inside the link.
+   - Unit test for filefinder: dump that would include dirs → list is files-only
+     and logs/warns on empty.
+   - Tiny test or assert that empty `join_summaries` raises `NullData` (not
+     `NameError`).
+5. **Docs**: note symlink-following for remote `rglob` in
+   `docs/getting_started/remote_paths.md` and
+   `.issueflows/04-designs-and-guides/otherpath-upath.md`.
+
+### Data flow (after)
+
+```text
+rawdatadir = scp://host/.../projects
+  → OtherPath.rglob("*.h5" | "*")
+  → walk follows projects/LongLife (symlink→dir)
+  → filefinder match / auto_use_file_list
+  → journal.raw_file_names populated
+```
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/internals/otherpath.py` | Symlink-following remote `rglob` (+ deep `listdir` via same path); cycle guard |
+| `cellpy/readers/filefinder.py` | File-only filter + clearer zero-file logging in `find_in_raw_file_directory` |
+| `cellpy/utils/batch_tools/batch_helpers.py` | Import `NullData` |
+| `tests/test_otherpaths.py` (or new focused unit module) | Mocked remote symlink / cycle tests |
+| `tests/test_otherpaths_sftp.py` + `docker/sftp-test/` | Symlink fixture + `onlylocal` assertion |
+| `tests/test_filefinder.py` | Files-only dump behaviour |
+| `tests/test_batch_helpers.py` or existing batch helper tests | `NullData` on empty join (add if missing) |
+| `docs/getting_started/remote_paths.md` | Symlink-follow note |
+| `.issueflows/04-designs-and-guides/otherpath-upath.md` | Record decision |
+
+## Test strategy
+
+- CI: `uv run pytest -m essential` (or project default gate) including new unit tests
+  (not `onlylocal`).
+- Local/opt-in: `uv run pytest tests/test_otherpaths_sftp.py -m onlylocal` with Docker.
+- Manual smoke (optional during build): point `rawdatadir` at
+  `scp://d1-odin-01.ad.ife.no/home/jepe@ad.ife.no/projects` and confirm
+  `search_for_files("20250709_lol079_01_cc", raw_extension="h5")` returns paths
+  under `LongLife/`.
+
+## Open questions
+
+None remaining after grill-me. Deferred by agreement:
+
+- **#687** — SSH-config Host aliases / key via config (separate issue).
+- Upstream fsspec fix — not waiting on it; cellpy walk is the product fix.
+
+## Grill-me decisions (summary)
+
+| # | Decision |
+| --- | --- |
+| Q1 | Fix in `OtherPath.rglob` / deep listing (not filefinder-only, not upstream-only) |
+| Q2 | Follow dir symlinks always + cycle guard |
+| Q3 | Apply to `rglob` + deep `listdir` only; shallow `glob`/`listdir` unchanged |
+| Q4 | `find_in_raw_file_directory`: files only + warn on zero |
+| Q5 | Unit mock (CI) + Docker symlink (`onlylocal`) |
+| Q6 | Docs in this PR |
+| Q7 | Include `NullData` import; exclude #687 |

--- a/.issueflows/03-solved-issues/issue688_status.md
+++ b/.issueflows/03-solved-issues/issue688_status.md
@@ -1,0 +1,18 @@
+# Issue #688 — Status
+
+- [x] Done
+
+## What's done
+
+- Symlink-following remote walk in `OtherPath.rglob` (+ deep `listdir`), cycle guard via inode/destination/path
+- `find_in_raw_file_directory` keeps regular files only; clearer zero-file critical log
+- `NullData` import in `batch_helpers.join_summaries`
+- Unit tests: `tests/test_otherpath_symlink_rglob.py`, filefinder files-only, NullData raise
+- Docker SFTP fixture: rw volume + `project_link` symlink; `onlylocal` test added
+- Docs: `docs/getting_started/remote_paths.md`, `otherpath-upath.md`, docker README
+- Live smoke on odin: finds files under `projects/LongLife` symlink
+- Essential suite green (628 passed); HISTORY bullet added
+
+## Remaining work
+
+- None

--- a/.issueflows/04-designs-and-guides/otherpath-upath.md
+++ b/.issueflows/04-designs-and-guides/otherpath-upath.md
@@ -17,3 +17,11 @@ Paramiko defaults.
 
 **Not a `pathlib.Path` subclass:** call sites must accept `OtherPath` / `PathLike`
 explicitly; do not rely on `isinstance(x, pathlib.Path)`.
+
+**Symlink-following remote walk (issue #688):** fsspec SFTP `rglob` / `find` treat
+directory symlinks as leaves, which breaks `rawdatadir=…/projects` when project
+dirs are links. `OtherPath.rglob` (and deep `listdir`) therefore use an explicit
+`ls(detail=True)` walk that recurses into links that resolve to directories, with a
+visited-set cycle guard (inode / link destination / path). Shallow `glob` /
+`listdir(levels≤1)` remain UPath passthrough. `filefinder.find_in_raw_file_directory`
+keeps only regular files so directory matches are not counted as “files”.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Follow directory symlinks in remote OtherPath.rglob so batch file discovery works under symlink project dirs. (#688).
+
 * Rate-limit noisy collector warnings from max_segments interpolation fallback and dqdv half-cycle failures. (#669).
 
 * Fix BatchICACollector fig_pr_cycle KeyError on cycle_num (use ICA cycle column). (#679).

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+import fnmatch
 import logging
 import os
 import pathlib
+import posixpath
 import shutil
 import tempfile
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 from upath import UPath
 
@@ -408,7 +410,109 @@ class OtherPath:
 
     def _wrap_remote_child(self, child: UPath) -> "OtherPath":
         child_path = child.path if child.path.startswith("/") else f"/{child.path}"
-        return OtherPath(f"{self._uri_prefix}{self._location}{child_path}")
+        return self._wrap_remote_path(child_path)
+
+    def _wrap_remote_path(self, child_path: str) -> "OtherPath":
+        path = child_path if child_path.startswith("/") else f"/{child_path}"
+        return OtherPath(f"{self._uri_prefix}{self._location}{path}")
+
+    @staticmethod
+    def _remote_rglob_matches(rel: str, name: str, pattern: str) -> bool:
+        """Match like ``pathlib.Path.rglob`` (``**/`` + pattern)."""
+        rel = rel.replace("\\", "/")
+        candidates = [pattern]
+        if not pattern.startswith("**/"):
+            candidates.append(f"**/{pattern}")
+        return any(
+            fnmatch.fnmatch(name, pattern) or fnmatch.fnmatch(rel, candidate)
+            for candidate in candidates
+        )
+
+    def _remote_rglob_walk(
+        self,
+        glob_str: str,
+        *,
+        testing: bool = False,
+    ) -> Generator["OtherPath", None, None]:
+        """Recursive remote listing that follows directory symlinks.
+
+        fsspec SFTP ``rglob`` / ``find`` treat symlink directories as leaves, which
+        breaks shared ``rawdatadir`` layouts where project folders are links
+        (issue #688). Walk with ``ls(detail=True)`` and recurse into links that
+        resolve to directories, with a visited-set cycle guard.
+        """
+        upath = self._upath_with_credentials(testing=testing)
+        fs = upath.fs
+        root = upath.path.rstrip("/") or "/"
+        visited: Set[Any] = set()
+
+        def visit_key(dir_path: str) -> Any:
+            """Identity for cycle detection (inode / link target / path)."""
+            try:
+                info = fs.info(dir_path)
+            except (FileNotFoundError, OSError, AttributeError):
+                return ("path", dir_path.rstrip("/") or "/")
+            if not isinstance(info, dict):
+                return ("path", dir_path.rstrip("/") or "/")
+            ino = info.get("ino", info.get("inode"))
+            if ino is not None:
+                return ("ino", ino)
+            dest = info.get("destination", info.get("target"))
+            if dest:
+                return ("path", str(dest).rstrip("/") or "/")
+            return ("path", dir_path.rstrip("/") or "/")
+
+        def walk(dir_path: str) -> Generator["OtherPath", None, None]:
+            key = visit_key(dir_path)
+            if key in visited:
+                return
+            visited.add(key)
+            try:
+                entries = fs.ls(dir_path, detail=True)
+            except (FileNotFoundError, OSError, PermissionError) as exc:
+                logging.debug("Remote ls failed for %s: %s", dir_path, exc)
+                return
+
+            for entry in entries:
+                if isinstance(entry, dict):
+                    child_path = entry.get("name") or ""
+                    etype = entry.get("type")
+                else:
+                    child_path = str(entry)
+                    etype = None
+                if not child_path:
+                    continue
+                name = posixpath.basename(child_path.rstrip("/"))
+                if name in (".", ".."):
+                    continue
+
+                if child_path.rstrip("/") == root:
+                    continue
+                if child_path.startswith(root + "/"):
+                    rel = child_path[len(root) + 1 :]
+                else:
+                    rel = name
+
+                is_dir = False
+                if etype == "directory":
+                    is_dir = True
+                elif etype == "link":
+                    try:
+                        is_dir = bool(fs.isdir(child_path))
+                    except (OSError, FileNotFoundError):
+                        is_dir = False
+                elif etype is None:
+                    try:
+                        is_dir = bool(fs.isdir(child_path))
+                    except (OSError, FileNotFoundError):
+                        is_dir = False
+
+                if self._remote_rglob_matches(rel, name, glob_str):
+                    yield self._wrap_remote_path(child_path)
+                if is_dir:
+                    yield from walk(child_path)
+
+        yield from walk(root)
 
     def glob(self, glob_str: str, *args: Any, **kwargs: Any) -> Generator["OtherPath", None, None]:
         testing = kwargs.pop("testing", False)
@@ -423,9 +527,7 @@ class OtherPath:
     def rglob(self, glob_str: str, *args: Any, **kwargs: Any) -> Generator["OtherPath", None, None]:
         testing = kwargs.pop("testing", False)
         if self.is_external:
-            upath = self._upath_with_credentials(testing=testing)
-            for child in upath.rglob(glob_str):
-                yield self._wrap_remote_child(child)
+            yield from self._remote_rglob_walk(glob_str, testing=testing)
             return
         for child in pathlib.Path(os.fspath(self)).rglob(glob_str):
             yield OtherPath(child)
@@ -434,15 +536,13 @@ class OtherPath:
         """List directory contents (shallow by default for remote)."""
         testing = kwargs.pop("testing", False)
         if self.is_external:
-            upath = self._upath_with_credentials(testing=testing)
-            if levels == 0:
-                pattern = "*"
-            elif levels == 1:
-                pattern = "*"
-            else:
-                pattern = "**/*"
-            for child in upath.glob(pattern) if levels <= 1 else upath.rglob("*"):
-                yield self._wrap_remote_child(child)
+            if levels <= 1:
+                upath = self._upath_with_credentials(testing=testing)
+                for child in upath.glob("*"):
+                    yield self._wrap_remote_child(child)
+                return
+            # Deep listing shares symlink-following walk with rglob (#688).
+            yield from self.rglob("*", testing=testing)
             return
         base = pathlib.Path(os.fspath(self))
         if not base.is_dir():

--- a/cellpy/readers/filefinder.py
+++ b/cellpy/readers/filefinder.py
@@ -112,13 +112,23 @@ def find_in_raw_file_directory(
             matches = []
 
         for match in matches:
+            # rglob("*") also yields directories; journal matching needs files only (#688).
+            try:
+                if not match.is_file():
+                    continue
+            except (OSError, FileNotFoundError) as exc:
+                logging.debug("Skipping %s (is_file failed: %s)", match, exc)
+                continue
             if match.is_external:
                 file_list.append(match.full_path)
             else:
                 file_list.append(str(match).replace("\\", "/"))
     number_of_files = len(file_list)
     if number_of_files == 0:
-        logging.critical("No files found")
+        logging.critical(
+            "No files found (recursive search returned no regular files; "
+            "directories/symlinks alone are not counted)"
+        )
     logging.info(f"Found {number_of_files} files")
     return file_list
 

--- a/cellpy/utils/batch_tools/batch_helpers.py
+++ b/cellpy/utils/batch_tools/batch_helpers.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 import cellpy.parameters.internal_settings
 from cellpy import filefinder, prms
+from cellpy.exceptions import NullData
 from cellpy.readers import data_structures as core
 import cellpy.config as config
 

--- a/docker/sftp-test/README.md
+++ b/docker/sftp-test/README.md
@@ -18,4 +18,6 @@ docker compose -f docker/sftp-test/compose.yml down -v
 
 The pytest session fixture starts/stops compose automatically when Docker is
 available; these tests are marked `onlylocal` and are deselected by the default
-`addopts` marker filter.
+`addopts` marker filter. After start it creates a directory symlink
+`testdata/project_link` → `nested` (volume is mounted read-write) so
+`OtherPath.rglob` symlink-following can be exercised (#688).

--- a/docker/sftp-test/compose.yml
+++ b/docker/sftp-test/compose.yml
@@ -14,7 +14,8 @@ services:
     # User is chrooted to /home/cellpy; data volume appears as /testdata.
     command: cellpy:cellpy:1001:100:testdata
     volumes:
-      - ./data:/home/cellpy/testdata:ro
+      # rw so integration tests can create directory symlinks (#688).
+      - ./data:/home/cellpy/testdata:rw
     healthcheck:
       test: ["CMD-SHELL", "pgrep sshd >/dev/null || exit 1"]
       interval: 2s

--- a/docs/getting_started/remote_paths.md
+++ b/docs/getting_started/remote_paths.md
@@ -77,6 +77,12 @@ Use `cellpy.utils.helpers.check_connection()` (or
   pass) and returns a local `pathlib.Path`.
 - `OtherPath` is **not** a subclass of `pathlib.Path`. Prefer
   `isinstance(x, OtherPath)` or `os.fspath(x)` for local paths.
+- Remote `OtherPath.rglob` (and deep `listdir`) **follows directory symlinks**
+  when walking a tree, with a cycle guard. This matters when `rawdatadir` is a
+  shared projects root and each project folder is a symlink (common on some
+  lab file servers). Plain fsspec/UPath `rglob` does not follow those links.
+  Shallow `glob` / `listdir(levels≤1)` stay non-recursive and do not add extra
+  follow behaviour.
 
 ## Live SFTP tests (Docker)
 

--- a/tests/test_batch_helpers_nulldata.py
+++ b/tests/test_batch_helpers_nulldata.py
@@ -1,0 +1,11 @@
+"""Regression: join_summaries must raise NullData, not NameError (#688)."""
+
+import pytest
+
+from cellpy.exceptions import NullData
+from cellpy.utils.batch_tools import batch_helpers
+
+
+def test_join_summaries_empty_raises_nulldata():
+    with pytest.raises(NullData, match="No summaries available"):
+        batch_helpers.join_summaries({}, selected_summaries=["discharge_capacity"])

--- a/tests/test_filefinder.py
+++ b/tests/test_filefinder.py
@@ -167,3 +167,28 @@ def test_list_raw_file_directory_only_filename(raw_tree):
         "runA_02.res",
         "runB_01.res",
     ]
+
+
+def test_find_in_raw_file_directory_files_only(raw_tree, caplog):
+    """Directories matching ``*`` must not be counted as files (#688)."""
+    import logging
+
+    raw_dir, _ = raw_tree
+    with caplog.at_level(logging.INFO):
+        file_list = filefinder.find_in_raw_file_directory(raw_file_dir=raw_dir)
+    names = sorted(pathlib.Path(f).name for f in file_list)
+    assert "sub" not in names
+    assert "runA_01.res" in names
+    assert "runA_03.res" in names
+    assert any("Found " in r.message and "files" in r.message for r in caplog.records)
+
+
+def test_find_in_raw_file_directory_empty_warns(tmp_path, caplog):
+    import logging
+
+    empty = tmp_path / "empty_raw"
+    empty.mkdir()
+    with caplog.at_level(logging.CRITICAL):
+        file_list = filefinder.find_in_raw_file_directory(raw_file_dir=empty)
+    assert file_list == []
+    assert any("No files found" in r.message for r in caplog.records)

--- a/tests/test_otherpath_symlink_rglob.py
+++ b/tests/test_otherpath_symlink_rglob.py
@@ -1,0 +1,166 @@
+"""Unit tests for remote OtherPath.rglob symlink following (issue #688)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.internals.connections import OtherPath
+
+
+class _FakeFS:
+    """Minimal fsspec-like FS: projects/LongLife is a symlink to real_store."""
+
+    def __init__(self):
+        self.tree = {
+            "/home/user/projects": [
+                {
+                    "name": "/home/user/projects/LongLife",
+                    "type": "link",
+                    "size": 8,
+                    "destination": "/data/LongLife",
+                },
+                {"name": "/home/user/projects/plain", "type": "directory", "size": 0},
+            ],
+            "/home/user/projects/LongLife": [
+                {
+                    "name": "/home/user/projects/LongLife/20250709_lol079_01_cc_01.h5",
+                    "type": "file",
+                    "size": 10,
+                },
+            ],
+            "/home/user/projects/plain": [
+                {
+                    "name": "/home/user/projects/plain/other.h5",
+                    "type": "file",
+                    "size": 4,
+                },
+            ],
+            # Cycle via two link paths that share destination /real/loop
+            "/home/user/cycle": [
+                {
+                    "name": "/home/user/cycle/loop_a",
+                    "type": "link",
+                    "destination": "/real/loop",
+                },
+            ],
+            "/home/user/cycle/loop_a": [
+                {
+                    "name": "/home/user/cycle/loop_a/loop_b",
+                    "type": "link",
+                    "destination": "/real/loop",
+                },
+                {
+                    "name": "/home/user/cycle/loop_a/ok.h5",
+                    "type": "file",
+                    "size": 1,
+                },
+            ],
+            "/home/user/cycle/loop_a/loop_b": [
+                {
+                    "name": "/home/user/cycle/loop_a/loop_b/again",
+                    "type": "link",
+                    "destination": "/real/loop",
+                },
+            ],
+        }
+        self._info = {
+            "/home/user/projects/LongLife": {
+                "name": "/home/user/projects/LongLife",
+                "type": "directory",
+                "destination": "/data/LongLife",
+            },
+            "/home/user/cycle/loop_a": {
+                "name": "/home/user/cycle/loop_a",
+                "type": "directory",
+                "destination": "/real/loop",
+            },
+            "/home/user/cycle/loop_a/loop_b": {
+                "name": "/home/user/cycle/loop_a/loop_b",
+                "type": "directory",
+                "destination": "/real/loop",
+            },
+            "/home/user/cycle/loop_a/loop_b/again": {
+                "name": "/home/user/cycle/loop_a/loop_b/again",
+                "type": "directory",
+                "destination": "/real/loop",
+            },
+        }
+        self.link_dirs = set(self._info)
+
+    def info(self, path):
+        path = path.rstrip("/") or "/"
+        if path in self._info:
+            return dict(self._info[path])
+        if path in self.tree:
+            return {"name": path, "type": "directory"}
+        for entries in self.tree.values():
+            for e in entries:
+                if e["name"] == path:
+                    return dict(e)
+        raise FileNotFoundError(path)
+
+    def ls(self, path, detail=True):
+        path = path.rstrip("/") or "/"
+        entries = self.tree.get(path, [])
+        if detail:
+            return list(entries)
+        return [e["name"] for e in entries]
+
+    def isdir(self, path):
+        path = path.rstrip("/") or "/"
+        if path in self.tree or path in self.link_dirs:
+            return True
+        return False
+
+    def isfile(self, path):
+        path = path.rstrip("/") or "/"
+        for entries in self.tree.values():
+            for e in entries:
+                if e["name"] == path and e.get("type") == "file":
+                    return True
+        return False
+
+
+class _FakeUPath:
+    def __init__(self, *args, fs=None, **kwargs):
+        self._url = str(args[0])
+        after_scheme = self._url.split("://", 1)[-1]
+        self.path = "/" + after_scheme.split("/", 1)[-1]
+        self.storage_options = kwargs
+        self.fs = fs if fs is not None else _FakeFS()
+        self.name = self.path.rstrip("/").rsplit("/", 1)[-1]
+        self.protocol = "sftp"
+
+    def __str__(self):
+        return self._url
+
+
+@pytest.fixture
+def fake_remote(monkeypatch, mock_env_cellpy_key_filename):
+    shared_fs = _FakeFS()
+
+    class _BoundFakeUPath(_FakeUPath):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, fs=shared_fs, **kwargs)
+
+    monkeypatch.setattr("cellpy.internals.otherpath.UPath", _BoundFakeUPath)
+    return shared_fs
+
+
+def test_rglob_follows_directory_symlink(fake_remote):
+    root = OtherPath("sftp://user@host/home/user/projects")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True))
+    assert "20250709_lol079_01_cc_01.h5" in names
+    assert "other.h5" in names
+
+
+def test_rglob_star_includes_symlink_children(fake_remote):
+    root = OtherPath("sftp://user@host/home/user/projects")
+    paths = [p.raw_path for p in root.rglob("*", testing=True)]
+    assert any(p.endswith("20250709_lol079_01_cc_01.h5") for p in paths)
+
+
+def test_rglob_cycle_guard_terminates(fake_remote):
+    root = OtherPath("sftp://user@host/home/user/cycle")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True))
+    assert names == ["ok.h5"]

--- a/tests/test_otherpaths_sftp.py
+++ b/tests/test_otherpaths_sftp.py
@@ -91,6 +91,19 @@ def _wait_for_sftp(timeout: float = 30.0) -> None:
     raise TimeoutError(f"SFTP server not ready on {SFTP_HOST}:{SFTP_PORT}: {last_err}")
 
 
+def _ensure_project_symlink() -> None:
+    """Create ``testdata/project_link`` -> ``nested`` inside the container (#688)."""
+    # Run as root in the container; volume is rw for this purpose.
+    _compose(
+        "exec",
+        "-T",
+        "cellpy-sftp",
+        "sh",
+        "-c",
+        "ln -sfn nested /home/cellpy/testdata/project_link",
+    )
+
+
 @pytest.fixture(scope="session")
 def sftp_server():
     """Start the docker SFTP fixture for the test session."""
@@ -102,6 +115,10 @@ def sftp_server():
     _compose("up", "-d", "--wait")
     try:
         _wait_for_sftp()
+        try:
+            _ensure_project_symlink()
+        except subprocess.CalledProcessError as exc:
+            pytest.skip(f"Could not create SFTP symlink fixture: {exc}")
         yield {
             "user": SFTP_USER,
             "password": SFTP_PASSWORD,
@@ -172,6 +189,22 @@ def test_remote_glob_rglob_and_joinpath(sftp_env):
     assert child.exists() is True
     assert child.name == "sample.txt"
     assert child.parent.name == "nested"
+
+
+def test_remote_rglob_follows_directory_symlink(sftp_env):
+    """Symlink project dirs under rawdatadir must be searched (#688)."""
+    root = OtherPath(_uri(sftp_env, REMOTE_ROOT))
+    link = OtherPath(_uri(sftp_env, REMOTE_ROOT, "project_link"))
+    assert link.exists() is True
+    # Listing detail from parent should see a link; rglob must still find files.
+    names = sorted(p.name for p in root.rglob("sample.txt"))
+    assert "sample.txt" in names
+    via_link = [
+        p
+        for p in root.rglob("sample.txt")
+        if "project_link" in p.raw_path.replace("\\", "/")
+    ]
+    assert via_link, "expected sample.txt reached via project_link symlink"
 
 
 def test_remote_copy_returns_local_path_with_content(sftp_env, tmp_path):


### PR DESCRIPTION
## Summary
- Remote `OtherPath.rglob` (and deep `listdir`) now walks with `ls(detail=True)` and **follows directory symlinks**, with a cycle guard — fixes batch discovery when `rawdatadir` is a shared projects root and project folders are links (e.g. odin `projects/LongLife`).
- `find_in_raw_file_directory` counts **regular files only** and logs clearly when none are found.
- Import `NullData` in `batch_helpers.join_summaries` so empty batches raise the right exception.

Closes #688.

## Test plan
- [x] `uv run pytest -m essential` (628 passed)
- [x] Unit: `tests/test_otherpath_symlink_rglob.py`, filefinder files-only, NullData
- [x] Live smoke on odin: `search_for_files` finds `…/projects/LongLife/20250709_lol079_01_cc_01.h5`
- [ ] Optional: `uv run pytest tests/test_otherpaths_sftp.py -m onlylocal` (Docker)


Made with [Cursor](https://cursor.com)