### PR TITLE
docs: app-builder note on polars/pandas boundary + quiet startup (#791d)

### DIFF
--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -121,6 +121,23 @@ Suggested layering:
    (`summary` for cycle tables; slices of `raw` for plots).
 4. **Export** — offer `.cellpy` (canonical) plus CSV/Excel for the user.
 
+!!! tip "DataFrame types & quiet startup (building GUIs)"
+
+    - **polars vs pandas — know the boundary.** A cell's frames
+      (`c.data.raw` / `.steps` / `.summary`) are **pandas**; a
+      `cellpy.collect.Collection.data` is **polars**, and `Collection.plot()`
+      converts to pandas internally. Convert explicitly at the seam
+      (`collection.data.to_pandas()` / `pl.from_pandas(df)`) rather than mixing
+      the two in UI code.
+    - **Instrument picker for free.** `cellpy.list_instruments()` returns
+      `[{"id", "label", "models", "suffixes"}, ...]` (quiet — no per-module
+      warnings), ready to drive an import form.
+    - **Keep the console quiet.** cellpy logs through the `cellpy` logger; raise
+      its level in an app you want silent:
+      `logging.getLogger("cellpy").setLevel(logging.ERROR)`. Suppress one-off
+      deprecation notices (e.g. `get_summary()` → `c.data.summary`) with
+      `warnings.filterwarnings("ignore", category=DeprecationWarning, module="cellpy")`.
+
 Skeleton (UI-agnostic):
 
 ```python


### PR DESCRIPTION
Adds a tip to the app/agents guide covering item **(d)** of #791: the polars (`Collection.data`) vs pandas (`c.data.*`) boundary and `Collection.plot`'s internal `to_pandas`; `cellpy.list_instruments()` for an instrument picker; and how to quiet cellpy's logger / deprecation warnings in an app.

Part of #791 (items a/b/c split into separate issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)