### PR TITLE
feat: add cellpy.read_meta for cheap metadata peeks (#799)

### DIFF
--- a/.issueflows/03-solved-issues/issue799_original.md
+++ b/.issueflows/03-solved-issues/issue799_original.md
@@ -1,0 +1,9 @@
+# Issue #799: Lightweight metadata read: read_meta(path) without a full get()
+
+Source: https://github.com/jepegit/cellpy/issues/799
+
+## Original issue text
+
+Split from #791 (item a). Listing many `.cellpy` files (a project browser) currently needs a full `cellpy.get(...)` per file just to show mass / area / #cycles. A cheap `read_meta(path)` that reads the header metadata (v9 `meta.json` sidecar / hdf5 metadata) **without** materialising raw/steps/summary would make file browsers snappy.
+
+Relates to the v9 container (`readers/cellpy_file/`, meta.json is already a separate zip member) and the metadata models.

--- a/.issueflows/03-solved-issues/issue799_plan.md
+++ b/.issueflows/03-solved-issues/issue799_plan.md
@@ -1,0 +1,29 @@
+# Issue #799 — plan
+
+## Goal
+
+Add a cheap `read_meta(path)` that returns cellpy-file metadata **without** loading raw/steps/summary frames, so project browsers can show mass/area (and similar) quickly.
+
+## Approach
+
+- **v9 `.cellpy` (zip):** read only the `meta.json` zip member (same document as full load).
+- **Standalone `*.meta.json`:** delegate to existing `load_meta_archive`.
+- **Legacy HDF5 `.cellpy`/`.h5`:** read `/info` (and test-dependent if present) into a browser-friendly dict with a top-level `cell` map of scalar fields — no frames.
+- **Out of scope:** `#cycles` (not in meta; needs summary peek) — document in docstring.
+- Export as `cellpy.readers.cellpy_file.read_meta` and top-level `cellpy.read_meta`.
+
+## Files to touch
+
+- `cellpy/readers/cellpy_file/v9.py` — `read_meta` for zip
+- `cellpy/readers/cellpy_file/meta_archive.py` — dispatcher + HDF5 helper (or thin `read_meta` module)
+- `cellpy/readers/cellpy_file/__init__.py` — export
+- `cellpy/__init__.py` — top-level export
+- `tests/test_read_meta.py` — essential tests
+- `docs/getting_started/agents.md` — one recipe line
+- `HISTORY.md` — Unreleased bullet (at close)
+
+## Test strategy
+
+- Save v8 fixture → v9 `.cellpy` in `tmp_path`; `read_meta` equals zip `meta.json`; monkeypatch parquet reader to fail if called.
+- HDF5 fixture: `read_meta` returns `cell.mass` without requiring full `get`.
+- Missing file / non-cellpy → clear errors.

--- a/.issueflows/03-solved-issues/issue799_status.md
+++ b/.issueflows/03-solved-issues/issue799_status.md
@@ -1,0 +1,15 @@
+# Issue #799 — status
+
+## Done
+
+- [x] `read_meta` for v9 zip (`meta.json` only), `*.meta.json`, and HDF5 `/info`
+- [x] Top-level `cellpy.read_meta` + `cellpy_file` export
+- [x] Essential tests (`tests/test_read_meta.py`)
+- [x] Docs: `agents.md` + `AGENTS.md`
+
+## Notes
+
+- `#cycles` left out of scope (not in meta document).
+- Cycle confirm covered plan auto-confirm.
+
+- [x] Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,7 @@ Quick facts:
 
 - Product: Python library + `cellpy` CLI — not a hosted GUI server.
 - Entry: `import cellpy` then `c = cellpy.get(path, mass=..., instrument=...)`.
+- Metadata peek (no frames): `cellpy.read_meta(path)` → dict with `cell` / `tests`.
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Lightweight `cellpy.read_meta(path)` peeks v9 / HDF5 cellpy-file metadata
+  without loading raw/steps/summary frames. (#799)
+
 * Batch: load BatBase / custom JSON journals via `cellpy.batch.load(..., db_reader=...)`
   with file search after read (`reader=` alias). (#345)
 

--- a/cellpy/__init__.py
+++ b/cellpy/__init__.py
@@ -37,12 +37,24 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Sanctioned top-level API (v2, issue #509): ``cellpy.get`` is the primary
 # entry point; ``cellpy.merge_cells`` and ``cellpy.print_instruments`` are the
-# supporting conveniences. Everything else is reached via explicit module
-# paths (``cellpy.cellreader``, ``cellpy.config`` / ``cellpy.config.session``).
+# supporting conveniences. ``cellpy.read_meta`` peeks cellpy-file metadata
+# without loading frames (issue #799). Everything else is reached via explicit
+# module paths (``cellpy.cellreader``, ``cellpy.config`` / ``cellpy.config.session``).
 get = cellreader.get
 merge_cells = cellreader.merge_cells
 print_instruments = readers.cellreader.print_instruments
 list_instruments = readers.data_structures.list_instruments
+
+
+def read_meta(path):
+    """Read cellpy-file metadata without loading raw/steps/summary frames.
+
+    See ``cellpy.readers.cellpy_file.read_meta`` for details.
+    """
+    from cellpy.readers.cellpy_file import read_meta as _read_meta
+
+    return _read_meta(path)
+
 
 __all__ = [
     "cellreader",
@@ -54,6 +66,7 @@ __all__ = [
     "merge_cells",
     "print_instruments",
     "list_instruments",
+    "read_meta",
     "do",
     # "ureg",
     # "Q",

--- a/cellpy/readers/cellpy_file/__init__.py
+++ b/cellpy/readers/cellpy_file/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "load",
     "load_meta_archive",
     "read_fid_table",
+    "read_meta",
     "read_table",
     "save",
     "save_meta_archive",
@@ -62,4 +63,8 @@ def __getattr__(name: str):
         from cellpy.readers.cellpy_file.meta_archive import load_meta_archive
 
         return load_meta_archive
+    if name == "read_meta":
+        from cellpy.readers.cellpy_file.meta_archive import read_meta
+
+        return read_meta
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cellpy/readers/cellpy_file/meta_archive.py
+++ b/cellpy/readers/cellpy_file/meta_archive.py
@@ -255,3 +255,90 @@ def load_meta_archive(path: PathLike) -> dict:
             f"Unsupported meta archive version {version} in {path}"
         )
     return doc
+
+
+def _scalarize_hdf5_meta_row(meta_dict: Mapping[str, Any]) -> dict[str, Any]:
+    """Collapse single-row HDF5 meta columns (list-of-one) to scalars."""
+    out: dict[str, Any] = {}
+    for key, value in meta_dict.items():
+        if isinstance(value, list):
+            out[key] = value[0] if len(value) == 1 else value
+        else:
+            out[key] = value
+    return out
+
+
+def _read_meta_hdf5(path: Path) -> dict:
+    """Read HDF5 ``/info`` metadata without loading raw/steps/summary."""
+    from cellpy.parameters import prms
+    from cellpy.readers import externals
+    from cellpy.readers.cellpy_file.format import require_hdf5_support
+
+    require_hdf5_support(f"reading metadata from the HDF5 cellpy-file {path}")
+    parent = prms._cellpyfile_root
+    common_dir = prms._cellpyfile_common_meta
+    test_dir = prms._cellpyfile_test_dependent_meta
+
+    with externals.pandas.HDFStore(path) as store:
+        try:
+            meta_table = store.select(parent + common_dir)
+        except KeyError as e:
+            raise WrongFileVersion(
+                f"No common metadata table in HDF5 cellpy-file {path}"
+            ) from e
+        cell = _scalarize_hdf5_meta_row(meta_table.to_dict(orient="list"))
+        tests: dict[str, Any] = {}
+        try:
+            test_table = store.select(parent + test_dir)
+        except KeyError:
+            test_table = None
+        if test_table is not None and not test_table.empty:
+            # One row per test in typical files; expose row 0 under "0".
+            row = test_table.iloc[0].to_dict()
+            tests["0"] = row
+
+    return {
+        "cellpy_file_version": cell.get("cellpy_file_version", 0),
+        "cell": cell,
+        "tests": tests,
+        "loaded_from": str(path),
+    }
+
+
+def read_meta(path: PathLike) -> dict:
+    """Read cellpy-file metadata without materialising raw/steps/summary.
+
+    Supports v9 ``.cellpy`` zips (``meta.json`` member), standalone
+    ``*.meta.json`` archives, and legacy HDF5 cellpy files (``/info`` only).
+
+    Cycle counts are **not** in the metadata document — use a full
+    ``cellpy.get`` (or a summary peek) when a browser needs ``#cycles``.
+
+    Args:
+        path: Path to a ``.cellpy`` / ``.h5`` / ``.hdf5`` file or a
+            ``*.meta.json`` archive.
+
+    Returns:
+        A metadata document. For v9 / ``*.meta.json`` this is the archive
+        shape (``cell``, ``tests``, units, …). For HDF5 it is a reduced
+        dict with at least ``cellpy_file_version``, ``cell``, and ``tests``.
+
+    Raises:
+        IOError: If ``path`` does not exist.
+        WrongFileVersion: If the file is an unsupported cellpy version.
+        CorruptCellpyFile: If a v9 zip is missing ``meta.json``.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise IOError(f"File does not exist: {path}")
+
+    name = path.name.lower()
+    if name.endswith(".meta.json"):
+        return load_meta_archive(path)
+
+    from cellpy.readers.cellpy_file import v9 as cellpy_file_v9
+
+    if cellpy_file_v9.is_zip_cellpy(path):
+        return cellpy_file_v9.read_meta(path)
+
+    return _read_meta_hdf5(path)

--- a/cellpy/readers/cellpy_file/v9.py
+++ b/cellpy/readers/cellpy_file/v9.py
@@ -224,11 +224,44 @@ def load(filename: PathLike, *, selector=None) -> LoadResult:
     return LoadResult.from_limits(data, CELLPY_FILE_VERSION, limits)
 
 
+def read_meta(path: PathLike) -> dict:
+    """Read the v9 ``meta.json`` document without loading parquet frames.
+
+    Args:
+        path: Path to a v9 ``.cellpy`` zip archive.
+
+    Returns:
+        The metadata archive document (same shape as written by ``save``).
+
+    Raises:
+        IOError: If ``path`` is missing.
+        CorruptCellpyFile: If the zip has no ``meta.json`` member.
+        WrongFileVersion: If ``cellpy_file_version`` is not the current v9.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise IOError(f"File does not exist: {path}")
+
+    with zipfile.ZipFile(path, mode="r") as zf:
+        try:
+            meta_raw = zf.read(META_JSON_NAME)
+        except KeyError as e:
+            raise CorruptCellpyFile(
+                f"{path} is a zip but missing {META_JSON_NAME}"
+            ) from e
+        meta_doc = json.loads(meta_raw.decode("utf-8"))
+
+    version = int(meta_doc.get("cellpy_file_version", 0))
+    if version != CELLPY_FILE_VERSION:
+        raise WrongFileVersion(
+            f"Unsupported zip cellpy version {version} in {path}"
+        )
+    return meta_doc
+
+
 def get_version_from_zip(path: PathLike) -> int:
     """Read ``cellpy_file_version`` from a v9 zip's ``meta.json``."""
-    with zipfile.ZipFile(path, mode="r") as zf:
-        meta_doc = json.loads(zf.read(META_JSON_NAME).decode("utf-8"))
-    return int(meta_doc.get("cellpy_file_version", 0))
+    return int(read_meta(path).get("cellpy_file_version", 0))
 
 
 def suggest_extension() -> str:

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -74,8 +74,15 @@ c = cellpy.get(
     mass=0.85,  # active material mass in mg (instrument-dependent context)
     instrument="arbin_res",  # omit to use config default / extension guess
 )
-c.save("out/my_cell.cellpy")  # HDF5 cellpy file — fast reload later
+c.save("out/my_cell.cellpy")  # cellpy file — fast reload later
 c.to_csv("out/csv_export")
+```
+
+Peek metadata only (no raw/steps/summary — good for file browsers):
+
+```python
+meta = cellpy.read_meta("out/my_cell.cellpy")
+mass = meta["cell"]["mass"]  # also under tests["0"]["cell"] on v9 archives
 ```
 
 Reload a `.cellpy` file the same way:

--- a/tests/test_read_meta.py
+++ b/tests/test_read_meta.py
@@ -1,0 +1,71 @@
+"""Essential tests for lightweight ``read_meta`` (issue #799)."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import cellpy
+from cellpy.readers.cellpy_file import CELLPY_FILE_VERSION, read_meta, v9 as cellpy_file_v9
+from cellpy.readers.cellpy_file.format import META_JSON_NAME
+from tests.cellpy_file_support import load_cellpy_file
+
+HDF5_DIR = Path(__file__).resolve().parents[1] / "testdata" / "hdf5"
+V8_WITH_FIDS = HDF5_DIR / "20160805_test001_45_cc_v8_with_fids.h5"
+
+
+def _require_v8_with_fids() -> Path:
+    if not V8_WITH_FIDS.is_file():
+        pytest.skip(f"missing characterization fixture: {V8_WITH_FIDS}")
+    return V8_WITH_FIDS
+
+
+@pytest.mark.essential
+def test_read_meta_v9_matches_zip_member(tmp_path):
+    source = _require_v8_with_fids()
+    cell = load_cellpy_file(source)
+    outfile = tmp_path / "peek.cellpy"
+    cell.save(outfile)
+
+    with zipfile.ZipFile(outfile) as zf:
+        expected = json.loads(zf.read(META_JSON_NAME).decode("utf-8"))
+
+    meta = read_meta(outfile)
+    assert meta == expected
+    assert meta["cellpy_file_version"] == CELLPY_FILE_VERSION
+    assert "mass" in meta["cell"]
+    assert cellpy.read_meta(outfile) == meta
+
+
+@pytest.mark.essential
+def test_read_meta_v9_does_not_touch_parquet(tmp_path, monkeypatch):
+    source = _require_v8_with_fids()
+    cell = load_cellpy_file(source)
+    outfile = tmp_path / "no_parquet.cellpy"
+    cell.save(outfile)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("parquet member must not be read by read_meta")
+
+    monkeypatch.setattr(cellpy_file_v9, "_read_parquet_member", _boom)
+    meta = read_meta(outfile)
+    assert meta["cellpy_file_version"] == CELLPY_FILE_VERSION
+
+
+@pytest.mark.essential
+def test_read_meta_hdf5_common_fields():
+    source = _require_v8_with_fids()
+    meta = read_meta(source)
+    assert meta["cellpy_file_version"] == 8
+    assert "mass" in meta["cell"]
+    assert "active_electrode_area" in meta["cell"]
+
+
+@pytest.mark.essential
+def test_read_meta_missing_file(tmp_path):
+    missing = tmp_path / "nope.cellpy"
+    with pytest.raises(IOError, match="does not exist"):
+        read_meta(missing)


### PR DESCRIPTION
## Summary
- Add `cellpy.read_meta(path)` / `cellpy_file.read_meta` to read v9 `meta.json`, `*.meta.json`, or HDF5 `/info` without loading frames.
- Essential tests + agents docs.

Closes #799

## Test plan
- [x] `uv run pytest tests/test_read_meta.py -m essential`
- [ ] CI on the PR


Made with [Cursor](https://cursor.com)