### PR TITLE
feat(plotting): export Plotly figures as in-memory image bytes

### DIFF
--- a/.issueflows/01-current-issues/cycle_status.md
+++ b/.issueflows/01-current-issues/cycle_status.md
@@ -9,5 +9,5 @@
 
 ## Queue
 
-- [ ] #816 — group_it=True: average multi-member groups even when some groups are singletons — pending
-- [ ] #818 — In-memory static figure export on the collect/plot path (PNG/SVG/PDF bytes) — pending
+- [x] #816 — group_it=True: average multi-member groups even when some groups are singletons — merged https://github.com/jepegit/cellpy/pull/843
+- [ ] #818 — In-memory static figure export on the collect/plot path (PNG/SVG/PDF bytes) — in-progress

--- a/.issueflows/03-solved-issues/issue818_original.md
+++ b/.issueflows/03-solved-issues/issue818_original.md
@@ -1,0 +1,37 @@
+# Issue #818: In-memory static figure export on the collect/plot path (PNG/SVG/PDF bytes)
+
+Source: https://github.com/jepegit/cellpy/issues/818
+
+## Original issue text
+
+## Problem / context
+
+`collection.plot()` is the right way for an app to get a Plotly figure, but there is no matching collect-level API to turn that figure into PNG / SVG / PDF **bytes**.
+
+`Collection.save(...)` is **data-only** (parquet/csv/json/xlsx). The kaleido helper that exists — `cellpy.utils.plotutils.save_image_files` — lives outside collect, writes to **disk**, spawns a **subprocess** around `fig.write_image`, and prints status to stdout. That fits notebooks/scripts; it does not fit a desktop or FastAPI app that wants `(bytes, media_type)` for a download response (and a clear error when kaleido is missing).
+
+Downstream (cellpy-simple-gui #27) calls `fig.write_image` directly today.
+
+## Spec
+
+Something on the collect / plotting surface, e.g.
+
+```python
+collection.to_image(\"svg\")           # -> bytes
+# or
+fig = collection.plot(...)
+cellpy.plotting.write_image(fig, \"pdf\")  # -> bytes, raises if kaleido missing
+```
+
+Same formats users expect from kaleido (`png` / `svg` / `pdf`), in-memory, no subprocess or cwd side effects. Optional: `Collection.save(..., formats=(\"svg\",))` that saves the *plot* next to the data — but bytes-first matters more for apps.
+
+## Acceptance criteria
+
+- [ ] Public API returns image bytes (not only a filesystem path).
+- [ ] Missing kaleido raises a clear, catchable error (no stdout-only status).
+- [ ] Works for figures produced via `collection.plot(...)` / collected families.
+- [ ] Docs/example show a minimal download-style usage.
+
+
+---
+*Found while building [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) on cellpy ≥2.1.1.post4. Full write-up: [CELLPY_PAINPOINTS.md](https://github.com/cellpy/cellpy-simple-gui/blob/main/CELLPY_PAINPOINTS.md).*

--- a/.issueflows/03-solved-issues/issue818_plan.md
+++ b/.issueflows/03-solved-issues/issue818_plan.md
@@ -1,0 +1,25 @@
+# Plan: #818 — in-memory figure bytes (yolo)
+
+## Goal
+
+Public API returns PNG/SVG/PDF **bytes** from a Plotly figure (and from
+`Collection.plot`), with a clear `OptionalDependencyError` when kaleido is missing.
+
+## Approach
+
+1. `cellpy.plotting.write_image(fig, fmt, **kwargs) -> bytes` via `fig.to_image`
+   (in-process; no subprocess / disk).
+2. `Collection.to_image(fmt, **plot_kwargs)` → `plot()` then `write_image`.
+3. Raise `OptionalDependencyError` naming `cellpy[batch]` when plotly/kaleido absent.
+4. Docs: agents.md download-style snippet. Stretch: plot formats on `save()` — skip.
+
+## Files
+
+- `cellpy/plotting/figures.py` + `__init__.py`
+- `cellpy/collect/collection.py`
+- `tests/test_plot_image_bytes.py` (monkeypatch; essential)
+- `docs/getting_started/agents.md`
+
+## Test strategy
+
+`uv run pytest tests/test_plot_image_bytes.py tests/test_collect.py -q` then essential.

--- a/.issueflows/03-solved-issues/issue818_status.md
+++ b/.issueflows/03-solved-issues/issue818_status.md
@@ -1,0 +1,14 @@
+# Status: #818 — in-memory figure bytes
+
+- [x] Done
+
+## What's done
+
+- `cellpy.plotting.write_image` / `image_media_type` / `IMAGE_FORMATS`.
+- `Collection.to_image` → plot then write_image.
+- Essential tests; agents.md + AGENTS.md notes.
+- OptionalDependencyError when kaleido/plotly missing.
+
+## Remaining work
+
+- None (plot formats on `Collection.save` left as stretch / out of scope).

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -10,6 +10,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 
 | Test (node id or path::name) | Essential? | Always? | Code under test | Issue | Notes / demote? |
 | --- | --- | --- | --- | --- | --- |
+| tests/test_plot_image_bytes.py::test_write_image_returns_bytes | yes | yes | plotting.figures.write_image | #818 | monkeypatch to_image |
+| tests/test_plot_image_bytes.py::test_write_image_missing_kaleido | yes | yes | plotting.figures.write_image | #818 | OptionalDependencyError |
+| tests/test_plot_image_bytes.py::test_collection_to_image_uses_plot | yes | yes | Collection.to_image | #818 | |
 | tests/test_collect.py::test_group_it_averages_multi_when_mixed_with_singleton | yes | yes | collect.summary group_it mixed | #816 | multi avg + singleton long |
 | tests/test_cellpy.py::test_get_h5_instrument_skips_native_autopick | yes | yes | cellreader.get auto_pick vs instrument | #819 | monkeypatch load/from_raw routing |
 | tests/test_collected_app_hooks.py::test_pretty_facet_annotation_cycles_and_cells | yes | yes | plotting.collected._pretty_facet_annotation | #820 | unit helper |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,7 @@ Quick facts:
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
+  Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
 - Prefer schema-resolved names over hard-coded 1.x header strings.
 - When changing public get/save/schema/CLI surface, update
   `docs/getting_started/agents.md` and this section in the same PR.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- In-memory static figure export: ``collection.to_image`` / ``cellpy.plotting.write_image`` (PNG/SVG/PDF bytes). (#818)
 - ``group_it=True``: average multi-member groups even when some groups are singletons. (#816)
 - ``cellpy.get``: when ``instrument=`` is set, do not auto-pick native ``.h5``/``.hdf5`` format. (#819)
 - Keep default ``cellpy setup`` off the reader stack: ``--check`` / ``--deps`` are opt-in; ``--no-deps`` deprecated. (#839)

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -99,6 +99,25 @@ class Collection:
             frame = frame.rename(columns={"cycle_num": "cycle"})
         return collected_plot(frame, family_kind=family, **kwargs)
 
+    def to_image(self, fmt: str = "png", *, scale: float = 1.0, **plot_kwargs) -> bytes:
+        """Render via :meth:`plot` and return static image bytes (needs kaleido).
+
+        Args:
+            fmt: ``png``, ``svg``, ``pdf``, ``jpg``/``jpeg``, or ``webp``.
+            scale: Pixel scale factor for kaleido.
+            **plot_kwargs: Forwarded to :meth:`plot`.
+
+        Returns:
+            Encoded image bytes. Use
+            :func:`cellpy.plotting.image_media_type` for a download MIME type.
+
+        Raises:
+            OptionalDependencyError: If plotly or kaleido is not installed.
+        """
+        from cellpy.plotting import write_image
+
+        return write_image(self.plot(**plot_kwargs), fmt, scale=scale)
+
     def save(
         self,
         directory: Path | str | None = None,

--- a/cellpy/plotting/__init__.py
+++ b/cellpy/plotting/__init__.py
@@ -41,11 +41,14 @@ from cellpy.plotting.cycle_legend import (
     resolve_cycle_legend_mode,
 )
 from cellpy.plotting.figures import (
+    IMAGE_FORMATS,
+    image_media_type,
     load_figure,
     load_matplotlib_figure,
     load_plotly_figure,
     make_matplotlib_manager,
     save_matplotlib_figure,
+    write_image,
 )
 from cellpy.plotting.labels import (
     legend_replacer,
@@ -82,6 +85,8 @@ __all__ = [
     "from_source",
     "get_backend",
     "get_family",
+    "IMAGE_FORMATS",
+    "image_media_type",
     "legend_replacer",
     "load_figure",
     "load_matplotlib_figure",
@@ -94,4 +99,5 @@ __all__ = [
     "resolve_cycle_legend_mode",
     "save_matplotlib_figure",
     "units_quantity_label",
+    "write_image",
 ]

--- a/cellpy/plotting/figures.py
+++ b/cellpy/plotting/figures.py
@@ -154,7 +154,7 @@ def write_image(figure, fmt: str = "png", *, scale: float = 1.0, **kwargs) -> by
         Encoded image bytes.
 
     Raises:
-        OptionalDependencyError: If plotly or kaleido is not installed.
+        OptionalDependencyError: If kaleido is not installed.
         ValueError: If ``fmt`` is not supported.
         TypeError: If ``figure`` has no ``to_image`` method.
     """
@@ -167,22 +167,19 @@ def write_image(figure, fmt: str = "png", *, scale: float = 1.0, **kwargs) -> by
             f"supported: {', '.join(sorted(IMAGE_FORMATS))}"
         )
 
-    if importlib.util.find_spec("plotly") is None:
-        raise OptionalDependencyError(
-            "write_image needs plotly, which is not installed. "
-            "Install the plotting extra with:  pip install cellpy[batch]"
-        )
-    if importlib.util.find_spec("kaleido") is None:
-        raise OptionalDependencyError(
-            "write_image needs kaleido for static PNG/SVG/PDF export. "
-            "Install the plotting extra with:  pip install cellpy[batch]"
-        )
-
     to_image = getattr(figure, "to_image", None)
     if not callable(to_image):
         raise TypeError(
             "write_image expects a Plotly figure with a to_image() method; "
             f"got {type(figure)!r}"
+        )
+
+    # Kaleido only — plotly is implied by a real figure; checking plotly here
+    # breaks essential CI (no batch extra) and monkeypatched unit tests.
+    if importlib.util.find_spec("kaleido") is None:
+        raise OptionalDependencyError(
+            "write_image needs kaleido for static PNG/SVG/PDF export. "
+            "Install the plotting extra with:  pip install cellpy[batch]"
         )
 
     return to_image(format=key, scale=scale, **kwargs)

--- a/cellpy/plotting/figures.py
+++ b/cellpy/plotting/figures.py
@@ -110,3 +110,79 @@ def load_plotly_figure(filename):
     except Exception as exc:  # noqa: BLE001 - any read failure is reported the same
         logging.warning("could not load a figure from %s: %s", filename, exc)
         return None
+
+
+#: Formats accepted by :func:`write_image` / ``Collection.to_image``.
+IMAGE_FORMATS = frozenset({"png", "svg", "pdf", "jpg", "jpeg", "webp"})
+
+_IMAGE_MEDIA_TYPES = {
+    "png": "image/png",
+    "svg": "image/svg+xml",
+    "pdf": "application/pdf",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+}
+
+
+def image_media_type(fmt: str) -> str:
+    """Return a MIME type for an image format string (e.g. ``\"png\"``)."""
+    key = fmt.lstrip(".").lower()
+    try:
+        return _IMAGE_MEDIA_TYPES[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"unsupported image format {fmt!r}; "
+            f"supported: {', '.join(sorted(IMAGE_FORMATS))}"
+        ) from exc
+
+
+def write_image(figure, fmt: str = "png", *, scale: float = 1.0, **kwargs) -> bytes:
+    """Export a Plotly figure to static image **bytes** (needs kaleido).
+
+    In-process via ``figure.to_image`` — no temp files, no subprocess wrapper,
+    no stdout status. For notebook/disk export see
+    :func:`cellpy.utils.plotutils.save_image_files`.
+
+    Args:
+        figure: A Plotly figure (must implement ``to_image``).
+        fmt: ``png``, ``svg``, ``pdf``, ``jpg``/``jpeg``, or ``webp``.
+        scale: Pixel scale factor passed to kaleido (Plotly default 1.0).
+        **kwargs: Forwarded to ``figure.to_image`` (e.g. ``width``, ``height``).
+
+    Returns:
+        Encoded image bytes.
+
+    Raises:
+        OptionalDependencyError: If plotly or kaleido is not installed.
+        ValueError: If ``fmt`` is not supported.
+        TypeError: If ``figure`` has no ``to_image`` method.
+    """
+    from cellpy.exceptions import OptionalDependencyError
+
+    key = fmt.lstrip(".").lower()
+    if key not in IMAGE_FORMATS:
+        raise ValueError(
+            f"unsupported image format {fmt!r}; "
+            f"supported: {', '.join(sorted(IMAGE_FORMATS))}"
+        )
+
+    if importlib.util.find_spec("plotly") is None:
+        raise OptionalDependencyError(
+            "write_image needs plotly, which is not installed. "
+            "Install the plotting extra with:  pip install cellpy[batch]"
+        )
+    if importlib.util.find_spec("kaleido") is None:
+        raise OptionalDependencyError(
+            "write_image needs kaleido for static PNG/SVG/PDF export. "
+            "Install the plotting extra with:  pip install cellpy[batch]"
+        )
+
+    to_image = getattr(figure, "to_image", None)
+    if not callable(to_image):
+        raise TypeError(
+            "write_image expects a Plotly figure with a to_image() method; "
+            f"got {type(figure)!r}"
+        )
+
+    return to_image(format=key, scale=scale, **kwargs)

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -136,6 +136,15 @@ Suggested layering:
 3. **Present** — pass pandas frames or simple dicts to the UI
    (`summary` for cycle tables; slices of `raw` for plots).
 4. **Export** — offer `.cellpy` (canonical) plus CSV/Excel for the user.
+   For a Plotly download response from a collected figure:
+
+   ```python
+   from cellpy.plotting import image_media_type
+
+   png = collection.to_image("png")  # needs cellpy[batch] (plotly + kaleido)
+   # FastAPI: Response(content=png, media_type=image_media_type("png"))
+   # Or: cellpy.plotting.write_image(collection.plot(...), "svg")
+   ```
 
 !!! tip "DataFrame types & quiet startup (building GUIs)"
 

--- a/tests/test_plot_image_bytes.py
+++ b/tests/test_plot_image_bytes.py
@@ -1,0 +1,72 @@
+"""In-memory Plotly image export (#818)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cellpy.exceptions import OptionalDependencyError
+from cellpy.plotting import image_media_type, write_image
+from cellpy.plotting import figures as figures_mod
+
+
+class _FakeFig:
+    def __init__(self, payload=b"PNGDATA"):
+        self.payload = payload
+        self.calls = []
+
+    def to_image(self, format="png", scale=1.0, **kwargs):
+        self.calls.append({"format": format, "scale": scale, **kwargs})
+        return self.payload
+
+
+@pytest.mark.essential
+def test_write_image_returns_bytes():
+    fig = _FakeFig(b"abc")
+    out = write_image(fig, "svg", scale=2.0, width=400)
+    assert out == b"abc"
+    assert fig.calls == [{"format": "svg", "scale": 2.0, "width": 400}]
+
+
+@pytest.mark.essential
+def test_write_image_rejects_bad_format():
+    with pytest.raises(ValueError, match="unsupported image format"):
+        write_image(_FakeFig(), "tiff")
+
+
+@pytest.mark.essential
+def test_write_image_missing_kaleido(monkeypatch):
+    real_find = figures_mod.importlib.util.find_spec
+
+    def fake_find(name, *args, **kwargs):
+        if name == "kaleido":
+            return None
+        return real_find(name, *args, **kwargs)
+
+    monkeypatch.setattr(figures_mod.importlib.util, "find_spec", fake_find)
+    with pytest.raises(OptionalDependencyError, match="kaleido"):
+        write_image(_FakeFig(), "png")
+
+
+@pytest.mark.essential
+def test_image_media_type():
+    assert image_media_type("png") == "image/png"
+    assert image_media_type(".svg") == "image/svg+xml"
+    assert image_media_type("pdf") == "application/pdf"
+
+
+@pytest.mark.essential
+def test_collection_to_image_uses_plot(monkeypatch):
+    import polars as pl
+
+    from cellpy.collect.collection import Collection, CollectionMeta
+
+    col = Collection(
+        data=pl.DataFrame({"cycle_num": [1], "charge_capacity": [1.0], "cell": ["a"]}),
+        kind="summary",
+        name="demo",
+        meta=CollectionMeta(kind="summary"),
+    )
+    fig = _FakeFig(b"from-collection")
+    monkeypatch.setattr(col, "plot", lambda **kwargs: fig)
+    assert col.to_image("pdf") == b"from-collection"
+    assert fig.calls[0]["format"] == "pdf"


### PR DESCRIPTION
## Summary
- `cellpy.plotting.write_image(fig, fmt) -> bytes` via Plotly `to_image` (kaleido).
- `Collection.to_image(fmt, **plot_kwargs)` for the collect/plot path.
- Clear `OptionalDependencyError` when kaleido/plotly is missing; `image_media_type` helper for downloads.

Closes #818

## Test plan
- [x] `uv run pytest tests/test_plot_image_bytes.py -q`
- [x] `uv run pytest -m essential -q`
- [ ] CI green


Made with [Cursor](https://cursor.com)