### PR TITLE
perf: speed up remote auto_use_file_list / OtherPath.rglob dump

### DIFF
--- a/.issueflows/03-solved-issues/issue690_original.md
+++ b/.issueflows/03-solved-issues/issue690_original.md
@@ -1,0 +1,52 @@
+# Issue #690: perf: speed up remote auto_use_file_list / OtherPath.rglob dump
+
+Source: https://github.com/jepegit/cellpy/issues/690
+
+## Original issue text
+
+## Summary
+
+After #688, remote batch discovery works again when project folders under `rawdatadir` are symlinks, but `Batch.auto_use_file_list=True` against a shared projects root is **very slow**.
+
+Observed (odin, `rawdatadir=…/projects`):
+
+```text
+13:35:58  Searching for files matching: *
+13:38:52  Found 18279 files
+```
+
+≈ **3 minutes** before journal matching; the subsequent per-cell `fnmatch` and loads were fine.
+
+Related: #688 (correctness — symlink follow). This issue is **performance**.
+
+## Why it’s slow
+
+1. **Scope** — dump walks the entire `projects` tree (all symlink project dirs), not the batch’s project.
+2. **Chatty SFTP** — `OtherPath._remote_rglob_walk` does many round-trips (`ls` per directory, `info` for cycle guard, `isdir` on links). Pre-UPath/Fabric listing was closer to a single remote `find`.
+3. **Extra STATs** — `filefinder.find_in_raw_file_directory` calls `is_file()` on every `rglob("*")` hit (dirs match `*`), amplifying round-trips on large trees.
+
+## Expected improvements (any subset welcome)
+
+- Prefer a **single remote find** / bulk listing when the backend supports it (Paramiko/SFTP exec or fsspec `find` with symlink follow), falling back to the current walk.
+- When `ls(detail=True)` already provides `type=file` / `type=directory`, **do not** call `is_file()` again for filtering in `find_in_raw_file_directory`.
+- Avoid redundant `info()` calls in the walk when `ls` detail is enough for cycle keys (path / destination).
+- Optional: cache the file list for the session / journal recreate.
+- Document that `auto_use_file_list` over a huge shared root is expensive; point users at project-scoped `rawdatadir` or the project-subdir search issue (companion issue).
+
+## Acceptance criteria
+
+- [ ] Dumping a remote `…/projects` tree with ~10k–20k files is substantially faster than today (order-of-magnitude goal: seconds–tens of seconds, not minutes), or we clearly document + warn when the dump will be huge.
+- [ ] No regression on #688 symlink-following behaviour.
+- [ ] Unit/integration tests cover the fast path (or mocked round-trip counts) where practical.
+- [ ] Docs note performance trade-offs for `auto_use_file_list`.
+
+## Workarounds (current)
+
+- Set `rawdatadir` to the project folder (`…/projects/LongLife`), or
+- Set `auto_use_file_list: false`.
+
+## Comments (curated summary)
+
+- **Clarifications / constraints**: Project-scoped search with fuzzy folder hints is out of scope here — tracked as companion #691.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-26._

