### PR TITLE
feat(collect): cellpy.collect foundation + cross-cell bug fixed (#705)

### DIFF
--- a/cellpy/collect/__init__.py
+++ b/cellpy/collect/__init__.py
@@ -1,0 +1,37 @@
+"""cellpy.collect -- collection as a first-class product (collectors redesign, #705).
+
+A collection is a product, not a side effect: :class:`Collection` = a tidy frame
+plus provenance. Built on ``cellpy.batch.aggregate`` (Epic A), replacing the
+``utils/collectors`` "elevated arguments" machinery and fixing the cross-cell
+cycle-narrowing bug by design. ``cellpy.utils.collectors`` becomes a shim (B3).
+
+Arcs: options/collection/collect_summaries + per-cell curves (#705, this arc);
+rate/group pipeline (#706); convenience class + shims (#707); plotting (#708).
+"""
+
+from __future__ import annotations
+
+from cellpy.collect.cells import CellItem, iter_cells
+from cellpy.collect.collection import Collection, CollectionMeta, load_collection
+from cellpy.collect.curves import collect_cycles
+from cellpy.collect.options import (
+    CurveOptions,
+    IcaOptions,
+    SaveOptions,
+    SummaryOptions,
+)
+from cellpy.collect.summary import collect_summaries
+
+__all__ = [
+    "Collection",
+    "CollectionMeta",
+    "load_collection",
+    "collect_summaries",
+    "collect_cycles",
+    "iter_cells",
+    "CellItem",
+    "SummaryOptions",
+    "CurveOptions",
+    "IcaOptions",
+    "SaveOptions",
+]

--- a/cellpy/collect/cells.py
+++ b/cellpy/collect/cells.py
@@ -1,0 +1,46 @@
+"""Per-cell iteration for collection (collectors redesign, #705).
+
+Successor of ``pick_named_cell`` with **per-cell isolation**: one cell's filter
+results never leak into the next (fixes the cross-cell ``cycles`` narrowing bug
+at collectors.py:1609/1691). Also carries the label-mapper idea (presentation
+names != file names).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from cellpy.batch.journal import FILENAME
+
+
+@dataclass
+class CellItem:
+    """One cell in a collection pass, with its group metadata."""
+
+    label: str
+    group: Any
+    sub_group: Any
+    cell: Any
+
+
+def iter_cells(
+    batch: Any, label_mapper: Mapping[str, str] | None = None
+) -> Iterator[CellItem]:
+    """Yield the batch's loaded cells with their journal group/sub_group."""
+    lookup: dict[str, tuple[Any, Any]] = {}
+    pages = batch.journal.pages
+    if FILENAME in pages.columns:
+        has_group = "group" in pages.columns
+        has_sub = "sub_group" in pages.columns
+        for row in pages.iter_rows(named=True):
+            lookup[row[FILENAME]] = (
+                row.get("group") if has_group else None,
+                row.get("sub_group") if has_sub else None,
+            )
+
+    for label, cell in batch.cells.items():
+        group, sub_group = lookup.get(label, (None, None))
+        name = label_mapper.get(label, label) if label_mapper else label
+        yield CellItem(label=name, group=group, sub_group=sub_group, cell=cell)

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -1,0 +1,105 @@
+"""The Collection product (collectors redesign, #705).
+
+A collection is a *product, not a side effect*: a tidy frame plus provenance
+(what was collected, from which batch, with which options, by which cellpy
+version, when). It can be saved, re-loaded and re-plotted without
+re-collecting -- ``meta.json`` next to the data makes collections reproducible
+artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import polars as pl
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cellpy_version() -> str:
+    try:
+        import cellpy
+
+        return getattr(cellpy, "__version__", "unknown")
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+@dataclass
+class CollectionMeta:
+    """Provenance for a :class:`Collection`."""
+
+    kind: str
+    batch_name: str | None = None
+    options: dict = field(default_factory=dict)
+    cellpy_version: str = field(default_factory=_cellpy_version)
+    created_utc: str = field(default_factory=_now_utc)
+    cells_included: list[str] = field(default_factory=list)
+    cells_skipped: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Collection:
+    """A tidy collected frame plus its provenance."""
+
+    data: pl.DataFrame
+    kind: str  # "summary" | "cycles" | "ica" | custom
+    name: str
+    meta: CollectionMeta
+
+    def to_wide(
+        self, values: str, index: str = "cycle_num", columns: str = "cell"
+    ) -> pl.DataFrame:
+        """Explicit, tested pivot to wide layout (replaces the try/except pivots)."""
+        return self.data.pivot(values=values, index=index, on=columns)
+
+    def save(
+        self,
+        directory: Path | str | None = None,
+        formats: tuple[str, ...] = ("parquet", "csv"),
+    ) -> list[Path]:
+        """Save the frame (+ ``meta.json``). No cwd fallback -- ``directory`` is explicit."""
+        if directory is None:
+            raise ValueError("save() needs an explicit directory (no cwd fallback)")
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+
+        written: list[Path] = []
+        for fmt in formats:
+            path = directory / f"{self.name}.{fmt}"
+            if fmt == "parquet":
+                self.data.write_parquet(path)
+            elif fmt == "csv":
+                self.data.write_csv(path)
+            else:
+                raise ValueError(f"unsupported collection format {fmt!r}")
+            written.append(path)
+
+        meta_path = directory / f"{self.name}.meta.json"
+        meta_path.write_text(json.dumps(asdict(self.meta), indent=2), encoding="utf-8")
+        written.append(meta_path)
+        return written
+
+
+def load_collection(path: Path | str) -> Collection:
+    """Load a saved collection (parquet/csv frame + ``meta.json`` if present)."""
+    path = Path(path)
+    if path.suffix == ".parquet":
+        data = pl.read_parquet(path)
+    elif path.suffix == ".csv":
+        data = pl.read_csv(path)
+    else:
+        raise ValueError(f"cannot load collection from {path.suffix!r}")
+
+    meta_path = path.with_suffix("").with_suffix(".meta.json")
+    if meta_path.is_file():
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta = CollectionMeta(**raw)
+    else:
+        meta = CollectionMeta(kind="unknown")
+    return Collection(data=data, kind=meta.kind, name=path.stem, meta=meta)

--- a/cellpy/collect/curves.py
+++ b/cellpy/collect/curves.py
@@ -1,0 +1,82 @@
+"""Cycle/capacity-curve collection (collectors redesign, #705).
+
+Per-cell rate/cycle selection is computed **per cell from the originally
+requested cycles** -- the fix for the cross-cell narrowing bug where the legacy
+``cycles_collector``/``ica_collector`` reassigned the shared ``cycles`` list
+inside the per-cell loop (collectors.py:1609/1691), silently dropping cycles
+for every cell after the first that lacked them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+from cellpy.collect.cells import iter_cells
+from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.collect.options import CurveOptions
+
+_KEYS = ("cell", "group", "sub_group", "cycle_num")
+
+
+def _as_polars(frame: Any) -> pl.DataFrame | None:
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    try:
+        return pl.from_pandas(frame)
+    except (TypeError, ValueError):
+        return None
+
+
+def collect_cycles(
+    batch: Any, options: CurveOptions | None = None, **overrides
+) -> Collection:
+    """Collect capacity-voltage curves per cell/cycle into one tidy Collection."""
+    opts = options or CurveOptions()
+    if overrides:
+        opts = opts.replace(**overrides)
+    requested = tuple(opts.cycles) if opts.cycles is not None else None
+
+    frames: list[pl.DataFrame] = []
+    for item in iter_cells(batch):
+        cell = item.cell
+        available = set(cell.get_cycle_numbers())
+        # PER-CELL isolation: derive this cell's cycles from the ORIGINAL
+        # request every iteration -- never narrow a shared variable.
+        if requested is None:
+            cell_cycles = sorted(available)
+        else:
+            cell_cycles = [cyc for cyc in requested if cyc in available]
+
+        for cyc in cell_cycles:
+            curve = _as_polars(cell.get_cap(cycle=cyc))
+            if curve is None or curve.height == 0:
+                continue
+            frames.append(
+                curve.with_columns(
+                    pl.lit(item.label).alias("cell"),
+                    pl.lit(item.group).alias("group"),
+                    pl.lit(item.sub_group).alias("sub_group"),
+                    pl.lit(cyc).alias("cycle_num"),
+                )
+            )
+
+    data = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    for transform in opts.transforms:
+        data = transform(data)
+
+    meta = CollectionMeta(
+        kind="cycles",
+        batch_name=batch.journal.name,
+        options={"cycles": list(requested) if requested else None, "rate": opts.rate},
+        cells_included=list(batch.cells),
+    )
+    return Collection(
+        data=data,
+        kind="cycles",
+        name=f"{batch.journal.name or 'batch'}_cycles",
+        meta=meta,
+    )

--- a/cellpy/collect/options.py
+++ b/cellpy/collect/options.py
@@ -1,0 +1,67 @@
+"""Collection options (collectors redesign, #705).
+
+One source of truth per option set: dataclasses shared by the pipeline
+functions and the convenience class. This replaces the legacy "elevated
+arguments" machinery -- ~20 parameters re-declared per collector subclass,
+packed into dicts and merged through three priority layers, with the same
+parameter documented in three places (collectors.py:995-1126, :306-316).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Callable
+
+#: A transform is a pure frame -> frame step applied after collection.
+Transform = Callable[["object"], "object"]
+
+
+@dataclass(frozen=True)
+class SummaryOptions:
+    """Options for :func:`cellpy.collect.collect_summaries`."""
+
+    columns: tuple[str, ...] | None = None  # summary columns to keep (+ keys)
+    group_it: bool = False  # group-average with std
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "SummaryOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class CurveOptions:
+    """Options for cycle/capacity-curve collection."""
+
+    cycles: tuple[int, ...] | None = None  # requested cycles (per cell, isolated)
+    rate: float | None = None  # rate-based cycle selection
+    rate_on: str | None = None
+    rate_std: float | None = None
+    inverse: bool = False
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "CurveOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class IcaOptions:
+    """Options for dQ/dV (ICA) collection."""
+
+    cycles: tuple[int, ...] | None = None
+    voltage_resolution: float | None = None
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "IcaOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class SaveOptions:
+    """Where/how a :class:`Collection` is saved (no cwd fallback)."""
+
+    directory: Path | None = None
+    formats: tuple[str, ...] = ("parquet", "csv")
+
+    def replace(self, **changes) -> "SaveOptions":
+        return replace(self, **changes)

--- a/cellpy/collect/summary.py
+++ b/cellpy/collect/summary.py
@@ -1,0 +1,52 @@
+"""Summary collection (collectors redesign, #705).
+
+Built on ``batch.aggregate.combine_summaries`` (the tidy long-format frame).
+The full rate-filtering / grouping / CV-partition feature set of the legacy
+``helpers.concat_summaries`` ports onto the options model here in B2 (#706);
+this arc lands the core collect-on-aggregate path + column selection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cellpy.batch import aggregate
+from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.collect.options import SummaryOptions
+
+_KEYS = ("cell", "group", "sub_group")
+
+
+def collect_summaries(
+    batch: Any, options: SummaryOptions | None = None, **overrides
+) -> Collection:
+    """Collect per-cell summaries into one tidy :class:`Collection`."""
+    opts = options or SummaryOptions()
+    if overrides:
+        opts = opts.replace(**overrides)
+
+    frame = aggregate.combine_summaries(batch.cells, batch.journal)
+
+    if opts.columns and frame.height:
+        keep = [c for c in (*_KEYS, "cycle_num") if c in frame.columns]
+        keep += [c for c in opts.columns if c in frame.columns and c not in keep]
+        frame = frame.select(keep)
+
+    for transform in opts.transforms:
+        frame = transform(frame)
+
+    meta = CollectionMeta(
+        kind="summary",
+        batch_name=batch.journal.name,
+        options={
+            "columns": list(opts.columns) if opts.columns else None,
+            "group_it": opts.group_it,
+        },
+        cells_included=list(batch.cells),
+    )
+    return Collection(
+        data=frame,
+        kind="summary",
+        name=f"{batch.journal.name or 'batch'}_summary",
+        meta=meta,
+    )

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,122 @@
+"""Tests for the cellpy.collect foundation (collectors redesign, #705)."""
+
+import polars as pl
+import pytest
+
+import cellpy
+from cellpy.batch import Batch, Journal
+from cellpy.batch.journal import FILENAME
+from cellpy.batch.store import CellStore
+from cellpy.collect import (
+    Collection,
+    CollectionMeta,
+    SummaryOptions,
+    collect_cycles,
+    collect_summaries,
+    load_collection,
+)
+from tests import fdv
+
+
+def _batch_with_cells(cells: dict, pages: pl.DataFrame) -> Batch:
+    b = Batch(Journal(name="b", project="p", pages=pages))
+    b._store = CellStore.from_cells(cells)
+    return b
+
+
+# ---- options ------------------------------------------------------------
+
+
+def test_summary_options_replace_is_immutable():
+    opts = SummaryOptions()
+    changed = opts.replace(group_it=True)
+    assert opts.group_it is False
+    assert changed.group_it is True
+
+
+# ---- Collection product -------------------------------------------------
+
+
+def test_collection_save_load_roundtrip_and_wide(tmp_path):
+    frame = pl.DataFrame(
+        {"cell": ["a", "a"], "cycle_num": [1, 2], "charge_capacity": [1.0, 2.0]}
+    )
+    col = Collection(frame, "summary", "test", CollectionMeta(kind="summary", batch_name="b"))
+
+    written = col.save(tmp_path, formats=("parquet", "csv"))
+    assert any(p.suffix == ".json" for p in written)
+    assert (tmp_path / "test.parquet").is_file()
+
+    loaded = load_collection(tmp_path / "test.parquet")
+    assert loaded.data.equals(frame)
+    assert loaded.meta.batch_name == "b"
+
+    wide = col.to_wide(values="charge_capacity", index="cycle_num", columns="cell")
+    assert "a" in wide.columns
+
+
+def test_collection_save_requires_directory():
+    col = Collection(pl.DataFrame({"a": [1]}), "summary", "x", CollectionMeta(kind="summary"))
+    with pytest.raises(ValueError, match="explicit directory"):
+        col.save(None)
+
+
+# ---- collect_summaries (on batch.aggregate) -----------------------------
+
+
+@pytest.fixture(scope="module")
+def real_batch():
+    cell = cellpy.get(cellpy_file=fdv.cellpy_file_path, testing=True)
+    return _batch_with_cells(
+        {"c45": cell}, pl.DataFrame({FILENAME: ["c45"], "group": [1], "sub_group": [1]})
+    )
+
+
+def test_collect_summaries(real_batch):
+    col = collect_summaries(real_batch)
+    assert col.kind == "summary"
+    assert col.data.height > 0
+    for key in ("cell", "group", "sub_group"):
+        assert key in col.data.columns
+    assert col.meta.cells_included == ["c45"]
+
+
+def test_collect_summaries_column_selection(real_batch):
+    col = collect_summaries(real_batch, columns=("charge_capacity",))
+    assert "charge_capacity" in col.data.columns
+    assert "cell" in col.data.columns  # keys always kept
+
+
+# ---- collect_cycles: the cross-cell narrowing bug is fixed by design ----
+
+
+class _FakeCell:
+    """A cell with a fixed set of available cycles."""
+
+    def __init__(self, cycles):
+        self._cycles = list(cycles)
+
+    def get_cycle_numbers(self):
+        return list(self._cycles)
+
+    def get_cap(self, cycle):
+        return pl.DataFrame({"capacity": [0.0, float(cycle)], "voltage": [0.1, 0.2]})
+
+
+def test_collect_cycles_per_cell_isolation():
+    """cell_a lacks cycle 3; cell_b must still keep it (collectors.py:1609 bug)."""
+    pages = pl.DataFrame(
+        {FILENAME: ["a", "b"], "group": [1, 1], "sub_group": [1, 2]}
+    )
+    b = _batch_with_cells(
+        {"a": _FakeCell([1, 2]), "b": _FakeCell([1, 2, 3])}, pages
+    )
+
+    col = collect_cycles(b, cycles=(1, 2, 3))
+    data = col.data
+
+    a_cycles = set(data.filter(pl.col("cell") == "a")["cycle_num"].to_list())
+    b_cycles = set(data.filter(pl.col("cell") == "b")["cycle_num"].to_list())
+    assert a_cycles == {1, 2}
+    # the bug: after cell_a narrowed the shared list, cell_b lost cycle 3
+    assert b_cycles == {1, 2, 3}


### PR DESCRIPTION
## B1 — `cellpy.collect` foundation

First arc of **Epic B** (collectors redesign, #696), on Epic A's `cellpy.batch.aggregate`. Since the A7 cutover means the legacy collectors can't run against the new facade (they're xfailed), Epic B is a **fresh build with new golden tests**, not a parity-port.

- **`options.py`** — `SummaryOptions`/`CurveOptions`/`IcaOptions`/`SaveOptions` (immutable `.replace()`) replacing the "elevated arguments" 3-layer merge.
- **`collection.py`** — `Collection` = tidy frame + provenance (`CollectionMeta`); `save` (parquet+csv+`meta.json`, **explicit directory, no cwd fallback**), `load_collection`, `to_wide`.
- **`cells.py`** — `iter_cells` with per-cell isolation.
- **`summary.py`** — `collect_summaries` on `batch.aggregate` + column selection.
- **`curves.py`** — `collect_cycles` **fixes the cross-cell cycle-narrowing bug** (collectors.py:1609/1691): each cell's cycles are derived from the *original* request every iteration, never narrowing a shared list.

### Tests (6, all green)
Per-cell-isolation regression (`cell_a` missing a cycle must **not** drop it for `cell_b`); `Collection` save/load round-trip + `to_wide`; `collect_summaries` on a real cell + column selection; options immutability.

Next: B2 (#706) — port `concat_summaries`' rate/group/CV feature set onto the options model; B3 (#707) convenience class + `utils.collectors` shim; B4 (#708) plotting handover.

Closes #705. Part of #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
