### PR TITLE
Fix batch-summary benchmark: use native combine_summaries, drop xfail

### DIFF
--- a/benchmarks/test_performance.py
+++ b/benchmarks/test_performance.py
@@ -49,22 +49,18 @@ def test_benchmark_single_cell_pipeline(benchmark):
     benchmark.pedantic(run, iterations=1, warmup_rounds=1)
 
 
-@pytest.mark.xfail(
-    reason="helpers.concat_summaries migrates onto polars in Epic C (#706); "
-    "benchmark re-baselines against cellpy.batch.combine_summaries then",
-    strict=False,
-)
 def test_benchmark_batch_summary_collection(benchmark, batch_twenty_cells):
-    """Batch summary collection on 20 cells (``concat_summaries``, same path as collector)."""
-    from cellpy.utils.helpers import concat_summaries
+    """Batch summary collection on 20 cells.
+
+    Exercises ``cellpy.batch.combine_summaries`` via ``Batch.combine_summaries``
+    -- the native polars collector path (Epic B/C), which replaced the pandas
+    ``helpers.concat_summaries`` this benchmark used before the flip.
+    """
 
     def run():
-        frame = concat_summaries(
-            batch_twenty_cells,
-            columns=["charge_capacity_gravimetric"],
-        )
+        frame = batch_twenty_cells.combine_summaries()
         assert frame is not None
-        assert not frame.empty
+        assert not frame.is_empty()
 
     benchmark.pedantic(run, iterations=1, warmup_rounds=0)
 


### PR DESCRIPTION
## Problem
The benchmark CI check fails with:
```
missing benchmark 'test_benchmark_batch_summary_collection' in current run
```

`test_benchmark_batch_summary_collection` was `xfail`ed pending the Epic C polars migration, still calling the old pandas `helpers.concat_summaries` — which now raises `AttributeError: 'DataFrame' object has no attribute 'index'` on the polars summary frames. An **xfailed benchmark records no result**, so `check_baseline.py` sees it absent from the current run and fails (it treats a baseline benchmark missing from the run as a regression).

## Fix
Epic B/C is done, so this does what the xfail note said to do "then": migrate the benchmark to the **native collector path** — `Batch.combine_summaries()` → `cellpy.batch.combine_summaries` (returns a polars frame) — and remove the `xfail`. The benchmark runs and records a result again.

## Verification
- `pytest benchmarks/test_performance.py::test_benchmark_batch_summary_collection --benchmark-only` → **1 passed** (was `1 xfailed`).
- Local mean ≈ 1.19× the committed ubuntu baseline — under the +20% warn line and far under the +100% hard-fail line, so `check_baseline.py` no longer reports it missing. The committed baseline value can be refreshed on CI when convenient (it was captured against the old pandas path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)