### PR TITLE
docs: clarify Neware nda loading via fastnda

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Clarify Neware docs: binary `.nda`/`.ndax` via `neware_nda` (bundled fastnda) vs exported `neware_txt` models.
+
 * Iterative docs fixes: example notebook typos/hedges, GITT intro quote, and batch config note for 1.x vs `cellpy.toml`. (#695).
 
 ## [2.0.0] - 2026-07-26

--- a/docs/examples/06_loading_different_formats.ipynb
+++ b/docs/examples/06_loading_different_formats.ipynb
@@ -45644,7 +45644,7 @@
    "id": "d9f8058d-4814-4300-a115-03fc902fc33b",
    "metadata": {},
    "source": [
-    "Neware support is limited today: one `model` is implemented (\"ONE\"). Using the method described above for getting information, currently you will see three model names appear. The \"default\" is the one that will be picked if no model name is provided (\"ONE\" for now), while \"UIO\" is just a nickname for the \"ONE\" model."
+    "Neware shows up in two ways:\n\n- **Binary `.nda` / `.ndax`** — load with `instrument=\"neware_nda\"`. That path uses a bundled [fastnda](https://pypi.org/project/fastnda/)-based reader (`cellpy.libs.local_fastnda`).\n- **Exported text/CSV** — load with `instrument=\"neware_txt\"` and a `model` for the export layout. The model names below (`ONE` / `UIO`, …) apply only to that text loader.\n\n```python\nc = cellpy.get(\"my_cell.nda\", instrument=\"neware_nda\")\n```\n\nFor exported Neware files, the default text `model` is `\"ONE\"` (`\"UIO\"` is a nickname for the same layout). Using the method above for instrument info, you will also see those model names listed under `neware_txt`:\n"
    ]
   },
   {

--- a/docs/examples/06_loading_different_formats.md
+++ b/docs/examples/06_loading_different_formats.md
@@ -335,7 +335,17 @@ plotutils.summary_plot(c, y="capacities", width=1200, height=400, y_range=[0, 10
 
 ## NEWARE
 
-Neware support is limited today: one `model` is implemented ("ONE"). Using the method described above for getting information, currently you will see three model names appear. The "default" is the one that will be picked if no model name is provided ("ONE" for now), while "UIO" is just a nickname for the "ONE" model.
+Neware shows up in two ways:
+
+- **Binary `.nda` / `.ndax`** — load with `instrument="neware_nda"`. That path uses a bundled [fastnda](https://pypi.org/project/fastnda/)-based reader (`cellpy.libs.local_fastnda`).
+- **Exported text/CSV** — load with `instrument="neware_txt"` and a `model` for the export layout. The model names below (`ONE` / `UIO`, …) apply only to that text loader.
+
+```python
+c = cellpy.get("my_cell.nda", instrument="neware_nda")
+```
+
+For exported Neware files, the default text `model` is `"ONE"` (`"UIO"` is a nickname for the same layout). Using the method above for instrument info, you will also see those model names listed under `neware_txt`:
+
 
 
 ```python


### PR DESCRIPTION
## Summary
- Update the NEWARE section in the formats tutorial: binary `.nda`/`.ndax` via `instrument="neware_nda"` (bundled fastnda / `cellpy.libs.local_fastnda`) vs exported text/CSV via `neware_txt` models.
- Follow-up to #695 / #722 — previous wording still implied Neware support was only the limited text models.

## Test plan
- [ ] Spot-check rendered NEWARE section on the formats example page
- [ ] Confirm `instrument="neware_nda"` wording matches `cellpy/readers/instruments/neware_nda.py`

Made with [Cursor](https://cursor.com)