### PR TITLE
E3 (runtime part 2): migrate headers_* resolvers to native (#715)

### DIFF
--- a/cellpy/plotting/context.py
+++ b/cellpy/plotting/context.py
@@ -25,10 +25,6 @@ class CellContext:
         return self.cell.data.summary
 
     @property
-    def headers_summary(self) -> Any:
-        return self.cell.headers_summary
-
-    @property
     def schema(self) -> Any:
         return self.cell.schema
 

--- a/cellpy/plotting/prepare/summary.py
+++ b/cellpy/plotting/prepare/summary.py
@@ -189,7 +189,7 @@ def _build_figure_spec(
 
     panels = tuple(
         PanelSpec(
-            columns=tuple(family.columns(c.headers_summary)) if i == 0 else (),
+            columns=tuple(family.columns(c.schema.summary)) if i == 0 else (),
             y_axis=AxisSpec(),
         )
         for i in range(max(number_of_rows, 1))
@@ -502,8 +502,8 @@ class SummaryPlotDataPreparer:
 
         if missing_columns and y == "capacities_absolute":
             # For absolute capacities, if _absolute columns don't exist, use base columns
-            hdr = c.headers_summary
-            base_columns = [hdr.charge_capacity_raw, hdr.discharge_capacity_raw]
+            hdr = c.schema.summary
+            base_columns = [hdr.charge_capacity, hdr.discharge_capacity]
             # Check if base columns exist
             if all(col in available_columns for col in base_columns):
                 column_set = base_columns
@@ -552,7 +552,7 @@ class SummaryPlotDataPreparer:
                 s.loc[s["variable"].str.contains("efficiency"), self.row] = 0
                 number_of_rows = 2
             elif y.endswith("_with_rate"):
-                hdr = c.headers_summary
+                hdr = c.schema.summary
                 rate_cols = {hdr.charge_c_rate, hdr.discharge_c_rate}
                 s[self.row] = 1
                 s.loc[s["variable"].isin(rate_cols), self.row] = 0
@@ -664,7 +664,7 @@ class SummaryPlotDataPreparer:
         * ``config.filters`` is forwarded to
           :func:`cellpy.filters.filter_summary`. The default
           ``rate_filter_columns`` resolves to both rate columns from
-          ``c.headers_summary`` (charge AND discharge).
+          ``c.schema.summary`` (charge AND discharge).
 
         Operates on a copy; the caller's ``summary`` argument is not
         mutated.
@@ -672,7 +672,7 @@ class SummaryPlotDataPreparer:
         out = summary.copy() if summary is not None else summary
 
         if config.nominal_capacity is not None:
-            hdr = c.headers_summary
+            hdr = c.schema.summary
             old_nom_cap = getattr(c.data, "nom_cap", None)
             if old_nom_cap in (None, 0):
                 logging.warning(
@@ -696,7 +696,7 @@ class SummaryPlotDataPreparer:
         if config.filters:
             from cellpy.filters import filter_summary
 
-            hdr = c.headers_summary
+            hdr = c.schema.summary
             filter_kwargs = dict(config.filters)
             if (
                 "rate" in filter_kwargs

--- a/cellpy/plotting/registry.py
+++ b/cellpy/plotting/registry.py
@@ -2,7 +2,7 @@
 ``SummaryPlotInfo._create_col_info`` column table (#636 / epic #567).
 
 Column names for summary families are header-bound (they depend on
-``c.headers_summary``), so each family carries a small resolver rather than a
+``c.schema.summary``), so each family carries a small resolver rather than a
 frozen list of strings. Non-summary families (e.g. ``cycles`` for
 ``cycles_plot``, #646) register with ``extras["entry_point"]`` so
 ``families(entry_point=...)`` / the summary oracle stay scoped.
@@ -107,7 +107,7 @@ def _register_family(family: PlotFamily) -> None:
 
 
 def _cap_raw(hdr: Any) -> list[str]:
-    return [hdr.charge_capacity_raw, hdr.discharge_capacity_raw]
+    return [hdr.charge_capacity, hdr.discharge_capacity]
 
 
 def _caps(hdr: Any, mode: str) -> list[str]:
@@ -121,7 +121,7 @@ def _split(cols: list[str]) -> list[str]:
 def _cumloss_columns(hdr: Any, mode: str) -> list[str]:
     return [
         hdr.charge_capacity + f"_{mode}" + "_cv",
-        hdr.cumulated_discharge_capacity_loss + f"_{mode}",
+        hdr.test_cumulated_discharge_capacity_loss + f"_{mode}",
         hdr.discharge_capacity + f"_{mode}",
         hdr.coulombic_efficiency,
     ]
@@ -137,7 +137,7 @@ def _fullcell_columns(hdr: Any, mode: str) -> list[str]:
 
 
 def _cumloss_transforms(hdr: Any, normalize_col: Callable[..., Any], mode: str) -> dict[str, Any]:
-    key = hdr.cumulated_discharge_capacity_loss + f"_{mode}"
+    key = hdr.test_cumulated_discharge_capacity_loss + f"_{mode}"
     return {key: {(2, key): normalize_col}}
 
 
@@ -152,7 +152,7 @@ def _register_builtin_families() -> None:
         PlotFamily(
             name="voltages",
             description="End-of-charge and end-of-discharge voltages vs cycle",
-            column_builder=lambda hdr: [hdr.end_voltage_charge, hdr.end_voltage_discharge],
+            column_builder=lambda hdr: [hdr.potential_end_charge, hdr.potential_end_discharge],
             mode=None,
         ),
         PlotFamily(

--- a/cellpy/readers/capacity_curves.py
+++ b/cellpy/readers/capacity_curves.py
@@ -640,10 +640,10 @@ def get_ocv(
     steps = cell.data.steps
     raw = cell.data.raw
 
-    hdr_steps = cell.headers_step_table
-    steps_cycle = hdr_steps.cycle
-    steps_step = hdr_steps.step
-    steps_type = hdr_steps.type
+    step_hdr = cell.schema.steps
+    steps_cycle = step_hdr.cycle_num
+    steps_step = step_hdr.step_num
+    steps_type = step_hdr.step_type
 
     ocv_steps = steps.loc[steps[steps_cycle].isin(cycles), :]
 

--- a/cellpy/utils/helpers.py
+++ b/cellpy/utils/helpers.py
@@ -1537,10 +1537,10 @@ def select_summary_based_on_rate(
     Returns:
         filtered summary (Pandas.DataFrame).
     """
-    # use the cell's own headers (native names via the shim after the flip)
-    # rather than the module-level legacy singletons.
-    hdr_steps = cell.headers_step_table
-    hdr_summary = cell.headers_summary
+    # native header access (#715): use the cell's schema, not the deprecated
+    # headers_step_table / headers_summary property shims.
+    step_hdr = cell.schema.steps
+    summary_hdr = cell.schema.summary
 
     if on is None:
         on = [StepType.CHARGE.value]
@@ -1549,10 +1549,10 @@ def select_summary_based_on_rate(
             on = [on]
 
     if rate_column is None:
-        rate_column = hdr_steps.rate_avr
+        rate_column = step_hdr.c_rate
 
     if on:
-        on_column = hdr_steps.type
+        on_column = step_hdr.step_type
 
     if rate is None:
         rate = 0.05
@@ -1560,7 +1560,7 @@ def select_summary_based_on_rate(
     if rate_std is None:
         rate_std = 0.1 * rate
 
-    cycle_number_header = hdr_summary.cycle_index
+    cycle_number_header = summary_hdr.cycle_num
 
     step_table = cell.data.steps
 
@@ -1597,7 +1597,7 @@ def select_summary_based_on_rate(
         cycles_mask = ~cycles_mask
 
     filtered_step_table = step_table[cycles_mask]
-    filtered_cycles = filtered_step_table[hdr_steps.cycle].unique()
+    filtered_cycles = filtered_step_table[step_hdr.cycle_num].unique()
 
     if inverted:
         filtered_index = summary.index.difference(filtered_cycles)

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -750,12 +750,12 @@ class SummaryPlotInfo:
 
         """
 
-        hdr = c.headers_summary
+        hdr = c.schema.summary
         x_axis_labels = {
-            hdr.cycle_index: "Cycle Number",
-            hdr.data_point: "Point",
-            hdr.test_time: with_cellpy_unit("Test Time", "time", units=c.cellpy_units),
-            hdr.datetime: "Date",
+            hdr.cycle_num: "Cycle Number",
+            hdr.datapoint_num_last: "Point",
+            hdr.last_test_time: with_cellpy_unit("Test Time", "time", units=c.cellpy_units),
+            "date_time": "Date",
             hdr.normalized_cycle_index: "Equivalent Full Cycle",  # hdr.normalized_cycle_index: "Normalized Cycle Number",
         }
 
@@ -883,7 +883,7 @@ class SummaryPlotInfo:
 
         Thin adapter over :mod:`cellpy.plotting.registry` (#636). Column-set
         selection for named ``y`` values lives in ``PlotFamily`` records; this
-        method only materialises them against ``c.headers_summary``. Keep in
+        method only materialises them against ``c.schema.summary``. Keep in
         sync with :meth:`_create_label_dict`.
 
         Args:
@@ -894,13 +894,13 @@ class SummaryPlotInfo:
 
         """
 
-        hdr = c.headers_summary
+        hdr = c.schema.summary
         x_columns = (
             [
-                hdr.cycle_index,
-                hdr.data_point,
-                hdr.test_time,
-                hdr.datetime,
+                hdr.cycle_num,
+                hdr.datapoint_num_last,
+                hdr.last_test_time,
+                "date_time",
                 hdr.normalized_cycle_index,
             ],
         )


### PR DESCRIPTION
## Epic E, arc E3 — runtime migration, part 2

Second slice of `headers_* → schema.*`: the **assign-to-variable** and **family-resolver** patterns (`hdr = c.headers_summary; hdr.<legacy_attr>`). Scope stayed small because most `hdr_summary`/`hdr_steps` usage is the module-level `get_headers_*` singleton (**not** deprecated) — only the functions that shadow with `cell.headers_*` are the shim.

### Migrated
- **`utils/helpers.py`** — `select_summary_based_on_rate` → `cell.schema.steps`/`cell.schema.summary`.
- **`readers/capacity_curves.py`** — `get_ocv` step lookup → `cell.schema.steps`.
- **`plotting/registry.py`** — the summary family resolvers use native attr names (`charge_capacity_raw`→`charge_capacity`, `cumulated_discharge_capacity_loss`→`test_cumulated_discharge_capacity_loss`, `end_voltage_*`→`potential_end_*`).
- **`plotting/prepare/summary.py`** + **`utils/plotutils.py`** — `hdr = c.schema.summary`; downstream attrs renamed to native (`cycle_index`→`cycle_num`, `data_point`→`datapoint_num_last`, `test_time`→`last_test_time`, `datetime`→`"date_time"`).
- **`plotting/context.py`** — removed the deprecated `headers_summary` passthrough property (no consumers remain).

Every native name was resolved via the runtime shim, so behaviour is preserved. **Verified:** `test_figure_specs` / `test_plotutils_headers` / `test_ocv_relax` / `test_cv_partition` → **89 passed**.

### Deferred
`exporters/bdf.py` keeps the shim for now — its `_COLUMN_MAP` is keyed by **legacy `_txt` field names** via `getattr(headers, spec.cellpy_field)`, so it needs a dedicated map→native migration (a small follow-up). Once bdf.py lands, the shim **properties can be removed** (the final E3 PR).

Refs #715