### PR TITLE
fix(cli): lazy imports for fast info --version

### DIFF
--- a/.issueflows/03-solved-issues/issue837_original.md
+++ b/.issueflows/03-solved-issues/issue837_original.md
@@ -1,0 +1,47 @@
+# Issue #837: perf(cli): cellpy info --version takes minutes on first run after conda-forge install
+
+Source: https://github.com/jepegit/cellpy/issues/837
+
+## Original issue text
+
+## Context
+
+After installing **cellpy 2.1.1.post6** from **conda-forge** into a fresh conda environment, the first CLI invocations appear frozen:
+
+- `cellpy info --version`
+- `cellpy setup -i`
+
+Eventually they complete (not a hard hang). Observed:
+
+| Run | Approx. time |
+|---|---|
+| First after install (cold) | **many minutes** |
+| Second run (warm) | **~5 s** |
+
+Warm ~5 s for a version print is still too slow. Cold multi-minute is a bad install/first-use experience (users give up).
+
+**Not in Stage 5 / 2.2 scope** (see [#783](https://github.com/jepegit/cellpy/issues/783) / stage5 plan). Treat as a **v2.1.x patch-stream** UX/perf bug. Related principles already exist (no import-time config I/O / lazy config singleton) but the CLI entry path still eagerly pulls the heavy stack.
+
+Filed from iterative session [#836](https://github.com/jepegit/cellpy/issues/836).
+
+## Likely cause
+
+`cellpy` console entry → `cellpy.cli` → `cellpy.cli_api` does `import cellpy` (and other heavy modules) at import time. `cellpy/__init__.py` eagerly imports readers / cellreader / etc., so even `info --version` pays the full scientific stack load. Cold cost amplified on Windows/conda by first-time DLL / filesystem / AV cache; warm path still ~5 s.
+
+## Spec
+
+Make light CLI commands (`info --version`, `--help`, and similar) avoid loading the full package graph until needed.
+
+## Acceptance criteria
+
+- [ ] Profile warm import path; identify top cost modules (document briefly in PR / issue comment).
+- [ ] `cellpy info --version` does not import the full reader/stack path (lazy imports in `cli` / `cli_api` / package init as needed).
+- [ ] Warm `cellpy info --version` is clearly faster than ~5 s on a typical dev machine (target: well under 1–2 s once OS cache is warm; exact budget TBD from profile).
+- [ ] Cold first-run after fresh conda install is improved enough that it no longer looks hung for minutes (or docs call out expected first-import cost if residual is environmental).
+- [ ] Existing CLI smoke / setup / info behaviors unchanged for heavier commands.
+- [ ] Regression guard: smoke or timing note so `--version` cannot silently regress to full-stack import.
+
+## Out of scope
+
+- Stage 5 feature work (live/incremental, instruments, etc.).
+- Broader scientific-import refactor beyond what the CLI light path needs.

--- a/.issueflows/03-solved-issues/issue837_plan.md
+++ b/.issueflows/03-solved-issues/issue837_plan.md
@@ -1,0 +1,60 @@
+# Issue #837 — plan
+
+## Goal
+
+Make `cellpy info --version` (and other light CLI entry) avoid loading the full scientific stack so warm runs are well under ~1–2 s and cold conda first-runs no longer look hung for minutes.
+
+## Constraints
+
+- Patch-stream (`v.2.1.2`); not Stage 5.
+- CLI surface / output of `info --version` stays the same (`[cellpy] version: …`).
+- Heavier commands (`setup`, `info --check`, convert, run, …) keep working; they may still pay full import cost when invoked.
+- No broad scientific-import redesign beyond what the light CLI path needs.
+- Prefer stdlib / existing patterns; no new dependencies.
+
+### Prior art
+
+- `cellpy.cli` → `cellpy.cli_api` (Typer adapters; library-first extract #568/#651).
+- Lazy config: `cellpy.config` PEP 562 / no import-time I/O (conventions + #453) — config itself is light once package is loaded; package `__init__` is still eager.
+- Tests: `tests/test_cellpy_cmd.py::test_info_version` (CliRunner); `tests/test_cli_api.py`.
+- Toolbox: no import-timing helper in `00-tools/` (profile ad hoc / document in issue comment).
+- Graph: not required for this scoped CLI import change.
+
+## Approach
+
+**Root cause (confirmed):** entry point `cellpy.cli:cli` imports `cli_api` at module load; `cli_api` does `import cellpy` (+ config / OtherPath / prmreader / …). `cellpy/__init__.py` eagerly imports readers/cellreader/…. Warm cost ~1.6 s for `import cellpy` alone in the uv env; cold conda amplifies DLL/cache cost to minutes. Second run ~5 s matches “full stack, warm cache.”
+
+**Strategy — light path for version (and cheap CLI bootstrap):**
+
+1. **Profile (document):** record warm timings for `typer`, `import cellpy`, `import cellpy.cli`, and post-fix `info --version` wall time; post short numbers on #837.
+2. **`cellpy/cli.py`:** remove module-level `from cellpy import cli_api`; import `cli_api` inside each command body (and `if __name__`). Registering Typer commands then only needs `typer` — so `cellpy --help` stays light.
+3. **`cellpy/cli_api.py`:**
+   - Drop eager `import cellpy` and other heavy top-level imports (`config`, `OtherPath`, `prmreader`, `internal_settings`, …).
+   - Resolve `VERSION` without package `__init__` — prefer `importlib.metadata.version("cellpy")` (works for conda/PyPI/editable; fallback to loading `cellpy._version` via `importlib.util` only if metadata missing in odd layouts).
+   - Lazy-import heavy modules inside the functions that need them (`setup_config`, `show_info` non-version branches, convert, run, …).
+   - `show_info(version=True)` must only need VERSION + echo.
+4. **Package `__init__.py`:** **required** — console entry `cellpy.cli:cli` always executes package init first. Make sanctioned top-level symbols lazy via PEP 562 `__getattr__` (keep `__version__` + NullHandler eager).
+5. **Regression guard:** test that after `CliRunner.invoke(..., ["info", "--version"])` (or after importing `cellpy.cli` alone), heavy modules such as `cellpy.readers.cellreader` are **not** in `sys.modules`. Keep existing `test_info_version` behavior assertion.
+6. **Cold-run note:** if residual cold delay remains environmental (AV/DLL), mention briefly in PR/`HISTORY` that first process after install can still be slower; the regression we fix is “must load full stack for `--version`.”
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| [`cellpy/cli.py`](../../../cellpy/cli.py) | Per-command lazy `cli_api` import |
+| [`cellpy/cli_api.py`](../../../cellpy/cli_api.py) | Light module import graph; metadata VERSION; lazy heavy deps |
+| [`tests/test_cellpy_cmd.py`](../../../tests/test_cellpy_cmd.py) | Import-graph regression for `--version` |
+| `.issueflows/01-current-issues/issue837_status.md` | Log profile numbers + Done checkbox at close |
+
+Optional: short `HISTORY.md` line at `/iflow-close`.
+
+## Test strategy
+
+- `uv run pytest tests/test_cellpy_cmd.py tests/test_cli_api.py -q` (or conda `cellpy_dev_313` if preferred locally).
+- Manual: warm `uv run cellpy info --version` timing before/after; if conda env available, spot-check there too.
+- No new deps; no full-suite gate for this change beyond essential CLI tests + existing suite at close.
+
+## Open questions
+
+1. **Package `__init__` lazy-load in this PR?** **Resolved:** yes — entry point forces it.
+2. **VERSION source:** **Resolved:** keep `cellpy._version` (already `importlib.metadata`).

--- a/.issueflows/03-solved-issues/issue837_status.md
+++ b/.issueflows/03-solved-issues/issue837_status.md
@@ -1,0 +1,16 @@
+# Issue #837: perf(cli) cold-start / slow `info --version`
+
+- [x] Done
+
+## What's done
+
+- Lazy `cellpy/__init__.py` (PEP 562) — required because entry point `cellpy.cli` always loads package init.
+- `cellpy/cli.py`: `_CliApiProxy` defers `cli_api` until a command runs.
+- `cellpy/cli_api.py`: lazy `config`/`prmreader`; deferred optional-dep probes; VERSION via `cellpy._version`.
+- Regression: `tests/test_cli_light_import.py` (essential; subprocess).
+- Design note: `.issueflows/04-designs-and-guides/cli-light-startup.md`.
+- Essential suite green at close; HISTORY `[Unreleased]` bullet.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/cli-light-startup.md
+++ b/.issueflows/04-designs-and-guides/cli-light-startup.md
@@ -1,0 +1,20 @@
+# CLI light startup (#837)
+
+## Context
+
+`cellpy` console entry is `cellpy.cli:cli`. Importing that module always runs
+`cellpy/__init__.py` first. Eager readers + module-level optional-dep probes in
+`cli_api` made `cellpy info --version` pay the full scientific stack (minutes
+cold after conda-forge install; ~5 s warm).
+
+## Decision
+
+- Keep package `__init__` symbols lazy (PEP 562) except `__version__` / logging.
+- Defer `cli_api` from `cli.py` until a command runs.
+- Probe optional deps (cookiecutter, github, lmfit, …) on demand, not at import.
+- Guard with `tests/test_cli_light_import.py` (subprocess + `sys.modules`).
+
+## Alternatives
+
+- Separate top-level entry module outside `cellpy` — rejected (more packaging churn).
+- Soften only `cli_api` — insufficient; entry point still loads package init.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -30,6 +30,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_v3_runner.py::test_no_recalc_skips_remake | yes | yes | batch.runner.load_cell | #825 | |
 | tests/test_batch.py::test_persist_skips_rewrite_when_loaded_from_cellpy | yes | yes | batch.facade._persist_cells | #825 | skip redundant save |
 | tests/test_batch.py::test_persist_rewrites_when_loaded_from_raw | yes | yes | batch.facade._persist_cells | #825 | |
+| tests/test_cli_light_import.py::test_info_version_avoids_cellreader_import | yes | yes | cellpy.__init__ / cli / cli_api light path | #837 | subprocess; cellreader must stay out of sys.modules |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Speed up CLI cold start: lazy package/CLI imports so ``cellpy info --version`` no longer loads the full reader stack. (#837)
 - Pretty-print cycles collector facet strips (Cycle N / cell label, not cycle_num=). (#820)
 - Honour share_y / match_axes on collected summary spread_plot. (#817)
 - ICA plotter: honour direction for line layouts; support direction='both'. (#821)

--- a/cellpy/__init__.py
+++ b/cellpy/__init__.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 
-""" """
+"""cellpy — battery cell cycling data tools."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
+from cellpy._version import __version__
 
 __author__ = (
     "Jan Petter Maehlen",
@@ -15,47 +23,19 @@ __email__ = (
     "julia.wind@ife.no",
 )
 
-import logging
-
-import cellpy._version
-
-from cellpy import parameters
-from cellpy import readers
-from cellpy.parameters import prms  # TODO: this might give circular ref
-from cellpy.parameters import prmreader
-
-__version__ = cellpy._version.__version__
-
-from cellpy.readers import cellreader, dbreader, filefinder, do, data_structures
-
-# from cellpy.readers.data_structures import Q, ureg
-
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Config loads lazily on first ``cellpy.config`` / ``config.*`` access, or via
 # ``cellpy.parameters.prmreader.initialize()`` (issue #453).
+#
+# Heavy submodules (readers / cellreader / …) are also lazy so ``import cellpy``
+# and the CLI entry point stay light (#837).
 
 # Sanctioned top-level API (v2, issue #509): ``cellpy.get`` is the primary
 # entry point; ``cellpy.merge_cells`` and ``cellpy.print_instruments`` are the
 # supporting conveniences. ``cellpy.read_meta`` peeks cellpy-file metadata
 # without loading frames (issue #799). Everything else is reached via explicit
 # module paths (``cellpy.cellreader``, ``cellpy.config`` / ``cellpy.config.session``).
-get = cellreader.get
-merge_cells = cellreader.merge_cells
-print_instruments = readers.cellreader.print_instruments
-list_instruments = readers.data_structures.list_instruments
-instrument_meta_schema = readers.data_structures.instrument_meta_schema
-
-
-def read_meta(path):
-    """Read cellpy-file metadata without loading raw/steps/summary frames.
-
-    See ``cellpy.readers.cellpy_file.read_meta`` for details.
-    """
-    from cellpy.readers.cellpy_file import read_meta as _read_meta
-
-    return _read_meta(path)
-
 
 __all__ = [
     "cellreader",
@@ -70,6 +50,54 @@ __all__ = [
     "instrument_meta_schema",
     "read_meta",
     "do",
-    # "ureg",
-    # "Q",
 ]
+
+_LAZY_MODULES = {
+    "parameters": "cellpy.parameters",
+    "readers": "cellpy.readers",
+    "prms": "cellpy.parameters.prms",
+    "prmreader": "cellpy.parameters.prmreader",
+    "cellreader": "cellpy.readers.cellreader",
+    "dbreader": "cellpy.readers.dbreader",
+    "filefinder": "cellpy.readers.filefinder",
+    "do": "cellpy.readers.do",
+    "data_structures": "cellpy.readers.data_structures",
+}
+
+_LAZY_ATTRS = {
+    "get": ("cellpy.readers.cellreader", "get"),
+    "merge_cells": ("cellpy.readers.cellreader", "merge_cells"),
+    "print_instruments": ("cellpy.readers.cellreader", "print_instruments"),
+    "list_instruments": ("cellpy.readers.data_structures", "list_instruments"),
+    "instrument_meta_schema": (
+        "cellpy.readers.data_structures",
+        "instrument_meta_schema",
+    ),
+}
+
+
+def read_meta(path):
+    """Read cellpy-file metadata without loading raw/steps/summary frames.
+
+    See ``cellpy.readers.cellpy_file.read_meta`` for details.
+    """
+    from cellpy.readers.cellpy_file import read_meta as _read_meta
+
+    return _read_meta(path)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_MODULES:
+        mod = importlib.import_module(_LAZY_MODULES[name])
+        globals()[name] = mod
+        return mod
+    if name in _LAZY_ATTRS:
+        mod_name, attr = _LAZY_ATTRS[name]
+        value = getattr(importlib.import_module(mod_name), attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_LAZY_MODULES) + list(_LAZY_ATTRS))

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import typer
-
-from cellpy import cli_api
 
 cli = typer.Typer(
     name="cellpy",
@@ -18,6 +16,25 @@ cli = typer.Typer(
 )
 
 setup_app = typer.Typer()
+
+
+class _CliApiProxy:
+    """Defer ``cellpy.cli_api`` import until a command actually runs (#837)."""
+
+    _mod: Any = None
+
+    def _load(self):
+        if self._mod is None:
+            from cellpy import cli_api as _cli_api
+
+            self._mod = _cli_api
+        return self._mod
+
+    def __getattr__(self, name: str):
+        return getattr(self._load(), name)
+
+
+cli_api = _CliApiProxy()
 
 
 # ----------------------- setup --------------------------------------
@@ -150,7 +167,8 @@ def setup_migrate(
 
 
 # Re-exports used by tests / callers that imported helpers from cellpy.cli
-get_package_prm_dir = cli_api.get_package_prm_dir
+def get_package_prm_dir():
+    return cli_api.get_package_prm_dir()
 
 
 def _write_toml_config_file(dst_file, dry_run, test_user=None):

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -22,6 +22,7 @@ commands bind that echo with ``_using_echo`` so private helpers can call
 from __future__ import annotations
 
 import getpass
+import importlib
 import logging
 import os
 import pathlib
@@ -32,24 +33,104 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable, Optional, Union
 
-import cellpy
-import cellpy._version
-import cellpy.config as config
-from cellpy.exceptions import ConfigFileNotWritten
-from cellpy.internals.otherpath import OtherPath
-from cellpy.parameters import prmreader
-from cellpy.parameters.internal_settings import OTHERPATHS
+from cellpy._version import __version__ as VERSION
 from cellpy.utils.template_registry import REGISTERED_TEMPLATES
 
 PathLike = Union[str, pathlib.Path]
 Echo = Callable[[str], None]
 
-VERSION = cellpy._version.__version__
 REPO = "jepegit/cellpy"
 USER = "jepegit"
 GITHUB_PWD_VAR_NAME = "GD_PWD"
 DEFAULT_EDITOR = "vim"
 EDITORS = {"Windows": "notepad"}
+
+
+class _LazyModule:
+    """Attribute proxy that imports ``qualname`` on first use (#837)."""
+
+    def __init__(self, qualname: str):
+        self._qualname = qualname
+        self._mod: Any = None
+
+    def _load(self):
+        if self._mod is None:
+            self._mod = importlib.import_module(self._qualname)
+        return self._mod
+
+    def __getattr__(self, name: str):
+        return getattr(self._load(), name)
+
+
+# Keep call sites as ``config.*`` / ``prmreader.*`` without paying import cost
+# for ``cellpy info --version``.
+config = _LazyModule("cellpy.config")
+prmreader = _LazyModule("cellpy.parameters.prmreader")
+
+# Optional deps — probed on demand (see ``_probe_optional_deps``), not at import.
+DIFFICULT_MISSING_MODULES: dict[str, str] = {}
+cookiecutter = None  # type: ignore
+github = None  # type: ignore
+Github = None  # type: ignore
+_optional_deps_probed = False
+
+
+def _probe_optional_deps() -> None:
+    """Import optional CLI extras once; record missing ones for setup messaging."""
+    global cookiecutter, github, Github, _optional_deps_probed
+    if _optional_deps_probed:
+        return
+    _optional_deps_probed = True
+    try:
+        import cookiecutter.exceptions  # noqa: F401
+        import cookiecutter.main  # noqa: F401
+        import cookiecutter.prompt  # noqa: F401
+        import cookiecutter as _cookiecutter
+
+        cookiecutter = _cookiecutter
+    except ModuleNotFoundError:
+        cookiecutter = None
+        DIFFICULT_MISSING_MODULES["cookiecutter"] = (
+            "Could not import cookiecutter (used by cellpy new). Try installing it, "
+            "for example by writing:\n\n         python -m pip install cookiecutter\n"
+        )
+    try:
+        import github as _github
+        from github import Github as _Github
+
+        github = _github
+        Github = _Github
+    except ModuleNotFoundError:
+        github = None
+        Github = None
+        DIFFICULT_MISSING_MODULES["github"] = (
+            "Could not import the github library (used by cellpy pull). Try installing "
+            "it, for example by writing:\n\n         python -m pip install github\n"
+        )
+    try:
+        import sqlalchemy_access  # noqa: F401
+    except ModuleNotFoundError:
+        DIFFICULT_MISSING_MODULES["sqlalchemy-access"] = (
+            "Could not import the sqlalchemy_access library (usually used when reading "
+            "arbin .res files on windows). If you need it, try installing it by writing:"
+            "\n\n         python -m pip install sqlalchemy-access\n"
+        )
+    try:
+        import lmfit  # noqa: F401
+    except ModuleNotFoundError:
+        DIFFICULT_MISSING_MODULES["lmfit"] = (
+            "Could not import the lmfit library (used when fitting ocv rlx data)."
+            " If you think you will need it, try installing it for example by writing:"
+            "\n\n         python -m pip install lmfit\n"
+        )
+    try:
+        import jinja2_time  # noqa: F401
+    except ModuleNotFoundError:
+        DIFFICULT_MISSING_MODULES["jinja2_time"] = (
+            "Could not import the jinja2_time library (used by cellpy new)."
+            " Try installing it, for example by writing:"
+            "\n\n         python -m pip install jinja2_time\n"
+        )
 
 
 def _silent(_message: str) -> None:
@@ -419,59 +500,9 @@ def _using_echo(echo: Optional[Echo] = None):
         _echo_var.reset(token)
 
 
-DIFFICULT_MISSING_MODULES: dict[str, str] = {}
-
-try:
-    import cookiecutter.exceptions
-    import cookiecutter.main
-    import cookiecutter.prompt
-except ModuleNotFoundError:
-    cookiecutter = None  # type: ignore
-    DIFFICULT_MISSING_MODULES["cookiecutter"] = (
-        "Could not import cookiecutter (used by cellpy new). Try installing it, "
-        "for example by writing:\n\n         python -m pip install cookiecutter\n"
-    )
-
-try:
-    import github
-    from github import Github
-except ModuleNotFoundError:
-    github = None  # type: ignore
-    Github = None  # type: ignore
-    DIFFICULT_MISSING_MODULES["github"] = (
-        "Could not import the github library (used by cellpy pull). Try installing "
-        "it, for example by writing:\n\n         python -m pip install github\n"
-    )
-
-try:
-    import sqlalchemy_access  # noqa: F401
-except ModuleNotFoundError:
-    DIFFICULT_MISSING_MODULES["sqlalchemy-access"] = (
-        "Could not import the sqlalchemy_access library (usually used when reading "
-        "arbin .res files on windows). If you need it, try installing it by writing:"
-        "\n\n         python -m pip install sqlalchemy-access\n"
-    )
-
-try:
-    import lmfit  # noqa: F401
-except ModuleNotFoundError:
-    DIFFICULT_MISSING_MODULES["lmfit"] = (
-        "Could not import the lmfit library (used when fitting ocv rlx data)."
-        " If you think you will need it, try installing it for example by writing:"
-        "\n\n         python -m pip install lmfit\n"
-    )
-
-try:
-    import jinja2_time  # noqa: F401
-except ModuleNotFoundError:
-    DIFFICULT_MISSING_MODULES["jinja2_time"] = (
-        "Could not import the jinja2_time library (used by cellpy new)."
-        " Try installing it, for example by writing:"
-        "\n\n         python -m pip install jinja2_time\n"
-    )
-
-
 def _create_dir(path, confirm=True, parents=True, exist_ok=True):
+    from cellpy.internals.otherpath import OtherPath
+
     if isinstance(path, OtherPath):
         if path.is_external:
             return path
@@ -521,6 +552,8 @@ def dump_env_file(env_filename):
 
 def get_package_prm_dir():
     """gets the folder where the cellpy package lives"""
+    import cellpy.parameters
+
     return pathlib.Path(cellpy.parameters.__file__).parent
 
 
@@ -542,6 +575,7 @@ def get_dst_file(user_dir, init_filename):
 
 def echo_missing_modules():
     """prints out the missing modules"""
+    _probe_optional_deps()
     for m in DIFFICULT_MISSING_MODULES:
         print(f"missing module: {m}")
         print(f"message: {DIFFICULT_MISSING_MODULES[m]}")
@@ -656,6 +690,8 @@ def _update_paths(
         if not custom_dir.parts[-1] == default_dir:
             h = h / default_dir
 
+    from cellpy.internals.otherpath import OtherPath
+
     if not reset:
         outdatadir = pathlib.Path(config.paths.outdatadir)
         rawdatadir = OtherPath(config.paths.rawdatadir)
@@ -756,6 +792,8 @@ def _ask_about_path(q, p):
 
 
 def _ask_about_otherpath(q, p):
+    from cellpy.internals.otherpath import OtherPath
+
     _say(f"\n[cellpy] (setup) input {q}")
     _say(f"[cellpy] (setup) current: {p}")
     new_path = input("[cellpy] (setup) new value (press enter to keep) >>> ").strip()
@@ -984,6 +1022,8 @@ def _check_config_file():
             "templatedir",
             "db_path",
         ]
+        from cellpy.parameters.internal_settings import OTHERPATHS
+
         missing = 0
         for k in required_dirs:
             value = prm_paths.get(k, None)
@@ -1079,6 +1119,8 @@ def _check(dry_run=False, full_check=True):
 
 
 def _write_config_file(user_dir, dst_file, init_filename, dry_run):
+    from cellpy.exceptions import ConfigFileNotWritten
+
     _say(" update configuration ".center(80, "-"))
     _say("[cellpy] (setup) Writing configurations to user directory:")
     _say(f"\n         {user_dir}\n")
@@ -1130,6 +1172,8 @@ def _write_config_file(user_dir, dst_file, init_filename, dry_run):
 
 
 def _write_env_file(user_dir, dst_file, dry_run):
+    from cellpy.exceptions import ConfigFileNotWritten
+
     _say(" update configuration ".center(80, "-"))
     _say("[cellpy] (setup) Writing environment file:")
     _say(f"\n         {dst_file}\n")
@@ -1319,6 +1363,7 @@ def _pull(gdirpath="examples", rootpath=None, u=None, pw=None):
                 _say("   - only None")
                 u = None
 
+    _probe_optional_deps()
     g = Github(u, pw)
     try:
         repo = g.get_repo(REPO)
@@ -1531,7 +1576,9 @@ def _new(
     existing_projects = os.listdir(selected_project_dir)
 
     os.chdir(selected_project_dir)
-    cellpy_version = cellpy.__version__
+    import cellpy as _cellpy
+
+    cellpy_version = _cellpy.__version__
 
     try:
         selected_template, cookie_dir = templates[template.lower()]
@@ -1635,6 +1682,7 @@ def setup_config(
 
         # notify of missing 'difficult' or optional modules
         if not no_deps:
+            _probe_optional_deps()
             _say("[cellpy] checking dependencies")
             for m in DIFFICULT_MISSING_MODULES:
                 _say(" [cellpy] WARNING! ".center(80, "-"))

--- a/tests/test_cli_light_import.py
+++ b/tests/test_cli_light_import.py
@@ -1,0 +1,40 @@
+"""CLI bootstrap must stay light (#837).
+
+``cellpy info --version`` should not drag in the reader stack. Run in a
+subprocess so prior test imports cannot pollute ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.essential
+def test_info_version_avoids_cellreader_import():
+    script = r"""
+import sys
+from typer.testing import CliRunner
+
+import cellpy.cli
+
+assert "cellpy.readers.cellreader" not in sys.modules, sorted(
+    m for m in sys.modules if m.startswith("cellpy")
+)
+
+result = CliRunner().invoke(cellpy.cli.cli, ["info", "--version"])
+assert result.exit_code == 0, result.output
+assert "[cellpy] version:" in result.output
+assert "cellpy.readers.cellreader" not in sys.modules, sorted(
+    m for m in sys.modules if m.startswith("cellpy")
+)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
## Summary
- Make `cellpy` package init and CLI bootstrap lazy so `cellpy info --version` no longer loads the reader stack / optional CLI extras.
- Fixes multi-minute cold start after conda-forge install (warm path was ~5s).
- Essential subprocess regression + design note.

Closes #837

## Test plan
- [x] `uv run pytest -m essential`
- [x] `uv run pytest tests/test_cli_light_import.py tests/test_cellpy_cmd.py tests/test_cli_api.py`
- [ ] Spot-check fresh conda env: `cellpy info --version` (warm should be sub-second after first cache)


Made with [Cursor](https://cursor.com)