### PR TITLE
fix(plotting): kaleido gate only for real Plotly figures

### DIFF
--- a/cellpy/plotting/figures.py
+++ b/cellpy/plotting/figures.py
@@ -174,9 +174,11 @@ def write_image(figure, fmt: str = "png", *, scale: float = 1.0, **kwargs) -> by
             f"got {type(figure)!r}"
         )
 
-    # Kaleido only — plotly is implied by a real figure; checking plotly here
-    # breaks essential CI (no batch extra) and monkeypatched unit tests.
-    if importlib.util.find_spec("kaleido") is None:
+    # Require kaleido only for real Plotly figures. Test stubs (and other
+    # callables with to_image) must keep working on essential CI, which does
+    # not install the batch extra / kaleido.
+    fig_module = getattr(type(figure), "__module__", "") or ""
+    if fig_module.startswith("plotly") and importlib.util.find_spec("kaleido") is None:
         raise OptionalDependencyError(
             "write_image needs kaleido for static PNG/SVG/PDF export. "
             "Install the plotting extra with:  pip install cellpy[batch]"

--- a/tests/test_plot_image_bytes.py
+++ b/tests/test_plot_image_bytes.py
@@ -19,6 +19,12 @@ class _FakeFig:
         return self.payload
 
 
+class _FakePlotlyFig(_FakeFig):
+    """Stub whose type module looks like Plotly (triggers kaleido gate)."""
+
+    __module__ = "plotly.graph_objs._figure"
+
+
 @pytest.mark.essential
 def test_write_image_returns_bytes():
     fig = _FakeFig(b"abc")
@@ -44,7 +50,7 @@ def test_write_image_missing_kaleido(monkeypatch):
 
     monkeypatch.setattr(figures_mod.importlib.util, "find_spec", fake_find)
     with pytest.raises(OptionalDependencyError, match="kaleido"):
-        write_image(_FakeFig(), "png")
+        write_image(_FakePlotlyFig(), "png")
 
 
 @pytest.mark.essential


### PR DESCRIPTION
## Summary
- Essential CI (no `cellpy[batch]` / kaleido) failed `write_image` stub tests on the `v2.1.2a1` release.
- Require kaleido only when `type(figure).__module__` starts with `plotly`; stubs keep working.
- Missing-kaleido test uses a Plotly-module stub.

## Test plan
- [x] `uv run pytest tests/test_plot_image_bytes.py -q`
- [ ] CI essential green

Refs #818

Made with [Cursor](https://cursor.com)