### PR TITLE
fix(collect): average multi groups when singletons are present

### DIFF
--- a/.issueflows/01-current-issues/cycle_status.md
+++ b/.issueflows/01-current-issues/cycle_status.md
@@ -1,0 +1,13 @@
+# Cycle status
+
+- [ ] Done
+
+- **queue:** yolo → `label:yolo`
+- **onfail:** stop
+- **started:** 2026-08-08T20:49:00Z
+- **repo:** jepegit/cellpy
+
+## Queue
+
+- [ ] #816 — group_it=True: average multi-member groups even when some groups are singletons — pending
+- [ ] #818 — In-memory static figure export on the collect/plot path (PNG/SVG/PDF bytes) — pending

--- a/.issueflows/03-solved-issues/issue816_original.md
+++ b/.issueflows/03-solved-issues/issue816_original.md
@@ -1,0 +1,34 @@
+# Issue #816: group_it=True: average multi-member groups even when some groups are singletons
+
+Source: https://github.com/jepegit/cellpy/issues/816
+
+## Original issue text
+
+## Problem / context
+
+`collect_summaries(..., group_it=True)` still silently returns a *wide, non-averaged* frame when **any** group has < 2 cells (the \"std needs ≥ 2 cells\" guard). One singleton disables averaging for *every* group — including those with plenty of members.
+
+`Collection.is_grouped` / `meta.grouped` (#790) fixed the observability side. The **all-or-nothing** averaging behaviour remains; GUIs that mix multi-cell and single-cell groups must partition selections themselves (cellpy-simple-gui #27) and then merge Plotly figures.
+
+Related merge friction (cellpy-simple-gui #39): long (averaged) and wide (per-cell) summary plots assign different subplot axis ids to the same `variable`, so naive `add_trace` puts singleton series on the wrong facet.
+
+## Spec
+
+1. When `group_it=True`, average groups with ≥ 2 cells and leave singletons as ordinary (non-spread) series in the **same** collection — not all-or-nothing.
+2. Prefer stable facet subplot ids across long (averaged) vs wide (per-cell) summary plots for the same column set (or a documented merge helper), so apps can combine traces without remapping axes.
+
+## Acceptance criteria
+
+- [ ] A selection with one multi-member group and one singleton still averages the multi-member group.
+- [ ] Singletons remain plottable as per-cell series (no forced empty/non-averaged whole collection).
+- [ ] `is_grouped` / `meta.grouped` stay accurate for the mixed result.
+- [ ] Tests cover mixed multi/singleton selections.
+- [ ] (Stretch) long vs wide summary facets for the same variables share subplot identity, or a merge helper is documented.
+
+## Out of scope
+
+- Changing default UI in downstream apps.
+
+
+---
+*Found while building [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) on cellpy ≥2.1.1.post4. Full write-up: [CELLPY_PAINPOINTS.md](https://github.com/cellpy/cellpy-simple-gui/blob/main/CELLPY_PAINPOINTS.md).*

--- a/.issueflows/03-solved-issues/issue816_plan.md
+++ b/.issueflows/03-solved-issues/issue816_plan.md
@@ -1,0 +1,25 @@
+# Plan: #816 — mixed group_it averaging (yolo)
+
+## Goal
+
+With `group_it=True`, average groups that have ≥2 cells and keep singleton
+groups as long-form series (`mean` = cell value, `std` = null) in the same
+frame. Drop all-or-nothing wide fallback when any multi-member group exists.
+
+## Approach
+
+1. In `collect_summaries`, partition journal groups into multi (≥2) vs singleton.
+2. Run `group_average` on multi only; unpivot singletons to the same long schema.
+3. `grouped=True` iff any multi group was averaged. All-singleton still wide + False.
+4. Stretch (long vs wide facet ids): **out of scope** for this yolo pass.
+
+## Files to touch
+
+- `cellpy/collect/summary.py` — partition gate
+- `cellpy/collect/_summary_ops.py` — `singletons_as_long` helper
+- `cellpy/collect/collection.py` — docstring tweak
+- `tests/test_collect.py` — mixed multi+singleton test; keep all-singleton fallback
+
+## Test strategy
+
+`uv run pytest tests/test_collect.py -q` then `uv run pytest -m essential -q`

--- a/.issueflows/03-solved-issues/issue816_status.md
+++ b/.issueflows/03-solved-issues/issue816_status.md
@@ -1,0 +1,14 @@
+# Status: #816 — mixed group_it averaging
+
+- [x] Done
+
+## What's done
+
+- Partition multi vs singleton groups in `collect_summaries`; average multis; singletons → long schema with null `std`.
+- `grouped=True` when any multi averaged; all-singleton still wide / False.
+- Essential test `test_group_it_averages_multi_when_mixed_with_singleton`.
+- Stretch (long vs wide facet subplot ids): left out of this pass.
+
+## Remaining work
+
+- None for core acceptance.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -10,6 +10,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 
 | Test (node id or path::name) | Essential? | Always? | Code under test | Issue | Notes / demote? |
 | --- | --- | --- | --- | --- | --- |
+| tests/test_collect.py::test_group_it_averages_multi_when_mixed_with_singleton | yes | yes | collect.summary group_it mixed | #816 | multi avg + singleton long |
 | tests/test_cellpy.py::test_get_h5_instrument_skips_native_autopick | yes | yes | cellreader.get auto_pick vs instrument | #819 | monkeypatch load/from_raw routing |
 | tests/test_collected_app_hooks.py::test_pretty_facet_annotation_cycles_and_cells | yes | yes | plotting.collected._pretty_facet_annotation | #820 | unit helper |
 | tests/test_collected_app_hooks.py::test_cycles_per_cell_facet_strips_are_pretty | yes | yes | plotting.collected collected_plot per_cell | #820 | no cell= strip |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- ``group_it=True``: average multi-member groups even when some groups are singletons. (#816)
 - ``cellpy.get``: when ``instrument=`` is set, do not auto-pick native ``.h5``/``.hdf5`` format. (#819)
 - Keep default ``cellpy setup`` off the reader stack: ``--check`` / ``--deps`` are opt-in; ``--no-deps`` deprecated. (#839)
 - Speed up CLI cold start: lazy package/CLI imports so ``cellpy info --version`` no longer loads the full reader stack. (#837)

--- a/cellpy/collect/_summary_ops.py
+++ b/cellpy/collect/_summary_ops.py
@@ -232,3 +232,37 @@ def group_average(
 
     sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
     return out.sort(sort_cols)
+
+
+def singletons_as_long(
+    frame: pl.DataFrame,
+    *,
+    keys: tuple[str, ...],
+    group_labels: dict[Any, Any] | None = None,
+) -> pl.DataFrame:
+    """Unpivot singleton-group rows into the ``group_average`` long schema.
+
+    ``mean`` is the cell value; ``std`` is null (no peers to spread). Used when
+    ``group_it=True`` mixes multi-member and singleton groups (#816).
+    """
+    if frame.height == 0 or "group" not in frame.columns:
+        return frame
+
+    id_cols = ["group"] + ([CYCLE] if CYCLE in frame.columns else [])
+    value_cols = _numeric_value_columns(frame, keys)
+    if not value_cols:
+        return frame
+
+    out = frame.unpivot(
+        index=id_cols, on=value_cols, variable_name="variable", value_name="mean"
+    ).with_columns(pl.lit(None).cast(pl.Float64).alias("std"))
+
+    if group_labels:
+        mapping = {k: v for k, v in group_labels.items() if v is not None}
+        if mapping:
+            out = out.with_columns(
+                pl.col("group").replace(mapping, default=None).alias("group_label")
+            )
+
+    sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
+    return out.sort(sort_cols)

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -41,9 +41,9 @@ class CollectionMeta:
     created_utc: str = field(default_factory=_now_utc)
     cells_included: list[str] = field(default_factory=list)
     cells_skipped: list[str] = field(default_factory=list)
-    #: True only when group-averaging actually ran (a group had >= 2 cells and
-    #: emitted the long ``mean``/``std`` frame). ``group_it=True`` that fell back
-    #: to a wide, non-averaged frame stays False.
+    #: True when at least one multi-member group was averaged (long
+    #: ``mean``/``std`` frame; singletons may share that schema with null
+    #: ``std``). ``group_it=True`` with only singletons stays wide / False.
     grouped: bool = False
 
 
@@ -61,10 +61,12 @@ class Collection:
 
     @property
     def is_grouped(self) -> bool:
-        """True when group-averaging actually happened (long ``mean``/``std``
-        frame). ``group_it=True`` that fell back to wide (a group with < 2 cells)
-        stays False -- so callers can adapt labels/plotting without sniffing for
-        a ``mean`` column."""
+        """True when at least one multi-member group was averaged.
+
+        Mixed multi+singleton selections stay True (long frame). All-singleton
+        ``group_it=True`` stays wide / False so callers can adapt without
+        sniffing for a ``mean`` column.
+        """
         return self.meta.grouped
 
     def to_wide(

--- a/cellpy/collect/summary.py
+++ b/cellpy/collect/summary.py
@@ -93,11 +93,14 @@ def collect_summaries(
         frame = frame.select(keep)
 
     grouped = False
-    if opts.group_it and frame.height:
-        # legacy guard: std needs >= 2 cells per group; disable if any group is
-        # short (a single-cell group -- or no group column -- keeps it wide).
+    if opts.group_it and frame.height and "group" in frame.columns:
+        # Average multi-member groups; keep singletons in the same long schema
+        # (mean = cell value, std = null). All-singleton (or no group ids) stays
+        # wide with grouped=False (#816; was all-or-nothing before).
         sizes = Counter(lookup.get(lbl, {}).get("group") for lbl in included)
-        if sizes and min(sizes.values()) >= 2:
+        multi = {g for g, n in sizes.items() if g is not None and n >= 2}
+        singles = {g for g, n in sizes.items() if g is not None and n == 1}
+        if multi:
             group_labels = {
                 m.get("group"): m.get("group_label")
                 for m in lookup.values()
@@ -105,9 +108,29 @@ def collect_summaries(
             }
             if opts.custom_group_labels:
                 group_labels = {**group_labels, **dict(opts.custom_group_labels)}
-            frame = ops.group_average(
-                frame, opts, keys=_KEYS, group_labels=group_labels or None
-            )
+            labels = group_labels or None
+            parts = [
+                ops.group_average(
+                    frame.filter(pl.col("group").is_in(list(multi))),
+                    opts,
+                    keys=_KEYS,
+                    group_labels=labels,
+                )
+            ]
+            if singles:
+                parts.append(
+                    ops.singletons_as_long(
+                        frame.filter(pl.col("group").is_in(list(singles))),
+                        keys=_KEYS,
+                        group_labels=labels,
+                    )
+                )
+            frame = pl.concat(parts, how="diagonal_relaxed")
+            sort_cols = [
+                c for c in ("group", ops.CYCLE, "variable") if c in frame.columns
+            ]
+            if sort_cols:
+                frame = frame.sort(sort_cols)
             grouped = True
 
     if frame.height and (opts.replace_inf_with_nan or opts.replace_extremes_with_nan):

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -184,11 +184,48 @@ def test_is_grouped_true_when_averaged():
 
 
 def test_is_grouped_false_on_single_cell_group_fallback():
-    # group_it=True but the (single-cell) group can't average -> wide fallback
+    # group_it=True but only a singleton group -> wide fallback
     pages = pl.DataFrame({FILENAME: ["x"], "group": [1], "sub_group": [1]})
     b = _batch_with_cells({"x": _SummaryCell([1.0, 2.0])}, pages)
     col = collect_summaries(b, group_it=True)
     assert col.is_grouped is False
+
+
+@pytest.mark.essential
+def test_group_it_averages_multi_when_mixed_with_singleton():
+    """Multi-member groups average even if another group is a singleton (#816)."""
+    pages = pl.DataFrame(
+        {
+            FILENAME: ["a", "b", "c"],
+            "group": [1, 1, 2],
+            "sub_group": [1, 2, 1],
+        }
+    )
+    b = _batch_with_cells(
+        {
+            "a": _SummaryCell([10.0, 20.0]),
+            "b": _SummaryCell([20.0, 40.0]),
+            "c": _SummaryCell([5.0, 7.0]),
+        },
+        pages,
+    )
+    col = collect_summaries(b, group_it=True, columns=("charge_capacity",))
+    assert col.is_grouped is True
+    data = col.data
+    for key in ("group", "cycle_num", "variable", "mean", "std"):
+        assert key in data.columns
+
+    g1 = data.filter(
+        (pl.col("group") == 1) & (pl.col("variable") == "charge_capacity")
+    ).sort("cycle_num")
+    assert g1["mean"].to_list() == [15.0, 30.0]
+    assert g1["std"].to_list() == pytest.approx([7.0710678, 14.1421356])
+
+    g2 = data.filter(
+        (pl.col("group") == 2) & (pl.col("variable") == "charge_capacity")
+    ).sort("cycle_num")
+    assert g2["mean"].to_list() == [5.0, 7.0]
+    assert g2["std"].to_list() == [None, None]
 
 
 def test_is_grouped_false_by_default(real_batch):


### PR DESCRIPTION
## Summary
- With `group_it=True`, average groups that have ≥2 cells even if other groups are singletons.
- Singletons share the long `mean`/`std` schema (`std` null); all-singleton selections stay wide.
- Essential regression for mixed multi+singleton selections.

Closes #816

## Test plan
- [x] `uv run pytest tests/test_collect.py -q`
- [x] `uv run pytest -m essential -q`
- [ ] CI green


Made with [Cursor](https://cursor.com)