### PR TITLE
feat(batch): Batch facade + load/from_journal (#702)

### DIFF
--- a/cellpy/batch/__init__.py
+++ b/cellpy/batch/__init__.py
@@ -40,8 +40,12 @@ from cellpy.batch.runner import load_cell, run
 from cellpy.batch.store import CellStore
 from cellpy.batch import aggregate, outputs, qc
 from cellpy.batch.aggregate import combine_summaries
+from cellpy.batch.facade import Batch, from_journal, load
 
 __all__ = [
+    "Batch",
+    "load",
+    "from_journal",
     "aggregate",
     "qc",
     "outputs",

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -1,0 +1,206 @@
+"""Batch facade (batch v3, #702).
+
+The thin, notebook-friendly ``Batch`` class that ties the pieces together:
+journal (#698) + policy/resolve_specs (#699) + runner/result/store (#700) +
+aggregate/qc/outputs (#701). Keeps the beloved surface the characterization net
+pinned (#697) -- ``pages``, ``cells``, ``summaries``, ``update``, ``report``,
+``save``, ``mark_as_bad``, ``drop`` -- while everything underneath is the new
+package.
+
+Plot wiring: ``plot()`` delegates to the plotting layer via a small legacy
+adapter; the full tidy-frame plot path lands with the collectors redesign
+(Epic B, batch plan section 4.7).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from cellpy.batch import aggregate, qc
+from cellpy.batch.journal import (
+    FILENAME,
+    Journal,
+    journal_from_frame,
+    read_journal,
+    write_journal,
+)
+from cellpy.batch.layout import BatchPaths, ensure_dirs
+from cellpy.batch.policy import LoadPolicy
+from cellpy.batch.result import BatchResult
+from cellpy.batch.runner import run
+from cellpy.batch.store import CellStore
+
+
+class Batch:
+    """A batch of cells: a journal, a lazy cell store, and derived frames."""
+
+    def __init__(self, journal: Journal, policy: LoadPolicy | None = None) -> None:
+        self.journal = journal
+        self.policy = policy or LoadPolicy()
+        self._store = CellStore()
+        self._result: BatchResult | None = None
+        self._summaries: pl.DataFrame | None = None
+
+    # -- data surface ----------------------------------------------------
+    @property
+    def pages(self) -> pl.DataFrame:
+        return self.journal.pages
+
+    @property
+    def cell_names(self) -> list[str]:
+        return self.journal.cell_names
+
+    @property
+    def cells(self) -> CellStore:
+        return self._store
+
+    @property
+    def result(self) -> BatchResult | None:
+        return self._result
+
+    def update(self, on_progress=None, **overrides) -> BatchResult:
+        """Load every cell (serial), caching them in the store."""
+        policy = replace(self.policy, **overrides) if overrides else self.policy
+        self._result = run(self.journal, policy, on_progress=on_progress)
+        self._store = CellStore.from_cells(self._result.cells())
+        self._summaries = None
+        return self._result
+
+    def load(self, **overrides) -> BatchResult:
+        """Load cells (alias of :meth:`update`, kept for the legacy surface)."""
+        return self.update(**overrides)
+
+    def recalc(self, **overrides) -> BatchResult:
+        return self.update(recalc=True, **overrides)
+
+    @property
+    def summaries(self) -> pl.DataFrame:
+        if self._summaries is None:
+            self._summaries = aggregate.combine_summaries(self._store, self.journal)
+        return self._summaries
+
+    def combine_summaries(self, **_kwargs) -> pl.DataFrame:
+        self._summaries = aggregate.combine_summaries(self._store, self.journal)
+        return self._summaries
+
+    def make_summaries(self) -> pl.DataFrame:
+        return self.combine_summaries()
+
+    def report(self, check: bool = True) -> pl.DataFrame:
+        return qc.check(self._store, self.journal)
+
+    # -- journal ops -----------------------------------------------------
+    def save(self, path: Path | str | None = None) -> Path:
+        target = Path(path) if path else Path(
+            f"cellpy_batch_{self.journal.name or 'batch'}.json"
+        )
+        return write_journal(self.journal, target)
+
+    def export_journal(self, path: Path | str | None = None) -> Path:
+        return self.save(path)
+
+    def create_journal(self) -> Journal:
+        return self.journal
+
+    def paginate(self) -> tuple[Path, ...]:
+        paths = BatchPaths.create(
+            self.journal.name or "batch", self.journal.project or ""
+        )
+        return ensure_dirs(paths)
+
+    def mark_as_bad(self, label: str) -> None:
+        bad = list(self.journal.session.get("bad_cells") or [])
+        if label not in bad:
+            bad.append(label)
+        self.journal.session["bad_cells"] = bad
+
+    def drop(self, label: str) -> "Batch":
+        self.journal.pages = self.journal.pages.filter(pl.col(FILENAME) != label)
+        self._store.unload(label)
+        self._summaries = None
+        return self
+
+    def link(self) -> "Batch":
+        """No-op in batch v3 (the store loads lazily); kept for the surface."""
+        return self
+
+    # -- plotting (delegated; full wiring is Epic B) ---------------------
+    def plot(self, backend: str | None = None, show: bool = False, **kwargs) -> Any:
+        from cellpy.plotting.batch_summary import batch_summary_plot
+
+        return batch_summary_plot(
+            _LegacyExperimentAdapter(self.journal, self._store),
+            backend=backend,
+            show=show,
+            **kwargs,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Batch(name={self.journal.name!r}, project={self.journal.project!r}, "
+            f"cells={len(self.journal)})"
+        )
+
+
+class _LegacyJournalAdapter:
+    def __init__(self, journal: Journal) -> None:
+        pdf = journal.pages.to_pandas()
+        if FILENAME in pdf.columns:
+            pdf = pdf.set_index(FILENAME, drop=False)
+        self.pages = pdf
+
+
+class _LegacyExperimentAdapter:
+    """Minimal shim so the legacy summary plotter can read the new Batch.
+
+    Full plotting on the tidy ``combine_summaries`` frame is Epic B.
+    """
+
+    def __init__(self, journal: Journal, store: CellStore) -> None:
+        self.journal = _LegacyJournalAdapter(journal)
+        summaries = []
+        for label, cell in store.items():
+            summary = getattr(getattr(cell, "data", None), "summary", None)
+            if summary is None:
+                continue
+            pdf = summary.to_pandas() if hasattr(summary, "to_pandas") else summary
+            pdf.name = label
+            summaries.append(pdf)
+        self.memory_dumped = {"summary_engine": summaries}
+        self.data = store
+
+
+# -- module-level constructors -------------------------------------------
+
+
+def from_journal(
+    journal_file: Path | str, policy: LoadPolicy | None = None, **_kwargs
+) -> Batch:
+    """Build a :class:`Batch` from a journal file (.json or .xlsx)."""
+    return Batch(read_journal(journal_file), policy=policy)
+
+
+def load(
+    name: str | None = None,
+    project: str | None = None,
+    *,
+    journal: Journal | None = None,
+    journal_file: Path | str | None = None,
+    frame: Any | None = None,
+    policy: LoadPolicy | None = None,
+    **_kwargs,
+) -> Batch:
+    """Build a :class:`Batch` from a journal source (file / frame / model / name)."""
+    if journal is not None:
+        model = journal
+    elif journal_file is not None:
+        model = read_journal(journal_file)
+    elif frame is not None:
+        model = journal_from_frame(frame, name=name, project=project)
+    else:
+        model = Journal(name=name, project=project)
+    return Batch(model, policy=policy)

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -1,0 +1,87 @@
+"""Tests for the batch v3 facade (#702)."""
+
+import polars as pl
+import pytest
+
+from cellpy.batch import Batch, combine_summaries, from_journal, load
+from cellpy.batch.journal import FILENAME, Journal
+from cellpy.batch.policy import LoadPolicy, SourcePreference
+from tests import fdv
+
+# the surface the characterization net (#697) pinned on the old Batch
+FACADE_MUST_KEEP = (
+    "pages", "cell_names", "cells", "summaries", "update", "load", "save",
+    "report", "combine_summaries", "make_summaries", "mark_as_bad", "drop",
+    "link", "recalc", "create_journal", "paginate", "journal", "export_journal",
+    "plot",
+)
+
+
+def _one_cell_batch():
+    journal = Journal(
+        name="t",
+        project="p",
+        pages=pl.DataFrame(
+            {FILENAME: ["c45"], "cellpy_file_name": [str(fdv.cellpy_file_path)]}
+        ),
+    )
+    return Batch(journal, LoadPolicy(source=SourcePreference.CELLPY_ONLY))
+
+
+def test_facade_public_surface():
+    b = Batch(Journal(name="t", project="p", pages=pl.DataFrame({FILENAME: []})))
+    for name in FACADE_MUST_KEEP:
+        assert hasattr(b, name), f"Batch lost `{name}`"
+
+
+def test_from_journal(parameters):
+    b = from_journal(parameters.journal_file_json_path)
+    assert isinstance(b, Batch)
+    assert len(b.pages) == 5
+    assert len(b.cell_names) == 5
+
+
+def test_update_then_summaries_parity():
+    b = _one_cell_batch()
+    result = b.update()
+    assert result["c45"].ok
+    assert set(b.cells) == {"c45"}
+
+    summaries = b.summaries
+    assert summaries.height > 0
+    assert "cell" in summaries.columns
+    # the facade must not distort values: same as aggregate over the same cells
+    assert summaries.equals(combine_summaries(b.cells, b.journal))
+
+
+def test_report_pass():
+    b = _one_cell_batch()
+    b.update()
+    assert b.report().row(0, named=True)["pass"] is True
+
+
+def test_mark_as_bad_and_drop():
+    b = _one_cell_batch()
+    b.mark_as_bad("c45")
+    assert "c45" in b.journal.session["bad_cells"]
+
+    b2 = _one_cell_batch()
+    b2.drop("c45")
+    assert len(b2.pages) == 0
+    assert b2.cell_names == []
+
+
+def test_save_roundtrip(tmp_path):
+    b = _one_cell_batch()
+    out = b.save(tmp_path / "j.json")
+    assert out.is_file()
+    reloaded = from_journal(out)
+    assert reloaded.cell_names == b.cell_names
+
+
+def test_load_from_frame():
+    frame = pl.DataFrame({FILENAME: ["a", "b"], "mass": [1.0, 2.0]})
+    b = load(name="n", project="p", frame=frame)
+    assert isinstance(b, Batch)
+    assert b.cell_names == ["a", "b"]
+    assert b.journal.name == "n" and b.journal.project == "p"


### PR DESCRIPTION
## A6 — batch v3: the `Batch` facade

Sixth arc of **Epic A** (batch v3, #696). The thin, notebook-friendly `Batch` class that ties the package together behind the surface the characterization net (#697) pinned.

### `cellpy/batch/facade.py`
- **`Batch`** — `pages`, `cell_names`, `cells` (lazy store), `summaries`/`combine_summaries`/`make_summaries` (cached, via `aggregate`), `update`/`load`/`recalc` (via `runner.run`), `report` (via `qc`), `save`/`export_journal`, `paginate` (via `layout.ensure_dirs`), `create_journal`, `mark_as_bad`, `drop`, `link`.
- **`load()` / `from_journal()`** — module-level constructors (file / frame / model / name).
- **`plot()`** delegates to the plotting layer via a small legacy adapter; the full tidy-frame plot path lands with the **collectors redesign (Epic B)** per batch plan §4.7.

### Tests — `tests/test_batch_v3_facade.py` (7, all green)
Surface completeness; `from_journal`; `update`→`summaries` **value parity** with `aggregate`; `report` pass; `mark_as_bad`/`drop`; `save` round-trip; `load(frame=)`. Full batch-v3 suite: **41 green**.

Cross-impl golden parity (old `Batch` vs new) runs at **A7 (#703)** when `utils.batch` delegates to `cellpy.batch` and A1's `test_batch.py` golden exercises the new path.

Closes #702. Part of #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
