### PR TITLE
feat(batch): process-pool + thread executors (#704)

### DIFF
--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -77,9 +77,12 @@ class Batch:
     def result(self) -> BatchResult | None:
         return self._result
 
-    def update(self, on_progress=None, **overrides) -> BatchResult:
-        """Load every cell (serial), caching them in the store.
+    def update(
+        self, on_progress=None, executor: str = "serial", **overrides
+    ) -> BatchResult:
+        """Load every cell, caching them in the store.
 
+        ``executor`` is ``"serial"`` (default), ``"threads"`` or ``"processes"``.
         Known :class:`LoadPolicy` fields in ``overrides`` update the policy;
         unknown (legacy) kwargs like ``testing`` are forwarded to the loader
         (``cellpy.get``) via ``loader_kwargs``.
@@ -95,7 +98,9 @@ class Batch:
                 policy = replace(
                     policy, loader_kwargs={**policy.loader_kwargs, **extra}
                 )
-        self._result = run(self.journal, policy, on_progress=on_progress)
+        self._result = run(
+            self.journal, policy, on_progress=on_progress, executor=executor
+        )
         self._store = CellStore.from_cells(self._result.cells())
         self._summaries = None
         return self._result

--- a/cellpy/batch/runner.py
+++ b/cellpy/batch/runner.py
@@ -1,14 +1,15 @@
-"""Batch runner (batch v3, #700).
+"""Batch runner (batch v3, #700, #704).
 
 Per-cell work is a pure function -- one cell in, one result out, no shared
 mutable state. Serial vs parallel execution is then a choice of executor, not a
-second 300-line method (the legacy ``update`` / ``parallel_update`` clone).
-This arc ships the serial executor; the process pool is A8 (#704).
+second 300-line method (the legacy ``update`` / ``parallel_update`` clone):
+``executor="serial" | "threads" | "processes"`` all reuse :func:`load_cell`.
 """
 
 from __future__ import annotations
 
 import time
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from typing import Any, Callable
 
 from cellpy import get as _cellpy_get
@@ -82,29 +83,106 @@ def load_cell(spec: CellSpec, policy: LoadPolicy | None = None) -> CellResult:
     )
 
 
+def _strip_cell(result: CellResult) -> CellResult:
+    """Drop the live cell (and un-pickleable exception) for cross-process return."""
+    if result.cell is None and (result.error is None or isinstance(result.error, RuntimeError)):
+        return result
+    return CellResult(
+        label=result.label,
+        outcome=result.outcome,
+        cell=None,
+        source=result.source,
+        seconds=result.seconds,
+        error=None if result.error is None else RuntimeError(str(result.error)),
+    )
+
+
+def _dispatch(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
+    if spec.label in bad:
+        return CellResult(spec.label, CellOutcome.SKIPPED, source=None)
+    return load_cell(spec, policy)
+
+
+def _dispatch_lite(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
+    """Process-pool worker: like :func:`_dispatch` but returns a picklable result.
+
+    The live :class:`CellpyCell` is not returned across the process boundary
+    (batch plan section 7, Windows pickling); ``executor="processes"`` yields
+    outcomes/timings, and cells are re-read from their cellpy files on demand.
+    """
+    return _strip_cell(_dispatch(spec, policy, bad))
+
+
+def _run_serial(specs, policy, bad, on_progress) -> list[CellResult]:
+    results: list[CellResult] = []
+    total = len(specs)
+    for index, spec in enumerate(specs, start=1):
+        result = _dispatch(spec, policy, bad)
+        results.append(result)
+        if on_progress is not None:
+            on_progress(index, total, result)
+    return results
+
+
+def _run_pool(pool_cls, worker, specs, policy, bad, on_progress) -> list[CellResult]:
+    results: list[CellResult | None] = [None] * len(specs)
+    total = len(specs)
+    with pool_cls() as pool:
+        futures = {
+            pool.submit(worker, spec, policy, bad): i
+            for i, spec in enumerate(specs)
+        }
+        done = 0
+        for future in as_completed(futures):
+            index = futures[future]
+            results[index] = future.result()
+            done += 1
+            if on_progress is not None:
+                on_progress(done, total, results[index])
+    return results  # type: ignore[return-value]
+
+
+def _run_threads(specs, policy, bad, on_progress) -> list[CellResult]:
+    return _run_pool(ThreadPoolExecutor, _dispatch, specs, policy, bad, on_progress)
+
+
+def _run_processes(specs, policy, bad, on_progress) -> list[CellResult]:
+    return _run_pool(ProcessPoolExecutor, _dispatch_lite, specs, policy, bad, on_progress)
+
+
+#: Available executors. Serial/threads keep live cells; processes returns
+#: outcomes only (frames/paths, not live objects) to stay pickle-safe.
+EXECUTORS = {
+    "serial": _run_serial,
+    "threads": _run_threads,
+    "processes": _run_processes,
+}
+
+
 def run(
     journal: Journal,
     policy: LoadPolicy | None = None,
     per_cell: dict | None = None,
     on_progress: ProgressHook | None = None,
+    executor: str = "serial",
 ) -> BatchResult:
-    """Load every cell in ``journal`` (serial), returning a :class:`BatchResult`.
+    """Load every cell in ``journal``, returning a :class:`BatchResult`.
 
-    Progress is reported via the ``on_progress`` callback; the runner never
-    imports tqdm or prints.
+    ``executor`` chooses ``"serial"`` (default), ``"threads"`` or
+    ``"processes"`` -- all reuse :func:`load_cell`. Progress is reported via the
+    ``on_progress`` callback; the runner never imports tqdm or prints.
     """
     policy = policy or LoadPolicy()
     specs = resolve_specs(journal, policy, per_cell)
-    bad = set(journal.session.get("bad_cells") or []) if policy.skip_bad_cells else set()
-
-    results: list[CellResult] = []
-    total = len(specs)
-    for index, spec in enumerate(specs, start=1):
-        if spec.label in bad:
-            result = CellResult(spec.label, CellOutcome.SKIPPED, source=None)
-        else:
-            result = load_cell(spec, policy)
-        results.append(result)
-        if on_progress is not None:
-            on_progress(index, total, result)
-    return BatchResult(results)
+    bad = (
+        frozenset(journal.session.get("bad_cells") or [])
+        if policy.skip_bad_cells
+        else frozenset()
+    )
+    try:
+        runner_fn = EXECUTORS[executor]
+    except KeyError:
+        raise ValueError(
+            f"unknown executor {executor!r}; choose one of {sorted(EXECUTORS)}"
+        ) from None
+    return BatchResult(runner_fn(specs, policy, bad, on_progress))

--- a/tests/test_batch_v3_runner.py
+++ b/tests/test_batch_v3_runner.py
@@ -139,3 +139,47 @@ def test_run_skips_bad_cells(parameters):
     j.session["bad_cells"] = ["c45"]
     br = run(j, LoadPolicy(source=SourcePreference.CELLPY_ONLY, skip_bad_cells=True))
     assert br["c45"].outcome == CellOutcome.SKIPPED
+
+
+# ---- executors (#704) ---------------------------------------------------
+
+
+def _two_cell_journal(cellpy_file):
+    return Journal(
+        name="t",
+        project="p",
+        pages=pl.DataFrame(
+            {
+                FILENAME: ["c_a", "c_b"],
+                "cellpy_file_name": [str(cellpy_file), str(cellpy_file)],
+            }
+        ),
+    )
+
+
+def test_run_threads_keeps_live_cells(parameters):
+    j = _two_cell_journal(parameters.cellpy_file_path)
+    seen = []
+    br = run(
+        j,
+        LoadPolicy(source=SourcePreference.CELLPY_ONLY),
+        executor="threads",
+        on_progress=lambda i, n, r: seen.append(i),
+    )
+    assert {r.label for r in br.loaded} == {"c_a", "c_b"}
+    assert all(r.cell is not None for r in br.loaded)  # live cells in threads
+    assert sorted(seen) == [1, 2]
+
+
+def test_run_processes_returns_outcomes(parameters):
+    j = _one_cell_journal("c45", parameters.cellpy_file_path)
+    br = run(j, LoadPolicy(source=SourcePreference.CELLPY_ONLY), executor="processes")
+    assert br["c45"].ok
+    # processes mode returns pickle-safe results (no live cell across the boundary)
+    assert br["c45"].cell is None
+
+
+def test_run_unknown_executor(parameters):
+    j = _one_cell_journal("c45", parameters.cellpy_file_path)
+    with pytest.raises(ValueError, match="unknown executor"):
+        run(j, executor="magic")


### PR DESCRIPTION
## A8 — batch v3: parallel executors

Final arc of **Epic A** (batch v3, #696). Serial vs parallel is a choice of executor, not a second 300-line method (the legacy `parallel_update` clone). Additive.

- **`runner.run(..., executor="serial" | "threads" | "processes")`** — all reuse `load_cell`. `threads` keep live cells (shared memory); `processes` return pickle-safe outcomes (no live `CellpyCell` across the boundary — cells re-read from files on demand; batch plan §7 / Windows pickling).
- **`EXECUTORS`** registry; unknown executor → `ValueError` listing the valid choices.
- **`Batch.update(executor=...)`** threads the choice through the facade.

### Tests (3, all green)
`threads` keep live cells + fire progress; `processes` return outcomes with `cell=None`; unknown executor raises. Full batch-v3 suite: **46 green**.

Deletion of the legacy `parallel_update`/dead stubs is **E4** (breaking).

**This completes Epic A (batch v3).** Closes #704. Part of #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
