### PR TITLE
Release prep: host-local Arbin goldens + HISTORY 2.1.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-28
+
 ### cellpy 2.1 (Stage 4)
 
 * **Batch / collect redesign.** New top-level `cellpy.batch` (journal / policy /
@@ -41,6 +43,10 @@
 * Clarify Neware docs: binary `.nda`/`.ndax` via `neware_nda` (bundled fastnda) vs exported `neware_txt` models.
 
 * Iterative docs fixes: example notebook typos/hedges, GITT intro quote, and batch config note for 1.x vs `cellpy.toml`. (#695).
+
+* Loader golden oracles for host-local Arbin SQL datetime (`arbin_sql_h5`)
+  compare relative offsets / omit `start_datetime`, so CEST regenerators and
+  UTC CI agree (#768).
 
 ## [2.0.0] - 2026-07-26
 

--- a/tests/data/goldens/README.md
+++ b/tests/data/goldens/README.md
@@ -22,7 +22,7 @@ Full convention, naming rules, and how to add suites: [`../../README.md`](../../
 | `loader_custom` | `testdata/data/custom_data_001.csv` + `custom_instrument_001.yml` | `raw.parquet`, `raw_units.json`, `meta.json`, `metrics.json` |
 | `loader_biologics_mpr` | `testdata/data/biol.mpr` | `raw.parquet`, `raw_units.json`, `meta.json`, `metrics.json` |
 | `loader_batmo_bdf` | `testdata/data/batmo_bdf.csv` | `raw.parquet`, `raw_units.json`, `meta.json`, `metrics.json` |
-| `loader_arbin_sql_h5` | `testdata/data/20200624_test001_cc_01.h5` | `raw.parquet`, `raw_units.json`, `meta.json`, `metrics.json` |
+| `loader_arbin_sql_h5` | `testdata/data/20200624_test001_cc_01.h5` | `raw.parquet`, `raw_units.json`, `meta.json`, `metrics.json` (host-local `date_time` / `start_datetime`: pytest compares relative offsets / omits start wall-clock) |
 | `curve_get_cap_*`, `curve_get_ccap_*`, `curve_get_dcap_*`, `curve_get_ocv_*` | `testdata/data/20160805_test001_45_cc_01.res` (via cellpy pipeline) | `curve.parquet`, `metrics.json`; `null_data.json` for NullData cases |
 | `ica_dqdv_*` | `testdata/data/20160805_test001_45_cc_01.res` (via cellpy pipeline) | `ica.parquet`, `metrics.json` |
 

--- a/tests/loader_golden_support.py
+++ b/tests/loader_golden_support.py
@@ -19,6 +19,16 @@ DATETIME_LIKE_COLUMNS = frozenset({"date_time"})
 TIMEDELTA_LIKE_COLUMNS = frozenset({"step_time", "test_time"})
 TEMPORAL_ABS_NS = 1_000
 
+# Instruments whose legacy ``date_time`` / ``start_datetime`` decode via
+# ``datetime.fromtimestamp`` (host-local). Absolute wall-clock values differ by
+# the host UTC offset (e.g. CEST laptop vs Linux CI); see
+# ``tests/test_loader_port_parity.py`` (``_LEGACY_DATETIME_IS_HOST_LOCAL``).
+# Goldens still record the regenerator's local values; comparisons use relative
+# offsets / omit ``start_datetime`` so the oracle is host-independent.
+HOST_LOCAL_DATETIME_INSTRUMENTS = frozenset(
+    {"arbin_sql_h5", "arbin_sql", "arbin_sql_7"}
+)
+
 # Raw columns that stay integer; all other int64 loader columns are coerced to
 # float64 so all-zero measurements (e.g. ac_impedance) match across platforms.
 INTEGER_RAW_COLUMNS = frozenset(
@@ -63,6 +73,11 @@ class LoaderGoldenSpec:
         self.from_raw_kwargs = from_raw_kwargs or {}
         self.instrument_file = instrument_file
         self.set_instrument_kwargs = set_instrument_kwargs or {}
+
+    @property
+    def legacy_datetime_is_host_local(self) -> bool:
+        """True when absolute ``date_time`` / ``start_datetime`` are host-local."""
+        return self.instrument in HOST_LOCAL_DATETIME_INSTRUMENTS
 
     @property
     def source_path(self) -> Path:
@@ -273,7 +288,23 @@ def assert_temporal_series_equal(
     assert act == pytest.approx(exp, abs=abs_ns)
 
 
-def assert_raw_matches_golden(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+def assert_host_local_datetime_series_equal(
+    actual: pd.Series, expected: pd.Series, *, abs_ns: int
+) -> None:
+    """Compare host-local datetime columns by offset from the first sample."""
+    act = pd.to_datetime(actual).astype("datetime64[ns]").astype("int64")
+    exp = pd.to_datetime(expected).astype("datetime64[ns]").astype("int64")
+    assert (act - act.iloc[0]).tolist() == pytest.approx(
+        (exp - exp.iloc[0]).tolist(), abs=abs_ns
+    )
+
+
+def assert_raw_matches_golden(
+    actual: pd.DataFrame,
+    expected: pd.DataFrame,
+    *,
+    host_local_datetime: bool = False,
+) -> None:
     """Compare loader raw frames with temporal column tolerance."""
     from tests.golden_support import sort_summary_columns
     from pandas.testing import assert_frame_equal
@@ -288,7 +319,41 @@ def assert_raw_matches_golden(actual: pd.DataFrame, expected: pd.DataFrame) -> N
         assert_frame_equal(actual[exact_cols], expected[exact_cols])
 
     for col in sorted(temporal_cols):
-        if col in actual.columns:
+        if col not in actual.columns:
+            continue
+        if host_local_datetime and col in DATETIME_LIKE_COLUMNS:
+            assert_host_local_datetime_series_equal(
+                actual[col], expected[col], abs_ns=TEMPORAL_ABS_NS
+            )
+        else:
             assert_temporal_series_equal(
                 actual[col], expected[col], abs_ns=TEMPORAL_ABS_NS
             )
+
+
+def assert_loader_meta_matches_golden(
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    *,
+    host_local_datetime: bool = False,
+) -> None:
+    """Compare loader meta payloads; omit host-local ``start_datetime`` when needed."""
+    if host_local_datetime:
+        actual = {
+            key: (
+                {k: v for k, v in value.items() if k != "start_datetime"}
+                if key == "meta_common" and isinstance(value, dict)
+                else value
+            )
+            for key, value in actual.items()
+        }
+        expected = {
+            key: (
+                {k: v for k, v in value.items() if k != "start_datetime"}
+                if key == "meta_common" and isinstance(value, dict)
+                else value
+            )
+            for key, value in expected.items()
+        }
+    assert actual == expected
+

--- a/tests/test_loader_goldens.py
+++ b/tests/test_loader_goldens.py
@@ -11,6 +11,7 @@ import pytest
 from tests.loader_golden_support import (
     LOADER_GOLDEN_SPECS,
     LoaderGoldenSpec,
+    assert_loader_meta_matches_golden,
     assert_raw_matches_golden,
     load_loader_snapshot,
 )
@@ -31,7 +32,11 @@ def test_loader_raw_matches_golden_parquet(spec: LoaderGoldenSpec):
 
     expected = pd.read_parquet(spec.golden_dir / "raw.parquet")
     raw, _, _ = load_loader_snapshot(spec)
-    assert_raw_matches_golden(raw, expected)
+    assert_raw_matches_golden(
+        raw,
+        expected,
+        host_local_datetime=spec.legacy_datetime_is_host_local,
+    )
 
 
 @pytest.mark.essential
@@ -64,7 +69,11 @@ def test_loader_meta_matches_golden(spec: LoaderGoldenSpec):
     }
     if "custom_info" in meta:
         actual["custom_info"] = meta["custom_info"]
-    assert actual == expected
+    assert_loader_meta_matches_golden(
+        actual,
+        expected,
+        host_local_datetime=spec.legacy_datetime_is_host_local,
+    )
 
 
 @pytest.mark.essential


### PR DESCRIPTION
## Summary
- Fix `loader_arbin_sql_h5` golden CI failures: compare host-local `date_time` by relative offset and omit `start_datetime` in meta (CEST regenerator vs UTC CI).
- Fold `HISTORY.md` `[Unreleased]` into `## [2.1.0] - 2026-07-28` for the v2.1 ship (#768).

## Test plan
- [x] `uv run pytest tests/test_loader_goldens.py -k arbin_sql_h5 -m essential`
- [x] `uv run pytest -m essential` (620 passed locally)
- [ ] CI green on this PR
- [ ] After merge: tag `v2.1.0` from clean `master` (remaining #768 phases)

Refs #768


Made with [Cursor](https://cursor.com)