### PR TITLE
fix(plotting): render group-averaged collected summaries (#785)

### DIFF
--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -177,7 +177,10 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
     else:
         mode = "lines"
 
-    g = curves.groupby("cell")
+    # Series key: per-cell frames use "cell"; group-averaged frames are keyed by
+    # "group" and have no "cell" column (#785).
+    series_col = "cell" if "cell" in curves.columns else "group"
+    g = curves.groupby(series_col)
     fig = make_subplots(
         rows=number_of_rows,
         cols=1,
@@ -1017,7 +1020,11 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
         )
 
     normalize_cycles = True if "equivalent_cycle" in id_vars else False
-    group_it = False if hdr_journal.group in id_vars else True
+    # A group-averaged frame is tidy long with ``mean``/``std`` and is keyed by
+    # ``group`` (no ``cell`` column) -- detect it by the ``mean`` column, NOT by
+    # the presence of ``group`` (a non-averaged wide frame also carries ``group``
+    # as a key, #785).
+    group_it = "mean" in id_vars
 
     cols = kwargs.pop("cols", 1)
 
@@ -1037,6 +1044,9 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
         group_cells = False
         y = "mean"
         standard_deviation = "std"
+        # the series is the group, not the (absent) per-cell column
+        if hdr_journal.group in id_vars:
+            z = hdr_journal.group
 
     else:
         y = "value"

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -166,3 +166,31 @@ def test_shim_still_reexports_the_shared_plotting_helpers():
         "collected_plot",
     ):
         assert hasattr(collectors_mod, name), name
+
+
+# ---- group-averaged summary renders (#785) ------------------------------
+
+
+def test_group_averaged_summary_renders():
+    """A group-averaged summary (keyed by ``group``, no ``cell`` column) must
+    plot -- previously KeyError 'cell' in spread_plot / y='value' in px.line."""
+    import polars as pl
+
+    from cellpy.batch.journal import FILENAME
+    from cellpy.collect import collect_summaries
+    from tests.test_collect import _batch_with_cells, _SummaryCell
+
+    pages = pl.DataFrame({FILENAME: ["x", "y"], "group": [1, 1], "sub_group": [1, 2]})
+    b = _batch_with_cells(
+        {"x": _SummaryCell([10.0, 20.0, 30.0]), "y": _SummaryCell([20.0, 40.0, 60.0])},
+        pages,
+    )
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    # genuinely averaged: long frame keyed by group, no per-cell column
+    assert "mean" in col.data.columns and "cell" not in col.data.columns
+
+    fig = col.plot()
+    assert fig is not None and len(fig.data) > 0, "grouped summary plot() produced nothing"
+
+    fig_spread = col.plot(spread=True)
+    assert fig_spread is not None and len(fig_spread.data) > 0, "spread plot produced nothing"


### PR DESCRIPTION
A group-averaged summary is tidy long, keyed by `group` (`mean`/`std`, no `cell` column). The renderer assumed a per-cell frame:

- `summary_plotter` detected "averaged" by the *absence* of a `group` column — but a non-averaged wide frame also has `group`, so it picked `y="value"` (missing) for the averaged frame. Now detects by the `mean` column and uses `group` as the series.
- `spread_plot` hard-coded `groupby("cell")` → `KeyError 'cell'`. Now groups by the available series column (`cell`, else `group`).

`col.plot()` and `col.plot(spread=True)` both render group-averaged summaries now (group as the series, mean ± std band). Per-cell path unchanged; adds an end-to-end regression test.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)