### PR TITLE
E3 (partial): remove make_new_cell (#715)

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -9,4 +9,3 @@ uv run python -m cellpy._deprecation
 | Name | Replacement | Introduced | Removal |
 | --- | --- | --- | --- |
 | `legacy header attribute access (headers_normal / _summary / _step_table)` | `c.schema.raw / c.schema.steps / c.schema.summary` | 2.0 | 2.1 |
-| `make_new_cell` | `CellpyCell.vacant` | 2.0 | 2.1 |

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -93,7 +93,7 @@ def write_deprecations_md(path: str | Path) -> None:
 
 def _seed_known_deprecations() -> None:
     """Register deprecations that exist before any runtime call (for doc generation)."""
-    _register("make_new_cell", "CellpyCell.vacant", removal="2.1")
+    # make_new_cell was removed in 2.1 (E3, #715) -- use CellpyCell.vacant.
     # Legacy header attribute access (headers_normal.voltage_txt, hdr_steps.cycle,
     # hdr_summary[...]) is shimmed to the native cellpycore schema names at the
     # native-headers flip (D6). One summary row here; the shim warns per attribute

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -215,15 +215,6 @@ def update_journal_cellpy_data_dir(
     return pages
 
 
-def make_new_cell():
-    """create an empty CellpyCell object."""
-    from cellpy._deprecation import warn_once
-
-    warn_once("make_new_cell", "CellpyCell.vacant")
-    new_cell = cellpy.cellreader.CellpyCell(initialize=True)
-    return new_cell
-
-
 def add_normalized_cycle_index(summary, nom_cap, column_name=None):
     """Adds normalized cycles to the summary data frame.
 

--- a/tests/test_deprecation_conventions.py
+++ b/tests/test_deprecation_conventions.py
@@ -13,7 +13,6 @@ from cellpy.exceptions import (
     LoaderError,
     UnitsError,
 )
-from cellpy.utils.helpers import make_new_cell
 
 
 @pytest.mark.essential
@@ -52,17 +51,11 @@ def test_warn_once_registers_for_deprecations_md():
 
 
 @pytest.mark.essential
-def test_make_new_cell_uses_warn_once():
-    _deprecation._WARNED_SITES.clear()
+def test_make_new_cell_removed():
+    # make_new_cell was removed in 2.1 (E3, #715); use CellpyCell.vacant.
+    import cellpy.utils.helpers as helpers
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", DeprecationWarning)
-        make_new_cell()
-        make_new_cell()
-
-    make_new_cell_warnings = [w for w in caught if "make_new_cell" in str(w.message)]
-    assert len(make_new_cell_warnings) == 1
-    assert "CellpyCell.vacant" in str(make_new_cell_warnings[0].message)
+    assert not hasattr(helpers, "make_new_cell")
 
 
 @pytest.mark.essential


### PR DESCRIPTION
## Epic E, arc E3 — partial: `make_new_cell`

Removes `make_new_cell`, a deprecated one-line shim over `CellpyCell.vacant` (`removal: 2.1`). This is the small, **fully-unblocked** half of E3, landed on its own so the big `headers_*` migration can follow separately.

- Deleted `make_new_cell` from `cellpy/utils/helpers.py`.
- Dropped its `_deprecation` seed row + regenerated `DEPRECATIONS.md`.
- Converted its `warn_once` test into a "removed" check.

The larger E3 work — migrating `headers_normal`/`headers_summary`/`headers_step_table` attribute access (~57 runtime + ~110 test sites, field-mapped to `schema.*`) then deleting the properties — remains under #715 and will land as its own PR(s).

Refs #715