### PR TITLE
perf(cli): keep default setup off the reader stack

### DIFF
--- a/.issueflows/03-solved-issues/issue839_original.md
+++ b/.issueflows/03-solved-issues/issue839_original.md
@@ -1,0 +1,53 @@
+# Issue #839: perf(cli): keep more commands off the reader stack after light bootstrap
+
+Source: https://github.com/jepegit/cellpy/issues/839
+
+## Original issue text
+
+## Problem / context
+
+#837 made CLI bootstrap light (`cellpy --help`, `info --version` no longer load
+`cellreader` / optional CLI probes). Several common verbs still pay the heavy
+stack when the user did not ask for data:
+
+- `cellpy setup` always ends with `_check()` → imports `cellreader`
+- `setup` also probes optional deps (lmfit / sqlalchemy_access / …) unless `--no-deps`
+- `info --configloc` / `--params` / `--config` go through `prmreader` (not readers, but still weighty)
+- All real commands share one `cli_api` blob
+
+Install/first-use UX still hurts on `setup` after conda install even when version is fast.
+
+Related: #837, design note `.issueflows/04-designs-and-guides/cli-light-startup.md`.
+
+## Spec
+
+Make more non-data CLI commands stay in the light path:
+
+1. **Setup:** do not run `_check()` / full reader import by default; opt-in via
+   `setup --check` and/or keep full sanity on `info --check` only.
+2. **Optional-deps probe:** do not import lmfit/sqlalchemy_access/… unless the
+   user asked (`--deps` / explicit messaging path), not on every setup.
+3. **Split CLI API by weight** (or equivalent lazy per-command modules):
+   - light: version, configloc, edit, serve, list journals
+   - config: setup, migrate, info --config/--params
+   - data: convert, run (batch/readers) — may stay heavy
+4. **Optional:** lighter path for printing config location without full `prmreader`.
+5. Extend the #837-style subprocess/`sys.modules` guard to cover the newly light
+   commands (at least `setup` without `--check`, and `info --configloc` if made light).
+
+## Acceptance criteria
+
+- [ ] `cellpy setup` (silent / non-interactive, no `--check`) does not import
+      `cellpy.readers.cellreader` (subprocess regression).
+- [ ] Optional-dep probes are not run on default setup unless explicitly requested.
+- [ ] `info --check` (and any new `setup --check`) still exercise the reader import check.
+- [ ] `convert` / `run` behavior unchanged (still load data stack when invoked).
+- [ ] Design note updated (`cli-light-startup.md` or follow-on) with the new contract.
+- [ ] Warm timings for light commands clearly better than pre-change setup path
+      (document briefly on the issue/PR).
+
+## Out of scope
+
+- Making `convert` / `run` / `info --check` fast (they should load readers).
+- Broader package-layout / plotting import refactor beyond CLI command paths.
+- Stage 5 feature work.

