### PR TITLE
B3: BatchCollector convenience class + standard_gravimetric recipe (#707)

### DIFF
--- a/cellpy/collect/__init__.py
+++ b/cellpy/collect/__init__.py
@@ -13,6 +13,13 @@ from __future__ import annotations
 
 from cellpy.collect.cells import CellItem, iter_cells
 from cellpy.collect.collection import Collection, CollectionMeta, load_collection
+from cellpy.collect.collector import (
+    BatchCollector,
+    cycles_collector,
+    normalize_column,
+    standard_gravimetric,
+    summary_collector,
+)
 from cellpy.collect.curves import collect_cycles
 from cellpy.collect.options import (
     CurveOptions,
@@ -34,4 +41,9 @@ __all__ = [
     "CurveOptions",
     "IcaOptions",
     "SaveOptions",
+    "BatchCollector",
+    "summary_collector",
+    "cycles_collector",
+    "standard_gravimetric",
+    "normalize_column",
 ]

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -1,0 +1,175 @@
+"""Convenience collector + recipes (collectors redesign, #707).
+
+:class:`BatchCollector` is the thin successor of the legacy
+``utils.collectors.BatchCollector`` family: run a collect function, hold the
+resulting :class:`~cellpy.collect.collection.Collection`, and offer
+``save`` / ``plot`` on top. It replaces the "elevated arguments" machinery --
+~20 parameters redeclared per subclass and merged through three priority
+layers (collectors.py:969/1202/1316) -- with a single options object plus a
+collect callable. The ``utils.collectors`` compatibility shim and the plotting
+handover land in B4 (#708).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import polars as pl
+
+from cellpy.collect.curves import collect_cycles
+from cellpy.collect.options import CurveOptions, SummaryOptions
+from cellpy.collect.summary import collect_summaries
+
+#: A collect function takes ``(batch, options, **overrides)`` -> Collection.
+Collector = Callable[..., Any]
+
+
+class BatchCollector:
+    """Run a collect function and hold its :class:`Collection`.
+
+    Args:
+        batch: the :class:`~cellpy.batch.Batch` to collect from.
+        collector: a collect callable, e.g. :func:`collect_summaries`.
+        options: the options dataclass for ``collector`` (optional).
+        name: display/base name (defaults to the batch/journal name).
+        autorun: run the collector immediately (default ``True``).
+        **overrides: option overrides forwarded to ``collector``.
+    """
+
+    def __init__(
+        self,
+        batch: Any,
+        collector: Collector,
+        options: Any | None = None,
+        *,
+        name: str | None = None,
+        autorun: bool = True,
+        **overrides,
+    ):
+        self.batch = batch
+        self.collector = collector
+        self.options = options
+        self.overrides = overrides
+        self.name = name or getattr(batch.journal, "name", None) or "batch"
+        self._collection: Any | None = None
+        if autorun:
+            self.update()
+
+    def update(self, **overrides) -> "BatchCollector":
+        """(Re)run the collector; extra kwargs merge into the option overrides."""
+        if overrides:
+            self.overrides = {**self.overrides, **overrides}
+        self._collection = self.collector(self.batch, self.options, **self.overrides)
+        return self
+
+    @property
+    def collection(self) -> Any:
+        if self._collection is None:
+            self.update()
+        return self._collection
+
+    @property
+    def data(self) -> pl.DataFrame:
+        return self.collection.data
+
+    def save(self, directory: str | Path, **kwargs) -> list[Path]:
+        """Persist the collection (explicit directory, no cwd fallback)."""
+        return self.collection.save(directory, **kwargs)
+
+    def plot(self, **kwargs) -> Any:
+        """Draw the collection. Wired to ``cellpy.plotting`` in B4 (#708)."""
+        plot = getattr(self.collection, "plot", None)
+        if plot is None:
+            raise NotImplementedError(
+                "Collection plotting is handed over to cellpy.plotting in B4 "
+                "(#708). Use `.data` for the collected frame in the meantime."
+            )
+        return plot(**kwargs)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        kind = getattr(self._collection, "kind", "?")
+        rows = getattr(getattr(self._collection, "data", None), "height", "?")
+        return f"<BatchCollector {self.name!r} kind={kind} rows={rows}>"
+
+
+def summary_collector(
+    batch: Any, options: SummaryOptions | None = None, *, autorun: bool = True, **overrides
+) -> BatchCollector:
+    """Convenience :class:`BatchCollector` bound to :func:`collect_summaries`."""
+    return BatchCollector(
+        batch, collect_summaries, options, autorun=autorun, **overrides
+    )
+
+
+def cycles_collector(
+    batch: Any, options: CurveOptions | None = None, *, autorun: bool = True, **overrides
+) -> BatchCollector:
+    """Convenience :class:`BatchCollector` bound to :func:`collect_cycles`."""
+    return BatchCollector(batch, collect_cycles, options, autorun=autorun, **overrides)
+
+
+def normalize_column(
+    column: str, norm_factor: float, out: str | None = None
+) -> Callable[[pl.DataFrame], pl.DataFrame]:
+    """Build a transform that adds ``100 * column / norm_factor`` as a new series.
+
+    Works on both the wide (non-grouped) frame -- adding an ``<out>`` column --
+    and the grouped long frame -- adding an ``<out>`` *variable* with ``mean``
+    (and ``std``) scaled. Missing columns are left untouched.
+    """
+    target = out or f"{column}_norm"
+
+    def _transform(frame: pl.DataFrame) -> pl.DataFrame:
+        if "variable" in frame.columns and "mean" in frame.columns:
+            sub = frame.filter(pl.col("variable") == column)
+            if sub.height == 0:
+                return frame
+            exprs = [
+                pl.lit(target).alias("variable"),
+                (100 * pl.col("mean") / norm_factor).alias("mean"),
+            ]
+            if "std" in sub.columns:
+                exprs.append((100 * pl.col("std") / norm_factor).alias("std"))
+            return pl.concat([frame, sub.with_columns(exprs)], how="diagonal_relaxed")
+        if column in frame.columns:
+            return frame.with_columns(
+                (100 * pl.col(column) / norm_factor).alias(target)
+            )
+        return frame
+
+    return _transform
+
+
+def standard_gravimetric(
+    batch: Any,
+    norm_factor: float = 120.0,
+    *,
+    group_it: bool = True,
+    columns: tuple[str, ...] = (
+        "charge_capacity",
+        "discharge_capacity",
+        "coulombic_efficiency",
+    ),
+    retention_on: str = "discharge_capacity",
+    autorun: bool = True,
+    **overrides,
+) -> BatchCollector:
+    """The standard gravimetric summary recipe.
+
+    Successor of ``collectors.standard_gravimetric_collector``: collect the
+    charge/discharge/CE metrics, partition capacity by CV step, average per
+    group, and add a normalized discharge-capacity-retention series
+    (``100 * discharge / norm_factor``). Uses native cellpycore column names
+    (the legacy ``*_gravimetric`` suffix is not part of the native schema).
+    The figure itself lands with the plotting handover in B4 (#708).
+    """
+    options = SummaryOptions(
+        columns=columns,
+        partition_by_cv=True,
+        group_it=group_it,
+        transforms=(normalize_column(retention_on, norm_factor),),
+    )
+    return BatchCollector(
+        batch, collect_summaries, options, autorun=autorun, **overrides
+    )

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -10,12 +10,16 @@ from cellpy.batch import Batch, Journal
 from cellpy.batch.journal import FILENAME
 from cellpy.batch.store import CellStore
 from cellpy.collect import (
+    BatchCollector,
     Collection,
     CollectionMeta,
     SummaryOptions,
     collect_cycles,
     collect_summaries,
     load_collection,
+    normalize_column,
+    standard_gravimetric,
+    summary_collector,
 )
 from tests import fdv
 
@@ -164,6 +168,72 @@ def test_collect_summaries_group_average_needs_group_column():
     b = _batch_with_cells({"x": _SummaryCell([1.0, 2.0])}, pages)
     col = collect_summaries(b, group_it=True)
     assert "variable" not in col.data.columns
+
+
+# ---- BatchCollector convenience + recipes (#707) ------------------------
+
+
+def test_batch_collector_autoruns_and_exposes_data(real_batch):
+    bc = BatchCollector(real_batch, collect_summaries, columns=("charge_capacity",))
+    assert bc.collection.kind == "summary"
+    assert "charge_capacity" in bc.data.columns
+
+
+def test_batch_collector_no_autorun_then_update(real_batch):
+    bc = BatchCollector(real_batch, collect_summaries, autorun=False)
+    assert bc._collection is None
+    bc.update(max_cycle=3)
+    assert bc.data["cycle_num"].max() <= 3
+
+
+def test_batch_collector_plot_points_to_b4(real_batch):
+    bc = summary_collector(real_batch)
+    with pytest.raises(NotImplementedError, match="#708"):
+        bc.plot()
+
+
+def test_batch_collector_save(real_batch, tmp_path):
+    bc = summary_collector(real_batch, columns=("charge_capacity",))
+    written = bc.save(tmp_path)
+    assert any(p.suffix == ".json" for p in written)
+
+
+def test_normalize_column_wide():
+    frame = pl.DataFrame({"cycle_num": [1, 2], "discharge_capacity": [60.0, 120.0]})
+    out = normalize_column("discharge_capacity", 120.0)(frame)
+    assert out["discharge_capacity_norm"].to_list() == [50.0, 100.0]
+
+
+def test_normalize_column_long():
+    frame = pl.DataFrame(
+        {
+            "group": [1, 1],
+            "cycle_num": [1, 2],
+            "variable": ["discharge_capacity", "discharge_capacity"],
+            "mean": [60.0, 120.0],
+            "std": [0.0, 0.0],
+        }
+    )
+    out = normalize_column("discharge_capacity", 120.0)(frame)
+    norm = out.filter(pl.col("variable") == "discharge_capacity_norm").sort("cycle_num")
+    assert norm["mean"].to_list() == [50.0, 100.0]
+
+
+def test_standard_gravimetric_recipe():
+    pages = pl.DataFrame(
+        {FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]}
+    )
+    b = _batch_with_cells(
+        {"x": _SummaryCell([60.0, 120.0]), "y": _SummaryCell([80.0, 160.0])}, pages
+    )
+    bc = standard_gravimetric(
+        b, norm_factor=120.0, columns=("charge_capacity",), retention_on="charge_capacity"
+    )
+    data = bc.data
+    # grouped long format with a normalized retention variable added
+    variables = set(data["variable"].to_list())
+    assert "charge_capacity" in variables
+    assert "charge_capacity_norm" in variables
 
 
 # ---- collect_cycles: the cross-cell narrowing bug is fixed by design ----


### PR DESCRIPTION
## Epic B, arc B3 (#707) — the convenience layer

New thin convenience layer in `cellpy/collect/collector.py`, successor of the legacy `utils.collectors.BatchCollector` family. **Additive only** — no legacy or plotting files touched.

### What's new
- **`BatchCollector`** — run a collect callable, hold the `Collection`, expose `data` / `save` / `plot` / `update`. Replaces the "elevated arguments" machinery (~20 parameters redeclared per subclass and merged through three priority layers, collectors.py:969/1202/1316) with a single options object + a collect function.
- **`summary_collector` / `cycles_collector`** — bound convenience factories.
- **`normalize_column`** — transform builder adding `100 * col / norm_factor`, working on both the wide (non-grouped) frame and the grouped long frame.
- **`standard_gravimetric`** — the standard recipe (charge/discharge/CE, `partition_by_cv`, group averaging, normalized discharge retention), using native cellpycore column names (the legacy `*_gravimetric` suffix is not part of the native schema).

### Re-sequencing note
The `utils.collectors` **shim + un-xfail is folded into B4** (#708) rather than here: the legacy `collectors` module is coupled to the plotting package (`BatchCollector` → `cellpy.plotting.collected_plot`, and `test_plotting_package.py` imports it un-xfailed), so its replacement belongs with the plotting handover. `BatchCollector.plot()` raises a clear `NotImplementedError` pointing to #708 until then.

### Tests
`tests/test_collect.py` — autorun/update, save, plot→B4 pointer, `normalize_column` (wide + long), and the `standard_gravimetric` recipe. Full local collect run: 19 passed.

Closes #707