### PR TITLE
B2: port concat_summaries feature set onto collect options (#706)

### DIFF
--- a/cellpy/collect/_summary_ops.py
+++ b/cellpy/collect/_summary_ops.py
@@ -1,0 +1,234 @@
+"""Per-cell summary operations for the collect pipeline (collectors redesign, #706).
+
+Polars-native ports of the meaty ``helpers.concat_summaries`` internals --
+rate-based cycle selection, CV partitioning, and group averaging -- that
+previously lived as pandas helpers keyed off the deprecated ``headers_summary``
+/ ``headers_step_table`` singletons. These use the cell's own ``schema`` (the
+2.1 native accessor) and operate on the tidy long frame produced by
+:mod:`cellpy.batch.aggregate`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+CYCLE = "cycle_num"
+_NORM_CYCLE_OUT = "equivalent_cycle"
+
+
+def schema_name(cell: Any, table: str, attr: str, default: str) -> str:
+    """Resolve a column name from ``cell.schema.<table>.<attr>`` (native, 2.1).
+
+    Falls back to ``default`` when the schema (or attribute) is unavailable so
+    the pipeline still works on light-weight/fake cells in tests.
+    """
+    schema = getattr(cell, "schema", None)
+    tbl = getattr(schema, table, None) if schema is not None else None
+    return getattr(tbl, attr, default) or default
+
+
+def to_polars(frame: Any) -> pl.DataFrame | None:
+    """Best-effort conversion of a cell frame (pandas or polars) to polars."""
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    try:
+        return pl.from_pandas(frame)
+    except (TypeError, ValueError):
+        return None
+
+
+def rate_cycles(cell: Any, opts: Any) -> list[int]:
+    """Cycle numbers whose ``rate_on`` step ran at ``opts.rate`` (± tolerance).
+
+    Port of ``helpers.select_summary_based_on_rate`` -- the step-table mask --
+    returning just the surviving cycle numbers (the summary filtering happens
+    in :func:`extract_cell_summary`). ``rate_inverse`` negates the *step* mask;
+    the caller handles ``rate_inverted`` (negating the *cycle* selection).
+    """
+    steps = to_polars(getattr(getattr(cell, "data", None), "steps", None))
+    if steps is None or steps.height == 0:
+        return []
+
+    rate_col = opts.rate_column or schema_name(cell, "steps", "c_rate", "c_rate")
+    type_col = schema_name(cell, "steps", "step_type", "step_type")
+    cyc_col = schema_name(cell, "steps", "cycle_num", CYCLE)
+    if rate_col not in steps.columns or cyc_col not in steps.columns:
+        return []
+
+    rate = opts.rate
+    std = opts.rate_std if opts.rate_std is not None else 0.1 * rate
+
+    on = opts.rate_on if opts.rate_on is not None else ("charge",)
+    if isinstance(on, str):
+        on = (on,)
+
+    mask = (pl.col(rate_col) < (rate + std)) & (pl.col(rate_col) > (rate - std))
+    if on and type_col in steps.columns:
+        mask = mask & pl.col(type_col).cast(pl.Utf8).is_in(list(on))
+    if opts.rate_inverse:
+        mask = ~mask
+
+    return steps.filter(mask)[cyc_col].unique().to_list()
+
+
+def cv_partition(cell: Any) -> pl.DataFrame | None:
+    """Split each numeric summary metric into ``*_non_cv`` / ``*_cv`` parts.
+
+    ``*_non_cv`` comes from ``make_summary(exclude_step_types=["cv_"])``; ``*_cv``
+    is ``full - non_cv`` clipped at zero (the CV-step contribution). Mirrors
+    ``helpers._partition_summary_based_on_cv_steps`` but polars-native and keyed
+    on the schema cycle column. Returns the full summary unchanged if the
+    engine cannot produce a no-CV variant.
+    """
+    cyc = schema_name(cell, "summary", "cycle_num", CYCLE)
+    full = to_polars(getattr(getattr(cell, "data", None), "summary", None))
+    if full is None or full.height == 0 or cyc not in full.columns:
+        return full
+
+    try:
+        no_cv = to_polars(
+            cell.make_summary(exclude_step_types=["cv_"], create_copy=True).data.summary
+        )
+    except (TypeError, ValueError, AttributeError):
+        return full
+    if no_cv is None or cyc not in no_cv.columns:
+        return full
+
+    numeric = [
+        c
+        for c, dt in zip(full.columns, full.dtypes)
+        if dt.is_numeric() and c != cyc and c in no_cv.columns
+    ]
+    if not numeric:
+        return full
+
+    renamed = no_cv.select([cyc, *numeric]).rename({c: f"{c}__nocv" for c in numeric})
+    joined = full.join(renamed, on=cyc, how="left")
+
+    additions: list[pl.Expr] = []
+    for c in numeric:
+        additions.append(pl.col(f"{c}__nocv").alias(f"{c}_non_cv"))
+        additions.append(
+            (pl.col(c) - pl.col(f"{c}__nocv")).clip(lower_bound=0).alias(f"{c}_cv")
+        )
+    return joined.with_columns(additions).drop([f"{c}__nocv" for c in numeric])
+
+
+def extract_cell_summary(cell: Any, opts: Any) -> pl.DataFrame | None:
+    """Per-cell summary frame with cycle-level options applied.
+
+    Applies (in legacy order) CV partition, max-cycle drop, rate selection and
+    ``remove_last``, then normalizes the cycle column to ``cycle_num`` and, when
+    requested, exposes the normalized cycle index as ``equivalent_cycle``.
+    """
+    cyc = schema_name(cell, "summary", "cycle_num", CYCLE)
+
+    if opts.partition_by_cv:
+        frame = cv_partition(cell)
+    else:
+        frame = to_polars(getattr(getattr(cell, "data", None), "summary", None))
+    if frame is None or frame.height == 0:
+        return None
+
+    if opts.max_cycle is not None and cyc in frame.columns:
+        frame = frame.filter(pl.col(cyc) <= opts.max_cycle)
+
+    if opts.rate is not None and cyc in frame.columns:
+        allowed = rate_cycles(cell, opts)
+        if opts.rate_inverted:
+            frame = frame.filter(~pl.col(cyc).is_in(allowed))
+        else:
+            frame = frame.filter(pl.col(cyc).is_in(allowed))
+
+    if opts.remove_last and frame.height > 0:
+        frame = frame.head(frame.height - 1)
+
+    if cyc != CYCLE and cyc in frame.columns:
+        frame = frame.rename({cyc: CYCLE})
+
+    if opts.normalize_cycles:
+        norm = schema_name(cell, "summary", "normalized_cycle_index", "")
+        if norm and norm in frame.columns:
+            frame = frame.rename({norm: _NORM_CYCLE_OUT})
+
+    return frame
+
+
+def _numeric_value_columns(frame: pl.DataFrame, keys: tuple[str, ...]) -> list[str]:
+    return [
+        c
+        for c, dt in zip(frame.columns, frame.dtypes)
+        if dt.is_numeric() and c not in keys
+    ]
+
+
+def clean_extremes(
+    frame: pl.DataFrame,
+    columns: list[str],
+    *,
+    replace_inf: bool,
+    replace_extremes: bool,
+    low: float,
+    high: float,
+) -> pl.DataFrame:
+    """Null out inf and out-of-range values in the given numeric columns."""
+    if not columns:
+        return frame
+    exprs: list[pl.Expr] = []
+    for c in columns:
+        expr = pl.col(c)
+        if replace_inf:
+            expr = pl.when(expr.is_infinite()).then(None).otherwise(expr)
+        if replace_extremes:
+            expr = (
+                pl.when((expr < low) | (expr > high)).then(None).otherwise(expr)
+            )
+        exprs.append(expr.alias(c))
+    return frame.with_columns(exprs)
+
+
+def group_average(
+    frame: pl.DataFrame,
+    opts: Any,
+    *,
+    keys: tuple[str, ...],
+    group_labels: dict[Any, Any] | None = None,
+) -> pl.DataFrame:
+    """Average per journal group -> tidy long ``(group, cycle_num, variable, mean, std)``.
+
+    Port of ``helpers._make_average`` + ``collect_frames`` grouping path. The
+    aggregate column is named ``mean`` regardless of ``average_method`` (legacy
+    backward-compat). ``std`` is the per-group standard deviation across cells.
+    """
+    if frame.height == 0 or "group" not in frame.columns:
+        return frame
+
+    id_cols = ["group"] + ([CYCLE] if CYCLE in frame.columns else [])
+    value_cols = _numeric_value_columns(frame, keys)
+    if not value_cols:
+        return frame
+
+    long = frame.unpivot(
+        index=id_cols, on=value_cols, variable_name="variable", value_name="_v"
+    )
+    stat = "median" if opts.average_method == "median" else "mean"
+    agg_expr = (
+        pl.col("_v").median() if stat == "median" else pl.col("_v").mean()
+    ).alias("mean")
+    out = long.group_by([*id_cols, "variable"]).agg(
+        agg_expr, pl.col("_v").std().alias("std")
+    )
+
+    if group_labels:
+        mapping = {k: v for k, v in group_labels.items() if v is not None}
+        if mapping:
+            out = out.with_columns(
+                pl.col("group").replace(mapping, default=None).alias("group_label")
+            )
+
+    sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
+    return out.sort(sort_cols)

--- a/cellpy/collect/options.py
+++ b/cellpy/collect/options.py
@@ -9,6 +9,7 @@ parameter documented in three places (collectors.py:995-1126, :306-316).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Callable
@@ -19,10 +20,55 @@ Transform = Callable[["object"], "object"]
 
 @dataclass(frozen=True)
 class SummaryOptions:
-    """Options for :func:`cellpy.collect.collect_summaries`."""
+    """Options for :func:`cellpy.collect.collect_summaries`.
 
+    One source of truth for the whole summary pipeline, replacing the ~30
+    keyword arguments of the legacy ``helpers.concat_summaries``. The three
+    meaty feature families it carries:
+
+    * **rate filtering** (``rate`` / ``rate_on`` / ``rate_std`` / ...): keep
+      only cycles whose ``rate_on`` step ran at the requested C-rate.
+    * **group averaging** (``group_it`` / ``average_method`` /
+      ``custom_group_labels``): average per journal group, emitting a tidy
+      long frame ``(group, cycle_num, variable, mean, std)``.
+    * **CV partition** (``partition_by_cv``): split each capacity metric into
+      ``*_non_cv`` / ``*_cv`` contributions.
+    """
+
+    # --- column selection -------------------------------------------------
     columns: tuple[str, ...] | None = None  # summary columns to keep (+ keys)
-    group_it: bool = False  # group-average with std
+
+    # --- cycle selection --------------------------------------------------
+    max_cycle: int | None = None  # drop cycles above this
+    remove_last: bool = False  # drop the final cycle (often incomplete)
+    only_selected: bool = False  # honour the journal ``selected`` column
+
+    # --- rate filtering ---------------------------------------------------
+    rate: float | None = None  # C-rate to keep (numeric, e.g. 0.05 for C/20)
+    rate_on: str | tuple[str, ...] | None = None  # step type(s), default charge
+    rate_std: float | None = None  # tolerance (default 10% of rate)
+    rate_column: str | None = None  # C-rate column (default schema c_rate)
+    rate_inverse: bool = False  # keep steps NOT at the rate
+    rate_inverted: bool = False  # keep cycles NOT selected by the rate
+
+    # --- CV partition -----------------------------------------------------
+    partition_by_cv: bool = False  # add *_non_cv / *_cv columns
+
+    # --- normalization ----------------------------------------------------
+    normalize_cycles: bool = False  # expose normalized (equivalent) cycle index
+
+    # --- grouping ---------------------------------------------------------
+    group_it: bool = False  # average per group -> long (variable/mean/std)
+    average_method: str = "mean"  # "mean" or "median" (column stays "mean")
+    custom_group_labels: Mapping | None = None  # group -> display label
+
+    # --- cleanup ----------------------------------------------------------
+    replace_inf_with_nan: bool = True  # inf -> null (plot-friendly)
+    replace_extremes_with_nan: bool = True  # out-of-range floats -> null
+    low_limit: float = -1e6
+    high_limit: float = 1e6
+
+    # --- post hooks -------------------------------------------------------
     transforms: tuple[Transform, ...] = ()
 
     def replace(self, **changes) -> "SummaryOptions":

--- a/cellpy/collect/summary.py
+++ b/cellpy/collect/summary.py
@@ -1,36 +1,128 @@
-"""Summary collection (collectors redesign, #705).
+"""Summary collection (collectors redesign, #705/#706).
 
-Built on ``batch.aggregate.combine_summaries`` (the tidy long-format frame).
-The full rate-filtering / grouping / CV-partition feature set of the legacy
-``helpers.concat_summaries`` ports onto the options model here in B2 (#706);
-this arc lands the core collect-on-aggregate path + column selection.
+Assembles per-cell summaries into one tidy :class:`Collection`, carrying the
+full rate-filtering / grouping / CV-partition feature set of the legacy
+``helpers.concat_summaries`` on the :class:`SummaryOptions` model. Cycle-level
+work (rate/CV/max-cycle) happens per cell in :mod:`._summary_ops`; combination,
+column selection, group averaging and cleanup happen on the combined frame.
 """
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
-from cellpy.batch import aggregate
+import polars as pl
+
+from cellpy.batch.journal import FILENAME
+from cellpy.collect import _summary_ops as ops
 from cellpy.collect.collection import Collection, CollectionMeta
 from cellpy.collect.options import SummaryOptions
 
-_KEYS = ("cell", "group", "sub_group")
+_KEYS = ("cell", "group", "sub_group", "group_label", "label", ops.CYCLE)
+
+
+def _pages_lookup(batch: Any) -> dict[str, dict[str, Any]]:
+    """label -> row-dict of journal metadata (group/sub_group/group_label/selected)."""
+    lookup: dict[str, dict[str, Any]] = {}
+    pages = batch.journal.pages
+    if FILENAME not in pages.columns:
+        return lookup
+    wanted = [
+        c
+        for c in ("group", "sub_group", "group_label", "label", "selected")
+        if c in pages.columns
+    ]
+    for row in pages.iter_rows(named=True):
+        lookup[row[FILENAME]] = {c: row.get(c) for c in wanted}
+    return lookup
 
 
 def collect_summaries(
     batch: Any, options: SummaryOptions | None = None, **overrides
 ) -> Collection:
-    """Collect per-cell summaries into one tidy :class:`Collection`."""
+    """Collect per-cell summaries into one tidy :class:`Collection`.
+
+    With defaults this is a plain long-format concatenation (one row per
+    cell/cycle). The options add rate filtering, CV partition, per-group
+    averaging and inf/extreme cleanup -- see :class:`SummaryOptions`.
+    """
     opts = options or SummaryOptions()
     if overrides:
         opts = opts.replace(**overrides)
 
-    frame = aggregate.combine_summaries(batch.cells, batch.journal)
+    lookup = _pages_lookup(batch)
+
+    frames: list[pl.DataFrame] = []
+    included: list[str] = []
+    for label, cell in batch.cells.items():
+        meta = lookup.get(label, {})
+        if opts.only_selected and "selected" in meta and meta.get("selected") != 1:
+            continue
+
+        frame = ops.extract_cell_summary(cell, opts)
+        if frame is None or frame.height == 0:
+            continue
+
+        frames.append(
+            frame.with_columns(
+                pl.lit(label).alias("cell"),
+                pl.lit(meta.get("group")).alias("group"),
+                pl.lit(meta.get("sub_group")).alias("sub_group"),
+                pl.lit(meta.get("group_label")).alias("group_label"),
+                pl.lit(meta.get("label")).alias("label"),
+            )
+        )
+        included.append(label)
+
+    frame = (
+        pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    )
 
     if opts.columns and frame.height:
-        keep = [c for c in (*_KEYS, "cycle_num") if c in frame.columns]
-        keep += [c for c in opts.columns if c in frame.columns and c not in keep]
+        keep = [c for c in _KEYS if c in frame.columns]
+        wanted = list(opts.columns)
+        if opts.partition_by_cv:
+            # keep the derived CV split alongside each requested metric
+            wanted = [
+                name
+                for col in wanted
+                for name in (col, f"{col}_non_cv", f"{col}_cv")
+            ]
+        keep += [c for c in wanted if c in frame.columns and c not in keep]
         frame = frame.select(keep)
+
+    grouped = False
+    if opts.group_it and frame.height:
+        # legacy guard: std needs >= 2 cells per group; disable if any group is
+        # short (a single-cell group -- or no group column -- keeps it wide).
+        sizes = Counter(lookup.get(lbl, {}).get("group") for lbl in included)
+        if sizes and min(sizes.values()) >= 2:
+            group_labels = {
+                m.get("group"): m.get("group_label")
+                for m in lookup.values()
+                if m.get("group_label") is not None
+            }
+            if opts.custom_group_labels:
+                group_labels = {**group_labels, **dict(opts.custom_group_labels)}
+            frame = ops.group_average(
+                frame, opts, keys=_KEYS, group_labels=group_labels or None
+            )
+            grouped = True
+
+    if frame.height and (opts.replace_inf_with_nan or opts.replace_extremes_with_nan):
+        if grouped:
+            clean_cols = [c for c in ("mean", "std") if c in frame.columns]
+        else:
+            clean_cols = ops._numeric_value_columns(frame, _KEYS)
+        frame = ops.clean_extremes(
+            frame,
+            clean_cols,
+            replace_inf=opts.replace_inf_with_nan,
+            replace_extremes=opts.replace_extremes_with_nan,
+            low=opts.low_limit,
+            high=opts.high_limit,
+        )
 
     for transform in opts.transforms:
         frame = transform(frame)
@@ -41,8 +133,11 @@ def collect_summaries(
         options={
             "columns": list(opts.columns) if opts.columns else None,
             "group_it": opts.group_it,
+            "rate": opts.rate,
+            "partition_by_cv": opts.partition_by_cv,
+            "max_cycle": opts.max_cycle,
         },
-        cells_included=list(batch.cells),
+        cells_included=included,
     )
     return Collection(
         data=frame,

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,4 +1,6 @@
-"""Tests for the cellpy.collect foundation (collectors redesign, #705)."""
+"""Tests for the cellpy.collect foundation (collectors redesign, #705/#706)."""
+
+from types import SimpleNamespace
 
 import polars as pl
 import pytest
@@ -85,6 +87,83 @@ def test_collect_summaries_column_selection(real_batch):
     col = collect_summaries(real_batch, columns=("charge_capacity",))
     assert "charge_capacity" in col.data.columns
     assert "cell" in col.data.columns  # keys always kept
+
+
+def test_collect_summaries_max_cycle(real_batch):
+    col = collect_summaries(real_batch, max_cycle=5)
+    assert col.data["cycle_num"].max() <= 5
+
+
+def test_collect_summaries_rate_filter(real_batch):
+    # charge C-rate is ~0.043 for cycles 1-3, ~0.085 from cycle 4 on.
+    col = collect_summaries(
+        real_batch, rate=0.043, rate_std=0.01, rate_on="charge"
+    )
+    assert set(col.data["cycle_num"].to_list()) == {1, 2, 3}
+
+
+def test_collect_summaries_rate_inverted(real_batch):
+    col = collect_summaries(
+        real_batch, rate=0.043, rate_std=0.01, rate_on="charge", rate_inverted=True
+    )
+    cycles = set(col.data["cycle_num"].to_list())
+    assert cycles and cycles.isdisjoint({1, 2, 3})
+
+
+def test_collect_summaries_partition_by_cv_adds_columns(real_batch):
+    # this cell has no cv_ steps, so *_cv columns are ~0 but must still appear.
+    col = collect_summaries(
+        real_batch, columns=("charge_capacity",), partition_by_cv=True
+    )
+    assert "charge_capacity_non_cv" in col.data.columns
+    assert "charge_capacity_cv" in col.data.columns
+
+
+# ---- group averaging (helpers._make_average port) -----------------------
+
+
+class _SummaryCell:
+    """A fake cell exposing a polars summary (schema falls back to defaults)."""
+
+    def __init__(self, charge_capacity):
+        self.data = SimpleNamespace(
+            summary=pl.DataFrame(
+                {
+                    "cycle_num": list(range(1, len(charge_capacity) + 1)),
+                    "charge_capacity": [float(v) for v in charge_capacity],
+                }
+            ),
+            steps=None,
+        )
+
+
+def test_collect_summaries_group_average():
+    pages = pl.DataFrame(
+        {FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]}
+    )
+    b = _batch_with_cells(
+        {"x": _SummaryCell([10.0, 20.0]), "y": _SummaryCell([20.0, 40.0])}, pages
+    )
+
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    data = col.data
+
+    # long format: one row per (group, cycle_num, variable) with mean + std
+    for key in ("group", "cycle_num", "variable", "mean", "std"):
+        assert key in data.columns
+
+    cc = data.filter(pl.col("variable") == "charge_capacity").sort("cycle_num")
+    assert cc["mean"].to_list() == [15.0, 30.0]
+    # std of [10, 20] (ddof=1) == 7.071...; of [20, 40] == 14.142...
+    assert cc["std"].to_list() == pytest.approx([7.0710678, 14.1421356])
+
+
+def test_collect_summaries_group_average_needs_group_column():
+    # no group column in pages -> grouping is a no-op, stays wide
+    pages = pl.DataFrame({FILENAME: ["x"]})
+    b = _batch_with_cells({"x": _SummaryCell([1.0, 2.0])}, pages)
+    col = collect_summaries(b, group_it=True)
+    assert "variable" not in col.data.columns
 
 
 # ---- collect_cycles: the cross-cell narrowing bug is fixed by design ----


### PR DESCRIPTION
## Epic B, arc B2 (#706) — the collectors feature port

Carries the meaty three feature families of the legacy `helpers.concat_summaries` onto the `SummaryOptions` model built in B1, polars-native and using the cell's `schema` headers (the legacy `headers_summary` / `headers_step_table` singletons are deprecated-for-removal in 2.1).

### Feature families
- **Rate filtering** — keep only cycles whose `rate_on` step ran at the requested C-rate (`rate` / `rate_on` / `rate_std` / `rate_column` / `rate_inverse` / `rate_inverted`). Ported from `select_summary_based_on_rate` as a polars step mask returning surviving cycles.
- **Group averaging** — average per journal group into a tidy long frame `(group, cycle_num, variable, mean, std)`. Ported from `_make_average` + `collect_frames`; keeps the *"<2 cells per group disables grouping"* guard and names the aggregate `mean` regardless of `average_method` (backward-compat).
- **CV partition** — split each numeric metric into `*_non_cv` / `*_cv` via `make_summary(exclude_step_types=["cv_"])`. Ported from `_partition_summary_based_on_cv_steps`; column selection expands to keep the derived split.

Plus `max_cycle` / `remove_last` / `only_selected` cycle selection, normalized (equivalent) cycle exposure, and inf/extreme cleanup.

### Layout
- `collect/_summary_ops.py` — per-cell polars ops (rate mask, CV partition, extraction, cleanup, group average).
- `collect/summary.py` — orchestration: per-cell extract → combine → select → group-average → cleanup → transforms.
- `collect/options.py` — `SummaryOptions` grown to the full pipeline, one source of truth (replaces ~30 `concat_summaries` kwargs).

### Tests
`tests/test_collect.py` — golden tests for max_cycle, rate filter (+ inverted), CV columns, and group averaging (mean/std values checked). Full local run: 52 passed, 5 planned xfails (B3/B4 collectors placeholders).

Closes #706