### PR TITLE
feat(collect): CurveOptions mode/method forwarded to get_cap (#788)

### DIFF
--- a/cellpy/collect/curves.py
+++ b/cellpy/collect/curves.py
@@ -39,6 +39,12 @@ def collect_cycles(
     if overrides:
         opts = opts.replace(**overrides)
     requested = tuple(opts.cycles) if opts.cycles is not None else None
+    # forward mode/method to get_cap only when set, so None keeps its defaults
+    cap_kwargs: dict[str, Any] = {}
+    if opts.mode is not None:
+        cap_kwargs["mode"] = opts.mode
+    if opts.method is not None:
+        cap_kwargs["method"] = opts.method
 
     frames: list[pl.DataFrame] = []
     for item in iter_cells(batch):
@@ -52,7 +58,7 @@ def collect_cycles(
             cell_cycles = [cyc for cyc in requested if cyc in available]
 
         for cyc in cell_cycles:
-            curve = _as_polars(cell.get_cap(cycle=cyc))
+            curve = _as_polars(cell.get_cap(cycle=cyc, **cap_kwargs))
             if curve is None or curve.height == 0:
                 continue
             frames.append(
@@ -71,7 +77,12 @@ def collect_cycles(
     meta = CollectionMeta(
         kind="cycles",
         batch_name=batch.journal.name,
-        options={"cycles": list(requested) if requested else None, "rate": opts.rate},
+        options={
+            "cycles": list(requested) if requested else None,
+            "rate": opts.rate,
+            "mode": opts.mode,
+            "method": opts.method,
+        },
         cells_included=list(batch.cells),
     )
     return Collection(

--- a/cellpy/collect/options.py
+++ b/cellpy/collect/options.py
@@ -84,6 +84,11 @@ class CurveOptions:
     rate_on: str | None = None
     rate_std: float | None = None
     inverse: bool = False
+    # capacity mode/method, forwarded per cell to ``CellpyCell.get_cap`` for
+    # parity with the single-cell call. ``None`` keeps ``get_cap``'s defaults
+    # (mode="gravimetric", method="back-and-forth").
+    mode: str | None = None  # "gravimetric" / "areal" / "absolute"
+    method: str | None = None  # "forth-and-forth" / "back-and-forth" / "forth"
     transforms: tuple[Transform, ...] = ()
 
     def replace(self, **changes) -> "CurveOptions":

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -58,6 +58,46 @@ def test_cycles_collector_runs_native_curve_cols(populated_batch):
     assert "voltage" not in cols, f"legacy curve name in {cols}"
 
 
+def test_collect_cycles_forwards_mode_and_method(populated_batch, monkeypatch):
+    """CurveOptions.mode/method reach the per-cell get_cap call (#788)."""
+    from cellpy.collect import collect_cycles
+
+    captured: dict = {}
+    cell0 = next(iter(populated_batch.cells.values()))
+    original = cell0.get_cap
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cell0, "get_cap", spy)
+    col = collect_cycles(populated_batch, cycles=(1,), mode="areal", method="forth")
+
+    assert captured.get("mode") == "areal"
+    assert captured.get("method") == "forth"
+    assert col.meta.options["mode"] == "areal"
+    assert col.meta.options["method"] == "forth"
+
+
+def test_collect_cycles_mode_method_default_to_none(populated_batch, monkeypatch):
+    """Unset mode/method are NOT forwarded, so get_cap keeps its own defaults (#788)."""
+    from cellpy.collect import collect_cycles
+
+    captured: dict = {}
+    cell0 = next(iter(populated_batch.cells.values()))
+    original = cell0.get_cap
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cell0, "get_cap", spy)
+    collect_cycles(populated_batch, cycles=(1,))
+
+    assert "mode" not in captured
+    assert "method" not in captured
+
+
 def test_ica_collector_uses_the_specced_frame(populated_batch):
     """The ICA frame is the specced frame (#566/#591): cycle/direction/voltage/
     capacity/dqdv, direction spelled out (cell-centric charge/discharge)."""


### PR DESCRIPTION
Adds `mode` (gravimetric/areal/absolute) and `method` (forth-and-forth/back-and-forth/forth) to `CurveOptions`, forwarded per cell to `CellpyCell.get_cap` in `collect_cycles` — parity with the single-cell call. Unset (`None`) keeps get_cap's defaults, so existing behaviour is unchanged unless opted into. Recorded in `CollectionMeta.options`.

Tests: spy on a cell's `get_cap` to prove forwarding, and that unset params are not forwarded.

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)