### PR TITLE
feat: quiet app-facing cellpy.list_instruments() (#786)

### DIFF
--- a/cellpy/__init__.py
+++ b/cellpy/__init__.py
@@ -26,7 +26,7 @@ from cellpy.parameters import prmreader
 
 __version__ = cellpy._version.__version__
 
-from cellpy.readers import cellreader, dbreader, filefinder, do
+from cellpy.readers import cellreader, dbreader, filefinder, do, data_structures
 
 # from cellpy.readers.data_structures import Q, ureg
 
@@ -42,6 +42,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 get = cellreader.get
 merge_cells = cellreader.merge_cells
 print_instruments = readers.cellreader.print_instruments
+list_instruments = readers.data_structures.list_instruments
 
 __all__ = [
     "cellreader",
@@ -52,6 +53,7 @@ __all__ = [
     "get",
     "merge_cells",
     "print_instruments",
+    "list_instruments",
     "do",
     # "ureg",
     # "Q",

--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -1026,6 +1026,91 @@ def instrument_configurations(search_text: str = "") -> Dict[str, Any]:
     return instruments
 
 
+# Vendor / file-format tokens used to build a human label from a loader id
+# (e.g. "arbin_sql_csv" -> "Arbin SQL (CSV)"). Low-maintenance: unknown vendors
+# fall back to a capitalised id, unknown format tokens to upper/title case.
+_INSTRUMENT_VENDOR_LABELS = {
+    "arbin": "Arbin",
+    "maccor": "Maccor",
+    "neware": "Neware",
+    "pec": "PEC",
+    "batmo": "BatMo",
+    "biologics": "Bio-Logic",
+}
+_INSTRUMENT_FORMAT_TOKENS = {
+    "txt": "(text)",
+    "csv": "(CSV)",
+    "xlsx": "(Excel)",
+    "h5": "(HDF5)",
+    "res": "(res)",
+    "nda": "(nda)",
+    "mpr": "(mpr)",
+    "bdf": "BDF",
+    "sql": "SQL",
+}
+
+
+def _instrument_label(loader_id: str) -> str:
+    """A display label derived from a loader id (no per-instrument table)."""
+    parts = loader_id.split("_")
+    vendor = _INSTRUMENT_VENDOR_LABELS.get(parts[0], parts[0].capitalize())
+    rest = [
+        _INSTRUMENT_FORMAT_TOKENS.get(
+            p, p.upper() if len(p) <= 2 else p.capitalize()
+        )
+        for p in parts[1:]
+    ]
+    return " ".join([vendor, *rest]).strip()
+
+
+def list_instruments() -> List[Dict[str, Any]]:
+    """Quiet, app-facing instrument listing.
+
+    Returns one dict per loader -- ``{"id", "label", "models", "suffixes"}`` --
+    suitable for building an instrument picker / ingestion form. Unlike
+    :func:`instrument_configurations`, it does **not** log a warning for each
+    skipped non-loader module, and it includes a human ``label`` and the raw
+    file ``suffixes``.
+
+    Example::
+
+        [{"id": "maccor_txt", "label": "Maccor (text)",
+          "models": ["default", "ZERO", ...], "suffixes": [".txt"]}, ...]
+    """
+    cellpy_logger = logging.getLogger("cellpy")
+    previous_level = cellpy_logger.level
+    cellpy_logger.setLevel(logging.ERROR)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            factory = InstrumentFactory()
+            for instrument, settings in find_all_instruments().items():
+                if instrument not in LOADERS_NOT_READY_FOR_PROD:
+                    factory.register_builder(instrument, settings)
+            loaders = factory.create_all()
+    finally:
+        cellpy_logger.setLevel(previous_level)
+
+    listing: List[Dict[str, Any]] = []
+    for loader_id, models in loaders.items():
+        suffixes = sorted(
+            {
+                f".{str(ext).lstrip('.')}"
+                for inst in models.values()
+                if (ext := getattr(inst, "raw_ext", None))
+            }
+        )
+        listing.append(
+            {
+                "id": loader_id,
+                "label": _instrument_label(loader_id),
+                "models": list(models.keys()),
+                "suffixes": suffixes,
+            }
+        )
+    return sorted(listing, key=lambda entry: entry["id"])
+
+
 def generate_default_factory():
     """This function searches for all available instrument readers
     and registers them in an InstrumentFactory instance.

--- a/tests/test_instrument_registering.py
+++ b/tests/test_instrument_registering.py
@@ -183,3 +183,39 @@ def test_factory_loader_is_package_path_class(parameters, instrument):
     assert type(loader).__module__ == f"cellpy.readers.instruments.{instrument}"
     assert type(loader) is module.DataLoader
     assert isinstance(loader, module.DataLoader)
+
+
+# ---- app-facing list_instruments (#786) ---------------------------------
+
+
+def test_list_instruments_shape_and_known_entry():
+    import cellpy
+
+    rows = cellpy.list_instruments()
+    assert isinstance(rows, list) and rows
+    for row in rows:
+        assert set(row) == {"id", "label", "models", "suffixes"}
+        assert isinstance(row["models"], list)
+        assert isinstance(row["suffixes"], list)
+
+    by_id = {row["id"]: row for row in rows}
+    assert "maccor_txt" in by_id
+    maccor = by_id["maccor_txt"]
+    assert maccor["label"] == "Maccor (text)"
+    assert maccor["suffixes"] == [".txt"]
+    assert maccor["models"]  # non-empty
+    # derived labels for a couple more (no per-instrument table)
+    assert by_id["arbin_sql_csv"]["label"] == "Arbin SQL (CSV)"
+    assert by_id["pec_csv"]["label"] == "PEC (CSV)"
+
+
+def test_list_instruments_is_quiet():
+    """No per-non-loader-module warnings escape (the whole point, #786)."""
+    import warnings
+
+    import cellpy
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cellpy.list_instruments()
+    assert not caught, [str(w.message) for w in caught]


### PR DESCRIPTION
`instrument_configurations()` logs a WARNING per non-loader module and returns no display label/suffix. Adds `cellpy.list_instruments()` → `[{"id", "label", "models", "suffixes"}, ...]` that:
- **silences** the skipped-module noise (cellpy logger → ERROR + warnings ignored during the scan), and
- includes a **human label** derived from the loader id (vendor + file-format tokens, no per-instrument table — e.g. `maccor_txt`→"Maccor (text)", `arbin_sql_csv`→"Arbin SQL (CSV)") and the raw file **suffix(es)** from the loaders' `raw_ext`.

Lets apps build an instrument picker / ingestion form directly from cellpy.

Tests: structure + known labels/suffixes, and a no-warnings-escape check.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)