### PR TITLE
docs: sync 2.1 migration guide + batch/collect API refs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+### cellpy 2.1 (Stage 4)
+
+* **Batch / collect redesign.** New top-level `cellpy.batch` (journal / policy /
+  runner / store / aggregate / outputs / facade) and `cellpy.collect`
+  (options / collection / summary / curves / ica) packages replace the
+  `utils/batch_tools` "farm/barn" machinery. `cellpy.utils.batch` and
+  `cellpy.utils.collectors` remain as permanent re-export shims. (#697–#708, #716)
+* **Bug fix (collectors):** cross-cell cycle collection no longer reassigns the
+  shared `cycles` list — a cell missing a requested cycle no longer drops that
+  cycle for every cell after it. (#705)
+* New `Batch.tests` / `aggregate.combine_tests`. (#711)
+* **Breaking — 2.0 deprecation shims removed (Epic E).** Every shim that warned
+  *"removed in 2.1"* is gone; see
+  [`docs/getting_started/migration_v2.0_to_2.1.md`](docs/getting_started/migration_v2.0_to_2.1.md):
+    * `CellpyCell.headers_normal` / `_summary` / `_step_table` → `c.schema.raw` /
+      `.summary` / `.steps`; `make_new_cell()` → `CellpyCell.vacant()`. (#715)
+    * ICA 1.x shims (`Converter`, `dqdv_cycle` / `dqdv_cycles` / `dqdv_np`, the
+      legacy `dqdv` kwargs, the duplicate `dq` column) → `ica.dqdv`. (#714)
+    * Plotting `interactive=`, `xlim=` / `ylim=`, `summary_plot_legacy`, and the
+      **seaborn + bokeh** backends removed (plotly + matplotlib remain). (#713)
+    * `cellpy/utils/batch_tools/` deleted; the DB-journal path is now native in
+      `cellpy.batch`. (#716)
+    * The `prms.*` global-mutation shim (`prms.Paths` / `prms.Reader` / …) →
+      `cellpy.config` (`config.paths.x = …` or `config.override(...)`). The
+      `CellpyCell.mass` / `.nom_cap` property facades are **kept**. (#717)
+
 * Tried shipping marimo notebooks in the docs (#724); withdrawn — Zensical
   embeds could not keep a real marimo table/plot experience without hanging
   Pyodide or replacing widgets with non-marimo UI.

--- a/cellpy/batch/__init__.py
+++ b/cellpy/batch/__init__.py
@@ -1,0 +1,75 @@
+"""cellpy.batch -- the batch v3 subsystem (#696).
+
+A boring, standard architecture for batch processing, which replaced the
+``utils/batch_tools`` "farm/barn" machinery (removed in 2.1, E4 #716);
+``cellpy.utils.batch`` is a thin re-export/shim.
+
+Modules land incrementally (plan sections 4 & 6):
+    journal  -- Journal model + json readers/writers  (#698, this arc)
+    layout   -- BatchPaths: pure path computation + ensure_dirs  (#698)
+    policy   -- LoadPolicy / CellSpec typed options  (#699)
+    runner   -- load_cell / run -> BatchResult  (#700)
+    ...
+"""
+
+from __future__ import annotations
+
+from cellpy.batch.journal import (
+    Journal,
+    journal_from_custom_json,
+    journal_from_frame,
+    read_custom_json,
+    read_journal,
+    write_journal,
+)
+from cellpy.batch.layout import BatchPaths, ensure_dirs
+from cellpy.batch.policy import (
+    CellSpec,
+    LoadPolicy,
+    SourcePreference,
+    parse_argument,
+    resolve_specs,
+)
+from cellpy.batch.result import (
+    BatchLoadError,
+    BatchResult,
+    CellOutcome,
+    CellResult,
+)
+from cellpy.batch.runner import load_cell, run
+from cellpy.batch.store import CellStore
+from cellpy.batch import aggregate, outputs, qc
+from cellpy.batch.aggregate import combine_summaries, combine_tests
+from cellpy.batch.db import journal_from_db
+from cellpy.batch.facade import Batch, from_journal, load
+
+__all__ = [
+    "Batch",
+    "load",
+    "from_journal",
+    "aggregate",
+    "qc",
+    "outputs",
+    "combine_summaries",
+    "combine_tests",
+    "Journal",
+    "read_journal",
+    "write_journal",
+    "journal_from_frame",
+    "read_custom_json",
+    "journal_from_custom_json",
+    "BatchPaths",
+    "ensure_dirs",
+    "SourcePreference",
+    "LoadPolicy",
+    "CellSpec",
+    "resolve_specs",
+    "parse_argument",
+    "CellResult",
+    "BatchResult",
+    "CellOutcome",
+    "BatchLoadError",
+    "load_cell",
+    "run",
+    "CellStore",
+]

--- a/cellpy/batch/_dbengine.py
+++ b/cellpy/batch/_dbengine.py
@@ -1,0 +1,426 @@
+"""Native DB-journal engine for batch v3 (E4, #716).
+
+Reads a batch selection from a cellpy database (the simple Excel reader or the
+JSON readers) into a pandas ``pages`` frame, then hands it to
+:mod:`cellpy.batch.db` which converts it to the polars :class:`Journal`.
+
+This is the native replacement for the ``LabJournal.from_db`` path that used
+to live in ``cellpy/utils/batch_tools`` (``batch_journals`` + ``engines`` +
+``batch_helpers``), removed in 2.1. The database readers themselves
+(:mod:`cellpy.readers.dbreader`, :mod:`cellpy.readers.json_dbreader`) are
+unchanged and still own the actual db access; only the journal-building glue
+moved here.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import warnings
+from typing import Any, List, Optional
+
+import pandas as pd
+
+import cellpy.config as config
+from cellpy import filefinder, prms
+from cellpy.exceptions import UnderDefined
+from cellpy.parameters.internal_settings import (
+    get_headers_journal,
+    get_headers_summary,
+)
+from cellpy.readers import data_structures as core
+from cellpy.readers import dbreader, json_dbreader
+from cellpy.readers.data_structures import PagesDictBase
+
+hdr_journal = get_headers_journal()
+hdr_summary = get_headers_summary()
+
+PagesDict = PagesDictBase
+
+CELL_TYPE_IDS = ["cc", "ec", "eth"]
+
+
+# --- reader construction ---------------------------------------------------
+
+
+def make_db_reader(
+    db_reader: Any = "default",
+    db_file: str | None = None,
+    column_map: Any = None,
+):
+    """Build a db-reader object from a ``db_reader`` selector.
+
+    Mirrors the reader construction that used to live in
+    ``LabJournal.__init__``. Returns ``None`` for ``"off"``/``None`` (no db).
+    A reader object passed in directly is returned unchanged.
+    """
+    if db_reader is None:
+        return None
+
+    if not isinstance(db_reader, str):
+        # already a reader object
+        return db_reader
+
+    if db_reader == "off":
+        return None
+    if db_reader == "default":
+        db_reader = config.db.db_type
+
+    if db_reader in ("simple_excel_reader", "default"):
+        return dbreader.Reader()
+
+    if db_reader == "batbase_json_reader":
+        if db_file is None:
+            raise UnderDefined("db_file is not provided")
+        import os
+
+        if not os.path.exists(db_file):
+            raise FileNotFoundError(f"The file {db_file} does not exist")
+        return json_dbreader.BatBaseJSONReader(json_file=db_file)
+
+    if db_reader == "custom_json_reader":
+        if db_file is None:
+            raise UnderDefined("db_file is not provided")
+        import os
+
+        if not os.path.exists(db_file):
+            raise FileNotFoundError(f"The file {db_file} does not exist")
+        return json_dbreader.CustomJSONReader(json_file=db_file, column_map=column_map)
+
+    if db_reader == "sql_db_reader":
+        raise NotImplementedError("sql_db_reader is not implemented yet")
+
+    raise UnderDefined(f"The db-reader '{db_reader}' is not supported")
+
+
+# --- helpers (ported from batch_helpers) -----------------------------------
+
+
+def create_factory():
+    """Build an instrument factory (used to resolve raw-file extensions)."""
+    instrument_factory = core.InstrumentFactory()
+    instruments = core.find_all_instruments()
+    for instrument_id, instrument in instruments.items():
+        instrument_factory.register_builder(instrument_id, instrument)
+    return instrument_factory
+
+
+def find_files(
+    info_dict,
+    file_list=None,
+    pre_path=None,
+    sub_folders=None,
+    skip_file_search=False,
+    **kwargs,
+):
+    """Find raw/cellpy files for each cell using :mod:`cellpy.filefinder`.
+
+    Populates ``raw_file_names`` and ``cellpy_file_name`` in ``info_dict``.
+    When ``skip_file_search`` is True the dict is returned unchanged (e.g.
+    when a custom JSON db already carries the paths).
+    """
+    if skip_file_search:
+        return info_dict
+
+    sub_folders = sub_folders or config.file_names.sub_folders
+    instrument_factory = create_factory()
+    file_name_indicators = info_dict.get(
+        hdr_journal["file_name_indicator"], hdr_journal["filename"]
+    )
+
+    if hdr_journal["raw_file_names"] not in info_dict:
+        info_dict[hdr_journal["raw_file_names"]] = []
+    if hdr_journal["cellpy_file_name"] not in info_dict:
+        info_dict[hdr_journal["cellpy_file_name"]] = []
+
+    for i, run_name in enumerate(file_name_indicators):
+        try:
+            instrument = info_dict[hdr_journal["instrument"]][i]
+            raw_ext = instrument_factory.query(instrument, "raw_ext")
+            if raw_ext:
+                config.file_names.raw_extension = raw_ext
+        except IndexError:
+            warnings.warn(f"no instrument given for {run_name}")
+
+        logging.debug(f"checking for {run_name}")
+        raw_files, cellpyfile = filefinder.search_for_files(
+            run_name,
+            file_list=file_list,
+            with_prefix=True,
+            pre_path=pre_path,
+            sub_folders=sub_folders,
+            **kwargs,
+        )
+        if not raw_files:
+            raw_files = None
+        info_dict[hdr_journal["raw_file_names"]].append(raw_files)
+        info_dict[hdr_journal["cellpy_file_name"]].append(cellpyfile)
+
+    return info_dict
+
+
+def fix_groups(groups):
+    """Renumber arbitrary group labels to consecutive ints starting at 1."""
+    _groups = []
+    unique_groups = list(set(groups))
+    lookup = {}
+    for i, g in enumerate(unique_groups):
+        lookup[g] = i + 1
+    for g in groups:
+        _groups.append(lookup[g])
+    return _groups
+
+
+def make_unique_groups(info_df):
+    """Clean up group numbering and assign per-group sub-group numbers."""
+    unique_g = info_df[hdr_journal.group].unique()
+    unique_g = sorted(unique_g)
+    new_unique_g = list(range(len(unique_g)))
+    info_df[hdr_journal.sub_group] = info_df[hdr_journal.group] * 0
+    for i, j in zip(unique_g, new_unique_g):
+        counter = 1
+        for indx, _row in info_df.loc[info_df[hdr_journal.group] == i].iterrows():
+            info_df.at[indx, hdr_journal.sub_group] = counter
+            counter += 1
+        info_df.loc[info_df[hdr_journal.group] == i, hdr_journal.group] = j + 1
+    return info_df
+
+
+def _remove_date_and_celltype(label):
+    parts = label.split("_")
+    parts.pop(0)
+    try:
+        if parts[-1] in CELL_TYPE_IDS:
+            parts.pop(-1)
+    except IndexError:
+        logging.debug("could not remove date and cell type; using label as is")
+        return label
+    return "_".join(parts)
+
+
+def create_labels(label, *args):
+    """Re-format a run-name into a display label (drops the leading date)."""
+    return _remove_date_and_celltype(label)
+
+
+# --- pages-dict builders (ported from engines) -----------------------------
+
+
+def _query(reader_method, cell_ids, column_name=None):
+    if not any(cell_ids):
+        logging.debug("Received empty cell_ids")
+        return []
+
+    try:
+        if column_name is None:
+            result = [reader_method(cell_id) for cell_id in cell_ids]
+        else:
+            result = [reader_method(column_name, cell_id) for cell_id in cell_ids]
+    except Exception as e:
+        logging.debug("Error in querying db.")
+        logging.debug(e)
+        result = [None for _ in range(len(cell_ids))]
+    return result
+
+
+def _create_pages_dict(
+    reader,
+    cell_ids: Optional[List[Any]] = None,
+    batch_name: Optional[str] = None,
+    include_key: bool = False,
+    include_individual_arguments: bool = True,
+    additional_column_names: Optional[List[str]] = None,
+) -> PagesDict:
+    """Build the raw ``pages`` dict from a reader and a set of cell IDs."""
+    if cell_ids is None:
+        logging.debug("cell_ids is None")
+        pages_dict = reader.from_batch(
+            batch_name=batch_name,
+            include_key=include_key,
+            include_individual_arguments=include_individual_arguments,
+        )
+        return pages_dict
+
+    logging.debug("cell_ids is not None")
+    pages_dict = dict()
+    pages_dict[hdr_journal["filename"]] = _query(reader.get_cell_name, cell_ids)
+    number_of_cells = len(pages_dict[hdr_journal["filename"]])
+    logging.debug(f"number of cells in the batch: {number_of_cells}")
+    if include_key:
+        pages_dict[hdr_journal["id_key"]] = cell_ids
+    if include_individual_arguments:
+        pages_dict[hdr_journal["argument"]] = _query(reader.get_args, cell_ids)
+    pages_dict[hdr_journal["mass"]] = _query(reader.get_mass, cell_ids)
+    pages_dict[hdr_journal["total_mass"]] = _query(reader.get_total_mass, cell_ids)
+    try:
+        pages_dict[hdr_journal["nom_cap_specifics"]] = _query(
+            reader.get_nom_cap_specifics, cell_ids
+        )
+    except Exception as e:
+        logging.debug(f"Error in getting nom_cap_specifics: {e}")
+        pages_dict[hdr_journal["nom_cap_specifics"]] = "gravimetric"
+    try:
+        _file_name_indicator = _query(reader.get_file_name_indicator, cell_ids)
+        if _file_name_indicator is None:
+            _file_name_indicator = _query(reader.get_cell_name, cell_ids)
+        pages_dict[hdr_journal["file_name_indicator"]] = _file_name_indicator
+    except Exception as e:
+        logging.debug(f"Error in getting file_name_indicator: {e}")
+        pages_dict[hdr_journal["file_name_indicator"]] = pages_dict[
+            hdr_journal["filename"]
+        ]
+
+    journal_fields = [
+        ("loading", reader.get_loading),
+        ("nom_cap", reader.get_nom_cap),
+        ("area", reader.get_area),
+        ("experiment", reader.get_experiment_type),
+        ("fixed", reader.inspect_hd5f_fixed),
+        ("label", reader.get_label),
+        ("cell_type", reader.get_cell_type),
+        ("instrument", reader.get_instrument),
+        ("comment", reader.get_comment),
+        ("group", reader.get_group),
+    ]
+
+    for field_name, reader_method in journal_fields:
+        try:
+            pages_dict[hdr_journal[field_name]] = _query(reader_method, cell_ids)
+        except Exception as e:
+            logging.debug(f"Error in getting {field_name}: {e}")
+
+    if additional_column_names is not None:
+        for k in additional_column_names:
+            try:
+                pages_dict[k] = _query(reader.get_by_column_label, cell_ids, k)
+            except Exception as e:
+                logging.info(f"Could not retrieve from column {k} ({e})")
+
+    pages_dict[hdr_journal["raw_file_names"]] = []
+    pages_dict[hdr_journal["cellpy_file_name"]] = []
+
+    return pages_dict
+
+
+def _report_suspected_duplicate_id(e, what="do it", on=None):
+    logging.warning(f"could not {what}")
+    logging.warning(f"{on}")
+    logging.warning("maybe you have a corrupted db?")
+    logging.warning(
+        "typically happens if the cell_id is not unique (several rows or records in "
+        "your db has the same cell_id or key) or if you have non-unique cell names"
+    )
+    logging.warning(e)
+
+
+def _check_pages_frame(pages):
+    duplicates = pages.index.duplicated()
+    if duplicates.any():
+        logging.critical(
+            f"Oh no! Found {duplicates.sum()} duplicate cell names in your db - "
+            "this is not allowed!"
+        )
+        logging.critical(f"Duplicate cell names: {pages.index[duplicates].tolist()}")
+    logging.debug(f"pages.shape: {pages.shape}")
+
+
+def simple_db_engine(
+    reader=None,
+    cell_ids=None,
+    file_list=None,
+    pre_path=None,
+    include_key=False,
+    include_individual_arguments=True,
+    additional_column_names=None,
+    batch_name=None,
+    clean_journal=False,
+    **kwargs,
+) -> pd.DataFrame:
+    """Look up cell metadata from the db and find the matching files.
+
+    Returns a pandas ``pages`` frame indexed by cell name. ``reader`` is a
+    :class:`cellpy.readers.dbreader.Reader` (or a JSON reader exposing a
+    ``pages_dict``); ``cell_ids`` are pre-selected db keys, or ``batch_name``
+    is used to select. ``**kwargs`` are forwarded to the file finder.
+    """
+    logging.debug("simple_db_engine")
+    if reader is None:
+        reader = dbreader.Reader()
+        logging.debug("No reader provided. Creating one myself.")
+
+    if isinstance(reader, str):
+        match reader:
+            case "simple_excel_reader":
+                reader = dbreader.Reader()
+            case "batbase_json_reader":
+                reader = json_dbreader.BatBaseJSONReader()
+            case _:
+                raise ValueError(f"Invalid reader: {reader}")
+
+    if isinstance(reader, dbreader.Reader):
+        pages_dict = _create_pages_dict(
+            reader=reader,
+            cell_ids=cell_ids,
+            batch_name=batch_name,
+            include_key=include_key,
+            include_individual_arguments=include_individual_arguments,
+            additional_column_names=additional_column_names,
+        )
+    elif hasattr(reader, "pages_dict"):
+        pages_dict = reader.pages_dict
+        logging.debug(
+            "pages_dict from reader (number of cells): "
+            f"{len(pages_dict.get(hdr_journal['filename'], []))}"
+        )
+    else:
+        raise UnderDefined(
+            "Unsupported reader (must be dbreader.Reader or provide "
+            f"pages_dict): {type(reader)}"
+        )
+
+    del reader
+
+    _groups = pages_dict[hdr_journal["group"]]
+    groups = fix_groups(_groups)
+    pages_dict[hdr_journal["group"]] = groups
+
+    my_timer_start = time.time()
+    logging.debug("finding files")
+    pages_dict = find_files(
+        pages_dict, file_list=file_list, pre_path=pre_path, **kwargs
+    )
+    logging.debug("files found")
+    my_timer_end = time.time()
+    if (my_timer_end - my_timer_start) > 5.0:
+        logging.debug(
+            "The function find_files was very slow. "
+            "Save your journal so you don't have to run it again!"
+        )
+
+    pages = pd.DataFrame(pages_dict)
+    if clean_journal:
+        if hdr_journal["file_name_indicator"] in pages.columns:
+            pages = pages.drop(columns=[hdr_journal["file_name_indicator"]])
+
+    try:
+        pages = pages.sort_values([hdr_journal.group, hdr_journal.filename])
+    except TypeError as e:
+        _report_suspected_duplicate_id(
+            e, "sort the values", pages[[hdr_journal.group, hdr_journal.filename]]
+        )
+
+    pages = make_unique_groups(pages)
+
+    try:
+        pages[hdr_journal.label] = pages[hdr_journal.filename].apply(create_labels)
+    except AttributeError as e:
+        _report_suspected_duplicate_id(
+            e, "make labels", pages[[hdr_journal.label, hdr_journal.filename]]
+        )
+    except IndexError as e:
+        logging.debug(f"Could not make labels: {e}")
+    else:
+        pages.set_index(hdr_journal["filename"], inplace=True)
+
+    _check_pages_frame(pages)
+    return pages

--- a/cellpy/batch/aggregate.py
+++ b/cellpy/batch/aggregate.py
@@ -1,0 +1,133 @@
+"""Batch aggregation (batch v3, #701).
+
+Turns a set of loaded cells into one tidy, long-format frame with ``cell`` /
+``group`` / ``sub_group`` key columns -- replacing the legacy wide/multiindex
+``join_summaries`` machinery. This is the frame the collectors redesign
+(Epic B) builds on, so it lands here as ``batch.aggregate.combine_summaries``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import polars as pl
+
+from cellpy.batch.journal import FILENAME, Journal
+
+
+def _group_lookup(journal: Journal | None) -> dict[str, tuple[Any, Any]]:
+    """label -> (group, sub_group) from the journal pages."""
+    lookup: dict[str, tuple[Any, Any]] = {}
+    if journal is None:
+        return lookup
+    pages = journal.pages
+    if FILENAME not in pages.columns:
+        return lookup
+    has_group = "group" in pages.columns
+    has_sub = "sub_group" in pages.columns
+    for row in pages.iter_rows(named=True):
+        lookup[row[FILENAME]] = (
+            row.get("group") if has_group else None,
+            row.get("sub_group") if has_sub else None,
+        )
+    return lookup
+
+
+def _summary_of(cell: Any) -> pl.DataFrame | None:
+    summary = getattr(getattr(cell, "data", None), "summary", None)
+    if summary is None:
+        return None
+    if isinstance(summary, pl.DataFrame):
+        return summary
+    try:
+        return pl.from_pandas(summary)
+    except (TypeError, ValueError):
+        return None
+
+
+#: Scalar TestMeta fields surfaced by :func:`combine_tests` (skips nested/object
+#: fields like ``cell``; ``raw_file_names`` is joined to a string).
+_TEST_FIELDS = (
+    "test_id",
+    "cell_name",
+    "cycle_mode",
+    "test_family",
+    "test_type",
+    "source_type",
+    "source_uri",
+    "channel",
+    "creator",
+    "start_datetime",
+    "loaded_datetime",
+    "voltage_lim_low",
+    "voltage_lim_high",
+    "comment",
+)
+
+
+def _tests_of(cell: Any) -> list[dict[str, Any]]:
+    """Per-test metadata records of a cell as plain dicts (native fields only)."""
+    data = getattr(cell, "data", None)
+    collection = getattr(data, "tests", None)
+    if collection is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for record in collection:
+        row = {f: getattr(record, f, None) for f in _TEST_FIELDS}
+        raw_files = getattr(record, "raw_file_names", None)
+        if raw_files:
+            row["raw_file_names"] = "; ".join(str(p) for p in raw_files)
+        rows.append(row)
+    return rows
+
+
+def combine_tests(
+    cells: Mapping[str, Any], journal: Journal | None = None
+) -> pl.DataFrame:
+    """Per-test metadata across the batch as one tidy long-format frame.
+
+    One row per (cell, ``test_id``) carrying the native ``TestMeta`` fields plus
+    ``cell``/``group``/``sub_group`` keys. Surfaces the per-test records that a
+    merged (campaign) cell holds in ``Data.tests`` (#506) at the batch level.
+    Returns an empty frame when no cell exposes test metadata.
+    """
+    lookup = _group_lookup(journal)
+    rows: list[dict[str, Any]] = []
+    for label, cell in cells.items():
+        group, sub_group = lookup.get(label, (None, None))
+        for row in _tests_of(cell):
+            rows.append(
+                {"cell": label, "group": group, "sub_group": sub_group, **row}
+            )
+    if not rows:
+        return pl.DataFrame()
+    return pl.DataFrame(rows)
+
+
+def combine_summaries(
+    cells: Mapping[str, Any], journal: Journal | None = None
+) -> pl.DataFrame:
+    """Concatenate per-cell summaries into one tidy long-format frame.
+
+    Each row keeps its cell's summary columns plus ``cell``/``group``/
+    ``sub_group`` keys. Cells without a summary are skipped. Returns an empty
+    frame when nothing has a summary.
+    """
+    lookup = _group_lookup(journal)
+    frames: list[pl.DataFrame] = []
+    for label, cell in cells.items():
+        summary = _summary_of(cell)
+        if summary is None or summary.height == 0:
+            continue
+        group, sub_group = lookup.get(label, (None, None))
+        frames.append(
+            summary.with_columns(
+                pl.lit(label).alias("cell"),
+                pl.lit(group).alias("group"),
+                pl.lit(sub_group).alias("sub_group"),
+            )
+        )
+    if not frames:
+        return pl.DataFrame()
+    return pl.concat(frames, how="diagonal_relaxed")

--- a/cellpy/batch/db.py
+++ b/cellpy/batch/db.py
@@ -1,0 +1,88 @@
+"""Journal-from-database (batch v3, #703).
+
+Reads a batch selection from a cellpy database (the simple Excel reader or the
+JSON readers) into a new :class:`~cellpy.batch.journal.Journal`. The database
+parsing is done natively by :mod:`cellpy.batch._dbengine` (E4, #716); the db
+readers themselves live in :mod:`cellpy.readers.dbreader` /
+:mod:`cellpy.readers.json_dbreader`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from cellpy.batch import _dbengine
+from cellpy.batch.journal import FILENAME, Journal, _empty_session, _to_polars
+from cellpy.readers import dbreader
+
+
+def journal_from_db(
+    name: str,
+    project: str,
+    *,
+    db_reader: str = "default",
+    db_file: str | None = None,
+    batch_col: str | None = None,
+    raw_file_dir: Any = None,
+    cellpy_file_dir: Any = None,
+    **kwargs: Any,
+) -> Journal:
+    """Read a batch from a database into a :class:`Journal`.
+
+    ``db_reader`` selects the reader (``"default"``/``"simple_excel_reader"``,
+    ``"batbase_json_reader"``, ``"custom_json_reader"``); ``db_file`` and
+    ``column_map`` are forwarded for the JSON readers.
+    """
+    column_map = kwargs.pop("column_map", None)
+    dbreader_kwargs = kwargs.pop("dbreader_kwargs", None) or {}
+
+    reader = _dbengine.make_db_reader(
+        db_reader=db_reader, db_file=db_file, column_map=column_map
+    )
+
+    engine_kwargs: dict[str, Any] = dict(kwargs)
+    if raw_file_dir is not None:
+        engine_kwargs["raw_file_dir"] = raw_file_dir
+    if cellpy_file_dir is not None:
+        engine_kwargs["cellpy_file_dir"] = cellpy_file_dir
+
+    if reader is None:
+        logging.debug("no db reader; creating empty journal pages")
+        pdf = _empty_pages()
+    else:
+        if isinstance(reader, dbreader.Reader):  # simple excel-db
+            id_keys = reader.select_batch(name, batch_col or "b01", **dbreader_kwargs)
+            if len(id_keys) != len(set(id_keys)):
+                duplicates = sorted({x for x in id_keys if id_keys.count(x) > 1})
+                logging.warning(f"Found duplicate id_keys: {duplicates}")
+            pdf = _dbengine.simple_db_engine(reader, id_keys, **engine_kwargs)
+        else:
+            pdf = _dbengine.simple_db_engine(
+                reader, batch_name=name, **engine_kwargs
+            )
+
+        if pdf.empty:
+            logging.critical(
+                "EMPTY JOURNAL PAGES: are you sure you have provided correct "
+                f"input to batch? (name={name!r}, project={project!r})"
+            )
+
+    if FILENAME not in pdf.columns:
+        pdf = pdf.rename_axis(FILENAME).reset_index()
+    else:
+        pdf = pdf.reset_index(drop=True)
+
+    return Journal(
+        name=name,
+        project=project,
+        pages=_to_polars(pdf),
+        session=_empty_session(),
+        meta={"name": name, "project": project},
+    )
+
+
+def _empty_pages():
+    import pandas as pd
+
+    return pd.DataFrame()

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -1,0 +1,288 @@
+"""Batch facade (batch v3, #702).
+
+The thin, notebook-friendly ``Batch`` class that ties the pieces together:
+journal (#698) + policy/resolve_specs (#699) + runner/result/store (#700) +
+aggregate/qc/outputs (#701). Keeps the beloved surface the characterization net
+pinned (#697) -- ``pages``, ``cells``, ``summaries``, ``update``, ``report``,
+``save``, ``mark_as_bad``, ``drop`` -- while everything underneath is the new
+package.
+
+Plot wiring: ``plot()`` delegates to the plotting layer via a small legacy
+adapter; the full tidy-frame plot path lands with the collectors redesign
+(Epic B, batch plan section 4.7).
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields, replace
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from cellpy.batch import aggregate, qc
+from cellpy.batch.journal import (
+    FILENAME,
+    Journal,
+    journal_from_frame,
+    read_journal,
+    write_journal,
+)
+from cellpy.batch.layout import BatchPaths, ensure_dirs
+from cellpy.batch.policy import LoadPolicy
+from cellpy.batch.result import BatchResult
+from cellpy.batch.runner import run
+from cellpy.batch.store import CellStore
+
+
+class Batch:
+    """A batch of cells: a journal, a lazy cell store, and derived frames."""
+
+    def __init__(
+        self,
+        journal: Journal,
+        policy: LoadPolicy | None = None,
+        _db: dict | None = None,
+    ) -> None:
+        self.journal = journal
+        self.policy = policy or LoadPolicy()
+        self._store = CellStore()
+        self._result: BatchResult | None = None
+        self._summaries: pl.DataFrame | None = None
+        self._db = _db  # deferred db-read config for create_journal()
+
+    @classmethod
+    def from_db(
+        cls, name: str, project: str, policy: LoadPolicy | None = None, **db_kwargs
+    ) -> "Batch":
+        """Build a batch by reading a database (Excel or JSON)."""
+        from cellpy.batch.db import journal_from_db
+
+        return cls(journal_from_db(name, project, **db_kwargs), policy=policy)
+
+    # -- data surface ----------------------------------------------------
+    @property
+    def pages(self) -> pl.DataFrame:
+        return self.journal.pages
+
+    @property
+    def cell_names(self) -> list[str]:
+        return self.journal.cell_names
+
+    @property
+    def cells(self) -> CellStore:
+        return self._store
+
+    @property
+    def result(self) -> BatchResult | None:
+        return self._result
+
+    def update(
+        self, on_progress=None, executor: str = "serial", **overrides
+    ) -> BatchResult:
+        """Load every cell, caching them in the store.
+
+        ``executor`` is ``"serial"`` (default), ``"threads"`` or ``"processes"``.
+        Known :class:`LoadPolicy` fields in ``overrides`` update the policy;
+        unknown (legacy) kwargs like ``testing`` are forwarded to the loader
+        (``cellpy.get``) via ``loader_kwargs``.
+        """
+        policy = self.policy
+        if overrides:
+            known = {f.name for f in fields(LoadPolicy)}
+            policy_over = {k: v for k, v in overrides.items() if k in known}
+            extra = {k: v for k, v in overrides.items() if k not in known}
+            if policy_over:
+                policy = replace(policy, **policy_over)
+            if extra:
+                policy = replace(
+                    policy, loader_kwargs={**policy.loader_kwargs, **extra}
+                )
+        self._result = run(
+            self.journal, policy, on_progress=on_progress, executor=executor
+        )
+        self._store = CellStore.from_cells(self._result.cells())
+        self._summaries = None
+        return self._result
+
+    def load(self, **overrides) -> BatchResult:
+        """Load cells (alias of :meth:`update`, kept for the legacy surface)."""
+        return self.update(**overrides)
+
+    def recalc(self, **overrides) -> BatchResult:
+        return self.update(recalc=True, **overrides)
+
+    @property
+    def summaries(self) -> pl.DataFrame:
+        if self._summaries is None:
+            self._summaries = aggregate.combine_summaries(self._store, self.journal)
+        return self._summaries
+
+    def combine_summaries(self, **_kwargs) -> pl.DataFrame:
+        self._summaries = aggregate.combine_summaries(self._store, self.journal)
+        return self._summaries
+
+    @property
+    def tests(self) -> pl.DataFrame:
+        """Per-test metadata across the batch (tidy long-format, #506/F6-D2).
+
+        One row per (cell, ``test_id``) with the native ``TestMeta`` fields plus
+        ``cell``/``group``/``sub_group`` keys -- the per-test records a merged
+        (campaign) cell carries. Empty frame if no cell exposes test metadata.
+        """
+        return aggregate.combine_tests(self._store, self.journal)
+
+    def make_summaries(self) -> pl.DataFrame:
+        return self.combine_summaries()
+
+    def report(self, check: bool = True) -> pl.DataFrame:
+        return qc.check(self._store, self.journal)
+
+    # -- journal ops -----------------------------------------------------
+    def save(self, path: Path | str | None = None) -> Path:
+        target = Path(path) if path else Path(
+            f"cellpy_batch_{self.journal.name or 'batch'}.json"
+        )
+        return write_journal(self.journal, target)
+
+    def export_journal(self, path: Path | str | None = None) -> Path:
+        return self.save(path)
+
+    def create_journal(self, **kwargs) -> Journal:
+        """Populate the journal from the configured database (if any).
+
+        Mirrors the legacy ``init()`` -> ``create_journal()`` flow: ``init``
+        stores the db config, ``create_journal`` performs the read.
+        """
+        if self._db is not None:
+            from cellpy.batch.db import journal_from_db
+
+            config = {**self._db, **kwargs}
+            self.journal = journal_from_db(
+                self.journal.name, self.journal.project, **config
+            )
+            self._summaries = None
+        return self.journal
+
+    def paginate(self) -> tuple[Path, ...]:
+        paths = BatchPaths.create(
+            self.journal.name or "batch", self.journal.project or ""
+        )
+        return ensure_dirs(paths)
+
+    def mark_as_bad(self, label: str) -> None:
+        bad = list(self.journal.session.get("bad_cells") or [])
+        if label not in bad:
+            bad.append(label)
+        self.journal.session["bad_cells"] = bad
+
+    def drop(self, label: str) -> "Batch":
+        self.journal.pages = self.journal.pages.filter(pl.col(FILENAME) != label)
+        self._store.unload(label)
+        self._summaries = None
+        return self
+
+    def link(self) -> "Batch":
+        """No-op in batch v3 (the store loads lazily); kept for the surface."""
+        return self
+
+    # -- plotting (delegated; full wiring is Epic B) ---------------------
+    def plot(self, backend: str | None = None, show: bool = False, **kwargs) -> Any:
+        from cellpy.plotting.batch_summary import batch_summary_plot
+
+        return batch_summary_plot(
+            _LegacyExperimentAdapter(self.journal, self._store),
+            backend=backend,
+            show=show,
+            **kwargs,
+        )
+
+    @property
+    def experiment(self) -> "_LegacyExperimentAdapter":
+        """Backward-compat view for legacy consumers (helpers/collectors).
+
+        ``cellpy.utils.helpers`` and ``cellpy.utils.collectors`` still reach
+        into ``b.experiment.{cell_names,data,journal.pages,summary_frames}``.
+        This adapter keeps them working against the new Batch until they are
+        migrated (Epic B/C); it is not part of the blessed API.
+        """
+        return _LegacyExperimentAdapter(self.journal, self._store)
+
+    def __repr__(self) -> str:
+        return (
+            f"Batch(name={self.journal.name!r}, project={self.journal.project!r}, "
+            f"cells={len(self.journal)})"
+        )
+
+
+class _LegacyJournalAdapter:
+    def __init__(self, journal: Journal) -> None:
+        pdf = journal.pages.to_pandas()
+        if FILENAME in pdf.columns:
+            pdf = pdf.set_index(FILENAME, drop=False)
+        self.pages = pdf
+
+
+class _LegacyExperimentAdapter:
+    """Minimal shim exposing the legacy ``experiment`` surface over a new Batch.
+
+    Covers what ``helpers``/``collectors`` and the summary plotter read:
+    ``journal.pages``, ``cell_names``, ``data``, ``summary_frames`` and
+    ``memory_dumped``. Full migration of those consumers is Epic B/C.
+    """
+
+    def __init__(self, journal: Journal, store: CellStore) -> None:
+        self.journal = _LegacyJournalAdapter(journal)
+        self.data = store
+        self.cell_names = list(store)
+        summaries = []
+        summary_frames = {}
+        for label, cell in store.items():
+            summary = getattr(getattr(cell, "data", None), "summary", None)
+            if summary is None:
+                continue
+            pdf = summary.to_pandas() if hasattr(summary, "to_pandas") else summary
+            pdf.name = label
+            summaries.append(pdf)
+            summary_frames[label] = pdf
+        self.memory_dumped = {"summary_engine": summaries}
+        self.summary_frames = summary_frames
+
+
+# -- module-level constructors -------------------------------------------
+
+
+def from_journal(
+    journal_file: Path | str, policy: LoadPolicy | None = None, **_kwargs
+) -> Batch:
+    """Build a :class:`Batch` from a journal file (.json or .xlsx)."""
+    return Batch(read_journal(journal_file), policy=policy)
+
+
+def load(
+    name: str | None = None,
+    project: str | None = None,
+    *,
+    journal: Journal | None = None,
+    journal_file: Path | str | None = None,
+    frame: Any | None = None,
+    db: str | bool | None = None,
+    policy: LoadPolicy | None = None,
+    **kwargs,
+) -> Batch:
+    """Build a :class:`Batch` from a journal source.
+
+    Source precedence: explicit ``journal`` model, ``journal_file``, ``frame``,
+    then a database read (``db`` reader name, or when only ``name``/``project``
+    are given). Falls back to an empty named journal.
+    """
+    if journal is not None:
+        return Batch(journal, policy=policy)
+    if journal_file is not None:
+        return Batch(read_journal(journal_file), policy=policy)
+    if frame is not None:
+        return Batch(journal_from_frame(frame, name=name, project=project), policy=policy)
+    if db is not None or (name and project):
+        reader = db if isinstance(db, str) else "default"
+        return Batch.from_db(name, project, db_reader=reader, policy=policy, **kwargs)
+    return Batch(Journal(name=name, project=project), policy=policy)

--- a/cellpy/batch/journal.py
+++ b/cellpy/batch/journal.py
@@ -1,0 +1,267 @@
+"""Batch journal model + JSON IO (batch v3, #698).
+
+A journal is a *document*, not an actor: reading one never touches the
+filesystem layout, and the data model is separated from serialisation. This is
+the successor of ``utils/batch_tools/batch_journals.LabJournal`` (a ~1100-line
+class mixing data model, three file formats, path fixing, selection state and
+folder generation). Folder layout lives in :mod:`cellpy.batch.layout`.
+
+The on-disk JSON format is preserved for compatibility: a top-level object with
+``info_df`` (pages, pandas ``to_json`` "columns" orient), ``metadata`` and
+``session``. Pages follow the keys-in-columns law (polars report section 1.3):
+the cell label lives in the ``filename`` *column*, never in an index.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+
+from cellpy.parameters.internal_settings import (
+    get_headers_journal,
+    keys_journal_session,
+)
+
+_hdr = get_headers_journal()
+#: Name of the column holding the (unique) cell label.
+FILENAME = _hdr["filename"]
+
+#: Bump when the on-disk journal shape changes in a non-backward way.
+JOURNAL_FORMAT_VERSION = 1
+
+
+def _empty_session() -> dict:
+    return {key: None for key in keys_journal_session}
+
+
+@dataclass
+class Journal:
+    """A batch journal: the cells of an experiment plus session/meta state.
+
+    Attributes:
+        name: batch name.
+        project: project name.
+        pages: one row per cell; ``filename`` is a column (keys-in-columns).
+        session: mutable session state (starred/bad_cells/bad_cycles/notes).
+        meta: free-form metadata carried through save/load (name, project,
+            time_stamp, project_dir, ...).
+    """
+
+    name: str | None = None
+    project: str | None = None
+    pages: pl.DataFrame = field(default_factory=pl.DataFrame)
+    session: dict = field(default_factory=_empty_session)
+    meta: dict = field(default_factory=dict)
+
+    @property
+    def cell_names(self) -> list[str]:
+        """The cell labels, in page order."""
+        if FILENAME in self.pages.columns:
+            return self.pages[FILENAME].to_list()
+        return []
+
+    def __len__(self) -> int:
+        return self.pages.height
+
+
+def _to_polars(pdf: pd.DataFrame) -> pl.DataFrame:
+    """Convert a pandas pages frame to polars, column by column.
+
+    Columns that hold any python ``list`` (e.g. ``raw_file_names``, where a
+    cell may have several raw files) are normalised to a ``List[str]`` column:
+    scalar values are wrapped in a single-element list and nulls become empty
+    lists. This removes the legacy str-or-list ambiguity that made pages
+    impossible to represent as a typed frame.
+    """
+    data: dict[str, pl.Series] = {}
+    for col in pdf.columns:
+        values = pdf[col].tolist()
+        if any(isinstance(v, list) for v in values):
+            normalised = [
+                v
+                if isinstance(v, list)
+                else ([] if v is None or (isinstance(v, float) and pd.isna(v)) else [v])
+                for v in values
+            ]
+            data[col] = pl.Series(col, normalised, dtype=pl.List(pl.Utf8))
+        elif any(isinstance(v, dict) for v in values):
+            # e.g. the db `argument` column holds parsed dicts -> keep as-is
+            data[col] = pl.Series(col, values, dtype=pl.Object)
+        else:
+            try:
+                data[col] = pl.Series(col, values)
+            except (TypeError, OverflowError, pl.exceptions.PolarsError):
+                data[col] = pl.Series(col, values, dtype=pl.Object)
+    return pl.DataFrame(data)
+
+
+def _pages_from_info_df(info_df: dict) -> pl.DataFrame:
+    """Parse the legacy ``info_df`` mapping into a polars frame.
+
+    ``info_df`` is ``{column: {cell_label: value}}`` (pandas "columns" orient).
+    We parse via pandas (the format is pandas-shaped), guarantee the cell label
+    is a real ``filename`` column, and hand back polars.
+    """
+    pdf = pd.DataFrame(info_df)
+    pdf = pdf.dropna(how="all")
+    if FILENAME not in pdf.columns:
+        # the cell label only lived in the index -> promote it to a column
+        pdf = pdf.rename_axis(FILENAME).reset_index()
+    else:
+        pdf = pdf.reset_index(drop=True)
+    return _to_polars(pdf)
+
+
+def _pages_to_info_df(pages: pl.DataFrame) -> dict:
+    """Serialise pages back to the legacy ``info_df`` mapping."""
+    pdf = pages.to_pandas()
+    if FILENAME in pdf.columns:
+        pdf = pdf.set_index(FILENAME, drop=False)
+    return json.loads(pdf.to_json(default_handler=str))
+
+
+def read_journal(path: Path | str) -> Journal:
+    """Load a journal into the :class:`Journal` model.
+
+    ``.json`` is the native, round-trippable format. ``.xlsx`` is supported
+    **read-only** (a lab convenience); writing Excel is intentionally not
+    supported in batch v3 (see :func:`write_journal`).
+    """
+    path = Path(path)
+    if path.suffix == ".xlsx":
+        return _read_journal_excel(path)
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if "info_df" not in raw:
+        raise ValueError(f"not a cellpy journal (missing 'info_df'): {path}")
+
+    meta = raw.get("metadata") or {}
+    session = raw.get("session") or _empty_session()
+    for key in keys_journal_session:
+        session.setdefault(key, None)
+
+    pages = _pages_from_info_df(raw["info_df"])
+    return Journal(
+        name=meta.get("name"),
+        project=meta.get("project"),
+        pages=pages,
+        session=session,
+        meta=meta,
+    )
+
+
+def _read_journal_excel(path: Path) -> Journal:
+    """Read the ``pages`` sheet of an Excel journal (read-only)."""
+    pdf = pd.read_excel(path, sheet_name="pages", engine="openpyxl")
+    if FILENAME not in pdf.columns:
+        # legacy Excel writes the cell label as the (index) first column
+        first = pdf.columns[0]
+        if str(first).lower().startswith("unnamed") or first == "index":
+            pdf = pdf.rename(columns={first: FILENAME})
+    pdf = pdf.dropna(how="all").reset_index(drop=True)
+
+    meta: dict = {}
+    try:
+        mdf = pd.read_excel(path, sheet_name="meta", engine="openpyxl")
+        if {"parameter", "value"}.issubset(mdf.columns):
+            meta = dict(zip(mdf["parameter"], mdf["value"]))
+    except (ValueError, KeyError):
+        pass
+
+    return Journal(
+        name=meta.get("name", path.stem),
+        project=meta.get("project"),
+        pages=_to_polars(pdf),
+        meta=meta,
+    )
+
+
+def read_custom_json(path: Path | str, column_map: Mapping[str, str]) -> pl.DataFrame:
+    """Read an arbitrary JSON file into journal pages via a column map (#345).
+
+    ``column_map`` maps *source* JSON keys to cellpy journal keys, e.g.
+    ``{"cell_id": "filename", "mass_mg": "mass", "instrument_name": "instrument"}``.
+    The JSON may be a dict of columns (``{key: [values]}``) or a list of
+    records. At least one source key must map to ``filename``.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    pdf = pd.DataFrame(data)
+
+    rename = {
+        src: _hdr[cellpy_key]
+        for src, cellpy_key in column_map.items()
+        if src in pdf.columns
+    }
+    pdf = pdf.rename(columns=rename)
+    keep = [c for c in pdf.columns if c in set(rename.values())]
+    pdf = pdf[keep]
+
+    if FILENAME not in pdf.columns:
+        raise ValueError(
+            "column_map must map a source column to 'filename' "
+            f"(got mappings to {sorted(set(rename.values()))})"
+        )
+    return _to_polars(pdf.reset_index(drop=True))
+
+
+def journal_from_custom_json(
+    path: Path | str,
+    column_map: Mapping[str, str],
+    name: str | None = None,
+    project: str | None = None,
+) -> Journal:
+    """Build a :class:`Journal` from an arbitrary JSON file (#345)."""
+    return Journal(
+        name=name, project=project, pages=read_custom_json(path, column_map)
+    )
+
+
+def write_journal(journal: Journal, path: Path | str) -> Path:
+    """Write a :class:`Journal` to ``path`` in the compatible JSON format.
+
+    Only ``.json`` is written. Excel journals are read-only in batch v3
+    (metadata plan Step 4); export a report frame instead of a journal.
+    """
+    path = Path(path)
+    if path.suffix == ".xlsx":
+        raise ValueError(
+            "Excel journals are read-only in batch v3; write a .json journal "
+            "instead (use outputs.write_excel for report frames)."
+        )
+    meta = dict(journal.meta)
+    meta.setdefault("name", journal.name)
+    meta.setdefault("project", journal.project)
+    top_level = {
+        "info_df": _pages_to_info_df(journal.pages),
+        "metadata": meta,
+        "session": journal.session,
+    }
+    path.write_text(json.dumps(top_level, default=str), encoding="utf-8")
+    return path
+
+
+def journal_from_frame(
+    frame: pl.DataFrame | pd.DataFrame,
+    name: str | None = None,
+    project: str | None = None,
+) -> Journal:
+    """Build a journal from a dataframe of pages (polars or pandas).
+
+    The cell label must be available as a ``filename`` column (or the pandas
+    index, which is promoted to one).
+    """
+    if isinstance(frame, pl.DataFrame):
+        pages = frame
+    else:
+        pdf = frame
+        if FILENAME not in pdf.columns:
+            pdf = pdf.rename_axis(FILENAME).reset_index()
+        else:
+            pdf = pdf.reset_index(drop=True)
+        pages = _to_polars(pdf)
+    return Journal(name=name, project=project, pages=pages)

--- a/cellpy/batch/layout.py
+++ b/cellpy/batch/layout.py
@@ -1,0 +1,74 @@
+"""Batch folder layout (batch v3, #698).
+
+Pure path computation, separated from filesystem side effects. In the legacy
+``LabJournal`` code, exporting a batch created directories as a side effect of
+``paginate()`` (dumpers.py:22 obtained output folders by *calling* it). Here the
+two concerns are split: :class:`BatchPaths` only *computes* paths; the single
+:func:`ensure_dirs` function is the only thing that touches the filesystem.
+
+The layout mirrors the modern ``paginate`` default (batch_journals.py): the
+project directory is the current working directory, the batch dump directory is
+``<project_dir>/dump`` and raw exports live under ``<batch_dir>/raw_data``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Name of the per-project dump directory (kept identical to the legacy
+#: ``DEFAULT_OUTPUT_DIR_NAME`` so existing project folders keep working).
+DEFAULT_OUTPUT_DIR_NAME = "dump"
+
+#: Sub-directory of the dump directory that holds exported raw data.
+RAW_SUBDIR = "raw_data"
+
+
+@dataclass(frozen=True)
+class BatchPaths:
+    """Computed, immutable folder layout for one batch.
+
+    Nothing here creates directories -- constructing a ``BatchPaths`` and
+    reading its properties is free of side effects. Call :func:`ensure_dirs`
+    to materialise the folders.
+    """
+
+    name: str
+    project: str
+    project_dir: Path
+
+    @classmethod
+    def create(
+        cls, name: str, project: str, project_dir: Path | str | None = None
+    ) -> "BatchPaths":
+        """Build a layout; ``project_dir`` defaults to the current directory."""
+        base = Path(project_dir) if project_dir is not None else Path.cwd()
+        return cls(name=name, project=project, project_dir=base)
+
+    @property
+    def batch_dir(self) -> Path:
+        """The dump directory for this batch (``<project_dir>/dump``)."""
+        return self.project_dir / DEFAULT_OUTPUT_DIR_NAME
+
+    @property
+    def raw_dir(self) -> Path:
+        """Where exported raw data lives (``<batch_dir>/raw_data``)."""
+        return self.batch_dir / RAW_SUBDIR
+
+    def journal_file(self, suffix: str = ".json") -> Path:
+        """Path to the journal file for this batch (not created here)."""
+        return self.project_dir / f"cellpy_batch_{self.name}{suffix}"
+
+    def all_dirs(self) -> tuple[Path, ...]:
+        """Every directory this layout owns, parents first."""
+        return (self.project_dir, self.batch_dir, self.raw_dir)
+
+
+def ensure_dirs(paths: BatchPaths) -> tuple[Path, ...]:
+    """Create every directory in ``paths`` (idempotent). The *only* mkdir.
+
+    Returns the directories that were ensured (parents first).
+    """
+    for directory in paths.all_dirs():
+        directory.mkdir(parents=True, exist_ok=True)
+    return paths.all_dirs()

--- a/cellpy/batch/outputs.py
+++ b/cellpy/batch/outputs.py
@@ -1,0 +1,33 @@
+"""Pure output writers (batch v3, #701).
+
+Each writer takes a frame and an explicit path and writes it -- nothing more.
+Exporting never creates directory trees implicitly (that is
+``layout.ensure_dirs``); the parent directory must already exist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+
+def write_csv(frame: pl.DataFrame, path: Path | str) -> Path:
+    """Write ``frame`` to a CSV file at ``path``."""
+    path = Path(path)
+    frame.write_csv(path)
+    return path
+
+
+def write_parquet(frame: pl.DataFrame, path: Path | str) -> Path:
+    """Write ``frame`` to a Parquet file at ``path``."""
+    path = Path(path)
+    frame.write_parquet(path)
+    return path
+
+
+def write_excel(frame: pl.DataFrame, path: Path | str) -> Path:
+    """Write ``frame`` to an ``.xlsx`` file at ``path`` (via openpyxl)."""
+    path = Path(path)
+    frame.to_pandas().to_excel(path, index=False, engine="openpyxl")
+    return path

--- a/cellpy/batch/policy.py
+++ b/cellpy/batch/policy.py
@@ -1,0 +1,184 @@
+"""Typed batch loading options + spec resolution (batch v3, #699).
+
+Replaces the kwargs tunnels of the legacy ``CyclingExperiment.update`` (79
+``kwargs.pop/get`` calls, precedence documented in a single docstring) with two
+dataclasses and one pure function:
+
+- :class:`LoadPolicy` -- batch-wide loading knobs (``force_cellpy``/``force_raw``/
+  ``force_recalc``/... collapse into typed fields).
+- :class:`CellSpec` -- fully resolved per-cell loading instructions.
+- :func:`resolve_specs` -- the *single* place journal rows, policy-level
+  overrides and per-cell overrides merge, with the precedence the legacy code
+  smeared across ~200 lines of ``update()``:
+
+      journal row  <  journal ``argument``  <  policy overrides  <  per-cell
+
+The legacy merge was ``{**cell_spec_page, **kwargs, **cell_spec}``
+(batch_experiments.py:361); this reproduces it as a tested, pure function.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+from cellpy.batch.journal import FILENAME, Journal
+
+
+class SourcePreference(str, Enum):
+    """Which source a cell is loaded from."""
+
+    AUTO = "auto"  # cellpy file if fresh, else raw (today's default)
+    CELLPY_ONLY = "cellpy_only"  # replaces force_cellpy=True
+    RAW_ONLY = "raw_only"  # replaces force_raw_file=True
+
+
+@dataclass
+class LoadPolicy:
+    """Batch-wide loading options (one object instead of a kwargs tunnel)."""
+
+    source: SourcePreference = SourcePreference.AUTO
+    recalc: bool = False  # replaces force_recalc
+    max_cycle: int | None = None
+    accept_errors: bool = True  # errors collected, not raised
+    all_in_memory: bool = False
+    skip_bad_cells: bool = False
+    selector: dict | None = None  # forwarded to the cellpy-file loader
+    loader_kwargs: dict = field(default_factory=dict)  # the one escape hatch
+    #: batch-level per-field overrides applied to every cell (e.g. {"mass": 1.0}).
+    overrides: dict = field(default_factory=dict)
+
+
+@dataclass
+class CellSpec:
+    """Fully resolved per-cell loading instructions."""
+
+    label: str
+    raw_files: list = field(default_factory=list)
+    cellpy_file: Any | None = None
+    instrument: str | None = None
+    model: str | None = None
+    mass: float | None = None
+    nom_cap: float | None = None
+    area: float | None = None
+    cycle_mode: str | None = None
+    #: leftover per-cell knobs (recalc, data_points, ...) not mapped to a field.
+    overrides: dict = field(default_factory=dict)
+
+
+#: Journal columns that map directly to a typed :class:`CellSpec` field.
+_SPEC_FIELDS = ("instrument", "model", "mass", "nom_cap", "area", "cycle_mode")
+
+
+def _is_nan(value: Any) -> bool:
+    return isinstance(value, float) and value != value
+
+
+def _clean(value: Any) -> Any:
+    """Normalise pandas/polars null-ish values to ``None``."""
+    if value is None or _is_nan(value):
+        return None
+    return value
+
+
+def _coerce_scalar(value: Any) -> Any:
+    """Coerce a string spec value the way the legacy update() did."""
+    if not isinstance(value, str):
+        return value
+    low = value.strip().lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if low in ("none", ""):
+        return None
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+
+def parse_argument(argument: Any) -> dict:
+    """Parse a journal ``argument`` cell into a dict of coerced values.
+
+    Accepts a dict (``{"recalc": "False"}``), the compact string form
+    (``"recalc=False;data_points=(1, 10000)"``), or null-ish -> ``{}``.
+    """
+    if argument is None or _is_nan(argument):
+        return {}
+    if isinstance(argument, dict):
+        return {key: _coerce_scalar(val) for key, val in argument.items()}
+    if isinstance(argument, str):
+        text = argument.strip()
+        if not text:
+            return {}
+        parsed: dict = {}
+        for part in text.split(";"):
+            if "=" not in part:
+                continue
+            key, val = part.split("=", 1)
+            parsed[key.strip()] = _coerce_scalar(val.strip())
+        return parsed
+    return {}
+
+
+def _as_list(value: Any) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    return [value]
+
+
+def resolve_specs(
+    journal: Journal,
+    policy: LoadPolicy | None = None,
+    per_cell: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[CellSpec]:
+    """Resolve one :class:`CellSpec` per cell in ``journal``.
+
+    Precedence (later wins): journal columns < journal ``argument`` <
+    ``policy.overrides`` < ``per_cell[label]``.
+    """
+    policy = policy or LoadPolicy()
+    per_cell = per_cell or {}
+
+    specs: list[CellSpec] = []
+    for row in journal.pages.iter_rows(named=True):
+        label = row[FILENAME]
+
+        journal_fields = {
+            field_name: _clean(row.get(field_name))
+            for field_name in _SPEC_FIELDS
+            if field_name in row
+        }
+        # cell_type stands in for cycle_mode when the latter is absent
+        if not journal_fields.get("cycle_mode") and _clean(row.get("cell_type")):
+            journal_fields["cycle_mode"] = _clean(row.get("cell_type"))
+
+        argument = parse_argument(row.get("argument"))
+        overrides = dict(per_cell.get(label, {}))
+
+        merged = {**journal_fields, **argument, **policy.overrides, **overrides}
+
+        specs.append(
+            CellSpec(
+                label=label,
+                raw_files=_as_list(_clean(row.get("raw_file_names"))),
+                cellpy_file=_clean(row.get("cellpy_file_name")),
+                instrument=merged.get("instrument"),
+                model=merged.get("model"),
+                mass=merged.get("mass"),
+                nom_cap=merged.get("nom_cap"),
+                area=merged.get("area"),
+                cycle_mode=merged.get("cycle_mode"),
+                overrides={
+                    key: val
+                    for key, val in merged.items()
+                    if key not in _SPEC_FIELDS
+                },
+            )
+        )
+    return specs

--- a/cellpy/batch/qc.py
+++ b/cellpy/batch/qc.py
@@ -1,0 +1,92 @@
+"""Batch quality control (batch v3, #701).
+
+The legacy ``_check_cell_*`` family (batch.py:367-456) as one function that
+returns a tidy per-cell pass/fail frame, instead of ten methods feeding a
+styled report. The facade's ``report()`` renders this frame.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import polars as pl
+
+#: Preferred charge-capacity column for the cap statistics (native first).
+_CAP_COLS = ("charge_capacity_gravimetric", "charge_capacity")
+
+
+def _frame_len(frame: Any) -> int | None:
+    if frame is None:
+        return None
+    height = getattr(frame, "height", None)
+    if height is not None:
+        return int(height)
+    try:
+        return int(len(frame))
+    except TypeError:
+        return None
+
+
+def _cap_col(summary: Any) -> str | None:
+    columns = getattr(summary, "columns", [])
+    for candidate in _CAP_COLS:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _check_one(label: str, cell: Any) -> dict:
+    row: dict[str, Any] = {
+        "cell": label,
+        "empty": None,
+        "n_raw": None,
+        "n_steps": None,
+        "n_summary": None,
+        "n_cycles": None,
+        "max_cap": None,
+        "min_cap": None,
+        "avg_cap": None,
+        "std_cap": None,
+        "pass": False,
+    }
+    try:
+        row["empty"] = bool(cell.empty)
+    except Exception:  # noqa: BLE001 - QC never raises on a single cell
+        pass
+
+    data = getattr(cell, "data", None)
+    row["n_raw"] = _frame_len(getattr(data, "raw", None))
+    row["n_steps"] = _frame_len(getattr(data, "steps", None))
+    summary = getattr(data, "summary", None)
+    row["n_summary"] = _frame_len(summary)
+
+    steps = getattr(data, "steps", None)
+    if steps is not None and "cycle_num" in getattr(steps, "columns", []):
+        try:
+            row["n_cycles"] = int(steps["cycle_num"].max())
+        except Exception:  # noqa: BLE001
+            pass
+
+    if summary is not None and _frame_len(summary):
+        col = _cap_col(summary)
+        if col is not None:
+            series = summary[col]
+            try:
+                row["max_cap"] = float(series.max())
+                row["min_cap"] = float(series.min())
+                row["avg_cap"] = float(series.mean())
+                row["std_cap"] = float(series.std())
+            except Exception:  # noqa: BLE001
+                pass
+
+    row["pass"] = (row["empty"] is False) and bool(row["n_summary"])
+    return row
+
+
+def check(cells: Mapping[str, Any], journal: Any | None = None) -> pl.DataFrame:
+    """Return a tidy per-cell QC frame (one row per cell)."""
+    rows = [_check_one(label, cell) for label, cell in cells.items()]
+    if not rows:
+        return pl.DataFrame()
+    return pl.DataFrame(rows)

--- a/cellpy/batch/result.py
+++ b/cellpy/batch/result.py
@@ -1,0 +1,97 @@
+"""Batch run results (batch v3, #700).
+
+"Errors are data": a batch run returns a :class:`BatchResult` with a per-cell
+outcome, timing and captured exception, instead of the legacy mix of printing,
+partial ``errors`` lists and aborting. Printing/raising is the caller's policy
+(``result.raise_if_failed()`` for strict mode).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterator
+
+import polars as pl
+
+from cellpy.exceptions import CellpyError
+
+
+class CellOutcome(str, Enum):
+    LOADED = "loaded"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class BatchLoadError(CellpyError):
+    """Raised by :meth:`BatchResult.raise_if_failed` when cells failed."""
+
+
+@dataclass
+class CellResult:
+    """The outcome of loading one cell."""
+
+    label: str
+    outcome: CellOutcome
+    cell: Any | None = None
+    source: str | None = None  # "cellpy" | "raw" | None
+    seconds: float = 0.0
+    error: BaseException | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome == CellOutcome.LOADED
+
+
+@dataclass
+class BatchResult:
+    """The outcome of a batch run: one :class:`CellResult` per cell."""
+
+    results: list[CellResult] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.results)
+
+    def __iter__(self) -> Iterator[CellResult]:
+        return iter(self.results)
+
+    def __getitem__(self, label: str) -> CellResult:
+        for result in self.results:
+            if result.label == label:
+                return result
+        raise KeyError(label)
+
+    @property
+    def loaded(self) -> list[CellResult]:
+        return [r for r in self.results if r.outcome == CellOutcome.LOADED]
+
+    @property
+    def failed(self) -> list[CellResult]:
+        return [r for r in self.results if r.outcome == CellOutcome.FAILED]
+
+    @property
+    def skipped(self) -> list[CellResult]:
+        return [r for r in self.results if r.outcome == CellOutcome.SKIPPED]
+
+    def cells(self) -> dict[str, Any]:
+        """Mapping of label -> loaded cell, successful cells only."""
+        return {r.label: r.cell for r in self.loaded}
+
+    def raise_if_failed(self) -> "BatchResult":
+        """Strict mode: raise if any cell failed; otherwise return self."""
+        if self.failed:
+            labels = ", ".join(r.label for r in self.failed)
+            raise BatchLoadError(f"{len(self.failed)} cell(s) failed to load: {labels}")
+        return self
+
+    def report(self) -> pl.DataFrame:
+        """A tidy per-cell outcome frame (the dataframe ``errors`` only hinted at)."""
+        return pl.DataFrame(
+            {
+                "cell": [r.label for r in self.results],
+                "outcome": [r.outcome.value for r in self.results],
+                "source": [r.source for r in self.results],
+                "seconds": [r.seconds for r in self.results],
+                "error": [None if r.error is None else str(r.error) for r in self.results],
+            }
+        )

--- a/cellpy/batch/runner.py
+++ b/cellpy/batch/runner.py
@@ -1,0 +1,188 @@
+"""Batch runner (batch v3, #700, #704).
+
+Per-cell work is a pure function -- one cell in, one result out, no shared
+mutable state. Serial vs parallel execution is then a choice of executor, not a
+second 300-line method (the legacy ``update`` / ``parallel_update`` clone):
+``executor="serial" | "threads" | "processes"`` all reuse :func:`load_cell`.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from typing import Any, Callable
+
+from cellpy import get as _cellpy_get
+from cellpy.batch.journal import Journal
+from cellpy.batch.policy import CellSpec, LoadPolicy, SourcePreference, resolve_specs
+from cellpy.batch.result import BatchResult, CellOutcome, CellResult
+
+ProgressHook = Callable[[int, int, CellResult], None]
+
+
+def _get_kwargs(spec: CellSpec, policy: LoadPolicy) -> tuple[dict, str | None]:
+    """Map a resolved :class:`CellSpec` + policy onto ``cellpy.get`` kwargs.
+
+    Returns the kwargs and the source label ("cellpy"/"raw"/None) we expect.
+    """
+    kwargs: dict[str, Any] = {
+        "mass": spec.mass,
+        "nominal_capacity": spec.nom_cap,
+        "area": spec.area,
+        "cycle_mode": spec.cycle_mode,
+        "instrument": spec.instrument,
+        "model": spec.model,
+        "selector": policy.selector,
+    }
+
+    raw = spec.raw_files or None
+    if policy.source is SourcePreference.RAW_ONLY:
+        kwargs["filename"] = raw
+        source = "raw" if raw else None
+    elif policy.source is SourcePreference.CELLPY_ONLY:
+        kwargs["cellpy_file"] = spec.cellpy_file
+        source = "cellpy" if spec.cellpy_file else None
+    else:  # AUTO
+        kwargs["cellpy_file"] = spec.cellpy_file
+        kwargs["filename"] = raw
+        source = "cellpy" if spec.cellpy_file else ("raw" if raw else None)
+
+    kwargs = {key: val for key, val in kwargs.items() if val is not None}
+    kwargs.update(policy.loader_kwargs)
+    return kwargs, source
+
+
+def load_cell(spec: CellSpec, policy: LoadPolicy | None = None) -> CellResult:
+    """Load one cell from its resolved spec. Pure-ish: no prints, no mutation.
+
+    Returns a :class:`CellResult` carrying the cell or the exception; only
+    re-raises when ``policy.accept_errors`` is False.
+    """
+    policy = policy or LoadPolicy()
+    kwargs, source = _get_kwargs(spec, policy)
+
+    started = time.perf_counter()
+    try:
+        cell = _cellpy_get(**kwargs)
+    except Exception as error:  # noqa: BLE001 - errors are data (accept_errors)
+        if not policy.accept_errors:
+            raise
+        return CellResult(
+            label=spec.label,
+            outcome=CellOutcome.FAILED,
+            source=source,
+            seconds=time.perf_counter() - started,
+            error=error,
+        )
+    return CellResult(
+        label=spec.label,
+        outcome=CellOutcome.LOADED,
+        cell=cell,
+        source=source,
+        seconds=time.perf_counter() - started,
+    )
+
+
+def _strip_cell(result: CellResult) -> CellResult:
+    """Drop the live cell (and un-pickleable exception) for cross-process return."""
+    if result.cell is None and (result.error is None or isinstance(result.error, RuntimeError)):
+        return result
+    return CellResult(
+        label=result.label,
+        outcome=result.outcome,
+        cell=None,
+        source=result.source,
+        seconds=result.seconds,
+        error=None if result.error is None else RuntimeError(str(result.error)),
+    )
+
+
+def _dispatch(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
+    if spec.label in bad:
+        return CellResult(spec.label, CellOutcome.SKIPPED, source=None)
+    return load_cell(spec, policy)
+
+
+def _dispatch_lite(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
+    """Process-pool worker: like :func:`_dispatch` but returns a picklable result.
+
+    The live :class:`CellpyCell` is not returned across the process boundary
+    (batch plan section 7, Windows pickling); ``executor="processes"`` yields
+    outcomes/timings, and cells are re-read from their cellpy files on demand.
+    """
+    return _strip_cell(_dispatch(spec, policy, bad))
+
+
+def _run_serial(specs, policy, bad, on_progress) -> list[CellResult]:
+    results: list[CellResult] = []
+    total = len(specs)
+    for index, spec in enumerate(specs, start=1):
+        result = _dispatch(spec, policy, bad)
+        results.append(result)
+        if on_progress is not None:
+            on_progress(index, total, result)
+    return results
+
+
+def _run_pool(pool_cls, worker, specs, policy, bad, on_progress) -> list[CellResult]:
+    results: list[CellResult | None] = [None] * len(specs)
+    total = len(specs)
+    with pool_cls() as pool:
+        futures = {
+            pool.submit(worker, spec, policy, bad): i
+            for i, spec in enumerate(specs)
+        }
+        done = 0
+        for future in as_completed(futures):
+            index = futures[future]
+            results[index] = future.result()
+            done += 1
+            if on_progress is not None:
+                on_progress(done, total, results[index])
+    return results  # type: ignore[return-value]
+
+
+def _run_threads(specs, policy, bad, on_progress) -> list[CellResult]:
+    return _run_pool(ThreadPoolExecutor, _dispatch, specs, policy, bad, on_progress)
+
+
+def _run_processes(specs, policy, bad, on_progress) -> list[CellResult]:
+    return _run_pool(ProcessPoolExecutor, _dispatch_lite, specs, policy, bad, on_progress)
+
+
+#: Available executors. Serial/threads keep live cells; processes returns
+#: outcomes only (frames/paths, not live objects) to stay pickle-safe.
+EXECUTORS = {
+    "serial": _run_serial,
+    "threads": _run_threads,
+    "processes": _run_processes,
+}
+
+
+def run(
+    journal: Journal,
+    policy: LoadPolicy | None = None,
+    per_cell: dict | None = None,
+    on_progress: ProgressHook | None = None,
+    executor: str = "serial",
+) -> BatchResult:
+    """Load every cell in ``journal``, returning a :class:`BatchResult`.
+
+    ``executor`` chooses ``"serial"`` (default), ``"threads"`` or
+    ``"processes"`` -- all reuse :func:`load_cell`. Progress is reported via the
+    ``on_progress`` callback; the runner never imports tqdm or prints.
+    """
+    policy = policy or LoadPolicy()
+    specs = resolve_specs(journal, policy, per_cell)
+    bad = (
+        frozenset(journal.session.get("bad_cells") or [])
+        if policy.skip_bad_cells
+        else frozenset()
+    )
+    try:
+        runner_fn = EXECUTORS[executor]
+    except KeyError:
+        raise ValueError(
+            f"unknown executor {executor!r}; choose one of {sorted(EXECUTORS)}"
+        ) from None
+    return BatchResult(runner_fn(specs, policy, bad, on_progress))

--- a/cellpy/batch/store.py
+++ b/cellpy/batch/store.py
@@ -1,0 +1,76 @@
+"""Lazy cell store (batch v3, #700).
+
+Replaces ``batch_core.Data`` + ``experiment.cell_data_frames`` + the ``x_``
+prefixed accessor dict. A standard ``Mapping`` with lazy loading; tab completion
+comes from ``_ipython_key_completions_`` (the supported mechanism for
+``store["<TAB>"]``) instead of prefix-mangled attribute names -- which also
+removes the ``str.lstrip`` label-mangling bug (batch_core.py:180, where a cell
+named ``xenon_cell`` round-tripped to ``enon_cell``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Iterator
+
+
+class CellStore(Mapping):
+    """A lazy ``Mapping[str, CellpyCell]``.
+
+    Construct with per-label zero-argument loaders (called on first access) or
+    with already-loaded cells (:meth:`from_cells`). Loaded cells are cached.
+    """
+
+    def __init__(
+        self,
+        loaders: Mapping[str, Callable[[], Any]] | None = None,
+        cells: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._loaders: dict[str, Callable[[], Any]] = dict(loaders or {})
+        self._cache: dict[str, Any] = dict(cells or {})
+        # preserve insertion order, loaders first then any cache-only labels
+        self._labels: list[str] = list(self._loaders)
+        for label in self._cache:
+            if label not in self._loaders:
+                self._labels.append(label)
+
+    @classmethod
+    def from_cells(cls, cells: Mapping[str, Any]) -> "CellStore":
+        """Build a store over already-loaded cells (e.g. from a BatchResult)."""
+        return cls(cells=cells)
+
+    def __getitem__(self, label: str) -> Any:
+        if label in self._cache:
+            return self._cache[label]
+        if label in self._loaders:
+            cell = self._loaders[label]()
+            self._cache[label] = cell
+            return cell
+        raise KeyError(label)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._labels)
+
+    def __len__(self) -> int:
+        return len(self._labels)
+
+    def first(self) -> Any:
+        """Load and return the first cell."""
+        if not self._labels:
+            raise KeyError("no cells in store")
+        return self[self._labels[0]]
+
+    def sample(self) -> Any:
+        """Alias for :meth:`first` (a representative cell)."""
+        return self.first()
+
+    def is_loaded(self, label: str) -> bool:
+        return label in self._cache
+
+    def unload(self, label: str) -> None:
+        """Drop a loaded cell from the cache (explicit memory management)."""
+        self._cache.pop(label, None)
+
+    def _ipython_key_completions_(self) -> list[str]:
+        """Tab completion for ``store["<TAB>"]`` -- no prefix mangling."""
+        return list(self._labels)

--- a/cellpy/collect/__init__.py
+++ b/cellpy/collect/__init__.py
@@ -1,0 +1,55 @@
+"""cellpy.collect -- collection as a first-class product (collectors redesign, #705).
+
+A collection is a product, not a side effect: :class:`Collection` = a tidy frame
+plus provenance. Built on ``cellpy.batch.aggregate`` (Epic A), replacing the
+``utils/collectors`` "elevated arguments" machinery and fixing the cross-cell
+cycle-narrowing bug by design. ``cellpy.utils.collectors`` is now a thin shim
+whose legacy ``Batch*Collector`` family is removed in 2.1 (#708).
+
+Arcs: options/collection/collect_summaries + per-cell curves (#705); rate/group
+pipeline (#706); convenience class + recipes (#707); ICA collection + plotting
+handover (Collection.plot -> cellpy.plotting) + collectors shim (#708).
+"""
+
+from __future__ import annotations
+
+from cellpy.collect.cells import CellItem, iter_cells
+from cellpy.collect.collection import Collection, CollectionMeta, load_collection
+from cellpy.collect.collector import (
+    BatchCollector,
+    cycles_collector,
+    ica_collector,
+    normalize_column,
+    standard_gravimetric,
+    summary_collector,
+)
+from cellpy.collect.curves import collect_cycles
+from cellpy.collect.ica import collect_ica
+from cellpy.collect.options import (
+    CurveOptions,
+    IcaOptions,
+    SaveOptions,
+    SummaryOptions,
+)
+from cellpy.collect.summary import collect_summaries
+
+__all__ = [
+    "Collection",
+    "CollectionMeta",
+    "load_collection",
+    "collect_summaries",
+    "collect_cycles",
+    "collect_ica",
+    "iter_cells",
+    "CellItem",
+    "SummaryOptions",
+    "CurveOptions",
+    "IcaOptions",
+    "SaveOptions",
+    "BatchCollector",
+    "summary_collector",
+    "cycles_collector",
+    "ica_collector",
+    "standard_gravimetric",
+    "normalize_column",
+]

--- a/cellpy/collect/_summary_ops.py
+++ b/cellpy/collect/_summary_ops.py
@@ -1,0 +1,234 @@
+"""Per-cell summary operations for the collect pipeline (collectors redesign, #706).
+
+Polars-native ports of the meaty ``helpers.concat_summaries`` internals --
+rate-based cycle selection, CV partitioning, and group averaging -- that
+previously lived as pandas helpers keyed off the deprecated ``headers_summary``
+/ ``headers_step_table`` singletons. These use the cell's own ``schema`` (the
+2.1 native accessor) and operate on the tidy long frame produced by
+:mod:`cellpy.batch.aggregate`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+CYCLE = "cycle_num"
+_NORM_CYCLE_OUT = "equivalent_cycle"
+
+
+def schema_name(cell: Any, table: str, attr: str, default: str) -> str:
+    """Resolve a column name from ``cell.schema.<table>.<attr>`` (native, 2.1).
+
+    Falls back to ``default`` when the schema (or attribute) is unavailable so
+    the pipeline still works on light-weight/fake cells in tests.
+    """
+    schema = getattr(cell, "schema", None)
+    tbl = getattr(schema, table, None) if schema is not None else None
+    return getattr(tbl, attr, default) or default
+
+
+def to_polars(frame: Any) -> pl.DataFrame | None:
+    """Best-effort conversion of a cell frame (pandas or polars) to polars."""
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    try:
+        return pl.from_pandas(frame)
+    except (TypeError, ValueError):
+        return None
+
+
+def rate_cycles(cell: Any, opts: Any) -> list[int]:
+    """Cycle numbers whose ``rate_on`` step ran at ``opts.rate`` (± tolerance).
+
+    Port of ``helpers.select_summary_based_on_rate`` -- the step-table mask --
+    returning just the surviving cycle numbers (the summary filtering happens
+    in :func:`extract_cell_summary`). ``rate_inverse`` negates the *step* mask;
+    the caller handles ``rate_inverted`` (negating the *cycle* selection).
+    """
+    steps = to_polars(getattr(getattr(cell, "data", None), "steps", None))
+    if steps is None or steps.height == 0:
+        return []
+
+    rate_col = opts.rate_column or schema_name(cell, "steps", "c_rate", "c_rate")
+    type_col = schema_name(cell, "steps", "step_type", "step_type")
+    cyc_col = schema_name(cell, "steps", "cycle_num", CYCLE)
+    if rate_col not in steps.columns or cyc_col not in steps.columns:
+        return []
+
+    rate = opts.rate
+    std = opts.rate_std if opts.rate_std is not None else 0.1 * rate
+
+    on = opts.rate_on if opts.rate_on is not None else ("charge",)
+    if isinstance(on, str):
+        on = (on,)
+
+    mask = (pl.col(rate_col) < (rate + std)) & (pl.col(rate_col) > (rate - std))
+    if on and type_col in steps.columns:
+        mask = mask & pl.col(type_col).cast(pl.Utf8).is_in(list(on))
+    if opts.rate_inverse:
+        mask = ~mask
+
+    return steps.filter(mask)[cyc_col].unique().to_list()
+
+
+def cv_partition(cell: Any) -> pl.DataFrame | None:
+    """Split each numeric summary metric into ``*_non_cv`` / ``*_cv`` parts.
+
+    ``*_non_cv`` comes from ``make_summary(exclude_step_types=["cv_"])``; ``*_cv``
+    is ``full - non_cv`` clipped at zero (the CV-step contribution). Mirrors
+    ``helpers._partition_summary_based_on_cv_steps`` but polars-native and keyed
+    on the schema cycle column. Returns the full summary unchanged if the
+    engine cannot produce a no-CV variant.
+    """
+    cyc = schema_name(cell, "summary", "cycle_num", CYCLE)
+    full = to_polars(getattr(getattr(cell, "data", None), "summary", None))
+    if full is None or full.height == 0 or cyc not in full.columns:
+        return full
+
+    try:
+        no_cv = to_polars(
+            cell.make_summary(exclude_step_types=["cv_"], create_copy=True).data.summary
+        )
+    except (TypeError, ValueError, AttributeError):
+        return full
+    if no_cv is None or cyc not in no_cv.columns:
+        return full
+
+    numeric = [
+        c
+        for c, dt in zip(full.columns, full.dtypes)
+        if dt.is_numeric() and c != cyc and c in no_cv.columns
+    ]
+    if not numeric:
+        return full
+
+    renamed = no_cv.select([cyc, *numeric]).rename({c: f"{c}__nocv" for c in numeric})
+    joined = full.join(renamed, on=cyc, how="left")
+
+    additions: list[pl.Expr] = []
+    for c in numeric:
+        additions.append(pl.col(f"{c}__nocv").alias(f"{c}_non_cv"))
+        additions.append(
+            (pl.col(c) - pl.col(f"{c}__nocv")).clip(lower_bound=0).alias(f"{c}_cv")
+        )
+    return joined.with_columns(additions).drop([f"{c}__nocv" for c in numeric])
+
+
+def extract_cell_summary(cell: Any, opts: Any) -> pl.DataFrame | None:
+    """Per-cell summary frame with cycle-level options applied.
+
+    Applies (in legacy order) CV partition, max-cycle drop, rate selection and
+    ``remove_last``, then normalizes the cycle column to ``cycle_num`` and, when
+    requested, exposes the normalized cycle index as ``equivalent_cycle``.
+    """
+    cyc = schema_name(cell, "summary", "cycle_num", CYCLE)
+
+    if opts.partition_by_cv:
+        frame = cv_partition(cell)
+    else:
+        frame = to_polars(getattr(getattr(cell, "data", None), "summary", None))
+    if frame is None or frame.height == 0:
+        return None
+
+    if opts.max_cycle is not None and cyc in frame.columns:
+        frame = frame.filter(pl.col(cyc) <= opts.max_cycle)
+
+    if opts.rate is not None and cyc in frame.columns:
+        allowed = rate_cycles(cell, opts)
+        if opts.rate_inverted:
+            frame = frame.filter(~pl.col(cyc).is_in(allowed))
+        else:
+            frame = frame.filter(pl.col(cyc).is_in(allowed))
+
+    if opts.remove_last and frame.height > 0:
+        frame = frame.head(frame.height - 1)
+
+    if cyc != CYCLE and cyc in frame.columns:
+        frame = frame.rename({cyc: CYCLE})
+
+    if opts.normalize_cycles:
+        norm = schema_name(cell, "summary", "normalized_cycle_index", "")
+        if norm and norm in frame.columns:
+            frame = frame.rename({norm: _NORM_CYCLE_OUT})
+
+    return frame
+
+
+def _numeric_value_columns(frame: pl.DataFrame, keys: tuple[str, ...]) -> list[str]:
+    return [
+        c
+        for c, dt in zip(frame.columns, frame.dtypes)
+        if dt.is_numeric() and c not in keys
+    ]
+
+
+def clean_extremes(
+    frame: pl.DataFrame,
+    columns: list[str],
+    *,
+    replace_inf: bool,
+    replace_extremes: bool,
+    low: float,
+    high: float,
+) -> pl.DataFrame:
+    """Null out inf and out-of-range values in the given numeric columns."""
+    if not columns:
+        return frame
+    exprs: list[pl.Expr] = []
+    for c in columns:
+        expr = pl.col(c)
+        if replace_inf:
+            expr = pl.when(expr.is_infinite()).then(None).otherwise(expr)
+        if replace_extremes:
+            expr = (
+                pl.when((expr < low) | (expr > high)).then(None).otherwise(expr)
+            )
+        exprs.append(expr.alias(c))
+    return frame.with_columns(exprs)
+
+
+def group_average(
+    frame: pl.DataFrame,
+    opts: Any,
+    *,
+    keys: tuple[str, ...],
+    group_labels: dict[Any, Any] | None = None,
+) -> pl.DataFrame:
+    """Average per journal group -> tidy long ``(group, cycle_num, variable, mean, std)``.
+
+    Port of ``helpers._make_average`` + ``collect_frames`` grouping path. The
+    aggregate column is named ``mean`` regardless of ``average_method`` (legacy
+    backward-compat). ``std`` is the per-group standard deviation across cells.
+    """
+    if frame.height == 0 or "group" not in frame.columns:
+        return frame
+
+    id_cols = ["group"] + ([CYCLE] if CYCLE in frame.columns else [])
+    value_cols = _numeric_value_columns(frame, keys)
+    if not value_cols:
+        return frame
+
+    long = frame.unpivot(
+        index=id_cols, on=value_cols, variable_name="variable", value_name="_v"
+    )
+    stat = "median" if opts.average_method == "median" else "mean"
+    agg_expr = (
+        pl.col("_v").median() if stat == "median" else pl.col("_v").mean()
+    ).alias("mean")
+    out = long.group_by([*id_cols, "variable"]).agg(
+        agg_expr, pl.col("_v").std().alias("std")
+    )
+
+    if group_labels:
+        mapping = {k: v for k, v in group_labels.items() if v is not None}
+        if mapping:
+            out = out.with_columns(
+                pl.col("group").replace(mapping, default=None).alias("group_label")
+            )
+
+    sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
+    return out.sort(sort_cols)

--- a/cellpy/collect/cells.py
+++ b/cellpy/collect/cells.py
@@ -1,0 +1,46 @@
+"""Per-cell iteration for collection (collectors redesign, #705).
+
+Successor of ``pick_named_cell`` with **per-cell isolation**: one cell's filter
+results never leak into the next (fixes the cross-cell ``cycles`` narrowing bug
+at collectors.py:1609/1691). Also carries the label-mapper idea (presentation
+names != file names).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from cellpy.batch.journal import FILENAME
+
+
+@dataclass
+class CellItem:
+    """One cell in a collection pass, with its group metadata."""
+
+    label: str
+    group: Any
+    sub_group: Any
+    cell: Any
+
+
+def iter_cells(
+    batch: Any, label_mapper: Mapping[str, str] | None = None
+) -> Iterator[CellItem]:
+    """Yield the batch's loaded cells with their journal group/sub_group."""
+    lookup: dict[str, tuple[Any, Any]] = {}
+    pages = batch.journal.pages
+    if FILENAME in pages.columns:
+        has_group = "group" in pages.columns
+        has_sub = "sub_group" in pages.columns
+        for row in pages.iter_rows(named=True):
+            lookup[row[FILENAME]] = (
+                row.get("group") if has_group else None,
+                row.get("sub_group") if has_sub else None,
+            )
+
+    for label, cell in batch.cells.items():
+        group, sub_group = lookup.get(label, (None, None))
+        name = label_mapper.get(label, label) if label_mapper else label
+        yield CellItem(label=name, group=group, sub_group=sub_group, cell=cell)

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -1,0 +1,124 @@
+"""The Collection product (collectors redesign, #705).
+
+A collection is a *product, not a side effect*: a tidy frame plus provenance
+(what was collected, from which batch, with which options, by which cellpy
+version, when). It can be saved, re-loaded and re-plotted without
+re-collecting -- ``meta.json`` next to the data makes collections reproducible
+artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import polars as pl
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cellpy_version() -> str:
+    try:
+        import cellpy
+
+        return getattr(cellpy, "__version__", "unknown")
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+@dataclass
+class CollectionMeta:
+    """Provenance for a :class:`Collection`."""
+
+    kind: str
+    batch_name: str | None = None
+    options: dict = field(default_factory=dict)
+    cellpy_version: str = field(default_factory=_cellpy_version)
+    created_utc: str = field(default_factory=_now_utc)
+    cells_included: list[str] = field(default_factory=list)
+    cells_skipped: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Collection:
+    """A tidy collected frame plus its provenance."""
+
+    data: pl.DataFrame
+    kind: str  # "summary" | "cycles" | "ica" | custom
+    name: str
+    meta: CollectionMeta
+
+    #: collection kind -> ``collected_plot`` family (#657).
+    _FAMILY = {"summary": "summary", "cycles": "cycles", "ica": "ica"}
+
+    def to_wide(
+        self, values: str, index: str = "cycle_num", columns: str = "cell"
+    ) -> pl.DataFrame:
+        """Explicit, tested pivot to wide layout (replaces the try/except pivots)."""
+        return self.data.pivot(values=values, index=index, on=columns)
+
+    def plot(self, *, family_kind: str | None = None, **kwargs):
+        """Draw the collection via :func:`cellpy.plotting.collected_plot`.
+
+        The drawing lives in ``cellpy.plotting`` (#657); a collection just hands
+        it the tidy frame and the family. The only reconciliation needed is the
+        summary family's cycle column, which the summary plotter spells
+        ``cycle`` (capacity/ICA curves keep ``cycle_num`` / ``cycle``).
+        """
+        from cellpy.plotting import collected_plot
+
+        family = family_kind or self._FAMILY.get(self.kind, "cycles")
+        frame = self.data.to_pandas()
+        if family == "summary" and "cycle_num" in frame.columns:
+            frame = frame.rename(columns={"cycle_num": "cycle"})
+        return collected_plot(frame, family_kind=family, **kwargs)
+
+    def save(
+        self,
+        directory: Path | str | None = None,
+        formats: tuple[str, ...] = ("parquet", "csv"),
+    ) -> list[Path]:
+        """Save the frame (+ ``meta.json``). No cwd fallback -- ``directory`` is explicit."""
+        if directory is None:
+            raise ValueError("save() needs an explicit directory (no cwd fallback)")
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+
+        written: list[Path] = []
+        for fmt in formats:
+            path = directory / f"{self.name}.{fmt}"
+            if fmt == "parquet":
+                self.data.write_parquet(path)
+            elif fmt == "csv":
+                self.data.write_csv(path)
+            else:
+                raise ValueError(f"unsupported collection format {fmt!r}")
+            written.append(path)
+
+        meta_path = directory / f"{self.name}.meta.json"
+        meta_path.write_text(json.dumps(asdict(self.meta), indent=2), encoding="utf-8")
+        written.append(meta_path)
+        return written
+
+
+def load_collection(path: Path | str) -> Collection:
+    """Load a saved collection (parquet/csv frame + ``meta.json`` if present)."""
+    path = Path(path)
+    if path.suffix == ".parquet":
+        data = pl.read_parquet(path)
+    elif path.suffix == ".csv":
+        data = pl.read_csv(path)
+    else:
+        raise ValueError(f"cannot load collection from {path.suffix!r}")
+
+    meta_path = path.with_suffix("").with_suffix(".meta.json")
+    if meta_path.is_file():
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta = CollectionMeta(**raw)
+    else:
+        meta = CollectionMeta(kind="unknown")
+    return Collection(data=data, kind=meta.kind, name=path.stem, meta=meta)

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -1,0 +1,183 @@
+"""Convenience collector + recipes (collectors redesign, #707).
+
+:class:`BatchCollector` is the thin successor of the legacy
+``utils.collectors.BatchCollector`` family: run a collect function, hold the
+resulting :class:`~cellpy.collect.collection.Collection`, and offer
+``save`` / ``plot`` on top. It replaces the "elevated arguments" machinery --
+~20 parameters redeclared per subclass and merged through three priority
+layers (collectors.py:969/1202/1316) -- with a single options object plus a
+collect callable. The ``utils.collectors`` compatibility shim and the plotting
+handover land in B4 (#708).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import polars as pl
+
+from cellpy.collect.curves import collect_cycles
+from cellpy.collect.ica import collect_ica
+from cellpy.collect.options import CurveOptions, IcaOptions, SummaryOptions
+from cellpy.collect.summary import collect_summaries
+
+#: A collect function takes ``(batch, options, **overrides)`` -> Collection.
+Collector = Callable[..., Any]
+
+
+class BatchCollector:
+    """Run a collect function and hold its :class:`Collection`.
+
+    Args:
+        batch: the :class:`~cellpy.batch.Batch` to collect from.
+        collector: a collect callable, e.g. :func:`collect_summaries`.
+        options: the options dataclass for ``collector`` (optional).
+        name: display/base name (defaults to the batch/journal name).
+        autorun: run the collector immediately (default ``True``).
+        **overrides: option overrides forwarded to ``collector``.
+    """
+
+    def __init__(
+        self,
+        batch: Any,
+        collector: Collector,
+        options: Any | None = None,
+        *,
+        name: str | None = None,
+        autorun: bool = True,
+        **overrides,
+    ):
+        self.batch = batch
+        self.collector = collector
+        self.options = options
+        self.overrides = overrides
+        self.name = name or getattr(batch.journal, "name", None) or "batch"
+        self._collection: Any | None = None
+        if autorun:
+            self.update()
+
+    def update(self, **overrides) -> "BatchCollector":
+        """(Re)run the collector; extra kwargs merge into the option overrides."""
+        if overrides:
+            self.overrides = {**self.overrides, **overrides}
+        self._collection = self.collector(self.batch, self.options, **self.overrides)
+        return self
+
+    @property
+    def collection(self) -> Any:
+        if self._collection is None:
+            self.update()
+        return self._collection
+
+    @property
+    def data(self) -> pl.DataFrame:
+        return self.collection.data
+
+    def save(self, directory: str | Path, **kwargs) -> list[Path]:
+        """Persist the collection (explicit directory, no cwd fallback)."""
+        return self.collection.save(directory, **kwargs)
+
+    def plot(self, **kwargs) -> Any:
+        """Draw the collection. Wired to ``cellpy.plotting`` in B4 (#708)."""
+        plot = getattr(self.collection, "plot", None)
+        if plot is None:
+            raise NotImplementedError(
+                "Collection plotting is handed over to cellpy.plotting in B4 "
+                "(#708). Use `.data` for the collected frame in the meantime."
+            )
+        return plot(**kwargs)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        kind = getattr(self._collection, "kind", "?")
+        rows = getattr(getattr(self._collection, "data", None), "height", "?")
+        return f"<BatchCollector {self.name!r} kind={kind} rows={rows}>"
+
+
+def summary_collector(
+    batch: Any, options: SummaryOptions | None = None, *, autorun: bool = True, **overrides
+) -> BatchCollector:
+    """Convenience :class:`BatchCollector` bound to :func:`collect_summaries`."""
+    return BatchCollector(
+        batch, collect_summaries, options, autorun=autorun, **overrides
+    )
+
+
+def cycles_collector(
+    batch: Any, options: CurveOptions | None = None, *, autorun: bool = True, **overrides
+) -> BatchCollector:
+    """Convenience :class:`BatchCollector` bound to :func:`collect_cycles`."""
+    return BatchCollector(batch, collect_cycles, options, autorun=autorun, **overrides)
+
+
+def ica_collector(
+    batch: Any, options: IcaOptions | None = None, *, autorun: bool = True, **overrides
+) -> BatchCollector:
+    """Convenience :class:`BatchCollector` bound to :func:`collect_ica`."""
+    return BatchCollector(batch, collect_ica, options, autorun=autorun, **overrides)
+
+
+def normalize_column(
+    column: str, norm_factor: float, out: str | None = None
+) -> Callable[[pl.DataFrame], pl.DataFrame]:
+    """Build a transform that adds ``100 * column / norm_factor`` as a new series.
+
+    Works on both the wide (non-grouped) frame -- adding an ``<out>`` column --
+    and the grouped long frame -- adding an ``<out>`` *variable* with ``mean``
+    (and ``std``) scaled. Missing columns are left untouched.
+    """
+    target = out or f"{column}_norm"
+
+    def _transform(frame: pl.DataFrame) -> pl.DataFrame:
+        if "variable" in frame.columns and "mean" in frame.columns:
+            sub = frame.filter(pl.col("variable") == column)
+            if sub.height == 0:
+                return frame
+            exprs = [
+                pl.lit(target).alias("variable"),
+                (100 * pl.col("mean") / norm_factor).alias("mean"),
+            ]
+            if "std" in sub.columns:
+                exprs.append((100 * pl.col("std") / norm_factor).alias("std"))
+            return pl.concat([frame, sub.with_columns(exprs)], how="diagonal_relaxed")
+        if column in frame.columns:
+            return frame.with_columns(
+                (100 * pl.col(column) / norm_factor).alias(target)
+            )
+        return frame
+
+    return _transform
+
+
+def standard_gravimetric(
+    batch: Any,
+    norm_factor: float = 120.0,
+    *,
+    group_it: bool = True,
+    columns: tuple[str, ...] = (
+        "charge_capacity",
+        "discharge_capacity",
+        "coulombic_efficiency",
+    ),
+    retention_on: str = "discharge_capacity",
+    autorun: bool = True,
+    **overrides,
+) -> BatchCollector:
+    """The standard gravimetric summary recipe.
+
+    Successor of ``collectors.standard_gravimetric_collector``: collect the
+    charge/discharge/CE metrics, partition capacity by CV step, average per
+    group, and add a normalized discharge-capacity-retention series
+    (``100 * discharge / norm_factor``). Uses native cellpycore column names
+    (the legacy ``*_gravimetric`` suffix is not part of the native schema).
+    The figure itself lands with the plotting handover in B4 (#708).
+    """
+    options = SummaryOptions(
+        columns=columns,
+        partition_by_cv=True,
+        group_it=group_it,
+        transforms=(normalize_column(retention_on, norm_factor),),
+    )
+    return BatchCollector(
+        batch, collect_summaries, options, autorun=autorun, **overrides
+    )

--- a/cellpy/collect/curves.py
+++ b/cellpy/collect/curves.py
@@ -1,0 +1,82 @@
+"""Cycle/capacity-curve collection (collectors redesign, #705).
+
+Per-cell rate/cycle selection is computed **per cell from the originally
+requested cycles** -- the fix for the cross-cell narrowing bug where the legacy
+``cycles_collector``/``ica_collector`` reassigned the shared ``cycles`` list
+inside the per-cell loop (collectors.py:1609/1691), silently dropping cycles
+for every cell after the first that lacked them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+from cellpy.collect.cells import iter_cells
+from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.collect.options import CurveOptions
+
+_KEYS = ("cell", "group", "sub_group", "cycle_num")
+
+
+def _as_polars(frame: Any) -> pl.DataFrame | None:
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    try:
+        return pl.from_pandas(frame)
+    except (TypeError, ValueError):
+        return None
+
+
+def collect_cycles(
+    batch: Any, options: CurveOptions | None = None, **overrides
+) -> Collection:
+    """Collect capacity-voltage curves per cell/cycle into one tidy Collection."""
+    opts = options or CurveOptions()
+    if overrides:
+        opts = opts.replace(**overrides)
+    requested = tuple(opts.cycles) if opts.cycles is not None else None
+
+    frames: list[pl.DataFrame] = []
+    for item in iter_cells(batch):
+        cell = item.cell
+        available = set(cell.get_cycle_numbers())
+        # PER-CELL isolation: derive this cell's cycles from the ORIGINAL
+        # request every iteration -- never narrow a shared variable.
+        if requested is None:
+            cell_cycles = sorted(available)
+        else:
+            cell_cycles = [cyc for cyc in requested if cyc in available]
+
+        for cyc in cell_cycles:
+            curve = _as_polars(cell.get_cap(cycle=cyc))
+            if curve is None or curve.height == 0:
+                continue
+            frames.append(
+                curve.with_columns(
+                    pl.lit(item.label).alias("cell"),
+                    pl.lit(item.group).alias("group"),
+                    pl.lit(item.sub_group).alias("sub_group"),
+                    pl.lit(cyc).alias("cycle_num"),
+                )
+            )
+
+    data = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    for transform in opts.transforms:
+        data = transform(data)
+
+    meta = CollectionMeta(
+        kind="cycles",
+        batch_name=batch.journal.name,
+        options={"cycles": list(requested) if requested else None, "rate": opts.rate},
+        cells_included=list(batch.cells),
+    )
+    return Collection(
+        data=data,
+        kind="cycles",
+        name=f"{batch.journal.name or 'batch'}_cycles",
+        meta=meta,
+    )

--- a/cellpy/collect/ica.py
+++ b/cellpy/collect/ica.py
@@ -1,0 +1,93 @@
+"""dQ/dV (ICA) collection (collectors redesign, #708).
+
+Per-cell dQ/dV curves via :func:`cellpy.utils.ica.dqdv`, concatenated into one
+tidy frame with ``cell`` / ``group`` / ``sub_group`` keys. Mirrors
+:func:`cellpy.collect.curves.collect_cycles` -- including the per-cell cycle
+isolation that fixes the legacy cross-cell narrowing bug (collectors.py:1691) --
+but emits the specced ICA frame (#566): ``cycle, direction, voltage, capacity,
+dqdv`` (+ the deprecated ``dq`` duplicate until 2.1).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+from cellpy.collect.cells import iter_cells
+from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.collect.options import IcaOptions
+
+
+def _as_polars(frame: Any) -> pl.DataFrame | None:
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    try:
+        return pl.from_pandas(frame)
+    except (TypeError, ValueError):
+        return None
+
+
+def collect_ica(
+    batch: Any, options: IcaOptions | None = None, **overrides
+) -> Collection:
+    """Collect dQ/dV (incremental capacity) curves per cell into one Collection.
+
+    Cycle selection is derived per cell from the *originally requested* cycles
+    every iteration, so a cell missing a cycle never narrows the request for
+    the cells after it.
+    """
+    from cellpy.utils import ica
+
+    opts = options or IcaOptions()
+    if overrides:
+        opts = opts.replace(**overrides)
+    requested = tuple(opts.cycles) if opts.cycles is not None else None
+
+    dqdv_kwargs: dict[str, Any] = {}
+    if opts.voltage_resolution is not None:
+        dqdv_kwargs["voltage_resolution"] = opts.voltage_resolution
+
+    frames: list[pl.DataFrame] = []
+    for item in iter_cells(batch):
+        cell = item.cell
+        if requested is None:
+            cycles = None
+        else:
+            available = set(cell.get_cycle_numbers())
+            cycles = [c for c in requested if c in available]
+            if not cycles:
+                continue
+
+        curve = _as_polars(ica.dqdv(cell, cycles=cycles, **dqdv_kwargs))
+        if curve is None or curve.height == 0:
+            continue
+        frames.append(
+            curve.with_columns(
+                pl.lit(item.label).alias("cell"),
+                pl.lit(item.group).alias("group"),
+                pl.lit(item.sub_group).alias("sub_group"),
+            )
+        )
+
+    data = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    for transform in opts.transforms:
+        data = transform(data)
+
+    meta = CollectionMeta(
+        kind="ica",
+        batch_name=batch.journal.name,
+        options={
+            "cycles": list(requested) if requested else None,
+            "voltage_resolution": opts.voltage_resolution,
+        },
+        cells_included=list(batch.cells),
+    )
+    return Collection(
+        data=data,
+        kind="ica",
+        name=f"{batch.journal.name or 'batch'}_ica",
+        meta=meta,
+    )

--- a/cellpy/collect/options.py
+++ b/cellpy/collect/options.py
@@ -1,0 +1,113 @@
+"""Collection options (collectors redesign, #705).
+
+One source of truth per option set: dataclasses shared by the pipeline
+functions and the convenience class. This replaces the legacy "elevated
+arguments" machinery -- ~20 parameters re-declared per collector subclass,
+packed into dicts and merged through three priority layers, with the same
+parameter documented in three places (collectors.py:995-1126, :306-316).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Callable
+
+#: A transform is a pure frame -> frame step applied after collection.
+Transform = Callable[["object"], "object"]
+
+
+@dataclass(frozen=True)
+class SummaryOptions:
+    """Options for :func:`cellpy.collect.collect_summaries`.
+
+    One source of truth for the whole summary pipeline, replacing the ~30
+    keyword arguments of the legacy ``helpers.concat_summaries``. The three
+    meaty feature families it carries:
+
+    * **rate filtering** (``rate`` / ``rate_on`` / ``rate_std`` / ...): keep
+      only cycles whose ``rate_on`` step ran at the requested C-rate.
+    * **group averaging** (``group_it`` / ``average_method`` /
+      ``custom_group_labels``): average per journal group, emitting a tidy
+      long frame ``(group, cycle_num, variable, mean, std)``.
+    * **CV partition** (``partition_by_cv``): split each capacity metric into
+      ``*_non_cv`` / ``*_cv`` contributions.
+    """
+
+    # --- column selection -------------------------------------------------
+    columns: tuple[str, ...] | None = None  # summary columns to keep (+ keys)
+
+    # --- cycle selection --------------------------------------------------
+    max_cycle: int | None = None  # drop cycles above this
+    remove_last: bool = False  # drop the final cycle (often incomplete)
+    only_selected: bool = False  # honour the journal ``selected`` column
+
+    # --- rate filtering ---------------------------------------------------
+    rate: float | None = None  # C-rate to keep (numeric, e.g. 0.05 for C/20)
+    rate_on: str | tuple[str, ...] | None = None  # step type(s), default charge
+    rate_std: float | None = None  # tolerance (default 10% of rate)
+    rate_column: str | None = None  # C-rate column (default schema c_rate)
+    rate_inverse: bool = False  # keep steps NOT at the rate
+    rate_inverted: bool = False  # keep cycles NOT selected by the rate
+
+    # --- CV partition -----------------------------------------------------
+    partition_by_cv: bool = False  # add *_non_cv / *_cv columns
+
+    # --- normalization ----------------------------------------------------
+    normalize_cycles: bool = False  # expose normalized (equivalent) cycle index
+
+    # --- grouping ---------------------------------------------------------
+    group_it: bool = False  # average per group -> long (variable/mean/std)
+    average_method: str = "mean"  # "mean" or "median" (column stays "mean")
+    custom_group_labels: Mapping | None = None  # group -> display label
+
+    # --- cleanup ----------------------------------------------------------
+    replace_inf_with_nan: bool = True  # inf -> null (plot-friendly)
+    replace_extremes_with_nan: bool = True  # out-of-range floats -> null
+    low_limit: float = -1e6
+    high_limit: float = 1e6
+
+    # --- post hooks -------------------------------------------------------
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "SummaryOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class CurveOptions:
+    """Options for cycle/capacity-curve collection."""
+
+    cycles: tuple[int, ...] | None = None  # requested cycles (per cell, isolated)
+    rate: float | None = None  # rate-based cycle selection
+    rate_on: str | None = None
+    rate_std: float | None = None
+    inverse: bool = False
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "CurveOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class IcaOptions:
+    """Options for dQ/dV (ICA) collection."""
+
+    cycles: tuple[int, ...] | None = None
+    voltage_resolution: float | None = None
+    transforms: tuple[Transform, ...] = ()
+
+    def replace(self, **changes) -> "IcaOptions":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class SaveOptions:
+    """Where/how a :class:`Collection` is saved (no cwd fallback)."""
+
+    directory: Path | None = None
+    formats: tuple[str, ...] = ("parquet", "csv")
+
+    def replace(self, **changes) -> "SaveOptions":
+        return replace(self, **changes)

--- a/cellpy/collect/summary.py
+++ b/cellpy/collect/summary.py
@@ -1,0 +1,147 @@
+"""Summary collection (collectors redesign, #705/#706).
+
+Assembles per-cell summaries into one tidy :class:`Collection`, carrying the
+full rate-filtering / grouping / CV-partition feature set of the legacy
+``helpers.concat_summaries`` on the :class:`SummaryOptions` model. Cycle-level
+work (rate/CV/max-cycle) happens per cell in :mod:`._summary_ops`; combination,
+column selection, group averaging and cleanup happen on the combined frame.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+import polars as pl
+
+from cellpy.batch.journal import FILENAME
+from cellpy.collect import _summary_ops as ops
+from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.collect.options import SummaryOptions
+
+_KEYS = ("cell", "group", "sub_group", "group_label", "label", ops.CYCLE)
+
+
+def _pages_lookup(batch: Any) -> dict[str, dict[str, Any]]:
+    """label -> row-dict of journal metadata (group/sub_group/group_label/selected)."""
+    lookup: dict[str, dict[str, Any]] = {}
+    pages = batch.journal.pages
+    if FILENAME not in pages.columns:
+        return lookup
+    wanted = [
+        c
+        for c in ("group", "sub_group", "group_label", "label", "selected")
+        if c in pages.columns
+    ]
+    for row in pages.iter_rows(named=True):
+        lookup[row[FILENAME]] = {c: row.get(c) for c in wanted}
+    return lookup
+
+
+def collect_summaries(
+    batch: Any, options: SummaryOptions | None = None, **overrides
+) -> Collection:
+    """Collect per-cell summaries into one tidy :class:`Collection`.
+
+    With defaults this is a plain long-format concatenation (one row per
+    cell/cycle). The options add rate filtering, CV partition, per-group
+    averaging and inf/extreme cleanup -- see :class:`SummaryOptions`.
+    """
+    opts = options or SummaryOptions()
+    if overrides:
+        opts = opts.replace(**overrides)
+
+    lookup = _pages_lookup(batch)
+
+    frames: list[pl.DataFrame] = []
+    included: list[str] = []
+    for label, cell in batch.cells.items():
+        meta = lookup.get(label, {})
+        if opts.only_selected and "selected" in meta and meta.get("selected") != 1:
+            continue
+
+        frame = ops.extract_cell_summary(cell, opts)
+        if frame is None or frame.height == 0:
+            continue
+
+        frames.append(
+            frame.with_columns(
+                pl.lit(label).alias("cell"),
+                pl.lit(meta.get("group")).alias("group"),
+                pl.lit(meta.get("sub_group")).alias("sub_group"),
+                pl.lit(meta.get("group_label")).alias("group_label"),
+                pl.lit(meta.get("label")).alias("label"),
+            )
+        )
+        included.append(label)
+
+    frame = (
+        pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    )
+
+    if opts.columns and frame.height:
+        keep = [c for c in _KEYS if c in frame.columns]
+        wanted = list(opts.columns)
+        if opts.partition_by_cv:
+            # keep the derived CV split alongside each requested metric
+            wanted = [
+                name
+                for col in wanted
+                for name in (col, f"{col}_non_cv", f"{col}_cv")
+            ]
+        keep += [c for c in wanted if c in frame.columns and c not in keep]
+        frame = frame.select(keep)
+
+    grouped = False
+    if opts.group_it and frame.height:
+        # legacy guard: std needs >= 2 cells per group; disable if any group is
+        # short (a single-cell group -- or no group column -- keeps it wide).
+        sizes = Counter(lookup.get(lbl, {}).get("group") for lbl in included)
+        if sizes and min(sizes.values()) >= 2:
+            group_labels = {
+                m.get("group"): m.get("group_label")
+                for m in lookup.values()
+                if m.get("group_label") is not None
+            }
+            if opts.custom_group_labels:
+                group_labels = {**group_labels, **dict(opts.custom_group_labels)}
+            frame = ops.group_average(
+                frame, opts, keys=_KEYS, group_labels=group_labels or None
+            )
+            grouped = True
+
+    if frame.height and (opts.replace_inf_with_nan or opts.replace_extremes_with_nan):
+        if grouped:
+            clean_cols = [c for c in ("mean", "std") if c in frame.columns]
+        else:
+            clean_cols = ops._numeric_value_columns(frame, _KEYS)
+        frame = ops.clean_extremes(
+            frame,
+            clean_cols,
+            replace_inf=opts.replace_inf_with_nan,
+            replace_extremes=opts.replace_extremes_with_nan,
+            low=opts.low_limit,
+            high=opts.high_limit,
+        )
+
+    for transform in opts.transforms:
+        frame = transform(frame)
+
+    meta = CollectionMeta(
+        kind="summary",
+        batch_name=batch.journal.name,
+        options={
+            "columns": list(opts.columns) if opts.columns else None,
+            "group_it": opts.group_it,
+            "rate": opts.rate,
+            "partition_by_cv": opts.partition_by_cv,
+            "max_cycle": opts.max_cycle,
+        },
+        cells_included=included,
+    )
+    return Collection(
+        data=frame,
+        kind="summary",
+        name=f"{batch.journal.name or 'batch'}_summary",
+        meta=meta,
+    )

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,0 +1,24 @@
+# Batch
+
+Run a set of cells as one job: build a journal, load/update the cells, and
+aggregate their summaries.
+
+`cellpy.batch` is the 2.1 batch subsystem (it replaced the
+`cellpy.utils.batch_tools` machinery). `cellpy.utils.batch` remains as a thin
+re-export of the entry points below.
+
+## Entry points
+
+::: cellpy.batch
+
+## Facade
+
+::: cellpy.batch.facade
+
+## Journal
+
+::: cellpy.batch.journal
+
+## Aggregation
+
+::: cellpy.batch.aggregate

--- a/docs/api/collect.md
+++ b/docs/api/collect.md
@@ -1,0 +1,28 @@
+# Collect
+
+Turn a batch into one tidy, multi-cell frame: summaries, cycle/capacity curves,
+or dQ/dV (ICA).
+
+`cellpy.collect` is the 2.1 collectors redesign (it replaced the
+`BatchCollector` family). `cellpy.utils.collectors` remains as a thin
+re-export. Each collector returns a [`Collection`](#the-collection-product).
+
+## Collectors
+
+::: cellpy.collect
+
+## Summary collection
+
+::: cellpy.collect.summary
+
+## Cycle / capacity curves
+
+::: cellpy.collect.curves
+
+## Incremental capacity (ICA)
+
+::: cellpy.collect.ica
+
+## The Collection product
+
+::: cellpy.collect.collection

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,7 +18,9 @@ you already know what you want and need the signature.
 | Load a file, get capacities, save | [cellpy](cellpy.md) — `get`, `CellpyCell` |
 | The cell object and its frames | [Readers](readers.md) |
 | Instrument loaders and the plugin contract | [Instruments](instruments.md) |
-| Batch, plotting, helpers, ICA | [Utils](utils.md) |
+| Run a set of cells as one job | [Batch](batch.md) |
+| Collect a batch into one tidy frame | [Collect](collect.md) |
+| Plotting, helpers, ICA | [Utils](utils.md) |
 | Configuration and column schemas | [Parameters and config](parameters.md) |
 
 ## Stability

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,8 +1,13 @@
 # Utils
 
-Batch processing, plotting, and the analysis helpers.
+Plotting and the analysis helpers. Batch and collection moved to their own
+packages in 2.1 — see [Batch](batch.md) and [Collect](collect.md);
+`cellpy.utils.batch` / `cellpy.utils.collectors` are thin re-export shims of
+those.
 
-## Batch
+## Batch (shim)
+
+Re-exports [`cellpy.batch`](batch.md).
 
 ::: cellpy.utils.batch
 
@@ -18,5 +23,9 @@ Incremental capacity analysis lives at [`cellpy.ica`](ica.md) since 2.0;
 ::: cellpy.utils.ocv_rlx
 
 ::: cellpy.utils.helpers
+
+## Collectors (shim)
+
+Re-exports [`cellpy.collect`](collect.md).
 
 ::: cellpy.utils.collectors

--- a/docs/getting_started/migration_v1_to_v2.md
+++ b/docs/getting_started/migration_v1_to_v2.md
@@ -4,6 +4,9 @@ This guide maps **user-visible breaks** between the 1.x line and cellpy 2.0
 to a named fix or workaround. Keep the `v1.x` branch / 1.x PyPI releases if you
 need unchanged 1.x behaviour.
 
+**Already on 2.0?** See [Coming from cellpy 2.0](migration_v2.0_to_2.1.md) for
+the 2.0 → 2.1 shim removals (headers, ICA, plotting, batch, config).
+
 After **cellpy 2.0.0**, the `v1.x` line is **bugfix-only for 12 months** from
 the 2.0 release date (decision #438-6). Feature work lands only on 2.x.
 

--- a/docs/getting_started/migration_v2.0_to_2.1.md
+++ b/docs/getting_started/migration_v2.0_to_2.1.md
@@ -1,0 +1,214 @@
+# Migrating from cellpy 2.0 to 2.1
+
+cellpy **2.1** completes "Stage 4": it **removes the 2.0 deprecation shims**
+(breaking) and finishes the batch / collect redesign. Every 2.0 shim that
+warned *"removed in 2.1"* is now gone.
+
+**If you heeded the 2.0 `DeprecationWarning`s, you are already migrated.** This
+guide maps each removed surface to its replacement. What still warns (now with a
+2.2 removal date) is listed in
+[`DEPRECATIONS.md`](../reference/deprecations.md).
+
+## At a glance
+
+| Area | Removed in 2.1 | Use instead |
+|---|---|---|
+| Column names | `c.headers_normal` / `c.headers_summary` / `c.headers_step_table` | `c.schema.raw` / `c.schema.summary` / `c.schema.steps` |
+| Empty cell | `make_new_cell()` | `CellpyCell.vacant()` |
+| ICA | `ica.Converter`, `dqdv_cycle` / `dqdv_cycles` / `dqdv_np`, the duplicate `dq` column | `ica.dqdv(...)` |
+| Plotting | `interactive=`, `xlim=` / `ylim=`, `summary_plot_legacy` | `backend=` + the returned figure |
+| Plot backends | `backend="seaborn"`, `backend="bokeh"` | `"plotly"` (default) or `"matplotlib"` |
+| Batch package | `cellpy.utils.batch_tools.*` | `cellpy.batch` / `cellpy.collect` |
+| Config | `prms.Paths` / `prms.Reader` / … global-mutation shim | `cellpy.config` (or `cellpy.config.override(...)`) |
+
+`cellpy.utils.batch` and `cellpy.utils.collectors` remain as **permanent
+one-line re-export shims**, so the top-level import paths keep working.
+
+## Column headers: `c.headers_*` → `c.schema.*`
+
+The per-cell `headers_normal` / `headers_summary` / `headers_step_table`
+attributes were a 2.0 shim that mapped legacy `*_txt` names to the native
+cellpy-core column names. They are removed. `c.schema` is the replacement — and
+its contract is stronger: **whatever `c.schema.<frame>.<column>` returns is a
+valid key into `c.data.<frame>`** on both the native and legacy runtimes.
+
+| Legacy attribute | Replacement |
+|---|---|
+| `c.headers_normal` | `c.schema.raw` |
+| `c.headers_step_table` | `c.schema.steps` |
+| `c.headers_summary` | `c.schema.summary` |
+
+The column *names* changed too (native cellpy-core spelling). The most common:
+
+| Frame | Legacy `*_txt` / name | Native (`c.schema.*`) |
+|---|---|---|
+| raw | `voltage_txt` | `potential` |
+| raw | `current_txt` | `current` |
+| raw | `cycle_index_txt` | `cycle_num` |
+| raw | `step_index_txt` | `step_num` |
+| raw | `data_point_txt` | `datapoint_num` |
+| raw | `test_time_txt` | `test_time` |
+| raw | `charge_capacity_txt` | `cumulative_charge_capacity` |
+| raw | `discharge_capacity_txt` | `cumulative_discharge_capacity` |
+| steps | `type` | `step_type` |
+| steps | `cycle` | `cycle_num` |
+| steps | `step` | `step_num` |
+| steps | `rate_avr` | `c_rate` |
+| summary | `cycle_index` | `cycle_num` |
+| summary | `data_point` | `datapoint_num_last` |
+| summary | `test_time` | `last_test_time` |
+| summary | `end_voltage_charge` / `end_voltage_discharge` | `potential_end_charge` / `potential_end_discharge` |
+
+```python
+# 2.0
+hdr = c.headers_normal
+v = c.data.raw[hdr.voltage_txt]
+
+# 2.1
+v = c.data.raw[c.schema.raw.potential]
+```
+
+`make_new_cell()` is gone — use the classmethod `CellpyCell.vacant()`.
+
+## Incremental capacity analysis (ICA)
+
+The 1.x ICA compatibility layer is removed.
+
+| Removed | Use instead |
+|---|---|
+| `ica.Converter` | `ica.dqdv(...)` |
+| `ica.dqdv_cycle(...)` / `dqdv_cycles(...)` / `dqdv_np(...)` | `ica.dqdv(...)` |
+| `dqdv(..., split=…, tidy=…, cycle=…, label_direction=…)` | the current `dqdv` signature |
+| the duplicate `dq` output column | the single canonical dQ/dV column |
+
+For **multi-cell** ICA collection, prefer `cellpy.collect.collect_ica(batch)`
+(see the batch section below).
+
+## Plotting
+
+Legacy `summary_plot` knobs are removed:
+
+| Removed | Use instead |
+|---|---|
+| `interactive=True/False` | pick the engine with `backend=` |
+| `xlim=` / `ylim=` | `x_range=` / `y_range=` |
+| `summary_plot_legacy` | `summary_plot` |
+
+### Backends dropped: seaborn and bokeh
+
+Only **plotly** (default) and **matplotlib** remain. `backend="seaborn"` and
+`backend="bokeh"` now raise `ValueError`:
+
+```python
+from cellpy.utils.plotutils import summary_plot
+
+# 2.0: summary_plot(c, interactive=True, backend="seaborn")
+# 2.1:
+fig = summary_plot(c, backend="plotly")      # or backend="matplotlib"
+```
+
+## Batch and collectors
+
+The `cellpy.utils.batch_tools` "farm/barn" machinery is **removed**. The batch
+subsystem now lives in `cellpy.batch`, and the collectors in `cellpy.collect`.
+`cellpy.utils.batch` and `cellpy.utils.collectors` stay as thin re-exports.
+
+### Symbol map
+
+| 2.0 (`utils/batch_tools`) | 2.1 |
+|---|---|
+| `utils.batch.init(...)` | `cellpy.batch.load(...)` (or `cellpy.utils.batch.init`, shim) |
+| `batch_journals.LabJournal` + `from_db()` | `cellpy.batch.Batch.from_db(...)` |
+| `batch_journals.LabJournal().from_file(...)` | `cellpy.batch.from_journal(...)` |
+| `engines.simple_db_engine(...)` | internal — `cellpy.batch.Batch.from_db(...)` |
+| `BatchSummaryCollector` / `summary_collector(...)` | `cellpy.collect.collect_summaries(batch)` |
+| `BatchCyclesCollector` / `cycles_collector(...)` | `cellpy.collect.collect_cycles(batch)` |
+| `BatchICACollector` / `ica_collector(...)` | `cellpy.collect.collect_ica(batch)` |
+| `batch_exporters` / `dumpers` | `cellpy.batch` outputs (`Batch.combine_summaries()`, `to_bdf`, …) |
+
+### `iterate_batches` / `process_batch` are recipes now
+
+Instead of the removed helpers, loop over `cellpy.batch.load`:
+
+```python
+# process_batch(...) equivalent
+from cellpy import batch
+
+b = batch.load("my_batch", "my_project")
+b.update()
+summaries = b.combine_summaries()
+```
+
+```python
+# iterate_batches(...) equivalent
+for name in ("batch_a", "batch_b"):
+    b = batch.load(name, "my_project")
+    b.update()
+    ...
+```
+
+### Bug fix: cross-cell cycle narrowing
+
+The legacy `cycles_collector` / `ica_collector` reassigned the **shared**
+`cycles` list inside their per-cell loop. If the first cell lacked a requested
+cycle, that cycle was silently dropped for **every cell after it**.
+
+`cellpy.collect` computes the cycle selection **per cell from the originally
+requested cycles**, so one cell missing a cycle never narrows the request for
+the others.
+
+```text
+Request: cycles [1, 2, 3, 4, 5] across cells A, B, C
+  cell A has [1, 2, 3]  (missing 4, 5)
+
+2.0 (buggy): shared `cycles` narrows to [1, 2, 3] after A
+             → B and C also lose 4, 5
+2.1 (fixed): A returns [1, 2, 3]; B and C still return [1, 2, 3, 4, 5]
+```
+
+This is a **behavior change**: multi-cell curve/ICA collections now include
+cycles that were previously dropped. If you relied on the narrowed output, pass
+an explicit cycle list.
+
+## Configuration: `prms.*` → `cellpy.config`
+
+The `prms.Paths` / `prms.Reader` / `prms.Batch` / … capitalized-section shim
+(which forwarded reads and global mutation to `cellpy.config` with a
+`DeprecationWarning`) is removed. Use `cellpy.config` directly.
+
+| 2.0 | 2.1 |
+|---|---|
+| `prms.Paths.rawdatadir = ...` | `config.paths.rawdatadir = ...` |
+| `prms.FileNames.raw_extension` | `config.file_names.raw_extension` |
+| `prms.Reader.cycle_mode` | `config.reader.cycle_mode` |
+| `prms.Db` / `prms.DbCols` | `config.db` / `config.db_cols` |
+| `prms.Batch.auto_use_file_list` | `config.batch.auto_use_file_list` |
+| `prms.Instruments.tester` | `config.instruments.tester` |
+| `prms.CellInfo.*` | `config.defaults.cell_info.*` |
+| `prms.Materials.*` | `config.defaults.materials.*` |
+
+```python
+from cellpy import config
+
+# direct mutation (global, as before)
+config.paths.rawdatadir = "/data/raw"
+config.reader.cycle_mode = "cathode"
+
+# or scoped, auto-restoring:
+with config.override(reader={"cycle_mode": "cathode"}):
+    ...
+```
+
+**Kept past 2.1:** the `CellpyCell.mass`, `.nom_cap`, and `.nom_cap_specifics`
+property facades are *not* deprecated — `c.mass = 0.86` keeps working.
+
+## Deprecations remaining
+
+Only future-dated (2.2) deprecations still warn. See
+[`DEPRECATIONS.md`](../reference/deprecations.md) (generated from
+`cellpy._deprecation`; regenerate with `uv run python -m cellpy._deprecation`).
+
+| Name | Replacement | Removal |
+|---|---|---|
+| `MultiCycleOcvFit.data` | `MultiCycleOcvFit.cell` | 2.2 |
+| `MultiCycleOcvFit.set_data` | `MultiCycleOcvFit.set_cell` | 2.2 |

--- a/zensical.toml
+++ b/zensical.toml
@@ -68,6 +68,8 @@ nav = [
         { "API" = [
             "api/index.md",
             { "cellpy" = "api/cellpy.md" },
+            { "Batch" = "api/batch.md" },
+            { "Collect" = "api/collect.md" },
             { "ICA and DVA" = "api/ica.md" },
             { "Plotting" = "api/plotting.md" },
             { "Readers" = "api/readers.md" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -35,6 +35,7 @@ nav = [
         { "Basic usage" = "getting_started/basic_usage.md" },
         { "Using cellpy from an agent" = "getting_started/agents.md" },
         { "Coming from cellpy 1.x" = "getting_started/migration_v1_to_v2.md" },
+        { "Coming from cellpy 2.0" = "getting_started/migration_v2.0_to_2.1.md" },
     ] },
     { "Tutorials" = [
         "examples/index.md",


### PR DESCRIPTION
## Summary
- Cherry-pick docs from `master` into `v2-docs-stable` for the 2.1 ship (#768):
  - 2.0→2.1 migration guide (#720 / #755)
  - `cellpy.batch` / `cellpy.collect` API reference (#719 / #756)

Skipped #754 (marimo integrate into master) — marimo was withdrawn on this docs branch.

## Test plan
- [ ] Docs site / RTD build for `v2-docs-stable` looks sane
- [ ] Migration guide and API pages render

Refs #768


Made with [Cursor](https://cursor.com)