### PR TITLE
D2: surface per-test metadata as Batch.tests (#711)

### DIFF
--- a/cellpy/batch/__init__.py
+++ b/cellpy/batch/__init__.py
@@ -39,7 +39,7 @@ from cellpy.batch.result import (
 from cellpy.batch.runner import load_cell, run
 from cellpy.batch.store import CellStore
 from cellpy.batch import aggregate, outputs, qc
-from cellpy.batch.aggregate import combine_summaries
+from cellpy.batch.aggregate import combine_summaries, combine_tests
 from cellpy.batch.db import journal_from_db
 from cellpy.batch.facade import Batch, from_journal, load
 
@@ -51,6 +51,7 @@ __all__ = [
     "qc",
     "outputs",
     "combine_summaries",
+    "combine_tests",
     "Journal",
     "read_journal",
     "write_journal",

--- a/cellpy/batch/aggregate.py
+++ b/cellpy/batch/aggregate.py
@@ -46,6 +46,65 @@ def _summary_of(cell: Any) -> pl.DataFrame | None:
         return None
 
 
+#: Scalar TestMeta fields surfaced by :func:`combine_tests` (skips nested/object
+#: fields like ``cell``; ``raw_file_names`` is joined to a string).
+_TEST_FIELDS = (
+    "test_id",
+    "cell_name",
+    "cycle_mode",
+    "test_family",
+    "test_type",
+    "source_type",
+    "source_uri",
+    "channel",
+    "creator",
+    "start_datetime",
+    "loaded_datetime",
+    "voltage_lim_low",
+    "voltage_lim_high",
+    "comment",
+)
+
+
+def _tests_of(cell: Any) -> list[dict[str, Any]]:
+    """Per-test metadata records of a cell as plain dicts (native fields only)."""
+    data = getattr(cell, "data", None)
+    collection = getattr(data, "tests", None)
+    if collection is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for record in collection:
+        row = {f: getattr(record, f, None) for f in _TEST_FIELDS}
+        raw_files = getattr(record, "raw_file_names", None)
+        if raw_files:
+            row["raw_file_names"] = "; ".join(str(p) for p in raw_files)
+        rows.append(row)
+    return rows
+
+
+def combine_tests(
+    cells: Mapping[str, Any], journal: Journal | None = None
+) -> pl.DataFrame:
+    """Per-test metadata across the batch as one tidy long-format frame.
+
+    One row per (cell, ``test_id``) carrying the native ``TestMeta`` fields plus
+    ``cell``/``group``/``sub_group`` keys. Surfaces the per-test records that a
+    merged (campaign) cell holds in ``Data.tests`` (#506) at the batch level.
+    Returns an empty frame when no cell exposes test metadata.
+    """
+    lookup = _group_lookup(journal)
+    rows: list[dict[str, Any]] = []
+    for label, cell in cells.items():
+        group, sub_group = lookup.get(label, (None, None))
+        for row in _tests_of(cell):
+            rows.append(
+                {"cell": label, "group": group, "sub_group": sub_group, **row}
+            )
+    if not rows:
+        return pl.DataFrame()
+    return pl.DataFrame(rows)
+
+
 def combine_summaries(
     cells: Mapping[str, Any], journal: Journal | None = None
 ) -> pl.DataFrame:

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -122,6 +122,16 @@ class Batch:
         self._summaries = aggregate.combine_summaries(self._store, self.journal)
         return self._summaries
 
+    @property
+    def tests(self) -> pl.DataFrame:
+        """Per-test metadata across the batch (tidy long-format, #506/F6-D2).
+
+        One row per (cell, ``test_id``) with the native ``TestMeta`` fields plus
+        ``cell``/``group``/``sub_group`` keys -- the per-test records a merged
+        (campaign) cell carries. Empty frame if no cell exposes test metadata.
+        """
+        return aggregate.combine_tests(self._store, self.journal)
+
     def make_summaries(self) -> pl.DataFrame:
         return self.combine_summaries()
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -221,6 +221,47 @@ def test_normalize_column_long():
     assert norm["mean"].to_list() == [50.0, 100.0]
 
 
+# ---- Batch.tests: per-test metadata surface (F6 D2, #711) ---------------
+
+
+class _TestRecord:
+    def __init__(self, test_id, cell_name, cycle_mode="anode"):
+        self.test_id = test_id
+        self.cell_name = cell_name
+        self.cycle_mode = cycle_mode
+        self.raw_file_names = [f"{cell_name}.res"]
+
+
+class _MultiTestCell:
+    """A cell whose ``data.tests`` yields several per-test metadata records."""
+
+    def __init__(self, records):
+        self.data = SimpleNamespace(tests=records)
+
+
+def test_batch_tests_surfaces_per_test_metadata():
+    pages = pl.DataFrame({FILENAME: ["m"], "group": [1], "sub_group": [1]})
+    cell = _MultiTestCell(
+        [_TestRecord(0, "cell_A"), _TestRecord(1, "cell_B", cycle_mode="full")]
+    )
+    b = _batch_with_cells({"m": cell}, pages)
+
+    frame = b.tests
+    assert frame.height == 2  # one row per test_id
+    for key in ("cell", "group", "sub_group", "test_id", "cell_name", "cycle_mode"):
+        assert key in frame.columns
+    assert set(frame["test_id"].to_list()) == {0, 1}
+    assert frame.filter(pl.col("test_id") == 1)["cycle_mode"].item() == "full"
+    # list field flattened to a string
+    assert frame["raw_file_names"].dtype == pl.Utf8
+
+
+def test_batch_tests_empty_without_metadata():
+    pages = pl.DataFrame({FILENAME: ["x"]})
+    b = _batch_with_cells({"x": _SummaryCell([1.0])}, pages)  # no .data.tests
+    assert b.tests.height == 0
+
+
 def test_standard_gravimetric_recipe():
     pages = pl.DataFrame(
         {FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]}


### PR DESCRIPTION
## Epic D, arc D2 (#711) — test-level summaries in batch reports

Surfaces the per-test `TestMeta` records a cell carries in `Data.tests` (#506) at the batch level as a tidy long-format frame.

- **`aggregate.combine_tests(cells, journal)`** — one row per (cell, `test_id`) with the native scalar `TestMeta` fields (`cell_name`, `cycle_mode`, `test_family`/`type`, `source_type`/`uri`, `channel`, `creator`, start/loaded datetimes, voltage limits, comment) plus `cell`/`group`/`sub_group` keys. `raw_file_names` flattened to a string; nested/object fields skipped. Empty frame when no cell exposes metadata.
- **`Batch.tests`** property returning it; `combine_tests` exported from `cellpy.batch`.

### Note on scope
The issue referenced core `build_tests_summary` (ROADMAP) — that function **isn't in cellpycore yet** (it exists only as a docstring example). But the per-test metadata already lives on `Data.tests`, so this is delivered **app-side** with no core dependency, satisfying the acceptance (per-test summaries exposed, tidy long-format, native columns). A future core `build_tests_summary` could enrich each row with per-test *summary stats* on top of this metadata surface.

Verified on a real cell (1 test → 1 row) and a multi-test fake (2 `test_id`s → 2 rows).

Closes #711