### PR TITLE
Audit DEPRECATIONS.md: seed pending 2.2 deprecations + note kept facades (E5, #717)

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -8,3 +8,5 @@ uv run python -m cellpy._deprecation
 
 | Name | Replacement | Introduced | Removal |
 | --- | --- | --- | --- |
+| `MultiCycleOcvFit.data` | `MultiCycleOcvFit.cell` | 2.1 | 2.2 |
+| `MultiCycleOcvFit.set_data` | `MultiCycleOcvFit.set_cell` | 2.1 | 2.2 |

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -108,6 +108,30 @@ def _seed_known_deprecations() -> None:
     # Plotting shims (interactive=, xlim/ylim, backend="seaborn", summary_plot_legacy)
     # were removed in 2.1 (E1, #713) -- no longer registered here.
 
+    # The prms.* global-mutation shim (prms.Paths/Reader/... -> cellpy.config.*)
+    # was removed in 2.1 (E5, #717) -- use cellpy.config (e.g. config.paths.x = y)
+    # or cellpy.config.override(...). Not a pending deprecation, so not listed.
+
+    # KEPT past 2.1 (E5, #717): the CellpyCell.mass / .nom_cap / .nom_cap_specifics
+    # property facades are beloved and cheap -- deliberately NOT deprecated, so
+    # they are intentionally absent from this table.
+
+    # ocv_rlx: MultiCycleOcvFit.data/set_data were renamed to cell/set_cell in
+    # 2.1 (#709); the old names stay as deprecated aliases until 2.2. Seeded so
+    # the table lists them without needing to trigger the runtime warning.
+    _register(
+        "MultiCycleOcvFit.data",
+        "MultiCycleOcvFit.cell",
+        removal="2.2",
+        introduced="2.1",
+    )
+    _register(
+        "MultiCycleOcvFit.set_data",
+        "MultiCycleOcvFit.set_cell",
+        removal="2.2",
+        introduced="2.1",
+    )
+
 
 if __name__ == "__main__":
     _seed_known_deprecations()

--- a/cellpy/utils/ocv_rlx.py
+++ b/cellpy/utils/ocv_rlx.py
@@ -289,12 +289,22 @@ class MultiCycleOcvFit:
     def data(self):
         """Deprecated alias for :attr:`cell` (the held CellpyCell) -- #709 renamed
         it to end the ``self.data.data.steps`` double-``.data`` trap."""
-        warn_once("MultiCycleOcvFit.data", "MultiCycleOcvFit.cell", removal="2.2")
+        warn_once(
+            "MultiCycleOcvFit.data",
+            "MultiCycleOcvFit.cell",
+            removal="2.2",
+            introduced="2.1",
+        )
         return self.cell
 
     @data.setter
     def data(self, value):
-        warn_once("MultiCycleOcvFit.data", "MultiCycleOcvFit.cell", removal="2.2")
+        warn_once(
+            "MultiCycleOcvFit.data",
+            "MultiCycleOcvFit.cell",
+            removal="2.2",
+            introduced="2.1",
+        )
         self.cell = value
 
     @property
@@ -318,7 +328,10 @@ class MultiCycleOcvFit:
     def set_data(self, cellpydata):
         """Deprecated alias for :meth:`set_cell` (#709)."""
         warn_once(
-            "MultiCycleOcvFit.set_data", "MultiCycleOcvFit.set_cell", removal="2.2"
+            "MultiCycleOcvFit.set_data",
+            "MultiCycleOcvFit.set_cell",
+            removal="2.2",
+            introduced="2.1",
         )
         self.set_cell(cellpydata)
 


### PR DESCRIPTION
The DEPRECATIONS.md-audit slice of E5 (#717). Small and self-contained; the `prms.*` shim removal is a separate change.

## What
`DEPRECATIONS.md` is generated from `_seed_known_deprecations()` (so it doesn't need a runtime trigger to be complete). The `MultiCycleOcvFit.data` / `set_data` aliases (#709 — renamed to `cell` / `set_cell` in 2.1, kept until 2.2) already declared `removal="2.2"` at their runtime `warn_once` sites but were **never seeded**, so the table omitted them.

- Seed both ocv_rlx 2.2 aliases (introduced 2.1) and make the runtime `warn_once` sites pass `introduced="2.1"` to match; regenerate the table.
- Record, as explicit notes in the seed, the two E5 decisions:
  - the `prms.*` global-mutation shim is **removed in 2.1** (not a pending deprecation → not listed);
  - `CellpyCell.mass` / `.nom_cap` / `.nom_cap_specifics` are **KEPT past 2.1** (beloved, cheap — deliberately not deprecated, so intentionally absent from the table).

## Result — DEPRECATIONS.md now lists
| Name | Replacement | Introduced | Removal |
| --- | --- | --- | --- |
| `MultiCycleOcvFit.data` | `MultiCycleOcvFit.cell` | 2.1 | 2.2 |
| `MultiCycleOcvFit.set_data` | `MultiCycleOcvFit.set_cell` | 2.1 | 2.2 |

## Verification
`test_ocv_relax.py` + `test_deprecation_conventions.py` → 11 passed.

Part of #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)