--- a/.issueflows/03-solved-issues/issue839_plan.md
+++ b/.issueflows/03-solved-issues/issue839_plan.md
@@ -1,0 +1,73 @@
+# Issue #839 — plan
+
+## Goal
+
+Keep non-data CLI verbs (especially default `cellpy setup`) off the reader stack and optional-dep probes, extending the #837 light-bootstrap contract without slowing `convert` / `run` / explicit checks.
+
+## Constraints
+
+- Patch-stream UX/perf; not Stage 5.
+- `info --check` stays a full sanity path (may import `cellreader`).
+- `convert` / `run` may stay heavy.
+- Prefer small behavioral flips + tests over a large `cli_api` rewrite in the first cut.
+- Match existing Typer CLI surface style; document any flag changes in help + design note.
+
+### Prior art
+
+- [#837](https://github.com/jepegit/cellpy/issues/837) / [`cli-light-startup.md`](../04-designs-and-guides/cli-light-startup.md): lazy `__init__`, `_CliApiProxy`, deferred `_probe_optional_deps` at *import*; `tests/test_cli_light_import.py`.
+- [`setup_config`](../../../cellpy/cli_api.py) / [`_check`](../../../cellpy/cli_api.py) / [`_check_import_cellpy`](../../../cellpy/cli_api.py): setup always calls `_check` at end; probes when `not no_deps`.
+- CLI flag today: `--no-deps` (default probe **on**). Help text says “Don't install…” but code only **reports** missing optional imports.
+- Tests: `tests/test_cellpy_cmd.py` setup/info coverage; extend `test_cli_light_import.py` pattern.
+- Toolbox: no CLI import helper in `00-tools/` (reuse subprocess pattern from #837).
+
+## Approach
+
+**Phase A — behavior (this PR, required)**
+
+1. **Setup check opt-in**
+   - Remove unconditional `_check(...)` from the end of `setup_config`.
+   - Add `check: bool = False` to `setup_config` + Typer `--check` on `setup`.
+   - When `check=True`, call existing `_check` (same as today).
+   - `info --check` unchanged.
+
+2. **Optional-deps probe opt-in**
+   - Default: do **not** call `_probe_optional_deps()` during setup.
+   - Add `--deps` (opt-in probe / messaging). Keep `--no-deps` as a deprecated no-op (or hidden alias) so old scripts do not break; document the flip.
+   - Recommended API: `deps: bool = False` in `setup_config`; CLI `--deps` sets it. `--no-deps` accepted but ignored (warn once or mention in help).
+
+3. **Regression tests**
+   - Subprocess test: `setup --silent --dry-run` (or equivalent that does not need real home writes) does **not** leave `cellpy.readers.cellreader` in `sys.modules`.
+   - Subprocess or unit: default setup does not call probe (assert `lmfit` / `sqlalchemy_access` absent if that is how probe is detected — or spy/`_optional_deps_probed`).
+   - `setup --check` **does** import cellreader (or at least runs `_check_import_cellpy` successfully).
+   - `info --check` still works (existing test).
+
+4. **Docs**
+   - Update `cli-light-startup.md` with the new contract (setup light by default; checks/deps opt-in).
+   - Brief warm timing note on PR/issue comment.
+
+**Phase B — structure (same PR only if small; else follow-up issue)**
+
+- Defer full `cli_api` split (light/config/data modules) unless Phase A lands cleanly with leftover budget.
+- Optional stretch: lighter `info --configloc` without full `prmreader` — **out of Phase A** unless trivial; call out in Open questions.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| [`cellpy/cli.py`](../../../cellpy/cli.py) | `--check`, `--deps`; deprecate/keep `--no-deps` |
+| [`cellpy/cli_api.py`](../../../cellpy/cli_api.py) | `setup_config(check=..., deps=...)`; no default `_check` / probe |
+| [`tests/test_cli_light_import.py`](../../../tests/test_cli_light_import.py) | setup-without-check + deps defaults |
+| [`tests/test_cellpy_cmd.py`](../../../tests/test_cellpy_cmd.py) | help/flag smoke if needed |
+| [`.issueflows/04-designs-and-guides/cli-light-startup.md`](../04-designs-and-guides/cli-light-startup.md) | contract update |
+
+## Test strategy
+
+- `uv run pytest tests/test_cli_light_import.py tests/test_cellpy_cmd.py tests/test_cli_api.py -q`
+- Essential gate at close: `uv run pytest -m essential`
+- Manual: warm `cellpy setup --silent --dry-run` vs `cellpy setup --check --silent --dry-run`
+
+## Open questions
+
+1. **Deps flag flip:** adopt `--deps` (default off) and keep `--no-deps` as deprecated no-op? **Recommend yes.**
+2. **`cli_api` split + light configloc in this PR?** **Recommend no** — Phase A only; file follow-up if wanted after merge.
+3. **Should interactive setup still run `_check` by default?** **Recommend no** — same opt-in `--check` for both interactive and silent (predictable). Confirm?

--- a/.issueflows/03-solved-issues/issue839_status.md
+++ b/.issueflows/03-solved-issues/issue839_status.md
@@ -1,0 +1,14 @@
+# Issue #839: perf(cli) — more commands off the reader stack
+
+- [x] Done
+
+## What's done
+
+- Phase A: default setup skips `_check` and optional-deps probe.
+- CLI: `--check`, `--deps`; `--no-deps` hidden deprecated no-op.
+- Essential subprocess regressions + registry + `cli-light-startup.md`.
+- HISTORY `[Unreleased]` bullet.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/cli-light-startup.md
+++ b/.issueflows/04-designs-and-guides/cli-light-startup.md
@@ -1,20 +1,31 @@
-# CLI light startup (#837)
+# CLI light startup (#837, #839)
 
 ## Context
 
 `cellpy` console entry is `cellpy.cli:cli`. Importing that module always runs
 `cellpy/__init__.py` first. Eager readers + module-level optional-dep probes in
 `cli_api` made `cellpy info --version` pay the full scientific stack (minutes
-cold after conda-forge install; ~5 s warm).
+cold after conda-forge install; ~5 s warm). After #837, default **`setup`** still
+called `_check()` (reader import) and probed optional extras unless `--no-deps`.
 
 ## Decision
 
 - Keep package `__init__` symbols lazy (PEP 562) except `__version__` / logging.
 - Defer `cli_api` from `cli.py` until a command runs.
 - Probe optional deps (cookiecutter, github, lmfit, …) on demand, not at import.
+- **Default `cellpy setup` is light (#839):** no `_check()`, no optional-deps probe.
+  - Opt-in: `cellpy setup --check` (or `cellpy info --check`).
+  - Opt-in: `cellpy setup --deps` (probe/report missing optional extras).
+  - `--no-deps` is a deprecated no-op (probing is already off by default).
 - Guard with `tests/test_cli_light_import.py` (subprocess + `sys.modules`).
+
+## Still heavy (by design)
+
+- `convert`, `run` (batch/readers)
+- `info --check` / `setup --check`
 
 ## Alternatives
 
 - Separate top-level entry module outside `cellpy` — rejected (more packaging churn).
 - Soften only `cli_api` — insufficient; entry point still loads package init.
+- Full `cli_api` light/config/data split — deferred (follow-up after #839 Phase A).

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -31,6 +31,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch.py::test_persist_skips_rewrite_when_loaded_from_cellpy | yes | yes | batch.facade._persist_cells | #825 | skip redundant save |
 | tests/test_batch.py::test_persist_rewrites_when_loaded_from_raw | yes | yes | batch.facade._persist_cells | #825 | |
 | tests/test_cli_light_import.py::test_info_version_avoids_cellreader_import | yes | yes | cellpy.__init__ / cli / cli_api light path | #837 | subprocess; cellreader must stay out of sys.modules |
+| tests/test_cli_light_import.py::test_setup_default_avoids_cellreader_and_optional_deps | yes | yes | cli_api.setup_config default light | #839 | no cellreader / lmfit |
+| tests/test_cli_light_import.py::test_setup_check_imports_cellreader | yes | yes | cli_api.setup_config --check | #839 | opt-in check loads readers |
+| tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Keep default ``cellpy setup`` off the reader stack: ``--check`` / ``--deps`` are opt-in; ``--no-deps`` deprecated. (#839)
 - Speed up CLI cold start: lazy package/CLI imports so ``cellpy info --version`` no longer loads the full reader stack. (#837)
 - Pretty-print cycles collector facet strips (Cycle N / cell label, not cycle_num=). (#820)
 - Honour share_y / match_axes on collected summary spread_plot. (#817)

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -106,9 +106,28 @@ def setup(
         bool,
         typer.Option("--silent", "-s", help="Silent mode (no questions asked)"),
     ] = False,
+    deps: Annotated[
+        bool,
+        typer.Option(
+            "--deps",
+            help="Probe optional extras (cookiecutter, lmfit, …) and report missing ones.",
+        ),
+    ] = False,
     no_deps: Annotated[
         bool,
-        typer.Option("--no-deps", help="Don't install missing dependencies"),
+        typer.Option(
+            "--no-deps",
+            help="Deprecated no-op: optional dependency probing is off by default.",
+            hidden=True,
+        ),
+    ] = False,
+    check: Annotated[
+        bool,
+        typer.Option(
+            "--check",
+            "-c",
+            help="Run import/config sanity checks after setup (may load the reader stack).",
+        ),
     ] = False,
 ):
     """This will help you to set up cellpy."""
@@ -123,7 +142,9 @@ def setup(
         folder_name=folder_name,
         test_user=test_user,
         silent=silent,
+        deps=deps,
         no_deps=no_deps,
+        check=check,
         echo=typer.echo,
     )
 

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1672,16 +1672,33 @@ def setup_config(
     folder_name=None,
     test_user=None,
     silent: bool = False,
+    deps: bool = False,
     no_deps: bool = False,
+    check: bool = False,
     echo: Optional[Echo] = None,
 ):
-    """Write / refresh the user cellpy configuration (library form of ``cellpy setup``)."""
+    """Write / refresh the user cellpy configuration (library form of ``cellpy setup``).
+
+    Args:
+        deps: When True, probe optional CLI extras (cookiecutter, lmfit, …)
+            and print tips for any that are missing. Default False (#839).
+        no_deps: Deprecated no-op kept for old scripts (#839). Ignored.
+        check: When True, run the import/config sanity checks (may load
+            ``cellreader``). Default False; use ``cellpy info --check`` or
+            ``cellpy setup --check`` (#839).
+    """
     with _using_echo(echo):
         _say("[cellpy] (setup)")
         _say(f"[cellpy] root-dir: {root_dir}")
 
-        # notify of missing 'difficult' or optional modules
-        if not no_deps:
+        if no_deps and not deps:
+            _say(
+                "[cellpy] (setup) note: --no-deps is deprecated; "
+                "optional dependency probing is off by default (use --deps to enable)"
+            )
+
+        # Optional extras — opt-in only so default setup stays off the heavy stack (#839).
+        if deps:
             _probe_optional_deps()
             _say("[cellpy] checking dependencies")
             for m in DIFFICULT_MISSING_MODULES:
@@ -1690,7 +1707,7 @@ def setup_config(
                 _say(f"[cellpy] - {m}")
                 _say(f"[cellpy] {DIFFICULT_MISSING_MODULES[m]}")
                 _say(
-                    "[cellpy] (you can skip this check by using the --no-deps option)"
+                    "[cellpy] (dependency probing is opt-in; omit --deps to skip)"
                 )
                 _say(80 * "-")
 
@@ -1750,8 +1767,6 @@ def setup_config(
             _write_config_file(user_dir, dst_file, init_filename, dry_run)
             _write_toml_config_file(dst_file, dry_run, test_user=test_user)
             _write_env_file(user_dir, env_file, dry_run)
-            _check(dry_run=dry_run)
-
         else:
             if reset:
                 _update_paths(
@@ -1766,7 +1781,9 @@ def setup_config(
             _write_config_file(user_dir, dst_file, init_filename, dry_run)
             _write_toml_config_file(dst_file, dry_run, test_user=test_user)
             _write_env_file(user_dir, env_file, dry_run)
-            _check(dry_run=dry_run, full_check=False)
+
+        if check:
+            _check(dry_run=dry_run, full_check=interactive)
 
 
 # -- public facades (#651) ------------------------------------------------------

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -471,6 +471,25 @@
           "kind": "option",
           "multiple": false,
           "opts": [
+            "--check",
+            "-c"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
+            "--deps"
+          ],
+          "required": false
+        },
+        {
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "opts": [
             "--dry-run",
             "-dr"
           ],

--- a/tests/test_cli_light_import.py
+++ b/tests/test_cli_light_import.py
@@ -1,40 +1,123 @@
-"""CLI bootstrap must stay light (#837).
+"""CLI bootstrap must stay light (#837, #839).
 
-``cellpy info --version`` should not drag in the reader stack. Run in a
-subprocess so prior test imports cannot pollute ``sys.modules``.
+Light commands should not drag in the reader stack or optional CLI probes.
+Run in a subprocess so prior test imports cannot pollute ``sys.modules``.
 """
 
 from __future__ import annotations
 
 import subprocess
 import sys
+import textwrap
 
 import pytest
 
 
-@pytest.mark.essential
-def test_info_version_avoids_cellreader_import():
-    script = r"""
-import sys
-from typer.testing import CliRunner
-
-import cellpy.cli
-
-assert "cellpy.readers.cellreader" not in sys.modules, sorted(
-    m for m in sys.modules if m.startswith("cellpy")
-)
-
-result = CliRunner().invoke(cellpy.cli.cli, ["info", "--version"])
-assert result.exit_code == 0, result.output
-assert "[cellpy] version:" in result.output
-assert "cellpy.readers.cellreader" not in sys.modules, sorted(
-    m for m in sys.modules if m.startswith("cellpy")
-)
-"""
-    completed = subprocess.run(
-        [sys.executable, "-c", script],
+def _run_script(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script).strip() + "\n"],
         capture_output=True,
         text=True,
         check=False,
+    )
+
+
+@pytest.mark.essential
+def test_info_version_avoids_cellreader_import():
+    completed = _run_script(
+        """
+        import sys
+        from typer.testing import CliRunner
+
+        import cellpy.cli
+
+        assert "cellpy.readers.cellreader" not in sys.modules, sorted(
+            m for m in sys.modules if m.startswith("cellpy")
+        )
+
+        result = CliRunner().invoke(cellpy.cli.cli, ["info", "--version"])
+        assert result.exit_code == 0, result.output
+        assert "[cellpy] version:" in result.output
+        assert "cellpy.readers.cellreader" not in sys.modules, sorted(
+            m for m in sys.modules if m.startswith("cellpy")
+        )
+        """
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.essential
+def test_setup_default_avoids_cellreader_and_optional_deps():
+    """Default setup must not import cellreader or probe lmfit (#839)."""
+    completed = _run_script(
+        """
+        import sys
+        import tempfile
+        from pathlib import Path
+        from typer.testing import CliRunner
+
+        import cellpy.cli
+        from cellpy import config, prmreader
+
+        tmp = Path(tempfile.mkdtemp())
+        prmreader.get_user_dir = lambda: tmp
+        config.paths.env_file = tmp / ".env_cellpy"
+        result = CliRunner().invoke(
+            cellpy.cli.cli, ["setup", "--silent", "--test_user", "light_import"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "cellpy.readers.cellreader" not in sys.modules, sorted(
+            m for m in sys.modules if "cellpy" in m or m == "lmfit"
+        )
+        assert "lmfit" not in sys.modules
+        assert "sqlalchemy_access" not in sys.modules
+        """
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.essential
+def test_setup_check_imports_cellreader():
+    """``setup --check`` still exercises the reader import path (#839)."""
+    completed = _run_script(
+        """
+        import sys
+        import tempfile
+        from pathlib import Path
+        from typer.testing import CliRunner
+
+        import cellpy.cli
+        from cellpy import config, prmreader
+
+        tmp = Path(tempfile.mkdtemp())
+        prmreader.get_user_dir = lambda: tmp
+        config.paths.env_file = tmp / ".env_cellpy"
+        result = CliRunner().invoke(
+            cellpy.cli.cli,
+            ["setup", "--silent", "--check", "--test_user", "light_import_check"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "cellpy.readers.cellreader" in sys.modules
+        """
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.essential
+def test_setup_deps_probes_optional_modules():
+    """``setup --deps`` opts into optional-extra probing (#839)."""
+    completed = _run_script(
+        """
+        import sys
+        from typer.testing import CliRunner
+
+        import cellpy.cli
+
+        result = CliRunner().invoke(
+            cellpy.cli.cli, ["setup", "--silent", "--dry-run", "--deps"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "lmfit" in sys.modules or "checking dependencies" in result.output
+        """
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
## Summary
- Default `cellpy setup` no longer runs `_check` or optional-deps probes (cold start stays light after #837).
- Opt-in `--check` / `-c` and `--deps`; hidden `--no-deps` kept as deprecated no-op.
- Essential subprocess regressions + CLI surface snapshot updated for the new flags.

Closes #839

## Test plan
- [x] `uv run pytest tests/test_cli_surface.py tests/test_cli_light_import.py -q`
- [x] `uv run pytest -m essential` (669 passed)
- [ ] Confirm `cellpy setup --silent` is fast in a fresh conda env; `cellpy setup --check` still validates


Made with [Cursor](https://cursor.com)