### PR TITLE
feat(collect): Collection.is_grouped / meta.grouped flag (#790)

### DIFF
--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -41,6 +41,10 @@ class CollectionMeta:
     created_utc: str = field(default_factory=_now_utc)
     cells_included: list[str] = field(default_factory=list)
     cells_skipped: list[str] = field(default_factory=list)
+    #: True only when group-averaging actually ran (a group had >= 2 cells and
+    #: emitted the long ``mean``/``std`` frame). ``group_it=True`` that fell back
+    #: to a wide, non-averaged frame stays False.
+    grouped: bool = False
 
 
 @dataclass
@@ -54,6 +58,14 @@ class Collection:
 
     #: collection kind -> ``collected_plot`` family (#657).
     _FAMILY = {"summary": "summary", "cycles": "cycles", "ica": "ica"}
+
+    @property
+    def is_grouped(self) -> bool:
+        """True when group-averaging actually happened (long ``mean``/``std``
+        frame). ``group_it=True`` that fell back to wide (a group with < 2 cells)
+        stays False -- so callers can adapt labels/plotting without sniffing for
+        a ``mean`` column."""
+        return self.meta.grouped
 
     def to_wide(
         self, values: str, index: str = "cycle_num", columns: str = "cell"

--- a/cellpy/collect/summary.py
+++ b/cellpy/collect/summary.py
@@ -138,6 +138,7 @@ def collect_summaries(
             "max_cycle": opts.max_cycle,
         },
         cells_included=included,
+        grouped=grouped,
     )
     return Collection(
         data=frame,

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -170,6 +170,42 @@ def test_collect_summaries_group_average_needs_group_column():
     assert "variable" not in col.data.columns
 
 
+# ---- is_grouped flag (#790) ---------------------------------------------
+
+
+def test_is_grouped_true_when_averaged():
+    pages = pl.DataFrame({FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]})
+    b = _batch_with_cells(
+        {"x": _SummaryCell([10.0, 20.0]), "y": _SummaryCell([20.0, 40.0])}, pages
+    )
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    assert col.is_grouped is True
+    assert col.meta.grouped is True
+
+
+def test_is_grouped_false_on_single_cell_group_fallback():
+    # group_it=True but the (single-cell) group can't average -> wide fallback
+    pages = pl.DataFrame({FILENAME: ["x"], "group": [1], "sub_group": [1]})
+    b = _batch_with_cells({"x": _SummaryCell([1.0, 2.0])}, pages)
+    col = collect_summaries(b, group_it=True)
+    assert col.is_grouped is False
+
+
+def test_is_grouped_false_by_default(real_batch):
+    assert collect_summaries(real_batch).is_grouped is False
+
+
+def test_grouped_flag_survives_save_load(tmp_path):
+    pages = pl.DataFrame({FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]})
+    b = _batch_with_cells(
+        {"x": _SummaryCell([10.0, 20.0]), "y": _SummaryCell([20.0, 40.0])}, pages
+    )
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    col.save(tmp_path, formats=("parquet",))
+    loaded = load_collection(tmp_path / f"{col.name}.parquet")
+    assert loaded.is_grouped is True
+
+
 # ---- BatchCollector convenience + recipes (#707) ------------------------
 
 


### PR DESCRIPTION
`collect_summaries(group_it=True)` silently returns a wide, non-averaged frame when a group has < 2 cells. This surfaces whether averaging actually happened via `CollectionMeta.grouped` + a `Collection.is_grouped` property, so apps no longer sniff for a `mean` column. Defaults False; round-trips through save/load.

Tests: grouped→True, single-cell fallback→False, default→False, save/load survives.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)