### PR TITLE
docs: cut HISTORY for 2.1.1.post2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.1.1.post2] - 2026-07-30
+
+Post-release of 2.1.1 — collected summary facet y-axis controls for apps.
+
 * Per-panel y-limits (and clearer `share_y`) for collected summary facet
   plots. (#804)
 


### PR DESCRIPTION
## Summary
- Promote #804 HISTORY bullet into `## [2.1.1.post2] - 2026-07-30` ahead of tagging `v2.1.1.post2`.

## Test plan
- [x] HISTORY Keep a Changelog shape (empty Unreleased + new section)
- [ ] Tag `v2.1.1.post2` on master after merge (`gh release create`)


Made with [Cursor](https://cursor.com)