### PR TITLE
fix(batch): default cellpy paths when persisting frame loads

### DIFF
--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -447,20 +447,34 @@ def _resolve_policy(
     return replace(base, **updates) if updates else base
 
 
+def _default_cellpy_path(label: str) -> Path:
+    """Fallback ``.cellpy`` path under ``config.paths.cellpydatadir``."""
+    import cellpy.config as config
+
+    return Path(config.paths.cellpydatadir) / f"{label}.cellpy"
+
+
 def _persist_cells(batch: Batch, journal_path: Path) -> Path:
-    """Save loaded cells as ``.cellpy`` and write the journal JSON."""
+    """Save loaded cells as ``.cellpy`` and write the journal JSON.
+
+    When ``cellpy_file_name`` is missing or null (e.g. ``load(frame=...)``),
+    paths default to ``{cellpydatadir}/{label}.cellpy``.
+    """
     if _CELLPY_FILE_COL not in batch.pages.columns:
-        raise ValueError(
-            f"journal pages missing {_CELLPY_FILE_COL!r}; cannot persist cellpy files"
+        defaults = [str(_default_cellpy_path(lbl)) for lbl in batch.cell_names]
+        batch.journal.pages = batch.pages.with_columns(
+            pl.Series(_CELLPY_FILE_COL, defaults)
         )
 
     saved: list[str] = []
     for row in batch.pages.iter_rows(named=True):
         label = row[FILENAME]
         dest_raw = row.get(_CELLPY_FILE_COL)
-        if not dest_raw:
-            raise ValueError(f"no {_CELLPY_FILE_COL} for cell {label!r}")
-        dest = Path(dest_raw).with_suffix(".cellpy")
+        dest = (
+            Path(dest_raw).with_suffix(".cellpy")
+            if dest_raw
+            else _default_cellpy_path(label)
+        )
         dest.parent.mkdir(parents=True, exist_ok=True)
         if label in batch.cells and batch.cells.is_loaded(label):
             _log.info("saving %s -> %s", label, dest)

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -82,12 +82,15 @@ def test_save_roundtrip(tmp_path):
     assert reloaded.cell_names == b.cell_names
 
 
-def test_load_from_frame():
+def test_load_from_frame(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     frame = pl.DataFrame({FILENAME: ["a", "b"], "mass": [1.0, 2.0]})
-    b = load(name="n", project="p", frame=frame)
+    # No cellpy paths on the frame; persist fills defaults under cellpydatadir.
+    b = load(name="n", project="p", frame=frame, journal_dir=tmp_path)
     assert isinstance(b, Batch)
     assert b.cell_names == ["a", "b"]
     assert b.journal.name == "n" and b.journal.project == "p"
+    assert (tmp_path / "cellpy_batch_n.json").is_file()
 
 
 # ---- db path (#703) -----------------------------------------------------


### PR DESCRIPTION
## Summary
- Follow-up to #823: squash-merge landed before this commit
- When `load(frame=...)` pages lack `cellpy_file_name`, derive `{cellpydatadir}/{label}.cellpy` instead of raising
- Fixes `tests/test_batch_v3_facade.py::test_load_from_frame` (CI full suite)

## Test plan
- [x] `uv run pytest tests/test_batch_v3_facade.py::test_load_from_frame`
- [x] CI full (linux / uv) green


Made with [Cursor](https://cursor.com)