### PR TITLE
feat(batch): load custom/BatBase JSON with file search (#345)

### DIFF
--- a/.issueflows/03-solved-issues/issue345_original.md
+++ b/.issueflows/03-solved-issues/issue345_original.md
@@ -1,0 +1,23 @@
+# Issue #345: batch - read custom json
+
+Source: https://github.com/jepegit/cellpy/issues/345
+
+## Original issue text
+
+The batch utility should be able to get info from other JSON files than the currently supported ones.
+
+We also need to allow for file searching after reading the JSON file.
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - Support BatBase-exported JSON as a first-class journal source (user story: download from BatBase → point batch at the file → populate journal pages → filefinder fills raw/cellpy paths as usual). Optional `filetype` / reader kwarg (e.g. `batbase_v1` / `custom_json_reader`).
+  - Wire **file-search-after-read** on the blessed `cellpy.batch` path (not only the legacy db-reader path).
+- **Clarifications / constraints**:
+  - User story centers on BatBase JSON download → `batch.load(...)` (or equivalent); file-name indicators drive filefinder afterwards.
+  - Folded into batch v3 A2 (#698) historically; readers + post-read search belong in `cellpy/batch/journal.py` / db engine — improve patterns and align with recent BatBase changes.
+  - Milestone **v.2.1.2** (2026-07-28): self-contained patch; must not block v2.1.0 (already shipped).
+- **Superseded / retracted**:
+  - Closing solely via Stage-4 A2 / #698 — #345 was moved to **v.2.1.2** as a follow-up patch instead.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 4, last comment by @jepegit on 2026-07-28._

--- a/.issueflows/03-solved-issues/issue345_plan.md
+++ b/.issueflows/03-solved-issues/issue345_plan.md
@@ -1,0 +1,89 @@
+# Issue #345 plan — batch custom JSON + file search after read
+
+## Goal
+
+Make **custom / BatBase-style JSON** a first-class way to build a batch journal on the
+blessed `cellpy.batch` API, including **file search after read** so `raw_file_names` /
+`cellpy_file_name` are populated like `Batch.from_db(...)` already does for Excel/BatBase.
+
+## Constraints
+
+- Patch-scoped (`v.2.1.2`): additive; no Stage 5 / live-incremental work.
+- Reuse existing machinery — do **not** reimplement file search.
+- Keep cellpy journal JSON (`read_journal` / `from_journal`) behavior unchanged (paths already in pages; no forced re-search).
+- Back-compat: `cellpy.utils.batch.load(..., reader="custom_json_reader")` and
+  `Batch.from_db(db_reader="custom_json_reader"|"batbase_json_reader", ...)` must keep working.
+
+### Prior art
+
+| Hit | Role | Plan |
+|---|---|---|
+| `cellpy/batch/journal.py` — `read_custom_json` / `journal_from_custom_json` | Read-only custom JSON → pages/`Journal` | Keep; optionally document that file search needs the db path |
+| `cellpy/readers/json_dbreader.py` — `CustomJSONReader` / `BatBaseJSONReader` | DB-reader adapters + `column_map` | Keep as the search-enabled path |
+| `cellpy/batch/_dbengine.py` — `simple_db_engine` / `find_files` | Post-read file search | Reuse; expose `skip_file_search` if useful |
+| `cellpy/batch/db.py` — `journal_from_db` | Orchestrates reader → engine → `Journal` | Prefer this as the single integration path |
+| `cellpy/utils/batch.py` — `load(..., reader=...)` | Legacy shim already routes custom JSON → `Batch.from_db` | Mirror on blessed `Batch.load` / document |
+| `tests/test_batch.py` — custom JSON + file search via shim | Fixture-backed acceptance pattern | Mirror for `cellpy.batch` facade |
+| `tests/test_batch_v3.py` — `read_custom_json` unit tests | Read-only coverage | Keep; add facade+search test |
+
+Toolbox / graph: no dedicated helper; reuse `_dbengine.find_files` + `filefinder.search_for_files`.
+
+## Approach
+
+**Problem today:** Custom JSON is half-wired — `read_custom_json` exists on batch v3 but
+does **not** run file search; search only happens when going through
+`Batch.from_db` / `journal_from_db` + `CustomJSONReader`. Blessed `Batch.load(journal_file=...)`
+does not route custom/BatBase JSON the way the utils shim does.
+
+**Do this:**
+
+1. **Blessed load path** — Extend `Batch.load` / `from_journal` (whichever is the public
+   “path to journal” entry) so that when the caller asks for a JSON db reader
+   (`db_reader` / `reader` / `filetype` — pick one public name, prefer aligning with
+   existing `db_reader=` on `from_db`), a JSON file is loaded via `journal_from_db` →
+   `simple_db_engine` → `find_files`, not via bare `read_journal` / `read_custom_json`.
+2. **Expose kwargs** — Forward `column_map`, `raw_file_dir` / project paths, and
+   `skip_file_search` through `journal_from_db` → engine (engine already supports skip
+   internally; make it a public opt-out for JSON that already carries paths).
+3. **BatBase download story** — Ensure `db_reader="batbase_json_reader"` + `db_file=<download>`
+   (or `Batch.load(..., db_reader=...)`) is documented and covered by a facade-level test
+   (reader already exists).
+4. **Optional thin wrapper** — If useful for discoverability, add
+   `journal_from_custom_json(..., *, search_files=True, column_map=..., **dirs)` that
+   delegates to `journal_from_db` instead of only `read_custom_json`. Prefer one path over
+   two divergent implementations.
+5. **Docs** — Short note in batch docs / migration note: custom JSON needs `column_map` +
+   the db-reader/load path for file search; native cellpy journal JSON does not re-search.
+
+**Out of scope:** new JSON schemas beyond what `CustomJSONReader` / `BatBaseJSONReader`
+already accept; GUI work; #799/#800.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `cellpy/batch/facade.py` | Route `load` / public entry for custom & BatBase JSON → `from_db` / `journal_from_db` |
+| `cellpy/batch/db.py` | Forward `skip_file_search` (+ any missing path kwargs) |
+| `cellpy/batch/_dbengine.py` | Only if public kwargs need a small glue fix |
+| `cellpy/batch/journal.py` | Optional: `journal_from_custom_json` search flag → db path |
+| `tests/test_batch_v3_facade.py` (or sibling) | Facade test: custom JSON → pages + populated `raw_file_names` / `cellpy_file_name` |
+| Batch docs / HISTORY (close step) | Document the load pattern |
+
+## Test strategy
+
+- Project: `uv run pytest` (or conda `cellpy_dev_313` per project rules when running locally).
+- Add facade-level test mirroring `tests/test_batch.py` custom-JSON + search case, using
+  `tests/fixtures/custom_json_batch_like.json` (and BatBase fixture if cheap).
+- Keep existing `read_custom_json` unit tests green.
+- Essential gate: `uv run pytest -m essential` before close if the change is small enough;
+  otherwise targeted batch tests + a note in status.
+
+## Open questions
+
+1. **Public API shape for `Batch.load`:** prefer `db_reader=` (match `from_db`), or a
+   separate `filetype=` / `reader=` alias? **Resolved (Accept):** `db_reader=` canonical;
+   `reader=` alias.
+2. **Should `journal_from_custom_json` gain search-by-default?** **Resolved (Accept):** no —
+   keep it read-only; searching stays on `from_db` / `load(..., db_reader=...)`.
+3. **BatBase-only vs generic custom in this PR?** **Resolved (Accept):** ship both
+   (`custom_json_reader` + `batbase_json_reader`).

--- a/.issueflows/03-solved-issues/issue345_status.md
+++ b/.issueflows/03-solved-issues/issue345_status.md
@@ -1,0 +1,15 @@
+# Issue #345 status
+
+- [x] Done
+
+## What's done
+
+- Wired `cellpy.batch.load` for `custom_json_reader` / `batbase_json_reader`
+  (`db_reader=` canonical, `reader=` alias) → `Batch.from_db` + file search.
+- Documented `skip_file_search` on `journal_from_db`.
+- Facade tests in `tests/test_batch_v3_facade.py`; utils JSON regression green.
+- HISTORY Unreleased bullet.
+
+## Remaining work
+
+- None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Batch: load BatBase / custom JSON journals via `cellpy.batch.load(..., db_reader=...)`
+  with file search after read (`reader=` alias). (#345)
+
 * Add issue-flow as a uv `dev` dependency so agents get the CLI from
   `uv sync` / `uv run issue-flow`. (#809)
 

--- a/cellpy/batch/db.py
+++ b/cellpy/batch/db.py
@@ -33,6 +33,12 @@ def journal_from_db(
     ``db_reader`` selects the reader (``"default"``/``"simple_excel_reader"``,
     ``"batbase_json_reader"``, ``"custom_json_reader"``); ``db_file`` and
     ``column_map`` are forwarded for the JSON readers.
+
+    Extra kwargs (e.g. ``skip_file_search``, ``file_list``, ``pre_path``,
+    ``sub_folders``) are forwarded to
+    :func:`cellpy.batch._dbengine.simple_db_engine` /
+    :func:`cellpy.batch._dbengine.find_files`. Pass ``skip_file_search=True``
+    when the JSON already carries ``raw_file_names`` / ``cellpy_file_name``.
     """
     column_map = kwargs.pop("column_map", None)
     dbreader_kwargs = kwargs.pop("dbreader_kwargs", None) or {}

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -318,11 +318,18 @@ class _LegacyExperimentAdapter:
 
 # -- module-level constructors -------------------------------------------
 
+_JSON_DB_READERS = frozenset({"custom_json_reader", "batbase_json_reader"})
+
 
 def from_journal(
     journal_file: Path | str, policy: LoadPolicy | None = None, **_kwargs
 ) -> Batch:
-    """Build a :class:`Batch` from a journal file (.json or .xlsx)."""
+    """Build a :class:`Batch` from a cellpy journal file (.json or .xlsx).
+
+    For BatBase / custom JSON downloads that need post-read file search, use
+    :func:`load` with ``db_reader="batbase_json_reader"`` or
+    ``"custom_json_reader"`` (and ``column_map`` for custom JSON).
+    """
     return Batch(read_journal(journal_file), policy=policy)
 
 
@@ -341,22 +348,56 @@ def load(
     journal_file: Path | str | None = None,
     frame: Any | None = None,
     db: str | bool | None = None,
+    db_reader: str | None = None,
+    reader: str | None = None,
     policy: LoadPolicy | None = None,
     **kwargs,
 ) -> Batch:
     """Build a :class:`Batch` from a journal source.
 
     Source precedence: explicit ``journal`` model, ``journal_file``, ``frame``,
-    then a database read (``db`` reader name, or when only ``name``/``project``
-    are given). Falls back to an empty named journal.
+    then a database read (``db`` / ``db_reader`` reader name, or when only
+    ``name``/``project`` are given). Falls back to an empty named journal.
+
+    When ``journal_file`` points at a **BatBase or custom JSON** download (not a
+    cellpy journal), pass ``db_reader="batbase_json_reader"`` or
+    ``"custom_json_reader"`` (``reader=`` is accepted as an alias). That path
+    runs file search after read via :meth:`Batch.from_db`. Custom JSON also
+    needs ``column_map`` (source column → journal key; must map to
+    ``filename``). Native cellpy journal JSON does not re-search.
     """
+    # Canonical name is db_reader=; reader= matches the utils.batch shim.
+    if db_reader is None and reader is not None:
+        db_reader = reader
+    elif db_reader is not None and reader is not None and db_reader != reader:
+        raise ValueError(
+            f"conflicting db_reader={db_reader!r} and reader={reader!r}; "
+            "pass only db_reader= (canonical) or only reader= (alias)"
+        )
+
     if journal is not None:
         return Batch(journal, policy=policy)
     if journal_file is not None:
+        if db_reader in _JSON_DB_READERS:
+            if not name or not project:
+                raise ValueError(
+                    "name and project are required when loading a JSON db file "
+                    f"with db_reader={db_reader!r}"
+                )
+            return Batch.from_db(
+                name,
+                project,
+                db_reader=db_reader,
+                db_file=str(journal_file),
+                policy=policy,
+                **kwargs,
+            )
         return Batch(read_journal(journal_file), policy=policy)
     if frame is not None:
         return Batch(journal_from_frame(frame, name=name, project=project), policy=policy)
-    if db is not None or (name and project):
-        reader = db if isinstance(db, str) else "default"
-        return Batch.from_db(name, project, db_reader=reader, policy=policy, **kwargs)
+    if db is not None or db_reader is not None or (name and project):
+        chosen = db_reader
+        if chosen is None:
+            chosen = db if isinstance(db, str) else "default"
+        return Batch.from_db(name, project, db_reader=chosen, policy=policy, **kwargs)
     return Batch(Journal(name=name, project=project), policy=policy)

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -1,5 +1,7 @@
 """Tests for the batch v3 facade (#702)."""
 
+from pathlib import Path
+
 import polars as pl
 import pytest
 
@@ -125,3 +127,88 @@ def test_create_journal_reads_db(db_env):
     assert b.cell_names == []
     b.create_journal()
     assert set(b.cell_names) == _DB_CELLS
+
+
+# ---- custom / BatBase JSON + file search (#345) -------------------------
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+_CUSTOM_COLUMN_MAP = {
+    "cell_id": "filename",
+    "mass_mg": "mass",
+    "total_mass_mg": "total_mass",
+    "instrument_name": "instrument",
+}
+
+
+def test_load_custom_json_with_file_search(parameters):
+    """Blessed cellpy.batch.load routes custom JSON through from_db + find_files."""
+    fixture = _FIXTURES / "custom_json_batch_like.json"
+    assert fixture.is_file()
+
+    b = load(
+        name="test_batch",
+        project="test_project",
+        journal_file=str(fixture),
+        db_reader="custom_json_reader",
+        column_map=_CUSTOM_COLUMN_MAP,
+        raw_file_dir=parameters.raw_data_dir,
+        cellpy_file_dir=parameters.cellpy_data_dir,
+    )
+    assert isinstance(b, Batch)
+    assert b.cell_names == ["20160805_test001_45_cc"]
+    assert "raw_file_names" in b.pages.columns
+    assert "cellpy_file_name" in b.pages.columns
+
+
+def test_load_custom_json_reader_alias(parameters):
+    """reader= is accepted as an alias for db_reader=."""
+    fixture = _FIXTURES / "custom_json_batch_like.json"
+    b = load(
+        name="test_batch",
+        project="test_project",
+        journal_file=str(fixture),
+        reader="custom_json_reader",
+        column_map=_CUSTOM_COLUMN_MAP,
+        raw_file_dir=parameters.raw_data_dir,
+        cellpy_file_dir=parameters.cellpy_data_dir,
+    )
+    assert b.cell_names == ["20160805_test001_45_cc"]
+
+
+def test_load_batbase_json_with_file_search(parameters):
+    fixture = _FIXTURES / "cellpy_batbase_like.json"
+    assert fixture.is_file()
+
+    b = load(
+        name="test_batch",
+        project="test_project",
+        journal_file=str(fixture),
+        db_reader="batbase_json_reader",
+        raw_file_dir=parameters.raw_data_dir,
+        cellpy_file_dir=parameters.cellpy_data_dir,
+    )
+    assert isinstance(b, Batch)
+    assert b.cell_names == ["20160805_test001_45_cc"]
+    assert "raw_file_names" in b.pages.columns
+
+
+def test_load_json_db_requires_name_and_project():
+    fixture = _FIXTURES / "custom_json_batch_like.json"
+    with pytest.raises(ValueError, match="name and project"):
+        load(
+            journal_file=str(fixture),
+            db_reader="custom_json_reader",
+            column_map=_CUSTOM_COLUMN_MAP,
+        )
+
+
+def test_load_conflicting_db_reader_and_reader_alias():
+    with pytest.raises(ValueError, match="conflicting"):
+        load(
+            name="n",
+            project="p",
+            journal_file="x.json",
+            db_reader="custom_json_reader",
+            reader="batbase_json_reader",
+        )


### PR DESCRIPTION
## Summary
- Route `cellpy.batch.load(journal_file=..., db_reader=custom_json_reader|batbase_json_reader)` through `Batch.from_db` so post-read file search populates raw/cellpy paths.
- Accept `reader=` as an alias for `db_reader=`; document `skip_file_search` on `journal_from_db`.
- Facade tests for custom + BatBase JSON load paths.

Closes #345

## Test plan
- [x] `uv run pytest tests/test_batch_v3_facade.py`
- [x] `uv run pytest tests/test_batch.py::test_load_with_explicit_custom_json tests/test_batch.py::test_load_with_explicit_batbase_json`
- [ ] CI essential gate on the PR


Made with [Cursor](https://cursor.com)