### PR TITLE
fix(get): honour instrument over .h5/.hdf5 native auto-pick

### DIFF
--- a/.issueflows/03-solved-issues/issue819_original.md
+++ b/.issueflows/03-solved-issues/issue819_original.md
@@ -1,0 +1,28 @@
+# Issue #819: cellpy.get: when instrument= is set, do not auto-pick native .h5/.hdf5 format
+
+Source: https://github.com/jepegit/cellpy/issues/819
+
+## Original issue text
+
+## Problem / context
+
+`cellpy.get(..., auto_pick_cellpy_format=True)` (the default) treats `.h5` / `.hdf5` as native cellpy files whenever `instrument` is not exactly `arbin_sql_h5`. Other Arbin SQL variants (or a missing/mismatched instrument) then hit the native reader and fail with `No object named data_df in the file` — easy to misread as a corrupt file.
+
+cellpy already special-cases `arbin_sql_h5`, but apps that always pass an explicit instrument still need `auto_pick_cellpy_format=False` for defense in depth.
+
+**Workaround (cellpy-simple-gui #41):** `load_raw` always sets `auto_pick_cellpy_format=False`; Load cells stays on the native path and the UI hints that Arbin SQL HDF5 belongs under Import raw.
+
+## Spec
+
+When `instrument=` is set (any non-empty / non-native instrument), never auto-pick cellpy format from the `.h5`/`.hdf5` suffix — honour the instrument loader. Alternatively, document clearly that callers must disable auto-pick for every raw `.h5` loader.
+
+## Acceptance criteria
+
+- [ ] `cellpy.get(path_to_raw.h5, instrument=<raw_loader>)` does not route through the native cellpy reader solely because of the suffix.
+- [ ] Native `.cellpy` / intentional cellpy hdf5 loads without an instrument still work.
+- [ ] Regression test covers at least one raw `.h5` instrument path vs native pick.
+- [ ] Docs mention the rule (instrument wins over suffix auto-pick).
+
+
+---
+*Found while building [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) on cellpy ≥2.1.1.post4. Full write-up: [CELLPY_PAINPOINTS.md](https://github.com/cellpy/cellpy-simple-gui/blob/main/CELLPY_PAINPOINTS.md).*

--- a/.issueflows/03-solved-issues/issue819_plan.md
+++ b/.issueflows/03-solved-issues/issue819_plan.md
@@ -1,0 +1,71 @@
+# Plan: #819 — instrument wins over `.h5`/`.hdf5` auto-pick
+
+## Goal
+
+When `cellpy.get(..., instrument=<raw>)` is called on a `.h5`/`.hdf5` path,
+route through the instrument loader — never the native cellpy reader — solely
+because of the suffix. Uninstrumented native loads stay as today.
+
+## Constraints
+
+- Back-compat: `get(path.h5)` / `get(path.cellpy)` with **no** `instrument=`
+  still auto-picks native when `auto_pick_cellpy_format=True`.
+- `.cellpy` / `.cpy` remain unambiguous; auto-pick those even if `instrument=`
+  is set (only `.h5`/`.hdf5` collide with raw loaders).
+- Explicit `auto_pick_cellpy_format=False` stays the hard override.
+- No new deps; keep change inside `get()`.
+
+### Prior art
+
+- `cellpy.get` auto-pick gate:
+  [`cellpy/readers/cellreader.py`](cellpy/readers/cellreader.py) (~4252–4306) —
+  today uses allow-list `instruments_with_colliding_file_suffix = ["arbin_sql_h5"]`
+  (instrument **not in** list ⇒ pick native for `.h5`/`.hdf5`/`.cellpy`/`.cpy`).
+- Existing raw `.h5` coverage: `tests/test_arbin_sql_h5.py`,
+  `tests/test_loader_port_parity.py` (`arbin_sql_h5` fixture).
+- Docs mentioning `get` / instruments: `docs/getting_started/basic_usage.md`,
+  `docs/getting_started/agents.md`; get docstring in `cellreader.py`.
+- Toolbox: nothing relevant (`00-tools/` scanned).
+- Graph: skipped for this tiny gate change.
+
+## Approach
+
+1. Replace the colliding-instrument allow-list with a clearer rule:
+   - If `auto_pick_cellpy_format` is false → never auto-pick.
+   - If suffix is `.cellpy` / `.cpy` → auto-pick (instrument ignored).
+   - If suffix is `.h5` / `.hdf5`:
+     - auto-pick **only when** `instrument` is unset (`None` / empty);
+     - if `instrument` is set (truthy) → raw path (`load_cellpy_file = False`).
+2. Drop `instruments_with_colliding_file_suffix` (superseded; `arbin_sql_h5`
+   covered by “any set instrument”).
+3. Update `get` docstring: instrument wins over `.h5`/`.hdf5` suffix auto-pick.
+4. Short note in `docs/getting_started/basic_usage.md` (and one line in
+   `agents.md` if it already discusses instrument + get).
+5. Regression test: assert routing — with a `.h5` path + non-empty
+   `instrument=`, `CellpyCell.load` is **not** entered / `from_raw` **is**
+   (monkeypatch), vs no instrument ⇒ `load` path for same suffix. Plus keep
+   existing `arbin_sql_h5` load green.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/readers/cellreader.py` | Auto-pick condition + docstring |
+| `tests/test_cellpy.py` (or small new focused test module) | Routing regression |
+| `docs/getting_started/basic_usage.md` | Document rule |
+| `docs/getting_started/agents.md` | One-line note if fits existing get guidance |
+
+## Test strategy
+
+- `uv run pytest tests/test_cellpy.py -q` (or the new test file) +
+  `uv run pytest tests/test_arbin_sql_h5.py -q`
+- Fast gate later: `uv run pytest -m essential`
+
+## Open questions
+
+1. **Unset instrument:** treat only `None` as unset, or also `""`?
+   **Recommend:** truthy check (`if instrument:`) so `""` counts as unset.
+2. **`.cellpy`/`.cpy` with instrument set:** still auto-pick native?
+   **Recommend:** yes (unambiguous suffixes).
+3. **No other open design forks** — issue already chose “instrument wins”
+   over “document that callers must pass `auto_pick_cellpy_format=False`”.

--- a/.issueflows/03-solved-issues/issue819_status.md
+++ b/.issueflows/03-solved-issues/issue819_status.md
@@ -1,0 +1,14 @@
+# Status: #819 — instrument wins over `.h5`/`.hdf5` auto-pick
+
+- [x] Done
+
+## What's done
+
+- `get()` auto-pick: set `instrument=` skips native pick for `.h5`/`.hdf5`; `.cellpy`/`.cpy` still auto-pick; dropped `arbin_sql_h5` allow-list.
+- Docstring + `basic_usage.md` + `agents.md` + `AGENTS.md`.
+- Regression `test_get_h5_instrument_skips_native_autopick` (essential); registry row; `test_arbin_sql_h5` + `pytest -m essential` green.
+- HISTORY `[Unreleased]` bullet.
+
+## Remaining work
+
+- None (close: commit / push / PR).

--- a/.issueflows/04-designs-and-guides/cli-light-startup.md
+++ b/.issueflows/04-designs-and-guides/cli-light-startup.md
@@ -19,6 +19,12 @@ called `_check()` (reader import) and probed optional extras unless `--no-deps`.
   - `--no-deps` is a deprecated no-op (probing is already off by default).
 - Guard with `tests/test_cli_light_import.py` (subprocess + `sys.modules`).
 
+## Docs / mkdocstrings
+
+API pages must use the **defining** module path (e.g.
+`::: cellpy.readers.cellreader.get`), not `::: cellpy.get`. Griffe reads source
+statically and does not resolve PEP 562 `__getattr__` aliases (#837 / #842).
+
 ## Still heavy (by design)
 
 - `convert`, `run` (batch/readers)

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -10,6 +10,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 
 | Test (node id or path::name) | Essential? | Always? | Code under test | Issue | Notes / demote? |
 | --- | --- | --- | --- | --- | --- |
+| tests/test_cellpy.py::test_get_h5_instrument_skips_native_autopick | yes | yes | cellreader.get auto_pick vs instrument | #819 | monkeypatch load/from_raw routing |
 | tests/test_collected_app_hooks.py::test_pretty_facet_annotation_cycles_and_cells | yes | yes | plotting.collected._pretty_facet_annotation | #820 | unit helper |
 | tests/test_collected_app_hooks.py::test_cycles_per_cell_facet_strips_are_pretty | yes | yes | plotting.collected collected_plot per_cell | #820 | no cell= strip |
 | tests/test_collected_app_hooks.py::test_cycles_per_cycle_facet_strips_are_pretty | yes | yes | plotting.collected collected_plot per_cycle | #820 | Cycle N strips |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,7 @@ Quick facts:
 
 - Product: Python library + `cellpy` CLI — not a hosted GUI server.
 - Entry: `import cellpy` then `c = cellpy.get(path, mass=..., instrument=...)`.
+  For raw `.h5`/`.hdf5`, a set `instrument=` wins over native suffix auto-pick.
 - Metadata peek (no frames): `cellpy.read_meta(path)` → dict with `cell` / `tests`.
 - Ingestion form fields: `cellpy.instrument_meta_schema(instrument)` → `fields` / `units`.
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- ``cellpy.get``: when ``instrument=`` is set, do not auto-pick native ``.h5``/``.hdf5`` format. (#819)
 - Keep default ``cellpy setup`` off the reader stack: ``--check`` / ``--deps`` are opt-in; ``--no-deps`` deprecated. (#839)
 - Speed up CLI cold start: lazy package/CLI imports so ``cellpy info --version`` no longer loads the full reader stack. (#837)
 - Pretty-print cycles collector facet strips (Cycle N / cell label, not cycle_num=). (#820)

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -4179,6 +4179,8 @@ def get(
             (e.g. "2.12 cm**2") to override cellpy_units.
         estimate_area (bool): calculate area from loading if given (defaults to True).
         auto_pick_cellpy_format (bool): decide if it is a cellpy-file based on suffix.
+            For ``.h5`` / ``.hdf5``, a set ``instrument=`` wins over suffix auto-pick
+            (raw loader path). ``.cellpy`` / ``.cpy`` still auto-pick when enabled.
         auto_summary (bool): (re-) create summary.
         units (dict): update cellpy units (used after the file is loaded, e.g. when creating summary).
         step_kwargs (dict): sent to make_steps.
@@ -4250,7 +4252,6 @@ def get(
     from cellpy import log
 
     db_readers = list(DB_READER_INSTRUMENTS)
-    instruments_with_colliding_file_suffix = ["arbin_sql_h5"]
 
     step_kwargs = step_kwargs or {}
     summary_kwargs = summary_kwargs or {}
@@ -4298,12 +4299,14 @@ def get(
         logging.debug("got a single name")
         logging.debug(f"{filename=}")
         filename = internals.OtherPath(filename)
-        if (
-            auto_pick_cellpy_format
-            and instrument not in instruments_with_colliding_file_suffix
-            and filename.suffix in [".h5", ".hdf5", ".cellpy", ".cpy"]
-        ):
-            load_cellpy_file = True
+        # .cellpy/.cpy are unambiguous. .h5/.hdf5 collide with raw loaders
+        # (e.g. arbin_sql_h5): a set instrument= wins over suffix auto-pick.
+        if auto_pick_cellpy_format:
+            suffix = filename.suffix
+            if suffix in [".cellpy", ".cpy"]:
+                load_cellpy_file = True
+            elif suffix in [".h5", ".hdf5"] and not instrument:
+                load_cellpy_file = True
 
     if filename and cellpy_file and not load_cellpy_file:
         try:

--- a/docs/api/cellpy.md
+++ b/docs/api/cellpy.md
@@ -1,12 +1,15 @@
 # cellpy
 
-The top-level entry points — what most scripts need.
+The top-level entry points — what most scripts need. These are re-exported
+lazily as `cellpy.get`, `cellpy.merge_cells`, and `cellpy.print_instruments`
+(PEP 562); mkdocstrings documents the defining module because Griffe cannot
+resolve `__getattr__` aliases.
 
-::: cellpy.get
+::: cellpy.readers.cellreader.get
 
-::: cellpy.merge_cells
+::: cellpy.readers.cellreader.merge_cells
 
-::: cellpy.print_instruments
+::: cellpy.readers.cellreader.print_instruments
 
 ## Command-line API
 

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -73,6 +73,7 @@ c = cellpy.get(
     r"C:\data\my_cell_01.res",
     mass=0.85,  # active material mass in mg (instrument-dependent context)
     instrument="arbin_res",  # omit to use config default / extension guess
+    # For raw .h5/.hdf5, a set instrument= wins over native suffix auto-pick.
 )
 c.save("out/my_cell.cellpy")  # cellpy file — fast reload later
 c.to_csv("out/csv_export")

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -31,6 +31,10 @@ c = cellpy.get(
 `cellpy.get` loads the file, builds the step table, and creates the per-cycle
 summary (unless you opt out with keyword arguments).
 
+When you pass `instrument=` for a raw `.h5` / `.hdf5` file, that loader wins
+over suffix auto-pick of the native cellpy format. Omit `instrument` (or use a
+`.cellpy` / `.cpy` path) when you want the native reader.
+
 ## Inspect frames and schema
 
 Measurement tables live on `c.data`. Prefer **`c.schema`** for column names

--- a/tests/test_cellpy.py
+++ b/tests/test_cellpy.py
@@ -162,6 +162,55 @@ def test_get_cellpy():
     cellpy.get(filename=fdv.cellpy_file_path, testing=True)
 
 
+@pytest.mark.essential
+def test_get_h5_instrument_skips_native_autopick(monkeypatch, tmp_path):
+    """instrument= on .h5 must not route through CellpyCell.load (#819)."""
+    from cellpy.readers.cellreader import CellpyCell
+
+    h5_path = tmp_path / "raw_sample.h5"
+    h5_path.write_bytes(b"not-a-cellpy-file")
+    cellpy_path = tmp_path / "native_sample.cellpy"
+    cellpy_path.write_bytes(b"not-a-cellpy-file")
+    routes = {"load": 0, "from_raw": 0}
+
+    def fake_load(self, *args, **kwargs):
+        routes["load"] += 1
+
+    def fake_from_raw(self, *args, **kwargs):
+        routes["from_raw"] += 1
+
+    monkeypatch.setattr(CellpyCell, "load", fake_load)
+    monkeypatch.setattr(CellpyCell, "from_raw", fake_from_raw)
+    monkeypatch.setattr(CellpyCell, "set_instrument", lambda self, **kwargs: None)
+    monkeypatch.setattr(CellpyCell, "__bool__", lambda self: True)
+
+    import cellpy
+
+    cellpy.get(
+        filename=str(h5_path),
+        instrument="arbin_sql_h5",
+        auto_summary=False,
+        testing=True,
+    )
+    assert routes["from_raw"] == 1
+    assert routes["load"] == 0
+
+    routes["load"] = routes["from_raw"] = 0
+    cellpy.get(filename=str(h5_path), auto_summary=False, testing=True)
+    assert routes["load"] == 1
+    assert routes["from_raw"] == 0
+
+    routes["load"] = routes["from_raw"] = 0
+    cellpy.get(
+        filename=str(cellpy_path),
+        instrument="arbin_res",
+        auto_summary=False,
+        testing=True,
+    )
+    assert routes["load"] == 1
+    assert routes["from_raw"] == 0
+
+
 def test_get_empty():
     cellpy.get(testing=True)
 


### PR DESCRIPTION
## Summary
- When `cellpy.get(..., instrument=...)` is set, do not auto-pick the native cellpy reader for `.h5`/`.hdf5` solely from the suffix.
- Unambiguous `.cellpy`/`.cpy` suffixes still auto-pick; uninstrumented `.h5` loads stay native.
- Docs + essential routing regression test.

Closes #819

## Test plan
- [x] `uv run pytest tests/test_cellpy.py::test_get_h5_instrument_skips_native_autopick tests/test_arbin_sql_h5.py -q`
- [x] `uv run pytest -m essential -q`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)