### PR TITLE
feat(collect): Collection.save() supports xlsx and json (#789)

### DIFF
--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -95,14 +95,35 @@ class Collection:
                 self.data.write_parquet(path)
             elif fmt == "csv":
                 self.data.write_csv(path)
+            elif fmt == "json":
+                self.data.write_json(path)
+            elif fmt == "xlsx":
+                self._write_xlsx(path)
             else:
-                raise ValueError(f"unsupported collection format {fmt!r}")
+                raise ValueError(
+                    f"unsupported collection format {fmt!r} "
+                    "(supported: parquet, csv, json, xlsx)"
+                )
             written.append(path)
 
         meta_path = directory / f"{self.name}.meta.json"
         meta_path.write_text(json.dumps(asdict(self.meta), indent=2), encoding="utf-8")
         written.append(meta_path)
         return written
+
+    def _write_xlsx(self, path: Path) -> None:
+        """Write the frame as xlsx via polars (xlsxwriter), falling back to
+        pandas (openpyxl); raise a clear error if no Excel engine is installed."""
+        try:
+            self.data.write_excel(path)
+        except (ModuleNotFoundError, ImportError):
+            try:
+                self.data.to_pandas().to_excel(path, index=False)
+            except (ModuleNotFoundError, ImportError) as exc:
+                raise RuntimeError(
+                    "saving a collection as xlsx needs an Excel writer -- install "
+                    "'xlsxwriter' or 'openpyxl'"
+                ) from exc
 
 
 def load_collection(path: Path | str) -> Collection:

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -312,3 +312,42 @@ def test_collect_cycles_per_cell_isolation():
     assert a_cycles == {1, 2}
     # the bug: after cell_a narrowed the shared list, cell_b lost cycle 3
     assert b_cycles == {1, 2, 3}
+
+
+# ---- save formats (#789) ------------------------------------------------
+
+
+def _small_collection() -> Collection:
+    frame = pl.DataFrame(
+        {"cell": ["a", "b"], "cycle_num": [1, 1], "value": [1.5, 2.5]}
+    )
+    return Collection(
+        data=frame, kind="summary", name="c", meta=CollectionMeta(kind="summary")
+    )
+
+
+def test_collection_save_json_round_trips(tmp_path):
+    col = _small_collection()
+    written = col.save(tmp_path, formats=("json",))
+    json_path = tmp_path / "c.json"
+    assert json_path in written
+    assert json_path.is_file() and json_path.stat().st_size > 0
+    back = pl.read_json(json_path)
+    assert back.shape == col.data.shape
+    assert set(back.columns) == set(col.data.columns)
+
+
+def test_collection_save_xlsx(tmp_path):
+    col = _small_collection()
+    try:
+        col.save(tmp_path, formats=("xlsx",))
+    except RuntimeError:
+        pytest.skip("no Excel writer (xlsxwriter/openpyxl) installed")
+    xlsx_path = tmp_path / "c.xlsx"
+    assert xlsx_path.is_file() and xlsx_path.stat().st_size > 0
+
+
+def test_collection_save_rejects_unknown_format(tmp_path):
+    col = _small_collection()
+    with pytest.raises(ValueError, match="unsupported collection format"):
+        col.save(tmp_path, formats=("bogus",))


### PR DESCRIPTION
Adds `json` and `xlsx` to `Collection.save` formats (was parquet/csv only). xlsx uses polars `write_excel` with a pandas `to_excel` fallback and a clear error when no Excel writer is installed; unknown formats now name the supported set.

Tests: json round-trip, xlsx write (skips if no engine), unknown-format error.

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)