--- a/.issueflows/03-solved-issues/issue690_plan.md
+++ b/.issueflows/03-solved-issues/issue690_plan.md
@@ -1,0 +1,161 @@
+# Issue #690 — Plan
+
+## Goal
+
+Make remote `Batch.auto_use_file_list` / `find_in_raw_file_directory` dumps
+over a large shared `rawdatadir` (e.g. `…/projects` with symlink project dirs)
+substantially faster (seconds–tens of seconds, not minutes), without regressing
+#688 symlink-following behaviour, and document the remaining cost/trade-offs.
+
+## Constraints
+
+- Keep UPath-based `OtherPath`; do not bring Fabric back
+  ([otherpath-upath.md](../04-designs-and-guides/otherpath-upath.md)).
+- Preserve #688 semantics: remote `rglob` / deep `listdir` follow directory
+  symlinks with a cycle guard; shallow `glob` / `listdir(levels≤1)` stay
+  UPath passthrough.
+- `#691` (project-scoped / fuzzy folder search) is **out of scope** — only
+  mention as the recommended alternative when the dump root is huge.
+- Session/journal file-list cache is **optional / deferred** unless a tiny
+  hook falls out for free; not required for acceptance.
+- Prefer fixing listing in `OtherPath` so all callers benefit; filefinder
+  should stop paying extra remote STATs when the walk already knows `type`.
+
+### Prior art
+
+- Hot path: [`OtherPath._remote_rglob_walk`](../../cellpy/internals/otherpath.py)
+  — per-dir `fs.info` (cycle key) + `fs.ls(detail=True)` + `fs.isdir` on every
+  `type=link`; yields dirs and files for `*`.
+- Caller: [`filefinder.find_in_raw_file_directory`](../../cellpy/readers/filefinder.py)
+  — `rglob("*")` then **`match.is_file()` per hit** (another remote STAT for
+  every path, including directories).
+- Batch wiring: [`Batch.create_journal`](../../cellpy/utils/batch.py)
+  (`auto_use_file_list=True` → dump once, then local `fnmatch`).
+- #688 solution + design note:
+  [issue688_plan](../03-solved-issues/issue688_plan.md),
+  [otherpath-upath.md](../04-designs-and-guides/otherpath-upath.md),
+  docs in [`remote_paths.md`](../../docs/getting_started/remote_paths.md).
+- Tests to extend: [`tests/test_otherpath_symlink_rglob.py`](../../tests/test_otherpath_symlink_rglob.py)
+  (fake FS with call-count hooks), [`tests/test_filefinder.py`](../../tests/test_filefinder.py),
+  optional [`tests/test_otherpaths_sftp.py`](../../tests/test_otherpaths_sftp.py)
+  / [`docker/sftp-test/`](../../docker/sftp-test/).
+- fsspec `find` **does not** follow symlink dirs (#688 evidence) — not a drop-in
+  bulk fix unless we add our own follow or use remote shell `find -L`.
+- Toolbox: none relevant. Graph: skipped (`graphify-out/` absent).
+
+## Approach
+
+Ship two complementary speedups in one PR; keep a clean fallback to today’s walk.
+
+### 1. STAT diet on the existing walk (always on)
+
+In `_remote_rglob_walk`:
+
+- **Reuse `ls(detail=True)` metadata** when descending: pass ino / destination /
+  type from the parent entry into `visit_key` so we do **not** call `fs.info`
+  again for every directory we already listed.
+- For `type=link`: prefer cycle key from `destination` / listing detail; avoid
+  a separate `isdir` when we can decide “recurse vs file” with one attempt
+  (e.g. `ls` on the link path, or cached detail). Keep cycle-guard behaviour
+  identical to #688 tests.
+- Do **not** change which paths `rglob("*")` yields (dirs may still match `*`)
+  unless an explicit opt-in is used (below).
+
+### 2. File-only dump path for `find_in_raw_file_directory` (always on)
+
+- Add a small opt-in on remote listing, e.g. `rglob(..., files_only=True)` or a
+  private helper used only by the dump, that **filters with walk `type`**
+  (`file`, and links that resolve to files) and **never** calls `is_file()`
+  per match.
+- Local pathlib path: keep cheap `Path.is_file()` (or `files_only` via
+  `Path.is_file()` once — local cost is fine).
+- Log a clear warning when a remote dump returns a very large list (threshold
+  constant, e.g. ≥5k) pointing at project-scoped `rawdatadir` and `#691`.
+
+### 3. Bulk remote `find -L` fast path (preferred when available)
+
+When the remote backend can run a shell command (Paramiko client /
+  `fs` exec / similar), prefer a **single** remote listing for full-tree file
+  dumps:
+
+```text
+find -L <root> -type f -print
+```
+
+(or equivalent that follows directory symlinks and lists files only).
+
+- Map stdout lines → `OtherPath` / full paths; apply the same glob filter
+  (`*` / extension) client-side.
+- **Fallback** to the optimized walk on any failure (no shell, permission,
+  non-POSIX remote, empty/error output).
+- Scope: use for the dump / `files_only` case first; patterned `rglob("*.h5")`
+  may stay on the walk unless the same fast path is trivial to reuse.
+- Escape/quote the root path carefully; never interpolate untrusted patterns
+  into the shell command beyond the already-trusted path string.
+
+### 4. Docs + design note
+
+- [`docs/getting_started/remote_paths.md`](../../docs/getting_started/remote_paths.md):
+  note that `auto_use_file_list` over a huge shared root is expensive; prefer
+  project-scoped `rawdatadir`; mention `#691` for smarter scoping; document
+  fast-path + fallback briefly.
+- Update [otherpath-upath.md](../04-designs-and-guides/otherpath-upath.md)
+  with the perf strategy (STAT reuse + optional `find -L`).
+
+### Data flow (after)
+
+```text
+auto_use_file_list=True
+  → find_in_raw_file_directory(rawdatadir=…/projects)
+  → remote files_only dump:
+       try:  find -L … -type f   (1 round-trip)
+       else: optimized ls-walk (no per-hit is_file / fewer info)
+  → list[str] for journal fnmatch
+  → warn if N huge; docs point at project-scoped root / #691
+```
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/internals/otherpath.py` | STAT-efficient walk; optional `files_only`; `find -L` fast path + fallback |
+| `cellpy/readers/filefinder.py` | Use file-only remote dump; large-N warning; drop redundant `is_file` STATs |
+| `cellpy/utils/batch.py` | Optional: slightly clearer critical/info when dump is remote/huge (only if needed) |
+| `docs/getting_started/remote_paths.md` | Perf trade-offs + workarounds |
+| `.issueflows/04-designs-and-guides/otherpath-upath.md` | Perf note under symlink-walk section |
+| `tests/test_otherpath_symlink_rglob.py` | Round-trip / call-count asserts; `files_only`; fast-path mock |
+| `tests/test_filefinder.py` | Remote dump does not call `is_file` (mocked); large-N warn |
+| `tests/test_otherpaths_sftp.py` | Optional smoke if Docker path stays cheap |
+
+## Test strategy
+
+```bash
+uv run pytest -m essential
+uv run pytest tests/test_otherpath_symlink_rglob.py tests/test_filefinder.py
+# optional live:
+uv run pytest tests/test_otherpaths_sftp.py -m onlylocal
+```
+
+- Keep all #688 symlink / cycle tests green.
+- New unit tests: fake FS counters prove fewer `info` / `isdir` / `isfile`
+  calls; `files_only` omits directories; mocked exec returns bulk list and walk
+  is not used; exec failure falls back to walk.
+- Mark merge-gate tests `@pytest.mark.essential` only if they stay fast and
+  guard the dump contract (prefer extending existing essential filefinder /
+  OtherPath tests carefully).
+
+## Open questions
+
+1. **Include `find -L` in this PR?** Recommended **yes** (biggest win for
+   ~18k-file odin trees). Alternative: STAT diet + docs only in this PR, shell
+   find as a follow-up. **Default if you Accept without comment: include it.**
+2. **Large-N warn threshold?** Proposed **5000** files. OK?
+3. **Cache** across journal recreates in one process? Proposed **defer** (out
+   of this PR).
+
+## Scope check
+
+Single focused PR (listing perf + docs). Not mixing #691 project-scoped search.
+If `find -L` proves messy on Windows-dev / Paramiko access, ship (1)+(2)+docs
+and park (3) as a tiny follow-up issue — still meets “or document + warn” AC,
+but may miss the order-of-magnitude goal on odin until (3) lands.

--- a/.issueflows/03-solved-issues/issue690_status.md
+++ b/.issueflows/03-solved-issues/issue690_status.md
@@ -1,0 +1,18 @@
+# Issue #690 — Status
+
+- [x] Done
+
+## What's done
+
+- Plan accepted (include `find -L`, warn @ 5000, no cache).
+- STAT diet on `_remote_rglob_walk`: reuse `ls(detail=True)` for cycle keys; probe links with `ls` instead of `isdir`+`info`.
+- `rglob(..., files_only=True)` + `find -L … -type f` fast path with walk fallback.
+- `find_in_raw_file_directory` uses `files_only=True` (no per-hit `is_file()`); warn at ≥5000 paths.
+- Docs: `docs/getting_started/remote_paths.md`, `.issueflows/04-designs-and-guides/otherpath-upath.md`.
+- Tests: `tests/test_otherpath_symlink_rglob.py`, `tests/test_filefinder.py`.
+- Pytest: targeted suite green; `pytest -m essential` green on close.
+- HISTORY.md `[Unreleased]` bullet added.
+
+## Remaining work
+
+- None (ship via PR).

--- a/.issueflows/04-designs-and-guides/otherpath-upath.md
+++ b/.issueflows/04-designs-and-guides/otherpath-upath.md
@@ -25,3 +25,12 @@ dirs are links. `OtherPath.rglob` (and deep `listdir`) therefore use an explicit
 visited-set cycle guard (inode / link destination / path). Shallow `glob` /
 `listdir(levels≤1)` remain UPath passthrough. `filefinder.find_in_raw_file_directory`
 keeps only regular files so directory matches are not counted as “files”.
+
+**Remote dump performance (issue #690):** Chatty per-directory SFTP STATs made
+`auto_use_file_list` dumps over a huge shared projects root very slow. Mitigations:
+(1) reuse `ls(detail=True)` metadata for cycle keys / link targets instead of
+extra `info`/`isdir` round-trips; (2) `rglob(..., files_only=True)` filters by
+listing `type` so the dump does not call `is_file()` per path; (3) when Paramiko
+`exec_command` is available, prefer a single remote `find -L <root> -type f`
+and fall back to the optimized walk. Document that huge shared roots remain
+expensive; prefer project-scoped `rawdatadir` (companion #691 for smarter scoping).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Speed up remote auto_use_file_list / OtherPath.rglob dump. (#690).
+
 * Follow directory symlinks in remote OtherPath.rglob so batch file discovery works under symlink project dirs. (#688).
 
 * Rate-limit noisy collector warnings from max_segments interpolation fallback and dqdv half-cycle failures. (#669).

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -14,6 +14,7 @@ import logging
 import os
 import pathlib
 import posixpath
+import shlex
 import shutil
 import tempfile
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
@@ -428,11 +429,84 @@ class OtherPath:
             for candidate in candidates
         )
 
+    @staticmethod
+    def _remote_visit_key_from_info(info: Any, dir_path: str) -> Any:
+        """Build a cycle-guard key from ``ls``/``info`` detail when available."""
+        if not isinstance(info, dict):
+            return ("path", dir_path.rstrip("/") or "/")
+        ino = info.get("ino", info.get("inode"))
+        if ino is not None:
+            return ("ino", ino)
+        dest = info.get("destination", info.get("target"))
+        if dest:
+            return ("path", str(dest).rstrip("/") or "/")
+        return ("path", dir_path.rstrip("/") or "/")
+
+    def _remote_find_l_file_paths(self, fs: Any, root: str) -> Optional[List[str]]:
+        """Bulk list files via remote ``find -L`` when Paramiko exec is available.
+
+        Returns ``None`` on any failure so callers fall back to the ls-walk.
+        """
+        client = getattr(fs, "client", None)
+        exec_command = getattr(client, "exec_command", None) if client is not None else None
+        if exec_command is None:
+            return None
+        cmd = f"find -L {shlex.quote(root)} -type f -print"
+        try:
+            _stdin, stdout, stderr = exec_command(cmd, timeout=300)
+            exit_status = stdout.channel.recv_exit_status()
+            out = stdout.read()
+            err = stderr.read()
+        except (OSError, AttributeError, TypeError, ValueError) as exc:
+            logging.debug("Remote find -L failed for %s: %s", root, exc)
+            return None
+        if exit_status not in (0, None):
+            logging.debug(
+                "Remote find -L exit %s for %s: %s",
+                exit_status,
+                root,
+                err[:200] if isinstance(err, (bytes, bytearray)) else err,
+            )
+            return None
+        if isinstance(out, (bytes, bytearray)):
+            text = out.decode("utf-8", errors="replace")
+        else:
+            text = str(out)
+        paths: List[str] = []
+        for line in text.splitlines():
+            path = line.strip()
+            if path:
+                paths.append(path)
+        return paths
+
+    def _remote_rglob_from_find(
+        self,
+        glob_str: str,
+        *,
+        fs: Any,
+        root: str,
+    ) -> Optional[List["OtherPath"]]:
+        """Try bulk ``find -L`` listing; return matches or ``None`` to fall back."""
+        bulk = self._remote_find_l_file_paths(fs, root)
+        if bulk is None:
+            return None
+        matches: List["OtherPath"] = []
+        for child_path in bulk:
+            name = posixpath.basename(child_path.rstrip("/"))
+            if child_path.startswith(root + "/"):
+                rel = child_path[len(root) + 1 :]
+            else:
+                rel = name
+            if self._remote_rglob_matches(rel, name, glob_str):
+                matches.append(self._wrap_remote_path(child_path))
+        return matches
+
     def _remote_rglob_walk(
         self,
         glob_str: str,
         *,
         testing: bool = False,
+        files_only: bool = False,
     ) -> Generator["OtherPath", None, None]:
         """Recursive remote listing that follows directory symlinks.
 
@@ -440,30 +514,55 @@ class OtherPath:
         breaks shared ``rawdatadir`` layouts where project folders are links
         (issue #688). Walk with ``ls(detail=True)`` and recurse into links that
         resolve to directories, with a visited-set cycle guard.
+
+        When ``files_only`` is True, prefer a single remote ``find -L … -type f``
+        (issue #690) and fall back to this walk, filtering with listing ``type``
+        so callers do not need a per-path ``is_file()`` STAT.
         """
         upath = self._upath_with_credentials(testing=testing)
         fs = upath.fs
         root = upath.path.rstrip("/") or "/"
+
+        if files_only:
+            bulk_matches = self._remote_rglob_from_find(glob_str, fs=fs, root=root)
+            if bulk_matches is not None:
+                logging.debug(
+                    "Remote rglob used find -L fast path (%s paths) under %s",
+                    len(bulk_matches),
+                    root,
+                )
+                yield from bulk_matches
+                return
+
         visited: Set[Any] = set()
 
-        def visit_key(dir_path: str) -> Any:
+        def visit_key(dir_path: str, info: Any = None) -> Any:
             """Identity for cycle detection (inode / link target / path)."""
+            if info is not None:
+                return self._remote_visit_key_from_info(info, dir_path)
             try:
-                info = fs.info(dir_path)
+                fetched = fs.info(dir_path)
             except (FileNotFoundError, OSError, AttributeError):
                 return ("path", dir_path.rstrip("/") or "/")
-            if not isinstance(info, dict):
-                return ("path", dir_path.rstrip("/") or "/")
-            ino = info.get("ino", info.get("inode"))
-            if ino is not None:
-                return ("ino", ino)
-            dest = info.get("destination", info.get("target"))
-            if dest:
-                return ("path", str(dest).rstrip("/") or "/")
-            return ("path", dir_path.rstrip("/") or "/")
+            return self._remote_visit_key_from_info(fetched, dir_path)
 
-        def walk(dir_path: str) -> Generator["OtherPath", None, None]:
-            key = visit_key(dir_path)
+        def link_is_dir(child_path: str) -> bool:
+            """Decide whether a symlink should be recursed into.
+
+            Probe with ``ls`` (one round-trip) instead of a separate ``isdir``
+            STAT; cycle keys still prefer ``destination`` from parent ``ls``.
+            """
+            try:
+                fs.ls(child_path, detail=False)
+                return True
+            except (FileNotFoundError, OSError, PermissionError, NotADirectoryError):
+                return False
+
+        def walk(
+            dir_path: str,
+            dir_info: Any = None,
+        ) -> Generator["OtherPath", None, None]:
+            key = visit_key(dir_path, dir_info)
             if key in visited:
                 return
             visited.add(key)
@@ -477,9 +576,11 @@ class OtherPath:
                 if isinstance(entry, dict):
                     child_path = entry.get("name") or ""
                     etype = entry.get("type")
+                    child_info: Any = entry
                 else:
                     child_path = str(entry)
                     etype = None
+                    child_info = None
                 if not child_path:
                     continue
                 name = posixpath.basename(child_path.rstrip("/"))
@@ -497,20 +598,26 @@ class OtherPath:
                 if etype == "directory":
                     is_dir = True
                 elif etype == "link":
-                    try:
-                        is_dir = bool(fs.isdir(child_path))
-                    except (OSError, FileNotFoundError):
-                        is_dir = False
+                    is_dir = link_is_dir(child_path)
                 elif etype is None:
                     try:
                         is_dir = bool(fs.isdir(child_path))
                     except (OSError, FileNotFoundError):
                         is_dir = False
 
-                if self._remote_rglob_matches(rel, name, glob_str):
+                is_file = etype == "file" or (etype == "link" and not is_dir)
+                if etype is None and not is_dir:
+                    # Unknown listing shape: treat non-dirs as file candidates.
+                    is_file = True
+
+                if files_only:
+                    if is_file and self._remote_rglob_matches(rel, name, glob_str):
+                        yield self._wrap_remote_path(child_path)
+                elif self._remote_rglob_matches(rel, name, glob_str):
                     yield self._wrap_remote_path(child_path)
+
                 if is_dir:
-                    yield from walk(child_path)
+                    yield from walk(child_path, child_info)
 
         yield from walk(root)
 
@@ -526,10 +633,15 @@ class OtherPath:
 
     def rglob(self, glob_str: str, *args: Any, **kwargs: Any) -> Generator["OtherPath", None, None]:
         testing = kwargs.pop("testing", False)
+        files_only = bool(kwargs.pop("files_only", False))
         if self.is_external:
-            yield from self._remote_rglob_walk(glob_str, testing=testing)
+            yield from self._remote_rglob_walk(
+                glob_str, testing=testing, files_only=files_only
+            )
             return
         for child in pathlib.Path(os.fspath(self)).rglob(glob_str):
+            if files_only and not child.is_file():
+                continue
             yield OtherPath(child)
 
     def listdir(self, levels: int = 1, **kwargs: Any) -> Generator["OtherPath", None, None]:

--- a/cellpy/readers/filefinder.py
+++ b/cellpy/readers/filefinder.py
@@ -24,6 +24,9 @@ import cellpy.config as config
 # TODO: @jepe - add function for searching in database (sqlite, postgresql etc)
 # TODO: @jepe - allow for providing a glob pattern also when using file_list by editing the batch.py script
 
+# Warn when auto_use_file_list dumps a huge shared tree (issue #690).
+_LARGE_FILE_LIST_WARN = 5000
+
 
 def find_in_raw_file_directory(
     raw_file_dir: Union[OtherPath, pathlib.Path, str, None] = None,
@@ -66,7 +69,9 @@ def find_in_raw_file_directory(
         >>>)
 
     Notes:
-        Uses ``OtherPath.rglob`` (local pathlib or remote UPath/fsspec).
+        Uses ``OtherPath.rglob(..., files_only=True)`` so remote dumps can use
+        listing ``type`` / ``find -L`` without a per-path ``is_file()`` STAT
+        (issues #688 / #690).
     """
 
     file_list = []
@@ -97,7 +102,8 @@ def find_in_raw_file_directory(
     for d in raw_file_dir:
         logging.debug(f"searching in folder: {d}")
         try:
-            matches = list(d.rglob(glob_txt))
+            # files_only: directories matching "*" are excluded without remote is_file STATs.
+            matches = list(d.rglob(glob_txt, files_only=True))
         except Exception as exc:
             logging.critical(
                 f"Errors encounter when searching in {d.raw_path}: {exc}"
@@ -112,13 +118,6 @@ def find_in_raw_file_directory(
             matches = []
 
         for match in matches:
-            # rglob("*") also yields directories; journal matching needs files only (#688).
-            try:
-                if not match.is_file():
-                    continue
-            except (OSError, FileNotFoundError) as exc:
-                logging.debug("Skipping %s (is_file failed: %s)", match, exc)
-                continue
             if match.is_external:
                 file_list.append(match.full_path)
             else:
@@ -128,6 +127,15 @@ def find_in_raw_file_directory(
         logging.critical(
             "No files found (recursive search returned no regular files; "
             "directories/symlinks alone are not counted)"
+        )
+    elif number_of_files >= _LARGE_FILE_LIST_WARN:
+        logging.warning(
+            "Raw-file dump found %s files (>= %s). Walking a huge shared "
+            "rawdatadir (e.g. all projects) is slow over SFTP; prefer a "
+            "project-scoped rawdatadir, set auto_use_file_list=False, or see "
+            "issue #691 for project-scoped search.",
+            number_of_files,
+            _LARGE_FILE_LIST_WARN,
         )
     logging.info(f"Found {number_of_files} files")
     return file_list

--- a/docs/getting_started/remote_paths.md
+++ b/docs/getting_started/remote_paths.md
@@ -83,6 +83,14 @@ Use `cellpy.utils.helpers.check_connection()` (or
   lab file servers). Plain fsspec/UPath `rglob` does not follow those links.
   Shallow `glob` / `listdir(levels≤1)` stay non-recursive and do not add extra
   follow behaviour.
+- **`Batch.auto_use_file_list` / `find_in_raw_file_directory`:** dumping an
+  entire shared `rawdatadir` (all projects) over SFTP can still be expensive
+  even though cellpy follows symlinks. Prefer pointing `rawdatadir` at the
+  project folder, or set `auto_use_file_list: false`. Remote dumps use a
+  file-only listing (`files_only`) and, when the SSH session allows it, a
+  single remote `find -L … -type f` for speed, with a walk fallback. A warning
+  is logged if the dump returns thousands of paths. Smarter project-scoped
+  search is tracked separately (issue #691).
 
 ## Live SFTP tests (Docker)
 

--- a/tests/test_filefinder.py
+++ b/tests/test_filefinder.py
@@ -192,3 +192,56 @@ def test_find_in_raw_file_directory_empty_warns(tmp_path, caplog):
         file_list = filefinder.find_in_raw_file_directory(raw_file_dir=empty)
     assert file_list == []
     assert any("No files found" in r.message for r in caplog.records)
+
+
+def test_find_in_raw_file_directory_remote_no_isfile_stat(
+    monkeypatch, mock_env_cellpy_key_filename
+):
+    """Remote dump must not call is_file() per path (#690)."""
+    from tests.test_otherpath_symlink_rglob import _FakeFS, _FakeUPath
+
+    shared_fs = _FakeFS()
+
+    class _BoundFakeUPath(_FakeUPath):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, fs=shared_fs, **kwargs)
+
+    monkeypatch.setattr("cellpy.internals.otherpath.UPath", _BoundFakeUPath)
+    # filefinder does not pass testing=True; skip real key-file existence check.
+    monkeypatch.setattr(
+        "cellpy.internals.otherpath._credentials_from_env",
+        lambda *, testing=False: {},
+    )
+
+    from cellpy.internals.connections import OtherPath
+
+    calls = {"is_file": 0}
+    original = OtherPath.is_file
+
+    def _counting_is_file(self, *args, **kwargs):
+        calls["is_file"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(OtherPath, "is_file", _counting_is_file)
+
+    root = OtherPath("sftp://user@host/home/user/projects")
+    file_list = filefinder.find_in_raw_file_directory(raw_file_dir=root)
+    assert any("20250709_lol079_01_cc_01.h5" in p for p in file_list)
+    assert any(p.endswith("other.h5") for p in file_list)
+    assert calls["is_file"] == 0
+    assert shared_fs.isfile_calls == 0
+
+
+def test_find_in_raw_file_directory_large_n_warns(tmp_path, caplog, monkeypatch):
+    import logging
+
+    monkeypatch.setattr(filefinder, "_LARGE_FILE_LIST_WARN", 2)
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "a.res").write_text("x")
+    (raw / "b.res").write_text("y")
+    (raw / "c.res").write_text("z")
+    with caplog.at_level(logging.WARNING):
+        file_list = filefinder.find_in_raw_file_directory(raw_file_dir=raw)
+    assert len(file_list) == 3
+    assert any("huge shared" in r.message or "project-scoped" in r.message for r in caplog.records)

--- a/tests/test_otherpath_symlink_rglob.py
+++ b/tests/test_otherpath_symlink_rglob.py
@@ -1,6 +1,8 @@
-"""Unit tests for remote OtherPath.rglob symlink following (issue #688)."""
+"""Unit tests for remote OtherPath.rglob symlink following (#688) and perf (#690)."""
 
 from __future__ import annotations
+
+from types import SimpleNamespace
 
 import pytest
 
@@ -86,8 +88,14 @@ class _FakeFS:
             },
         }
         self.link_dirs = set(self._info)
+        self.info_calls = 0
+        self.isdir_calls = 0
+        self.ls_calls = 0
+        self.isfile_calls = 0
+        self.client = None
 
     def info(self, path):
+        self.info_calls += 1
         path = path.rstrip("/") or "/"
         if path in self._info:
             return dict(self._info[path])
@@ -100,19 +108,28 @@ class _FakeFS:
         raise FileNotFoundError(path)
 
     def ls(self, path, detail=True):
+        self.ls_calls += 1
         path = path.rstrip("/") or "/"
-        entries = self.tree.get(path, [])
+        # Symlink project dirs list via their path key (Paramiko follows for listdir).
+        entries = self.tree.get(path)
+        if entries is None and path in self.link_dirs:
+            # Destination-only keys are not listed; treat as empty dir listing success.
+            entries = []
+        if entries is None:
+            entries = []
         if detail:
             return list(entries)
         return [e["name"] for e in entries]
 
     def isdir(self, path):
+        self.isdir_calls += 1
         path = path.rstrip("/") or "/"
         if path in self.tree or path in self.link_dirs:
             return True
         return False
 
     def isfile(self, path):
+        self.isfile_calls += 1
         path = path.rstrip("/") or "/"
         for entries in self.tree.values():
             for e in entries:
@@ -164,3 +181,65 @@ def test_rglob_cycle_guard_terminates(fake_remote):
     root = OtherPath("sftp://user@host/home/user/cycle")
     names = sorted(p.name for p in root.rglob("*.h5", testing=True))
     assert names == ["ok.h5"]
+
+
+def test_rglob_files_only_skips_directories(fake_remote):
+    root = OtherPath("sftp://user@host/home/user/projects")
+    paths = [p.raw_path for p in root.rglob("*", testing=True, files_only=True)]
+    assert all(p.endswith(".h5") for p in paths)
+    assert any(p.endswith("20250709_lol079_01_cc_01.h5") for p in paths)
+    assert any(p.endswith("other.h5") for p in paths)
+
+
+def test_rglob_walk_avoids_per_dir_info_and_isdir(fake_remote):
+    """STAT diet (#690): reuse ls detail; probe links with ls, not isdir+info."""
+    root = OtherPath("sftp://user@host/home/user/projects")
+    list(root.rglob("*.h5", testing=True))
+    # Root may still call info once; children should use ls detail / destination.
+    assert fake_remote.info_calls <= 1
+    assert fake_remote.isdir_calls == 0
+
+
+def test_rglob_find_l_fast_path(fake_remote):
+    """When Paramiko exec is available, files_only uses find -L (#690)."""
+
+    class _Stdout:
+        def __init__(self, text: str):
+            self.channel = SimpleNamespace(recv_exit_status=lambda: 0)
+            self._text = text.encode("utf-8")
+
+        def read(self):
+            return self._text
+
+    class _Stderr:
+        def read(self):
+            return b""
+
+    def exec_command(cmd, timeout=None):
+        assert "find -L" in cmd
+        assert "-type f" in cmd
+        body = "\n".join(
+            [
+                "/home/user/projects/LongLife/20250709_lol079_01_cc_01.h5",
+                "/home/user/projects/plain/other.h5",
+            ]
+        )
+        return None, _Stdout(body), _Stderr()
+
+    fake_remote.client = SimpleNamespace(exec_command=exec_command)
+    ls_before = fake_remote.ls_calls
+    root = OtherPath("sftp://user@host/home/user/projects")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True, files_only=True))
+    assert names == ["20250709_lol079_01_cc_01.h5", "other.h5"]
+    assert fake_remote.ls_calls == ls_before  # walk not used
+
+
+def test_rglob_find_l_failure_falls_back_to_walk(fake_remote):
+    def exec_command(cmd, timeout=None):
+        raise OSError("no shell")
+
+    fake_remote.client = SimpleNamespace(exec_command=exec_command)
+    root = OtherPath("sftp://user@host/home/user/projects")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True, files_only=True))
+    assert "20250709_lol079_01_cc_01.h5" in names
+    assert fake_remote.ls_calls > 0


### PR DESCRIPTION
## Summary
- Speed up remote `auto_use_file_list` / `find_in_raw_file_directory` dumps: prefer `find -L … -type f` when Paramiko exec works, else an optimized symlink-following walk that reuses `ls(detail=True)` metadata.
- Use `rglob(..., files_only=True)` so dumps skip per-path `is_file()` STATs; warn when the list is huge (≥5000).
- Document trade-offs and point at project-scoped `rawdatadir` / #691.

Closes #690

## Test plan
- [x] `uv run pytest tests/test_otherpath_symlink_rglob.py tests/test_filefinder.py`
- [x] `uv run pytest -m essential`
- [ ] Optional: odin smoke with `auto_use_file_list=True` over shared `…/projects`


Made with [Cursor](https://cursor.com)