### PR TITLE
feat: instrument_meta_schema for ingestion forms (#800)

### DIFF
--- a/.issueflows/03-solved-issues/issue800_original.md
+++ b/.issueflows/03-solved-issues/issue800_original.md
@@ -1,0 +1,9 @@
+# Issue #800: Per-instrument metadata schema (which fields an instrument import needs)
+
+Source: https://github.com/jepegit/cellpy/issues/800
+
+## Original issue text
+
+Split from #791 (item b). When importing raw files, an app has to guess which metadata an instrument needs (mass? area? nominal capacity? default units?). A **declared schema per instrument** would let apps generate the correct ingestion form instead of showing every field for every instrument.
+
+Complements `cellpy.list_instruments()` (#786) and the loader contract (declarations, architecture plan §5); also relates to the external-metadata-source work (#784).

--- a/.issueflows/03-solved-issues/issue800_plan.md
+++ b/.issueflows/03-solved-issues/issue800_plan.md
@@ -1,0 +1,23 @@
+# Issue #800 — plan
+
+## Goal
+
+Apps can ask which `cellpy.get` metadata knobs to show for an instrument pick, instead of exposing every field blindly.
+
+## Approach
+
+- Add `instrument_meta_schema(instrument=None)` next to `list_instruments`.
+- Return a shared framework catalog (mass/area/loading/nominal_capacity/…) — code today has no per-loader required-meta diffs; `instrument` is echoed for future overrides.
+- Export as `cellpy.instrument_meta_schema`.
+- Do **not** change `list_instruments` row shape (breaks existing tests).
+
+## Files
+
+- `cellpy/readers/data_structures.py`
+- `cellpy/__init__.py`
+- `tests/test_instrument_meta_schema.py`
+- `docs/getting_started/agents.md`, `AGENTS.md`, `HISTORY.md`
+
+## Test strategy
+
+- Shape keys present; known field names; `instrument` echoed; units dict non-empty.

--- a/.issueflows/03-solved-issues/issue800_status.md
+++ b/.issueflows/03-solved-issues/issue800_status.md
@@ -1,0 +1,10 @@
+# Issue #800 — status
+
+## Done
+
+- [x] `instrument_meta_schema(instrument=None)` — shared `cellpy.get` meta catalog
+- [x] Top-level `cellpy.instrument_meta_schema` export
+- [x] Essential tests + agents docs
+- [x] Documented: no per-loader required diffs yet; `instrument` reserved for overrides
+
+- [x] Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ Quick facts:
 - Product: Python library + `cellpy` CLI — not a hosted GUI server.
 - Entry: `import cellpy` then `c = cellpy.get(path, mass=..., instrument=...)`.
 - Metadata peek (no frames): `cellpy.read_meta(path)` → dict with `cell` / `tests`.
+- Ingestion form fields: `cellpy.instrument_meta_schema(instrument)` → `fields` / `units`.
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* `cellpy.instrument_meta_schema(instrument)` describes `cellpy.get` metadata
+  knobs for building per-instrument ingestion forms. (#800)
+
 * Lightweight `cellpy.read_meta(path)` peeks v9 / HDF5 cellpy-file metadata
   without loading raw/steps/summary frames. (#799)
 

--- a/cellpy/__init__.py
+++ b/cellpy/__init__.py
@@ -44,6 +44,7 @@ get = cellreader.get
 merge_cells = cellreader.merge_cells
 print_instruments = readers.cellreader.print_instruments
 list_instruments = readers.data_structures.list_instruments
+instrument_meta_schema = readers.data_structures.instrument_meta_schema
 
 
 def read_meta(path):
@@ -66,6 +67,7 @@ __all__ = [
     "merge_cells",
     "print_instruments",
     "list_instruments",
+    "instrument_meta_schema",
     "read_meta",
     "do",
     # "ureg",

--- a/cellpy/readers/data_structures.py
+++ b/cellpy/readers/data_structures.py
@@ -1120,6 +1120,112 @@ def list_instruments() -> List[Dict[str, Any]]:
     return sorted(listing, key=lambda entry: entry["id"])
 
 
+def instrument_meta_schema(instrument: Optional[str] = None) -> Dict[str, Any]:
+    """Describe ``cellpy.get`` metadata knobs for building an ingestion form.
+
+    Today every loader shares the same framework-owned cell-meta catalog
+    (mass / area / loading / nominal capacity / cycle mode). The
+    ``instrument`` argument is accepted so apps can key forms per picker
+    selection; per-loader overrides can be added later without changing
+    the call shape.
+
+    Args:
+        instrument: Loader id from :func:`list_instruments` (e.g.
+            ``"maccor_txt"``). Optional; echoed in the return value.
+
+    Returns:
+        A dict with ``instrument``, ``fields`` (list of field descriptors),
+        and ``units`` (session default unit strings for numeric knobs).
+    """
+    # Session units (config stack); fall back if config is not initialised.
+    try:
+        from cellpy import config as cellpy_config
+
+        unit_cfg = cellpy_config.units
+        units = {
+            "mass": getattr(unit_cfg, "mass", "mg"),
+            "area": getattr(unit_cfg, "area", "cm**2"),
+            "nominal_capacity": getattr(unit_cfg, "nominal_capacity", "mAh/g"),
+            "loading": "mg/cm**2",
+        }
+    except Exception:
+        units = {
+            "mass": "mg",
+            "area": "cm**2",
+            "nominal_capacity": "mAh/g",
+            "loading": "mg/cm**2",
+        }
+    fields = [
+        {
+            "name": "mass",
+            "required": True,
+            "type": "number_or_quantity",
+            "unit": units["mass"],
+            "default": None,
+            "maps_to": "mass",
+            "help": "Active-material mass (recommended for specific capacities).",
+        },
+        {
+            "name": "area",
+            "required": False,
+            "type": "number_or_quantity",
+            "unit": units["area"],
+            "default": None,
+            "maps_to": "active_electrode_area",
+            "help": "Active electrode area.",
+        },
+        {
+            "name": "loading",
+            "required": False,
+            "type": "number_or_quantity",
+            "unit": units["loading"],
+            "default": None,
+            "maps_to": "loading",
+            "help": "Active-material loading.",
+        },
+        {
+            "name": "nominal_capacity",
+            "required": False,
+            "type": "number_or_quantity",
+            "unit": units["nominal_capacity"],
+            "default": None,
+            "maps_to": "nom_cap",
+            "help": "Nominal capacity (used for C-rate and related summaries).",
+        },
+        {
+            "name": "nom_cap_specifics",
+            "required": False,
+            "type": "enum",
+            "choices": ["gravimetric", "areal", "absolute"],
+            "default": "gravimetric",
+            "maps_to": "nom_cap_specifics",
+            "help": "How nominal_capacity is interpreted.",
+        },
+        {
+            "name": "cycle_mode",
+            "required": False,
+            "type": "enum",
+            "choices": ["anode", "cathode", "full"],
+            "default": None,
+            "maps_to": "cycle_mode",
+            "help": "Cycle polarity / cell type hint for summaries.",
+        },
+        {
+            "name": "estimate_area",
+            "required": False,
+            "type": "bool",
+            "default": True,
+            "maps_to": None,
+            "help": "Estimate area from mass and loading when area is omitted.",
+        },
+    ]
+    return {
+        "instrument": instrument,
+        "fields": fields,
+        "units": units,
+    }
+
+
 def generate_default_factory():
     """This function searches for all available instrument readers
     and registers them in an InstrumentFactory instance.

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -85,6 +85,14 @@ meta = cellpy.read_meta("out/my_cell.cellpy")
 mass = meta["cell"]["mass"]  # also under tests["0"]["cell"] on v9 archives
 ```
 
+Build an ingestion form for a picked instrument (shared `cellpy.get` meta knobs today):
+
+```python
+schema = cellpy.instrument_meta_schema("maccor_txt")
+for field in schema["fields"]:
+    print(field["name"], field["required"], field.get("unit"))
+```
+
 Reload a `.cellpy` file the same way:
 
 ```python

--- a/tests/test_instrument_meta_schema.py
+++ b/tests/test_instrument_meta_schema.py
@@ -1,0 +1,30 @@
+"""Essential tests for ``instrument_meta_schema`` (issue #800)."""
+
+from __future__ import annotations
+
+import pytest
+
+import cellpy
+from cellpy.readers.data_structures import instrument_meta_schema
+
+
+@pytest.mark.essential
+def test_instrument_meta_schema_shape():
+    schema = instrument_meta_schema("maccor_txt")
+    assert schema["instrument"] == "maccor_txt"
+    assert "fields" in schema and "units" in schema
+    names = [f["name"] for f in schema["fields"]]
+    assert "mass" in names
+    assert "area" in names
+    assert "nominal_capacity" in names
+    mass = next(f for f in schema["fields"] if f["name"] == "mass")
+    assert mass["required"] is True
+    assert mass["maps_to"] == "mass"
+    assert "mass" in schema["units"]
+
+
+@pytest.mark.essential
+def test_instrument_meta_schema_top_level_export():
+    schema = cellpy.instrument_meta_schema()
+    assert schema["instrument"] is None
+    assert any(f["name"] == "cycle_mode" for f in schema["fields"])


### PR DESCRIPTION
## Summary
- Add `cellpy.instrument_meta_schema(instrument)` describing shared `cellpy.get` metadata knobs for building ingestion forms.
- `instrument` is echoed for future per-loader overrides; today all loaders share one catalog.

Closes #800

## Test plan
- [x] `uv run pytest tests/test_instrument_meta_schema.py -m essential`
- [ ] CI on the PR


Made with [Cursor](https://cursor.com)