### PR TITLE
docs: API reference for cellpy.batch and cellpy.collect (G2, #719)

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,0 +1,24 @@
+# Batch
+
+Run a set of cells as one job: build a journal, load/update the cells, and
+aggregate their summaries.
+
+`cellpy.batch` is the 2.1 batch subsystem (it replaced the
+`cellpy.utils.batch_tools` machinery). `cellpy.utils.batch` remains as a thin
+re-export of the entry points below.
+
+## Entry points
+
+::: cellpy.batch
+
+## Facade
+
+::: cellpy.batch.facade
+
+## Journal
+
+::: cellpy.batch.journal
+
+## Aggregation
+
+::: cellpy.batch.aggregate

--- a/docs/api/collect.md
+++ b/docs/api/collect.md
@@ -1,0 +1,28 @@
+# Collect
+
+Turn a batch into one tidy, multi-cell frame: summaries, cycle/capacity curves,
+or dQ/dV (ICA).
+
+`cellpy.collect` is the 2.1 collectors redesign (it replaced the
+`BatchCollector` family). `cellpy.utils.collectors` remains as a thin
+re-export. Each collector returns a [`Collection`](#the-collection-product).
+
+## Collectors
+
+::: cellpy.collect
+
+## Summary collection
+
+::: cellpy.collect.summary
+
+## Cycle / capacity curves
+
+::: cellpy.collect.curves
+
+## Incremental capacity (ICA)
+
+::: cellpy.collect.ica
+
+## The Collection product
+
+::: cellpy.collect.collection

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,7 +18,9 @@ you already know what you want and need the signature.
 | Load a file, get capacities, save | [cellpy](cellpy.md) — `get`, `CellpyCell` |
 | The cell object and its frames | [Readers](readers.md) |
 | Instrument loaders and the plugin contract | [Instruments](instruments.md) |
-| Batch, plotting, helpers, ICA | [Utils](utils.md) |
+| Run a set of cells as one job | [Batch](batch.md) |
+| Collect a batch into one tidy frame | [Collect](collect.md) |
+| Plotting, helpers, ICA | [Utils](utils.md) |
 | Configuration and column schemas | [Parameters and config](parameters.md) |
 
 ## Stability

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,8 +1,13 @@
 # Utils
 
-Batch processing, plotting, and the analysis helpers.
+Plotting and the analysis helpers. Batch and collection moved to their own
+packages in 2.1 — see [Batch](batch.md) and [Collect](collect.md);
+`cellpy.utils.batch` / `cellpy.utils.collectors` are thin re-export shims of
+those.
 
-## Batch
+## Batch (shim)
+
+Re-exports [`cellpy.batch`](batch.md).
 
 ::: cellpy.utils.batch
 
@@ -18,5 +23,9 @@ Incremental capacity analysis lives at [`cellpy.ica`](ica.md) since 2.0;
 ::: cellpy.utils.ocv_rlx
 
 ::: cellpy.utils.helpers
+
+## Collectors (shim)
+
+Re-exports [`cellpy.collect`](collect.md).
 
 ::: cellpy.utils.collectors

--- a/zensical.toml
+++ b/zensical.toml
@@ -67,6 +67,8 @@ nav = [
         { "API" = [
             "api/index.md",
             { "cellpy" = "api/cellpy.md" },
+            { "Batch" = "api/batch.md" },
+            { "Collect" = "api/collect.md" },
             { "ICA and DVA" = "api/ica.md" },
             { "Plotting" = "api/plotting.md" },
             { "Readers" = "api/readers.md" },


### PR DESCRIPTION
The API-reference slice of Epic G. **Closes #719.**

## Gap
The 2.1 batch/collect redesign lives in `cellpy.batch` / `cellpy.collect`, but `docs/api/` only documented the `cellpy.utils.*` re-export **shims** — the new primary surfaces had no reference pages.

## What
- New **`docs/api/batch.md`** — `cellpy.batch` (entry points) + `facade` / `journal` / `aggregate`.
- New **`docs/api/collect.md`** — `cellpy.collect` (collectors) + `summary` / `curves` / `ica` / `collection`.
- Wired both into the Zensical nav and the API "Where to look" table.
- `utils.md`: relabel the batch/collectors sections as shims that re-export the new packages, with pointers.

The pages are docstring-generated (mkdocstrings), so they track the code. Schema (`cellpy.parameters.cell_schema`) and ICA/plotting were already covered; no dead references remain in `docs/api/`.

## Verification
Ran the CI docs build locally — `uvx --with mkdocstrings-python zensical build --clean`: **"No issues found", 0 warnings.** All referenced modules resolve and links are intact.

Closes #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)