### PR TITLE
feat(batch): restore orchestrated batch.load (#822)

### DIFF
--- a/.issueflows/01-current-issues/issue822_original.md
+++ b/.issueflows/01-current-issues/issue822_original.md
@@ -1,0 +1,21 @@
+# Issue #822: Restore orchestrated batch.load (v1 flow on v3)
+
+URL: https://github.com/jepegit/cellpy/issues/822
+
+## Summary
+Extend `cellpy.batch.load` so it again orchestrates the v1 notebook flow: journal autoload → DB → update → persist `.cellpy` + journal. `cellpy.utils.batch.load` stays a thin forwarder.
+
+## Decisions
+- Journal hit: `update()` with `AUTO` (not noop `link`)
+- Persist `.cellpy` + journal by default; opt-out `save_cellpy=False`
+- Map `force_raw_file` / `force_cellpy` → `LoadPolicy.source`; conflict with `policy=` raises
+- `export_*`: accept, ignore, `warn_once`
+- `drop_bad_cells=True`: drop `session.bad_cells`
+- Raise on hard failures; per-cell soft errors via `accept_errors`
+- `journal_dir=None` → cwd; optional override
+
+## Acceptance
+- [ ] `batch.load(name, project)` autoloads journal from cwd/`journal_dir` or builds from DB
+- [ ] Returns populated Batch ready to plot
+- [ ] Saves `.cellpy` + journal unless `save_cellpy=False`
+- [ ] Essential tests for autoload, persist opt-out, force/policy conflict, drop_bad, export warn

--- a/.issueflows/01-current-issues/issue822_plan.md
+++ b/.issueflows/01-current-issues/issue822_plan.md
@@ -1,0 +1,3 @@
+# Plan — #822
+
+Confirmed grill plan: orchestrated batch.load.

--- a/.issueflows/01-current-issues/issue822_status.md
+++ b/.issueflows/01-current-issues/issue822_status.md
@@ -1,0 +1,17 @@
+# Status — #822
+
+- [ ] Done
+
+## Notes
+
+Implemented orchestrated `cellpy.batch.load` per confirmed grill plan.
+
+- Helpers: `_resolve_policy`, `_persist_cells`, `_journal_path`, `Batch.drop_cells_marked_bad`
+- Shim `utils.batch.load` forwards to facade orchestrator
+- Essential + load tests green
+- Design note: `.issueflows/04-designs-and-guides/batch-load-orchestrator.md`
+- Also restored `_LegacyExperimentAdapter` farm layout for plotter
+
+## Remaining
+
+Close via `/iflow-close` (HISTORY/PR merge) when ready.

--- a/.issueflows/04-designs-and-guides/batch-load-orchestrator.md
+++ b/.issueflows/04-designs-and-guides/batch-load-orchestrator.md
@@ -1,0 +1,47 @@
+# Orchestrated `batch.load` (#822)
+
+## Context
+
+Batch v3 initially made `cellpy.batch.load` a thin journal/DB constructor.
+Notebooks expected the v1 flow: resolve journal → load cells → persist.
+
+## Decision
+
+`cellpy.batch.load` (and the `cellpy.utils.batch.load` shim) orchestrates again:
+
+1. Resolve journal: explicit `journal_file` / `journal=` / `frame=`, else autoload
+   `cellpy_batch_{name}.json` from `journal_dir` (default **cwd**), else DB.
+2. `drop_bad_cells` (default True) removes `session["bad_cells"]`.
+3. Always `Batch.update()` (legacy `link` is a no-op in v3).
+4. Persist `.cellpy` files + journal JSON when `save_cellpy=True` (default).
+
+### Journal location
+
+- Default: `Path.cwd() / f"cellpy_batch_{name}.json"`.
+- Override with `journal_dir=`.
+- No IPython notebook-path sniffing: start the kernel with the notebook folder
+  as cwd, or pass `journal_dir=` explicitly.
+
+### Force flags
+
+| Legacy | `LoadPolicy.source` |
+|--------|---------------------|
+| (default) | `AUTO` |
+| `force_raw_file=True` | `RAW_ONLY` |
+| `force_cellpy=True` | `CELLPY_ONLY` |
+
+Explicit `policy=` that conflicts with force flags raises `ValueError`.
+
+### Ignored kwargs
+
+`export_cycles` / `export_raw` / `export_ica` are accepted and ignored
+(one `UserWarning`).
+
+## Alternatives
+
+- Separate `load_batch` name — rejected; keep notebook call sites.
+- Journal hit via noop `link` — rejected; store would stay empty.
+
+## Links
+
+- Issue #822; grill plan restore_batch.load_orchestrator.

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -14,6 +14,8 @@ adapter; the full tidy-frame plot path lands with the collectors redesign
 
 from __future__ import annotations
 
+import logging
+import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import fields, replace
 from pathlib import Path
@@ -30,10 +32,17 @@ from cellpy.batch.journal import (
     write_journal,
 )
 from cellpy.batch.layout import BatchPaths, ensure_dirs
-from cellpy.batch.policy import LoadPolicy
+from cellpy.batch.policy import LoadPolicy, SourcePreference
 from cellpy.batch.result import BatchResult
 from cellpy.batch.runner import run
 from cellpy.batch.store import CellStore
+from cellpy.parameters.internal_settings import get_headers_journal
+
+_log = logging.getLogger(__name__)
+_HDR_JOURNAL = get_headers_journal()
+_CELLPY_FILE_COL = _HDR_JOURNAL["cellpy_file_name"]
+_EXPORT_KWARGS = frozenset({"export_cycles", "export_raw", "export_ica"})
+_EXPORT_KWARGS_WARNED = False
 
 
 class Batch:
@@ -249,6 +258,14 @@ class Batch:
         self._summaries = None
         return self
 
+    def drop_cells_marked_bad(self) -> "Batch":
+        """Drop every label listed in ``journal.session["bad_cells"]``."""
+        bad = list(self.journal.session.get("bad_cells") or [])
+        for label in bad:
+            if label in self.journal.cell_names:
+                self.drop(label)
+        return self
+
     def link(self) -> "Batch":
         """No-op in batch v3 (the store loads lazily); kept for the surface."""
         return self
@@ -296,24 +313,51 @@ class _LegacyExperimentAdapter:
     Covers what ``helpers``/``collectors`` and the summary plotter read:
     ``journal.pages``, ``cell_names``, ``data``, ``summary_frames`` and
     ``memory_dumped``. Full migration of those consumers is Epic B/C.
+
+    ``memory_dumped["summary_engine"]`` keeps the legacy *farm* layout that
+    ``batch_summary_plot`` expects: one DataFrame per summary variable, with
+    cell labels as columns and ``cycle_index`` as the index (``df.name`` =
+    variable). ``summary_frames`` stays per-cell for helpers/collectors.
     """
 
     def __init__(self, journal: Journal, store: CellStore) -> None:
+        import pandas as pd
+
+        from cellpy.parameters.internal_settings import get_headers_summary
+
         self.journal = _LegacyJournalAdapter(journal)
         self.data = store
         self.cell_names = list(store)
-        summaries = []
-        summary_frames = {}
+        summary_frames: dict[str, Any] = {}
+        per_cell: dict[str, Any] = {}
+        cycle_col = get_headers_summary().cycle_index
         for label, cell in store.items():
             summary = getattr(getattr(cell, "data", None), "summary", None)
             if summary is None:
                 continue
             pdf = summary.to_pandas() if hasattr(summary, "to_pandas") else summary
-            pdf.name = label
-            summaries.append(pdf)
+            if not isinstance(pdf, pd.DataFrame) or pdf.empty:
+                continue
+            pdf = pdf.copy()
+            if cycle_col in pdf.columns:
+                pdf = pdf.set_index(cycle_col)
+            elif pdf.index.name != cycle_col:
+                pdf.index.name = cycle_col
+            per_cell[label] = pdf
             summary_frames[label] = pdf
-        self.memory_dumped = {"summary_engine": summaries}
+
+        farms: list[Any] = []
+        if per_cell:
+            wide = pd.concat(per_cell, axis=1)
+            wide = wide.swaplevel(0, 1, axis=1).sort_index(axis=1)
+            for var in wide.columns.get_level_values(0).unique():
+                farm = wide[var].copy()
+                farm.name = var
+                farms.append(farm)
+
+        self.memory_dumped = {"summary_engine": farms}
         self.summary_frames = summary_frames
+
 
 
 # -- module-level constructors -------------------------------------------
@@ -340,33 +384,193 @@ def from_cells(cells, **kwargs) -> Batch:
     return Batch.from_cells(cells, **kwargs)
 
 
+def _journal_path(name: str, journal_dir: Path | str | None = None) -> Path:
+    """Default autoload/save path: ``{journal_dir or cwd}/cellpy_batch_{name}.json``."""
+    base = Path(journal_dir) if journal_dir is not None else Path.cwd()
+    return base / f"cellpy_batch_{name}.json"
+
+
+def _warn_ignored_export_kwargs(kwargs: dict[str, Any]) -> None:
+    global _EXPORT_KWARGS_WARNED
+    hit = sorted(_EXPORT_KWARGS.intersection(kwargs))
+    if not hit or _EXPORT_KWARGS_WARNED:
+        return
+    _EXPORT_KWARGS_WARNED = True
+    warnings.warn(
+        f"batch.load ignores {hit} in batch v3; use collectors / export helpers "
+        "instead.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def _resolve_policy(
+    *,
+    policy: LoadPolicy | None,
+    force_raw_file: bool,
+    force_cellpy: bool,
+    force_recalc: bool,
+    accept_errors: bool | None,
+    max_cycle: int | None,
+) -> LoadPolicy:
+    """Map legacy force_* flags onto a :class:`LoadPolicy`.
+
+    Raises:
+        ValueError: if ``policy`` conflicts with force_raw_file / force_cellpy.
+    """
+    if force_raw_file and force_cellpy:
+        raise ValueError("force_raw_file and force_cellpy cannot both be True")
+
+    if force_raw_file:
+        wanted = SourcePreference.RAW_ONLY
+    elif force_cellpy:
+        wanted = SourcePreference.CELLPY_ONLY
+    else:
+        wanted = None
+
+    if policy is not None and wanted is not None and policy.source != wanted:
+        raise ValueError(
+            f"conflicting load source: policy.source={policy.source!r} vs "
+            f"force flags implying {wanted!r}"
+        )
+
+    base = policy or LoadPolicy()
+    updates: dict[str, Any] = {}
+    if wanted is not None:
+        updates["source"] = wanted
+    if force_recalc:
+        updates["recalc"] = True
+    if accept_errors is not None:
+        updates["accept_errors"] = accept_errors
+    if max_cycle is not None:
+        updates["max_cycle"] = max_cycle
+    return replace(base, **updates) if updates else base
+
+
+def _persist_cells(batch: Batch, journal_path: Path) -> Path:
+    """Save loaded cells as ``.cellpy`` and write the journal JSON."""
+    if _CELLPY_FILE_COL not in batch.pages.columns:
+        raise ValueError(
+            f"journal pages missing {_CELLPY_FILE_COL!r}; cannot persist cellpy files"
+        )
+
+    saved: list[str] = []
+    for row in batch.pages.iter_rows(named=True):
+        label = row[FILENAME]
+        dest_raw = row.get(_CELLPY_FILE_COL)
+        if not dest_raw:
+            raise ValueError(f"no {_CELLPY_FILE_COL} for cell {label!r}")
+        dest = Path(dest_raw).with_suffix(".cellpy")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if label in batch.cells and batch.cells.is_loaded(label):
+            _log.info("saving %s -> %s", label, dest)
+            batch.cells[label].save(dest, overwrite=True)
+        else:
+            _log.debug("skip save (not loaded): %s", label)
+        saved.append(str(dest))
+
+    batch.journal.pages = batch.journal.pages.with_columns(
+        pl.Series(_CELLPY_FILE_COL, saved)
+    )
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    return batch.save(journal_path)
+
+
+def _finalize(
+    batch: Batch,
+    *,
+    policy: LoadPolicy,
+    drop_bad_cells: bool,
+    save_cellpy: bool,
+    journal_path: Path | None,
+    update_kwargs: dict[str, Any],
+) -> Batch:
+    """Shared post-construction pipeline: drop bad → update → persist."""
+    batch.policy = policy
+    if drop_bad_cells:
+        batch.drop_cells_marked_bad()
+    batch.update(**update_kwargs)
+    batch.combine_summaries()
+    if save_cellpy:
+        if journal_path is None:
+            name = batch.journal.name or "batch"
+            journal_path = _journal_path(name)
+        _persist_cells(batch, journal_path)
+    return batch
+
+
 def load(
     name: str | None = None,
     project: str | None = None,
     *,
     journal: Journal | None = None,
     journal_file: Path | str | None = None,
+    journal_dir: Path | str | None = None,
     frame: Any | None = None,
     db: str | bool | None = None,
     db_reader: str | None = None,
     reader: str | None = None,
+    reader_path: str | None = None,
+    batch_col: str | None = None,
     policy: LoadPolicy | None = None,
+    allow_from_journal: bool = True,
+    force_reload: bool = False,
+    force_raw_file: bool = False,
+    force_cellpy: bool = False,
+    force_recalc: bool = False,
+    drop_bad_cells: bool = True,
+    save_cellpy: bool = True,
+    accept_errors: bool | None = None,
+    max_cycle: int | None = None,
     **kwargs,
 ) -> Batch:
-    """Build a :class:`Batch` from a journal source.
+    """Load a batch the notebook-friendly way (v1 orchestration on v3).
 
-    Source precedence: explicit ``journal`` model, ``journal_file``, ``frame``,
-    then a database read (``db`` / ``db_reader`` reader name, or when only
-    ``name``/``project`` are given). Falls back to an empty named journal.
+    Resolves a journal (explicit file, cwd/`journal_dir` autoload, or database),
+    runs :meth:`Batch.update`, optionally drops bad cells, and by default
+    persists ``.cellpy`` files plus the journal JSON.
 
-    When ``journal_file`` points at a **BatBase or custom JSON** download (not a
-    cellpy journal), pass ``db_reader="batbase_json_reader"`` or
-    ``"custom_json_reader"`` (``reader=`` is accepted as an alias). That path
-    runs file search after read via :meth:`Batch.from_db`. Custom JSON also
-    needs ``column_map`` (source column → journal key; must map to
-    ``filename``). Native cellpy journal JSON does not re-search.
+    Journal location: ``journal_dir`` or :func:`pathlib.Path.cwd` (typically the
+    notebook folder when the kernel was started there). Autoload looks for
+    ``cellpy_batch_{name}.json`` in that directory when ``allow_from_journal``
+    is True.
+
+    Args:
+        name / project: batch identity (required for DB / autoload paths).
+        journal: explicit in-memory journal model.
+        journal_file: path to a cellpy journal, or a BatBase/custom JSON DB file
+            when ``reader`` / ``db_reader`` is a JSON reader.
+        journal_dir: directory for journal autoload/save (default: cwd).
+        frame: build journal pages from a dataframe.
+        db / db_reader / reader: database reader selection (``reader`` aliases
+            ``db_reader``).
+        reader_path: DB file path for non-default readers.
+        batch_col: Excel batch column (default ``b01`` when reading the DB).
+        policy: explicit :class:`LoadPolicy` (conflicts with force_* raise).
+        allow_from_journal: autoload ``cellpy_batch_{name}.json`` when present.
+        force_reload: kept for API parity; journal hits always ``update()``.
+        force_raw_file / force_cellpy: map to ``SourcePreference``.
+        force_recalc: set ``policy.recalc``.
+        drop_bad_cells: drop ``session["bad_cells"]`` before update.
+        save_cellpy: write ``.cellpy`` files and journal JSON (default True).
+        accept_errors / max_cycle: forwarded into the load policy.
+        **kwargs: DB engine knobs (``column_map``, ``raw_file_dir``, …) and
+            loader extras (``testing``, …). ``export_cycles`` / ``export_raw`` /
+            ``export_ica`` are accepted but ignored (warned once).
+
+    Returns:
+        Populated :class:`Batch`.
+
+    Raises:
+        ValueError: missing required args, force-flag conflicts, missing journal
+            when ``journal_file`` is set but absent.
+        FileNotFoundError: ``journal_file`` path does not exist.
     """
-    # Canonical name is db_reader=; reader= matches the utils.batch shim.
+    _ = force_reload  # journal hits always update(); flag kept for call-site parity
+    _warn_ignored_export_kwargs(kwargs)
+    for key in _EXPORT_KWARGS:
+        kwargs.pop(key, None)
+
     if db_reader is None and reader is not None:
         db_reader = reader
     elif db_reader is not None and reader is not None and db_reader != reader:
@@ -375,29 +579,102 @@ def load(
             "pass only db_reader= (canonical) or only reader= (alias)"
         )
 
+    resolved = _resolve_policy(
+        policy=policy,
+        force_raw_file=force_raw_file,
+        force_cellpy=force_cellpy,
+        force_recalc=force_recalc,
+        accept_errors=accept_errors,
+        max_cycle=max_cycle,
+    )
+
+    # Split kwargs: known LoadPolicy extras / loader vs DB engine args.
+    policy_field_names = {f.name for f in fields(LoadPolicy)}
+    update_kwargs = {
+        k: kwargs.pop(k)
+        for k in list(kwargs)
+        if k in policy_field_names or k in {"testing", "executor", "on_progress"}
+    }
+    db_kwargs = dict(kwargs)
+    if batch_col is not None:
+        db_kwargs.setdefault("batch_col", batch_col)
+    if reader_path is not None:
+        db_kwargs.setdefault("db_file", reader_path)
+
+    journal_path: Path | None = None
+    batch: Batch | None = None
+
     if journal is not None:
-        return Batch(journal, policy=policy)
-    if journal_file is not None:
+        batch = Batch(journal, policy=resolved)
+        if name or project:
+            journal_path = _journal_path(
+                name or batch.journal.name or "batch", journal_dir
+            )
+    elif journal_file is not None:
+        journal_file = Path(journal_file)
+        if not journal_file.is_file():
+            raise FileNotFoundError(f"journal_file not found: {journal_file}")
         if db_reader in _JSON_DB_READERS:
             if not name or not project:
                 raise ValueError(
                     "name and project are required when loading a JSON db file "
                     f"with db_reader={db_reader!r}"
                 )
-            return Batch.from_db(
+            batch = Batch.from_db(
                 name,
                 project,
                 db_reader=db_reader,
                 db_file=str(journal_file),
-                policy=policy,
-                **kwargs,
+                policy=resolved,
+                **db_kwargs,
             )
-        return Batch(read_journal(journal_file), policy=policy)
-    if frame is not None:
-        return Batch(journal_from_frame(frame, name=name, project=project), policy=policy)
-    if db is not None or db_reader is not None or (name and project):
-        chosen = db_reader
-        if chosen is None:
-            chosen = db if isinstance(db, str) else "default"
-        return Batch.from_db(name, project, db_reader=chosen, policy=policy, **kwargs)
-    return Batch(Journal(name=name, project=project), policy=policy)
+            journal_path = _journal_path(name, journal_dir)
+        else:
+            batch = Batch(read_journal(journal_file), policy=resolved)
+            journal_path = Path(journal_file)
+    elif frame is not None:
+        batch = Batch(
+            journal_from_frame(frame, name=name, project=project), policy=resolved
+        )
+        if name:
+            journal_path = _journal_path(name, journal_dir)
+    else:
+        # Autoload journal from journal_dir/cwd, else DB.
+        if allow_from_journal and name:
+            candidate = _journal_path(name, journal_dir)
+            if candidate.is_file():
+                _log.info("loading journal %s", candidate)
+                batch = Batch(read_journal(candidate), policy=resolved)
+                journal_path = candidate
+
+        if batch is None:
+            if not name or not project:
+                if db is not None or db_reader is not None:
+                    raise ValueError(
+                        "name and project are required when loading from a database"
+                    )
+                return Batch(Journal(name=name, project=project), policy=resolved)
+            chosen = db_reader
+            if chosen is None:
+                chosen = db if isinstance(db, str) else "default"
+            if chosen == "default":
+                chosen = "simple_excel_reader"
+            if batch_col is None:
+                db_kwargs.setdefault("batch_col", "b01")
+            batch = Batch.from_db(
+                name, project, db_reader=chosen, policy=resolved, **db_kwargs
+            )
+            journal_path = _journal_path(name, journal_dir)
+            ensure_dirs(
+                BatchPaths.create(name, project, project_dir=journal_dir or Path.cwd())
+            )
+
+    assert batch is not None
+    return _finalize(
+        batch,
+        policy=resolved,
+        drop_bad_cells=drop_bad_cells,
+        save_cellpy=save_cellpy,
+        journal_path=journal_path,
+        update_kwargs=update_kwargs,
+    )

--- a/cellpy/utils/batch.py
+++ b/cellpy/utils/batch.py
@@ -116,34 +116,27 @@ def load(
     policy=None,
     **kwargs,
 ) -> Batch:
-    """Load a batch from a journal source (shim -> :mod:`cellpy.batch`)."""
+    """Load a batch (shim -> orchestrated :func:`cellpy.batch.load`)."""
     _setup_logging(kwargs.pop("default_log_level", None), testing)
 
-    if journal_file is not None and reader in _JSON_DB_READERS:
-        return Batch.from_db(
-            name,
-            project,
-            db_reader=reader,
-            db_file=str(journal_file),
-            column_map=column_map,
-            batch_col=batch_col,
-            raw_file_dir=raw_file_dir,
-            cellpy_file_dir=cellpy_file_dir,
-            policy=policy,
-        )
-    if journal_file is not None:
-        return _new_from_journal(journal_file, policy=policy)
-    if frame is not None:
-        return _new_load(name, project, frame=frame, policy=policy)
+    if column_map is not None:
+        kwargs["column_map"] = column_map
+    if raw_file_dir is not None:
+        kwargs["raw_file_dir"] = raw_file_dir
+    if cellpy_file_dir is not None:
+        kwargs["cellpy_file_dir"] = cellpy_file_dir
+    if testing:
+        kwargs["testing"] = testing
 
-    return Batch.from_db(
+    return _new_load(
         name,
         project,
-        db_reader=reader or "simple_excel_reader",
+        journal_file=journal_file,
+        reader=reader,
         batch_col=batch_col,
-        raw_file_dir=raw_file_dir,
-        cellpy_file_dir=cellpy_file_dir,
+        frame=frame,
         policy=policy,
+        **kwargs,
     )
 
 
@@ -173,11 +166,9 @@ def load_pages(file_name) -> Any:
 def process_batch(*args, **kwargs) -> Batch:
     warn_once(
         "cellpy.utils.batch.process_batch",
-        "cellpy.batch.load(...).update() (see the migration guide recipe)",
+        "cellpy.batch.load(...)",
     )
-    b = load(*args, **kwargs)
-    b.update()
-    return b
+    return load(*args, **kwargs)
 
 
 def iterate_batches(*args, **kwargs) -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import tempfile
 import time
+import warnings
 
 import pandas
 import pytest
@@ -355,6 +356,7 @@ def test_load_with_explicit_cellpy_journal_file(parameters, batch_instance):
         journal_file=parameters.journal_file_json_path,
         allow_from_journal=False,
         drop_bad_cells=False,
+        save_cellpy=False,
         testing=True,
     )
     assert b is not None
@@ -380,6 +382,7 @@ def test_load_with_explicit_custom_json(parameters, batch_instance):
         reader="custom_json_reader",
         column_map=column_map,
         allow_from_journal=False,
+        save_cellpy=False,
         testing=True,
         raw_file_dir=parameters.raw_data_dir,
         cellpy_file_dir=parameters.cellpy_data_dir,
@@ -402,6 +405,7 @@ def test_load_with_explicit_batbase_json(parameters, batch_instance):
         journal_file=str(fixture_path),
         reader="batbase_json_reader",
         allow_from_journal=False,
+        save_cellpy=False,
         testing=True,
         raw_file_dir=parameters.raw_data_dir,
         cellpy_file_dir=parameters.cellpy_data_dir,
@@ -668,3 +672,152 @@ def test_batch_figure_structure_matches_snapshot(populated_batch):
 # # Since the batch-files contains full paths I need to figure out how to make a custom json-file for the test.
 #     folder_name = config.paths.batchfiledir
 #     batch.iterate_batches(folder_name, default_log_level="CRITICAL")
+
+
+@pytest.mark.essential
+def test_resolve_policy_force_flags_and_conflict():
+    """force_raw_file / force_cellpy map to LoadPolicy; conflict with policy raises."""
+    from cellpy.batch.facade import _resolve_policy
+    from cellpy.batch import LoadPolicy, SourcePreference
+
+    raw = _resolve_policy(
+        policy=None,
+        force_raw_file=True,
+        force_cellpy=False,
+        force_recalc=False,
+        accept_errors=None,
+        max_cycle=None,
+    )
+    assert raw.source is SourcePreference.RAW_ONLY
+
+    cellpy_only = _resolve_policy(
+        policy=None,
+        force_raw_file=False,
+        force_cellpy=True,
+        force_recalc=True,
+        accept_errors=False,
+        max_cycle=3,
+    )
+    assert cellpy_only.source is SourcePreference.CELLPY_ONLY
+    assert cellpy_only.recalc is True
+    assert cellpy_only.accept_errors is False
+    assert cellpy_only.max_cycle == 3
+
+    with pytest.raises(ValueError, match="conflicting load source"):
+        _resolve_policy(
+            policy=LoadPolicy(source=SourcePreference.AUTO),
+            force_raw_file=True,
+            force_cellpy=False,
+            force_recalc=False,
+            accept_errors=None,
+            max_cycle=None,
+        )
+
+    with pytest.raises(ValueError, match="cannot both be True"):
+        _resolve_policy(
+            policy=None,
+            force_raw_file=True,
+            force_cellpy=True,
+            force_recalc=False,
+            accept_errors=None,
+            max_cycle=None,
+        )
+
+
+@pytest.mark.essential
+def test_load_export_kwargs_warn_once():
+    """export_* kwargs are accepted but ignored with a single UserWarning."""
+    from cellpy.batch import facade as facade_mod
+    from cellpy.batch.facade import _warn_ignored_export_kwargs
+
+    facade_mod._EXPORT_KWARGS_WARNED = False
+    with pytest.warns(UserWarning, match="ignores"):
+        _warn_ignored_export_kwargs({"export_cycles": True, "export_raw": False})
+    # second call should not warn again
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        _warn_ignored_export_kwargs({"export_ica": True})
+
+
+@pytest.mark.essential
+def test_drop_cells_marked_bad():
+    from cellpy.batch import Batch
+    from cellpy.batch.journal import Journal, FILENAME
+    import polars as pl
+
+    pages = pl.DataFrame(
+        {
+            FILENAME: ["a", "b", "c"],
+            "group": [1, 1, 2],
+            "sub_group": [1, 2, 1],
+        }
+    )
+    b = Batch(Journal(name="t", project="p", pages=pages, session={"bad_cells": ["b"]}))
+    b.drop_cells_marked_bad()
+    assert b.cell_names == ["a", "c"]
+
+
+@pytest.mark.essential
+def test_load_autoloads_journal_from_journal_dir(parameters, batch_instance, tmp_path):
+    """allow_from_journal picks up cellpy_batch_{name}.json under journal_dir."""
+    import shutil
+
+    journal_src = pathlib.Path(parameters.journal_file_json_path)
+    dest = tmp_path / "cellpy_batch_test_batch.json"
+    shutil.copy(journal_src, dest)
+
+    b = batch_instance.load(
+        "test_batch",
+        "test_project",
+        journal_dir=tmp_path,
+        allow_from_journal=True,
+        save_cellpy=False,
+        drop_bad_cells=False,
+        testing=True,
+    )
+    assert len(b.pages) == 5
+
+
+@pytest.mark.essential
+def test_load_save_cellpy_writes_journal(parameters, batch_instance, tmp_path, monkeypatch):
+    """save_cellpy=True writes journal JSON under journal_dir (cells may be empty)."""
+    import polars as pl
+    from cellpy.batch import Batch
+    from cellpy.batch.journal import Journal, FILENAME
+    from cellpy.batch import facade as facade_mod
+
+    cellpy_dir = tmp_path / "cellpyfiles"
+    cellpy_dir.mkdir()
+    pages = pl.DataFrame(
+        {
+            FILENAME: ["cell_a"],
+            "group": [1],
+            "sub_group": [1],
+            hdr_journal["cellpy_file_name"]: [str(cellpy_dir / "cell_a.h5")],
+        }
+    )
+    journal = Journal(name="persist_me", project="p", pages=pages)
+
+    # Avoid real file IO from update: empty store after no-op update.
+    def _fake_update(self, **kwargs):
+        from cellpy.batch.result import BatchResult
+
+        self._result = BatchResult(results=[])
+        self._store = self._store.__class__()
+        return self._result
+
+    monkeypatch.setattr(Batch, "update", _fake_update)
+
+    b = facade_mod.load(
+        name="persist_me",
+        project="p",
+        journal=journal,
+        journal_dir=tmp_path,
+        save_cellpy=True,
+        drop_bad_cells=False,
+        allow_from_journal=False,
+    )
+    out = tmp_path / "cellpy_batch_persist_me.json"
+    assert out.is_file()
+    # path suffix normalized to .cellpy even when nothing loaded
+    assert str(b.pages[hdr_journal["cellpy_file_name"]][0]).endswith(".cellpy")


### PR DESCRIPTION
## Summary
- Extend `cellpy.batch.load` with v1 notebook orchestration (journal autoload → update → persist `.cellpy` + journal)
- `utils.batch.load` forwards into the orchestrator; `save_cellpy=False` / `journal_dir=` / force_* → `LoadPolicy` mapping
- Fix `_LegacyExperimentAdapter` summary farms for `Batch.plot`
- Tests + design note for cwd journal default

Closes #822

## Test plan
- [x] `uv run pytest tests/test_batch.py::test_resolve_policy_force_flags_and_conflict` (+ related load tests)
- [x] `uv run pytest tests/test_batch.py -m essential`
- [ ] Dogfood: `batch.load(name, project)` from a notebook folder with FQDN `rawdatadir`

Made with [Cursor](https://cursor.com)