### PR TITLE
E3 (runtime part 1): migrate direct headers_* accesses to native (#715)

### DIFF
--- a/cellpy/exporters/tabular.py
+++ b/cellpy/exporters/tabular.py
@@ -446,9 +446,9 @@ def cap_mod_normal(cell: "CellpyCell", capacity_modifier="reset", allctypes=True
     cycle_index_header = cell.schema.raw.cycle_num
     step_index_header = cell.schema.raw.step_num
     discharge_index_header = cell.schema.raw.cumulative_discharge_capacity
-    discharge_energy_index_header = cell.headers_normal.discharge_energy_txt
+    discharge_energy_index_header = cell.schema.raw.cumulative_discharge_energy
     charge_index_header = cell.schema.raw.cumulative_charge_capacity
-    charge_energy_index_header = cell.headers_normal.charge_energy_txt
+    charge_energy_index_header = cell.schema.raw.cumulative_charge_energy
 
     raw = cell.data.raw
 

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -2170,8 +2170,8 @@ class CellpyCell:
             return out
 
         out = dict()
-        # ustep is legacy-only (no native column) -> resolved via the D6 shim
-        step_hdr = self.headers_step_table.ustep if usteps else shdr.step_num
+        # ustep is legacy-only (no native column); kept as a literal name
+        step_hdr = "ustep" if usteps else shdr.step_num
         for cycle in cycle_numbers:
             steplist = []
             for s in steptypes:
@@ -2375,7 +2375,7 @@ class CellpyCell:
     def _select_usteps(self, cycle: int, steps: Union[list, np.ndarray]):
         # TODO: @jepe - insert sub_step here
         s_hdr = self.schema.steps.step_num
-        us_hdr = self.headers_step_table.ustep
+        us_hdr = "ustep"
         c_txt = self.schema.raw.cycle_num
         s_txt = self.schema.raw.step_num
         steps = self.data.steps.loc[self.data.steps[us_hdr].isin(steps), s_hdr].unique()
@@ -2778,7 +2778,7 @@ class CellpyCell:
             ``pandas.DataFrame`` (or list of ``pandas.Series`` if cycle=None and as_frame=False)
         """
 
-        y_header = self.headers_normal.datetime_txt
+        y_header = "date_time"
         return self.get_raw(
             y_header,
             cycle=cycle,
@@ -2902,7 +2902,7 @@ class CellpyCell:
         return self._sget(cycle, step, header)
 
     def _using_usteps(self):
-        if self.headers_step_table.ustep in self.data.steps.columns:
+        if "ustep" in self.data.steps.columns:
             return True
         return False
 
@@ -3227,7 +3227,7 @@ class CellpyCell:
                 f"seconds."
             )
 
-        date_time_hdr = self.headers_normal.datetime_txt
+        date_time_hdr = "date_time"
         cycle_index_hdr = self.schema.raw.cycle_num
         voltage_hdr = self.schema.raw.potential
         date_time_format = prms._date_time_format
@@ -3944,7 +3944,7 @@ class CellpyCell:
             else:
                 logging.debug("sorting columns")
                 new_first_col_list = [
-                    self.headers_normal.datetime_txt,
+                    "date_time",
                     self.schema.raw.test_time,
                     self.schema.raw.datapoint_num,
                     self.schema.raw.cycle_num,

--- a/cellpy/readers/slicing.py
+++ b/cellpy/readers/slicing.py
@@ -42,8 +42,8 @@ def _mod_raw_split_cycle(cell: "CellpyCell", data_point: int) -> None:
     hdr_cycle = cell.schema.raw.cycle_num
     hdr_c_cap = cell.schema.raw.cumulative_charge_capacity
     hdr_d_cap = cell.schema.raw.cumulative_discharge_capacity
-    hdr_c_energy = cell.headers_normal.charge_energy_txt
-    hdr_d_energy = cell.headers_normal.discharge_energy_txt
+    hdr_c_energy = cell.schema.raw.cumulative_charge_energy
+    hdr_d_energy = cell.schema.raw.cumulative_discharge_energy
 
     # modifying cycle numbers
     c_mask = r[hdr_data_point] >= data_point


### PR DESCRIPTION
## Epic E, arc E3 — runtime migration, part 1

First slice of the `headers_* → schema.*` migration, plus an important **scoping correction**: the deprecated surface is *only* the `CellpyCell.headers_normal`/`headers_summary`/`headers_step_table` **property** accesses (the `LegacyHeaderShim` that warns and maps to native). The module-level `headers_normal` singleton that the instrument loaders use for **pre-boundary column naming does not warn** and is out of scope — so this is a ~70-site migration, not the ~167 the raw grep suggested.

### Migrated (10 direct property accesses, non-loader runtime)
- `cellreader.py`: `self.headers_step_table.ustep` → `"ustep"` (legacy-only, no native column; the sites already guard `if "ustep" in ...steps.columns`) and `self.headers_normal.datetime_txt` → `"date_time"`.
- `exporters/tabular.py` + `readers/slicing.py`: `cell.headers_normal.charge/discharge_energy_txt` → `cell.schema.raw.cumulative_charge/discharge_energy`.

Every replacement is the **exact string the shim resolved to**, so behaviour is preserved. `test_cell_readers` green (97 passed). Tree stays green — the shim properties remain until the migration completes.

### Remaining (follow-up)
The assign-to-variable pattern (`hdr = c.headers_summary; hdr.<legacy_attr>`) needs per-attribute field mapping, concentrated in `utils/helpers.py` (~35), `plotutils.py` (~10), `plotting/prepare/summary.py` (~8), `capacity_curves.py`, `bdf.py`, `plotting/context.py`. That part completes the runtime migration and lets the shim properties be removed (the final E3 PR).

Refs #715