### PR TITLE
feat(batch): from_cells() -- build a batch from in-memory cells (#787)

### DIFF
--- a/cellpy/batch/__init__.py
+++ b/cellpy/batch/__init__.py
@@ -40,12 +40,13 @@ from cellpy.batch.store import CellStore
 from cellpy.batch import aggregate, outputs, qc
 from cellpy.batch.aggregate import combine_summaries, combine_tests
 from cellpy.batch.db import journal_from_db
-from cellpy.batch.facade import Batch, from_journal, load
+from cellpy.batch.facade import Batch, from_cells, from_journal, load
 
 __all__ = [
     "Batch",
     "load",
     "from_journal",
+    "from_cells",
     "aggregate",
     "qc",
     "outputs",

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -14,6 +14,7 @@ adapter; the full tidy-frame plot path lands with the collectors redesign
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import fields, replace
 from pathlib import Path
 from typing import Any
@@ -59,6 +60,72 @@ class Batch:
         from cellpy.batch.db import journal_from_db
 
         return cls(journal_from_db(name, project, **db_kwargs), policy=policy)
+
+    @classmethod
+    def from_cells(
+        cls,
+        cells: Mapping[str, Any] | Sequence[Any],
+        *,
+        groups: Mapping[str, Any] | None = None,
+        sub_groups: Mapping[str, Any] | None = None,
+        group_labels: Mapping[Any, str] | None = None,
+        selected: Mapping[str, bool] | None = None,
+        name: str = "in_memory",
+        project: str = "in_memory",
+        policy: LoadPolicy | None = None,
+    ) -> "Batch":
+        """Build a batch from already-loaded ``CellpyCell`` objects.
+
+        The pieces a batch needs -- a journal ``pages`` frame (polars, keyed by
+        ``filename``) plus a populated cell store -- are constructed here, so a
+        GUI/notebook holding cells in memory can feed them straight to
+        :func:`cellpy.collect.collect_summaries` / ``collect_cycles`` or
+        ``batch.plot()`` without writing a journal to disk.
+
+        Args:
+            cells: ``{label: CellpyCell}`` or a sequence of cells (labels are
+                taken from ``cell.cell_name``, falling back to ``cell_001`` ...,
+                de-duplicated).
+            groups / sub_groups: optional ``{label: value}`` maps (defaults:
+                group 1 for all; sub_group 1..N).
+            group_labels: optional ``{group: display label}`` map.
+            selected: optional ``{label: bool}`` (defaults True) for the journal
+                ``selected`` column.
+            name / project: journal name/project.
+        """
+        if isinstance(cells, Mapping):
+            cell_map: dict[str, Any] = dict(cells)
+        else:
+            cell_map = {}
+            for i, cell in enumerate(cells, start=1):
+                label = getattr(cell, "cell_name", None) or f"cell_{i:03d}"
+                base, n = label, 1
+                while label in cell_map:
+                    n += 1
+                    label = f"{base}_{n}"
+                cell_map[label] = cell
+
+        labels = list(cell_map)
+        groups = dict(groups or {})
+        sub_groups = dict(sub_groups or {})
+        selected = dict(selected or {})
+
+        group_col = [groups.get(lbl, 1) for lbl in labels]
+        pages_data: dict[str, list] = {
+            FILENAME: labels,
+            "group": group_col,
+            "sub_group": [sub_groups.get(lbl, i) for i, lbl in enumerate(labels, 1)],
+            "label": labels,
+            "selected": [bool(selected.get(lbl, True)) for lbl in labels],
+        }
+        if group_labels:
+            gl = dict(group_labels)
+            pages_data["group_label"] = [gl.get(g) for g in group_col]
+
+        pages = pl.DataFrame(pages_data)
+        batch = cls(Journal(name=name, project=project, pages=pages), policy=policy)
+        batch._store = CellStore.from_cells(cell_map)
+        return batch
 
     # -- data surface ----------------------------------------------------
     @property
@@ -257,6 +324,13 @@ def from_journal(
 ) -> Batch:
     """Build a :class:`Batch` from a journal file (.json or .xlsx)."""
     return Batch(read_journal(journal_file), policy=policy)
+
+
+def from_cells(cells, **kwargs) -> Batch:
+    """Build a :class:`Batch` from already-loaded cells (see
+    :meth:`Batch.from_cells`) -- feed it to ``collect_summaries`` /
+    ``collect_cycles`` or call ``batch.plot()``."""
+    return Batch.from_cells(cells, **kwargs)
 
 
 def load(

--- a/cellpy/collect/__init__.py
+++ b/cellpy/collect/__init__.py
@@ -13,6 +13,10 @@ handover (Collection.plot -> cellpy.plotting) + collectors shim.
 
 from __future__ import annotations
 
+# Re-exported for discoverability: build a Batch from in-memory cells, then feed
+# it to collect_summaries / collect_cycles (#787). The canonical home is
+# ``cellpy.batch.from_cells`` / ``Batch.from_cells``.
+from cellpy.batch.facade import from_cells
 from cellpy.collect.cells import CellItem, iter_cells
 from cellpy.collect.collection import Collection, CollectionMeta, load_collection
 from cellpy.collect.collector import (
@@ -40,6 +44,7 @@ __all__ = [
     "collect_summaries",
     "collect_cycles",
     "collect_ica",
+    "from_cells",
     "iter_cells",
     "CellItem",
     "SummaryOptions",

--- a/tests/test_from_cells.py
+++ b/tests/test_from_cells.py
@@ -1,0 +1,61 @@
+"""Building a batch from in-memory cells (#787)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+import cellpy
+from cellpy.batch import Batch
+from cellpy.batch.journal import FILENAME
+from cellpy.collect import collect_summaries, from_cells
+
+# reuse the lightweight fake summary cell from the collect tests
+from tests.test_collect import _SummaryCell
+
+
+def test_from_cells_dict_builds_batch_contract():
+    cells = {"A": _SummaryCell([10.0, 20.0]), "B": _SummaryCell([20.0, 40.0])}
+    b = from_cells(cells)
+
+    assert isinstance(b, Batch)
+    assert list(b.cells) == ["A", "B"]
+    assert b.journal.name == "in_memory"
+    # pages is polars, keyed by filename, matching the cell keys
+    assert isinstance(b.journal.pages, pl.DataFrame)
+    assert b.journal.pages[FILENAME].to_list() == ["A", "B"]
+    for col in ("group", "sub_group", "label", "selected"):
+        assert col in b.journal.pages.columns
+
+
+def test_from_cells_feeds_collect_summaries():
+    cells = {"A": _SummaryCell([10.0, 20.0]), "B": _SummaryCell([20.0, 40.0])}
+    b = from_cells(cells, groups={"A": 1, "B": 1})
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    # a real grouped average happened (2 cells in group 1)
+    for key in ("group", "cycle_num", "variable", "mean", "std"):
+        assert key in col.data.columns
+
+
+def test_from_cells_list_derives_and_dedupes_labels():
+    b = from_cells([_SummaryCell([1.0]), _SummaryCell([2.0])])
+    # no cell_name -> deterministic fallback labels
+    assert list(b.cells) == ["cell_001", "cell_002"]
+
+
+def test_from_cells_honours_groups_and_selected():
+    cells = {"A": _SummaryCell([1.0]), "B": _SummaryCell([2.0])}
+    b = from_cells(cells, groups={"A": 1, "B": 2}, selected={"B": False})
+    pages = b.journal.pages
+    lookup = {row[FILENAME]: row for row in pages.iter_rows(named=True)}
+    assert lookup["A"]["group"] == 1 and lookup["B"]["group"] == 2
+    assert lookup["A"]["selected"] is True and lookup["B"]["selected"] is False
+
+
+def test_from_cells_available_on_batch_collect_and_classmethod():
+    cells = {"A": _SummaryCell([1.0])}
+    # three entry points, same result contract
+    for maker in (from_cells, cellpy.batch.from_cells, Batch.from_cells):
+        b = maker(cells)
+        assert isinstance(b, Batch)
+        assert list(b.cells) == ["A"]


### PR DESCRIPTION
No public way existed to build the batch/journal contract `collect_summaries`/`collect_cycles` consume from already-loaded `CellpyCell` objects (cells a GUI/notebook holds in memory). Adds:

- `Batch.from_cells(cells, *, groups=, sub_groups=, group_labels=, selected=, name=, project=)` — canonical
- `cellpy.batch.from_cells(...)` and a `cellpy.collect.from_cells` re-export (discoverability)

Accepts `{label: cell}` or a sequence (labels from `cell_name`, de-duplicated); builds the polars `pages` frame (filename/group/sub_group/label/selected) + a populated `CellStore`. Returns a `Batch` ready for `collect_*` or `batch.plot()`.

Tests (new file): dict/list forms, label dedupe, groups/selected honoured, all three entry points.

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)