### PR TITLE
docs: v2.0.0 release readiness (HISTORY + #687 workaround)

### DIFF
--- a/.issueflows/02-partly-solved-issues/issue574_original.md
+++ b/.issueflows/02-partly-solved-issues/issue574_original.md
@@ -39,5 +39,7 @@ architecture plan §6 row 3.6.
 
 - **Additional tasks**:
   - Check alignment with guiding docs under `.issueflows/04-designs-and-guides`; update those docs if needed.
+- **Clarifications / constraints**:
+  - Phase C (`v2.0.0rc1`) already shipped from clean `master` after #671 (PyPI publish green). Remaining work is soak → stable `v2.0.0` + feedstock + start the v1.x 12-month bugfix-only window.
 
-_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-23._
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 2, last comment by @jepegit on 2026-07-24._

--- a/.issueflows/02-partly-solved-issues/issue574_plan.md
+++ b/.issueflows/02-partly-solved-issues/issue574_plan.md
@@ -1,133 +1,130 @@
 # Issue #574 plan — Stage 3.17: cellpy 2.0.0 release checklist
 
-**Status:** confirmed 2026-07-24 (Accept; Q2 override → `v2.0.0rc1`)
+**Status:** draft 2026-07-26 (supersedes 2026-07-24 confirmed rc1 plan — Phases A–C done)
 
 ## Goal
 
-Execute the **2.0.0 release gates** (benchmarks, parity, CI, docs/deps, Stage-3
-close-out), align guiding docs, then **tag/publish** `v2.0.0rc1` from a clean
-`master`. The stable `v2.0.0` cut and the formal start of the 12-month `v1.x`
-bugfix-only window wait until a later follow-up after rc soak (still tracked
-under this checklist / Stage 3 until closed).
+Re-run the **2.0.0 release gates** on current `master`, fold release notes, then
+**tag/publish stable `v2.0.0`** from a clean `master`, bump **conda-forge
+feedstock**, and **start the 12-month `v1.x` bugfix-only window** (#438-6).
+Close #574 / update #575 when done.
 
 ## Constraints
 
-- **Operational issue, not a feature.** Prefer evidence + tiny fixes over new
-  abstractions. No new release framework.
-- **Tag only from clean `master`** after the readiness PR merges — never from
-  `574-release-checklist`. Follow
-  [`.issueflows/04-designs-and-guides/release-procedure.md`](../04-designs-and-guides/release-procedure.md)
+- **Operational issue, not a feature.** Evidence + tiny fixes only. No new
+  release framework.
+- **Tag only from clean `master`** — never from `574-release-checklist`. Follow
+  [`release-procedure.md`](../04-designs-and-guides/release-procedure.md)
   (hygiene: no untracked `.issueflows/` on the tagged commit).
 - **Branching:** `master` = v2; `v1.x` = 1.x maintenance
-  ([`cellpy-v2-branching.md`](../04-designs-and-guides/cellpy-v2-branching.md)).
+  ([`cellpy-v2-branching.md`](../04-designs-and-guides/cellpy-v2-branching.md)
+  “At v2.0 release”).
 - **Acceptance bar** (release plan §4): no metric slower than 1.x; load/summary
-  expected to win after bridge removal. CI harness today: warn +20% / fail +100%
-  (`benchmarks/check_baseline.py` + `.github/workflows/benchmarks.yml`). Release
-  judgment uses the plan bar; CI hard-fail is the floor.
-- **`cellpycore` pin:** already `cellpycore==0.2.3` in `pyproject.toml`. Confirm
-  it is still the intended release pin (core #136 closed; pin-gate doc
-  [`v2-cellpycore-pin-gate.md`](../04-designs-and-guides/v2-cellpycore-pin-gate.md)
-  is partly historical — refresh if stale).
-- **Comment task:** check/update `.issueflows/04-designs-and-guides` so
-  release/branching/pin/docs text matches reality at ship time.
-- **Out of scope unless asked:** implementing #655 fixture inventory; cutting
-  another `aN`/`rcN` if we choose to delay stable.
+  expected to win. CI harness: warn +20% / fail +100%. Fail-band = hard blocker;
+  unexplained load/summary warn-band = block (same as rc1 decision).
+- **`cellpycore` pin:** currently `cellpycore==0.2.4` — confirm still intended
+  for stable (do not silently bump during this cut unless a gate forces it).
+- **Already shipped (do not redo):** `v2.0.0rc1` (2026-07-24), `v2.0.0rc2`
+  (2026-07-25; publish workflow green). Note: GitHub marks `v2.0.0rc2` as
+  *not* prerelease — fix that flag if still wrong, or leave a status note.
+- **#655** still non-blocking (rc1 decision stands).
+- **Out of scope unless decided in Open questions:** implementing #687 / #691
+  as part of this issue (open separate issues or park stable until they land).
 
 ### Prior art
 
 | Hit | Role |
 | --- | --- |
-| [`benchmarks/`](../../benchmarks/) + [`check_baseline.py`](../../benchmarks/check_baseline.py) + [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml) | GHA ubuntu baseline compare (issue #436 / #476 tiered gate) |
-| [`tests/parity.py`](../../tests/parity.py) + golden suites | Value-parity oracle; named `exceptions=` only |
-| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) jobs `essential (linux / uv)` / `full (linux / uv)` | Required CI gates named in the issue |
-| [`.github/workflows/docs.yml`](../../.github/workflows/docs.yml) + RTD | Docs build signal |
-| [`DEPRECATIONS.md`](../../DEPRECATIONS.md), [`docs/getting_started/migration_v1_to_v2.md`](../../docs/getting_started/migration_v1_to_v2.md) | #572 deliverables — verify complete, don't rewrite |
-| [`release-procedure.md`](../04-designs-and-guides/release-procedure.md), [`build-and-versioning.md`](../04-designs-and-guides/build-and-versioning.md) | Tag → GitHub release → PyPI trusted publish |
-| Sibling [`cellpy-feedstock`](../../../cellpy-feedstock/) | conda-forge follow-up after PyPI |
-| `00-tools/` | None for release ops — no new helper unless audit invents a reusable checker |
+| [`benchmarks/`](../../benchmarks/) + [`check_baseline.py`](../../benchmarks/check_baseline.py) + [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml) | GHA baseline compare |
+| [`tests/parity.py`](../../tests/parity.py) + golden suites | Value-parity oracle |
+| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) `essential` / `full` | Named CI gates |
+| [`.github/workflows/docs.yml`](../../.github/workflows/docs.yml) + RTD | Docs signal |
+| [`DEPRECATIONS.md`](../../DEPRECATIONS.md), [`docs/getting_started/migration_v1_to_v2.md`](../../docs/getting_started/migration_v1_to_v2.md) | Verify complete |
+| [`release-procedure.md`](../04-designs-and-guides/release-procedure.md) §B | Tag → release.yml → PyPI |
+| Sibling [`cellpy-feedstock`](../../../cellpy-feedstock/) | conda-forge after PyPI stable |
+| `00-tools/` | None for release ops |
 
 ## Approach
 
-Three phases on this issue. **Phase A+B** = the PR. **Phase C** = post-merge
-human release cut (same issue, not a second GitHub issue unless we abort ship).
+**Phases A–C (rc soak path) — DONE** (see `issue574_status.md`). This plan is
+**Phase D only**.
 
-### Phase A — Readiness audit (evidence first)
+### Phase D — Stable `v2.0.0`
 
-Record results in `issue574_status.md` (and tick the GitHub issue checkboxes when
-green). Do not tag yet.
+Two git moments again: optional readiness PR (HISTORY / docs / tiny gate fixes),
+then tag from clean `master`.
+
+#### D1 — Re-audit gates on current `master`
+
+Record in `issue574_status.md`. Do not tag until green.
 
 | Gate | How |
 | --- | --- |
-| Benchmarks | Dispatch **Benchmarks** workflow on `master` (or this branch once pushed); download/compare vs `benchmarks/baselines/v1x_ubuntu_py313.json`. Note load/summary deltas. Any warn-band (+20%) → investigate before ship (open Q). Fail-band (+100%) → hard blocker. |
-| Value-parity | `uv run pytest` paths that exercise golden / parity oracles (full suite covers them; call out any intentional `exceptions=` list in status — no silent widen). |
-| CI | Green `essential (linux / uv)` **and** `full (linux / uv)` on the PR (and on `master` before tag). Optionally kick `ci-scheduled` if weekly is stale. |
-| Docs / deprecations | Confirm migration guide + `DEPRECATIONS.md` current; Docs workflow / RTD published for latest `master`. |
-| Dependency budget / pin | Confirm #570 budget still true in `uv.lock`; keep or bump exact `cellpycore==…` for the release commit. |
-| Stage-3 close-out | Only open `cellpy2-stage3` issues today: **#574** (this) and tracking **#575**. Architecture-plan “open” list is stale — refresh that note if we touch architecture-plan. Decide **#655** (open on `v2.0.0` milestone, not stage-3 label) — see Open questions. |
-| Guiding docs | Diff `release-procedure.md`, `cellpy-v2-branching.md` “At v2.0 release”, `v2-cellpycore-pin-gate.md`, `ci-tiers.md` vs current truth; patch drift. |
+| CI | Wait for in-flight / latest `master` CI after #692; require green `essential (linux / uv)` **and** `full (linux / uv)`. |
+| Benchmarks | Latest **Benchmarks** on `master` (post-#692 already ran success once — confirm fail-band still clean; note load/summary warn vs rc1). |
+| Value-parity | Covered by full suite; call out any intentional `exceptions=` — no silent widen. |
+| Docs / deprecations | Migration guide + `DEPRECATIONS.md` still current; Docs/RTD ok for tip. |
+| Pin / lock | Confirm `cellpycore==0.2.4` + lock; no surprise editable sources. |
+| Stage-3 close-out | Only open `cellpy2-stage3`: **#574**, **#575**. After stable, close #574 and tick #575. |
+| Guiding docs | Tick [`cellpy-v2-branching.md`](../04-designs-and-guides/cellpy-v2-branching.md) “At v2.0 release”; refresh `release-procedure.md` dates/examples if stale (`rc1` → stable wording). |
 
-### Phase B — Gap fixes + release notes prep
+#### D2 — Release notes + readiness PR (if needed)
 
-Only what audit proves necessary:
+- `HISTORY.md`: fold `[Unreleased]` into **`## [2.0.0] - <date>`** (migration
+  headlines, support matrix, **v1.x 12-month window from this date**, pin).
+  Optionally backfill short `[2.0.0rc1]` / `[2.0.0rc2]` stubs if we want the
+  soak trail in HISTORY (nice-to-have, not a gate).
+- Only minimal patches if D1 finds blockers.
+- PR → `master`. Keep `.issueflows/01-current-issues/*` **off** the merge /
+  tagged tree.
 
-- Fix benchmark / parity / CI failures (minimal patches; new issues if large).
-- `HISTORY.md`: fold Unreleased into **`## [2.0.0] - <date>`** (migration headlines,
-  support matrix, v1.x 12-month window, pin).
-- Architecture-plan / issue-flow doc sync as needed (comment task).
-- PR → `master`. Keep `.issueflows/01-current-issues/*` **off** the merge if the
-  project prefers (or leave on branch only — never pollute the tagged tree).
+#### D3 — Tag stable + feedstock + window
 
-### Phase C — Ship rc1 (after merge, on clean `master`)
-
-Per `release-procedure.md` §B (pre-release on `master`):
+On clean `master` after D2 merges (or immediately if D1 green and no HISTORY PR
+required — prefer HISTORY PR first):
 
 1. `git switch master && git pull --ff-only`
 2. `git status` empty (no untracked)
-3. `UV_NO_SOURCES=1 uv lock && UV_NO_SOURCES=1 uv sync` if pin/lock changed
-4. `uv run pytest` (full) + confirm CI green
-5. `gh release create v2.0.0rc1 --target master --generate-notes` (or curated notes)
-6. Watch `release.yml` → PyPI (`--pre` channel)
-7. Update **cellpy-feedstock** only if conda should carry the rc (optional; default
-   = PyPI rc first, feedstock with stable later — see decisions)
-8. Confirm `v1.x` tip remains healthy; **do not** start the 12-month EOL clock yet
-   (clock starts at stable `v2.0.0`)
-9. Leave #574 open until stable ship **or** explicitly park after rc1 with remaining
-   work = “soak → re-run gates → `v2.0.0` + window announcement”
+3. `uv run pytest` (full) locally if any last-minute commit; else rely on green CI
+4. `gh release create v2.0.0 --target master` (curated or `--generate-notes`;
+   ensure **not** marked prerelease)
+5. Watch `release.yml` → PyPI **stable** channel
+6. Bump sibling **cellpy-feedstock** to `2.0.0` (stable only — prior decision)
+7. Confirm `v1.x` tip healthy; **announce 12-month bugfix-only window from
+   today's date** (#438-6) in release notes + tick branching checklist
+8. Close #574; update tracking #575
 
-**Split recommendation:** keep Phases A–C on **one issue** (checklist nature), but
-**two git moments** — readiness PR, then tag. If audit finds multi-day blockers,
-pause (#655-sized work becomes its own issue; do not inflate this PR).
+**Split:** keep Phase D on this one checklist issue. If D1 surfaces multi-day
+blockers (#687-sized), **pause** and open/fix that issue — do not inflate the
+release PR.
 
 ## Files to touch
 
 | Path | Change |
 | --- | --- |
-| `.issueflows/01-current-issues/issue574_status.md` | Gate evidence, checkbox progress |
-| `.issueflows/04-designs-and-guides/release-procedure.md` (and siblings as needed) | Align with ship reality |
-| `HISTORY.md` | `[2.0.0rc1]` section (stable `[2.0.0]` later) |
-| `pyproject.toml` / `uv.lock` | Only if pin bump required |
+| `.issueflows/01-current-issues/issue574_status.md` | D1 evidence, ship log |
+| `HISTORY.md` | `[2.0.0]` section from Unreleased |
+| `.issueflows/04-designs-and-guides/release-procedure.md` (+ branching checklist ticks) | Align with stable ship |
+| `pyproject.toml` / `uv.lock` | Only if pin forced |
 | `DEPRECATIONS.md` / migration guide | Only if audit finds gaps |
-| `benchmarks/` or tests | Only if gate fails need a fix |
+| `cellpy-feedstock/` (sibling) | Phase D3 version bump |
 | `architecture-plan/*` (sibling) | Optional status-row refresh |
-| `cellpy-feedstock/` (sibling) | Phase C version bump |
 
 ## Test strategy
 
-- Local / PR: `uv run pytest -m essential`, then `uv run pytest` (full) before
-  declaring CI gate ready.
-- Benchmarks: GHA **Benchmarks** workflow + `check_baseline.py` (not local Windows
-  numbers as ruler).
-- Release: `release.yml` essential + publish after tag.
+- Before tag: green GHA `essential` + `full` on `master`; Benchmarks fail-band clean.
+- Local optional: `uv run pytest -m essential` then `uv run pytest`.
+- Release: `release.yml` essential + publish after `v2.0.0` tag.
 - No new unit tests unless a gap-fix introduces behaviour.
 
-## Decisions (confirmed 2026-07-24)
+## Decisions carried forward (from 2026-07-24)
 
-1. **[#655](https://github.com/jepegit/cellpy/issues/655) does not block rc1 / 2.0** — follow-up fixture work; not a Stage-3 sub-issue.
-2. **Cut `v2.0.0rc1` first** (user override). Stable `v2.0.0` + 12-month `v1.x` window after soak.
-3. **Warn-band (+20%…+100%):** investigate; **block ship on unexplained load/summary warns**; other metrics may proceed if documented in status.
-4. **Feedstock:** PyPI rc1 first; feedstock bump with **stable** (or only if we explicitly want conda `--pre`).
-5. **Phase A on current `master` first** (benchmarks workflow + latest CI), then PR fixes on this branch.
+1. **#655** does not block 2.0.
+2. Warn-band: block ship on unexplained **load/summary** warns; other metrics may proceed if documented.
+3. Feedstock with **stable** only (not rc).
 
 ## Open questions
 
-- None remaining — proceed to `/iflow-build`.
+1. **Ship now?** Treat soak as done after rc1+rc2 (~2 days) and cut `v2.0.0` this session, or wait longer?
+2. **#687 (`scp://` SSH Host aliases)** — block stable, or ship with documented workaround (full HostName + `CELLPY_KEY_FILENAME`) and fix in a fast follow-up?
+3. **#691 (project-scoped filefinder)** — confirm non-blocking (enhancement).

--- a/.issueflows/02-partly-solved-issues/issue574_status.md
+++ b/.issueflows/02-partly-solved-issues/issue574_status.md
@@ -34,11 +34,12 @@
 - `HISTORY.md`: `## [2.0.0] - 2026-07-26` (+ support / #687 known limitation).
 - Docs: `remote_paths.md` Host-alias workaround; migration + configuration pointers.
 - Guiding docs: branching checklist ticks; release-procedure examples.
-- `/iflow-close`: essential tests green; readiness PR opened (see below).
+- `/iflow-close`: essential tests green; readiness PR
+  https://github.com/jepegit/cellpy/pull/693
 
 ## Remaining work
 
-- Merge readiness PR → clean `master`
+- Merge readiness PR #693 → clean `master`
 - Tag **`v2.0.0`**, watch `release.yml` → PyPI
 - conda-forge **cellpy-feedstock** bump to `2.0.0`
 - Announce 12-month `v1.x` window; tick remaining branching-checklist boxes;

--- a/.issueflows/02-partly-solved-issues/issue574_status.md
+++ b/.issueflows/02-partly-solved-issues/issue574_status.md
@@ -2,28 +2,50 @@
 
 - [ ] Done
 
-## Done so far
+## Decisions (Accept 2026-07-26)
 
-- Plan confirmed: ship **`v2.0.0rc1`** first; #655 non-blocking; feedstock with stable; audit `master` first.
-- **Phase A audit:** CI essential+full ✅, Docs ✅, Benchmarks fail-band ✅; load/summary warn accepted for rc1.
-- **Phase B:** guiding docs synced; readiness PR #671 merged (`955691a0`).
-- **Phase C (rc1):** tagged and published
-  - Release: https://github.com/jepegit/cellpy/releases/tag/v2.0.0rc1 (prerelease)
-  - Publish workflow: https://github.com/jepegit/cellpy/actions/runs/30091209188 — validate ✅ test ✅ publish ✅
-  - Install: `pip install --pre cellpy==2.0.0rc1`
+- Ship stable **now** after D1 green (rc1+rc2 soak treated as enough).
+- **#687** does **not** block: document workaround; fix as follow-up.
+- **#691** / **#655** non-blocking.
+
+## What's done
+
+### Phases A–C (prior)
+
+- Plan confirmed (rc1 path); #655 non-blocking; feedstock with stable.
+- Phase A audit (rc1): CI essential+full ✅, Docs ✅, Benchmarks fail-band ✅;
+  load/summary warn accepted for rc1.
+- Phase B readiness PR #671 merged.
+- Phase C: `v2.0.0rc1` + later `v2.0.0rc2` tagged/published from `master`.
+
+### Phase D1 — re-audit (2026-07-26)
+
+| Gate | Result |
+| --- | --- |
+| CI `essential` + `full` on `master` | ✅ [run 30204611332](https://github.com/jepegit/cellpy/actions/runs/30204611332) (#692) |
+| Benchmarks fail-band | ✅ [run 30204611339](https://github.com/jepegit/cellpy/actions/runs/30204611339) |
+| Benchmarks warn-band | ⚠ `single_cell_pipeline` **1.227**, `batch_summary_collection` **1.204** — accepted for stable (rc1 carry-forward). |
+| Pin | ✅ `cellpycore==0.2.4` |
+| Migration + `DEPRECATIONS.md` | ✅ |
+| Stage-3 open | only #574 + tracking #575 |
+
+### Phase D2 — readiness PR content
+
+- `HISTORY.md`: `## [2.0.0] - 2026-07-26` (+ support / #687 known limitation).
+- Docs: `remote_paths.md` Host-alias workaround; migration + configuration pointers.
+- Guiding docs: branching checklist ticks; release-procedure examples.
+- `/iflow-close`: essential tests green; readiness PR opened (see below).
 
 ## Remaining work
 
-- Soak rc1; re-run gates if needed
-- Tag stable **`v2.0.0`** from clean `master`
-- conda-forge feedstock bump (stable only)
-- Announce 12-month `v1.x` bugfix-only window from stable date (#438-6)
-- Close #574 / update #575 when stable ships
-- Optional: promote `HISTORY.md` Unreleased #574 bullet into `## [2.0.0rc1] - 2026-07-24` on a small follow-up commit
-- `/iflow-cleanup` for local `574-release-checklist` if still present (remote already deleted)
+- Merge readiness PR → clean `master`
+- Tag **`v2.0.0`**, watch `release.yml` → PyPI
+- conda-forge **cellpy-feedstock** bump to `2.0.0`
+- Announce 12-month `v1.x` window; tick remaining branching-checklist boxes;
+  close #574 / update #575
+- Optional: mark GitHub release `v2.0.0rc2` as prerelease
 
 ## Paused on
 
-- **Date:** 2026-07-24
-- **Branch:** `master` (rc1 shipped)
-- **Why:** waiting on rc soak → stable `v2.0.0`
+- **Date:** 2026-07-26
+- **Why:** D2 in PR; D3 tag/feedstock after merge

--- a/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
+++ b/.issueflows/04-designs-and-guides/cellpy-v2-branching.md
@@ -158,13 +158,13 @@ cellpy-core migration guide).
 Tracked by [#574](https://github.com/jepegit/cellpy/issues/574). Prefer an **rc
 soak** before the stable tag:
 
-- [ ] Full `uv run pytest` green on `master` (`essential` + `full` CI jobs)
-- [ ] Benchmark compare vs GHA `v1x` baseline: no fail-band (+100%); load/summary
+- [x] Full `uv run pytest` green on `master` (`essential` + `full` CI jobs)
+- [x] Benchmark compare vs GHA `v1x` baseline: no fail-band (+100%); load/summary
       warn-band (+20%) investigated or explained (see #574 status)
-- [ ] Tag **`v2.0.0rc1`** on `master` → PyPI `--pre` (soak)
+- [x] Tag **`v2.0.0rc1`** on `master` → PyPI `--pre` (soak); also `v2.0.0rc2`
 - [ ] Tag **`v2.0.0`** on `master` after soak
-- [ ] Pin exact `cellpycore==…` in the release commit (master currently `==0.2.4`)
-- [ ] Migration guide published (`docs/getting_started/migration_v1_to_v2.md`);
+- [x] Pin exact `cellpycore==…` in the release commit (master currently `==0.2.4`)
+- [x] Migration guide published (`docs/getting_started/migration_v1_to_v2.md`);
       `DEPRECATIONS.md` current
 - [ ] Update epic #402 / Stage-3 tracking #575; archive issue-flow docs to
       `03-solved-issues`

--- a/.issueflows/04-designs-and-guides/release-procedure.md
+++ b/.issueflows/04-designs-and-guides/release-procedure.md
@@ -39,8 +39,8 @@ PyPI trusted publishing.
 | `v2.0.0aN` / `bN` / `rcN` | **`master`** | pre-release only |
 | `v2.0.0` and later `v2.x.y` | **`master`** | stable |
 
-As of 2026-07-17: 1.x line at **`v1.1.0.post1`** on `v1.x`; v2 pre-releases from
-`master` (e.g. **`v2.0.0a1`**).
+As of 2026-07-26: 1.x line at **`v1.1.0.post3`** on `v1.x`; v2 soak tags
+`v2.0.0rc1` / `v2.0.0rc2` on `master` (stable cut tracked by #574).
 
 ---
 
@@ -92,10 +92,11 @@ uv run pytest -m essential   # full suite before v2.0.0 stable
 
 git status                   # must show a clean tree (no untracked)
 
-# Pre-release while soaking gates (alphas already shipped; next is rc):
-gh release create v2.0.0rc1 --target master --generate-notes
-# Stable only when #574 gates + soak are done:
-# gh release create v2.0.0 --target master --generate-notes
+# Pre-release soak (already shipped: v2.0.0rc1, v2.0.0rc2):
+# gh release create v2.0.0rcN --target master --generate-notes --prerelease
+# Stable when #574 gates + soak are done:
+gh release create v2.0.0 --target master --generate-notes
+
 
 gh run list --workflow release.yml --limit 1
 gh run watch <run-id>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-26
+
+* **Stable cellpy 2.0.0.** Native headers, v9 zip-of-parquet cellpy files
+  (v8 HDF5 still readable; write v8 via escape), `cellpycore==0.2.4`, and the
+  Stage-3 assembly close-out (#574). Soak tags: `v2.0.0rc1`, `v2.0.0rc2`.
+* **Support:** Python ≥3.13. The `v1.x` line is **bugfix-only for 12 months
+  from this release date** (decision #438-6). See
+  `docs/getting_started/migration_v1_to_v2.md` and `DEPRECATIONS.md`.
+* **Known limitation (#687):** `scp://` / `sftp://` URIs that use an OpenSSH
+  `Host` alias (short name from `~/.ssh/config`) may fail DNS after the
+  OtherPath → UPath switch. Workaround: put the real hostname in the URI and
+  set `CELLPY_KEY_FILENAME` — documented in
+  `docs/getting_started/remote_paths.md`. Fix tracked in #687.
+
 * Speed up remote auto_use_file_list / OtherPath.rglob dump. (#690).
 
 * Follow directory symlinks in remote OtherPath.rglob so batch file discovery works under symlink project dirs. (#688).

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -130,7 +130,7 @@ file:
 | Setting | Environment variable |
 | --- | --- |
 | password | `CELLPY_PASSWORD` |
-| ssh key file | `CELLPY_KEY_FILENAME` |
+| ssh key file | `CELLPY_KEY_FILENAME` (required for reliable remotes; see [Remote paths](remote_paths.md) / #687) |
 | host | `CELLPY_HOST` |
 | user | `CELLPY_USER` |
 

--- a/docs/getting_started/migration_v1_to_v2.md
+++ b/docs/getting_started/migration_v1_to_v2.md
@@ -1,15 +1,19 @@
 # Migrating from cellpy 1.x to 2.x
 
 This guide maps **user-visible breaks** between the 1.x line and cellpy 2.0
-(including current 2.0 alphas on `master`) to a named fix or workaround. Keep
-the `v1.x` branch / 1.x PyPI releases if you need unchanged 1.x behaviour.
+to a named fix or workaround. Keep the `v1.x` branch / 1.x PyPI releases if you
+need unchanged 1.x behaviour.
 
-After **cellpy 2.0 GA**, the `v1.x` line is **bugfix-only for 12 months** from
+After **cellpy 2.0.0**, the `v1.x` line is **bugfix-only for 12 months** from
 the 2.0 release date (decision #438-6). Feature work lands only on 2.x.
+
+**Remote paths:** if `scp://` / `sftp://` short SSH `Host` aliases stop
+resolving, use a real hostname + `CELLPY_KEY_FILENAME` — see
+[Remote paths](remote_paths.md) (#687).
 
 ## Support matrix (files)
 
-| | 1.x | 2.x (current alphas / intended GA) |
+| | 1.x | 2.x (2.0.0+) |
 |---|-----|-------------------------------------|
 | Default `save()` | HDF5 (`.h5` / `.hdf5` / `.cellpy` as HDF5) | **v9** zip-of-parquet + `meta.json` (`.cellpy`) |
 | `load()` | v4–v8 HDF5 | **v8 HDF5 and v9** only (sniffs zip vs HDF5). Pre-v8 raises `WrongFileVersion`. |

--- a/docs/getting_started/remote_paths.md
+++ b/docs/getting_started/remote_paths.md
@@ -34,8 +34,35 @@ Set one of these environment variables (or in your `.env_cellpy` file):
 | `CELLPY_PASSWORD` | Password fallback if no key is set |
 | `CELLPY_HOST` / `CELLPY_USER` | Optional helpers used by some tools/tests |
 
-Paramiko may also use your SSH agent and `~/.ssh/config` for the host/user in
-the URI. Do not put passwords in the cellpy YAML config file.
+Paramiko may also use your SSH agent for keys. Do not put passwords in the
+cellpy YAML config file.
+
+### OpenSSH `Host` aliases (known limitation, #687)
+
+URIs that use a short **`Host` alias** from `~/.ssh/config` (for example
+`scp://odin/...` when `Host odin` maps to a real `HostName`) often fail with
+`getaddrinfo` / DNS errors after the OtherPath → UPath switch. OpenSSH resolves
+the alias; Paramiko/fsspec as used today typically does **not**.
+
+**Workaround (supported today):**
+
+1. Put the **fully resolvable hostname** (or IP) in the URI, not the short alias.
+2. Export the private key explicitly (OpenSSH `IdentityFile` alone is not enough
+   for this path):
+
+```bash
+export CELLPY_KEY_FILENAME="/path/to/your/private_key"
+```
+
+```yaml
+Paths:
+  # use the real HostName from ssh config, not the Host alias
+  rawdatadir: scp://d1-odin-01.example.org/home/user/projects
+```
+
+If an earlier failed run left journal `raw_file_names` empty, recreate the
+journal after fixing the URI. Restoring full `~/.ssh/config` Host-alias support
+is tracked in [#687](https://github.com/jepegit/cellpy/issues/687).
 
 ## Configuring a remote raw-data directory
 


### PR DESCRIPTION
## Summary
- Fold `HISTORY.md` into `## [2.0.0] - 2026-07-26` (support matrix, 12-month `v1.x` window, soak tags).
- Document OpenSSH `Host` alias workaround for remote `scp://` / `sftp://` paths (#687 does not block ship).
- Refresh Stage-3 release guiding docs / branching checklist after rc1+rc2 soak.

## Gate evidence (master tip)
- CI essential + full green: https://github.com/jepegit/cellpy/actions/runs/30204611332
- Benchmarks fail-band green (warn-band accepted, same class as rc1): https://github.com/jepegit/cellpy/actions/runs/30204611339
- Pin: `cellpycore==0.2.4`

## After merge (D3 — not in this PR)
1. Tag `v2.0.0` from clean `master` → watch `release.yml` → PyPI
2. Bump conda-forge cellpy-feedstock
3. Close #574 / update #575

Refs #574

## Test plan
- [x] `uv run pytest -m essential` on this branch
- [ ] CI green on the PR
- [ ] After merge: tag + publish + feedstock (manual)


Made with [Cursor](https://cursor.com)