### PR TITLE
fix(config): report the config file that is actually loaded (#851)

### DIFF
--- a/.issueflows/01-current-issues/issue851_original.md
+++ b/.issueflows/01-current-issues/issue851_original.md
@@ -1,0 +1,52 @@
+# Issue #851: cellpy info / edit config / info --check still point at the legacy .conf after migration
+
+Source: https://github.com/jepegit/cellpy/issues/851
+
+## Original issue text
+
+## Problem / context
+
+After `cellpy setup migrate` writes `cellpy.toml`, the config *loader* correctly prefers it — `load_config` only falls back to the legacy YAML when no TOML was loaded (`cellpy/config/loader.py:203-213`). But the CLI still reports and edits the old file:
+
+```
+❯ cellpy setup migrate
+[cellpy] (setup migrate) source: C:\Users\jepe\.cellpy_prms_jepe.conf
+[cellpy] (setup migrate) target: C:\Users\jepe\AppData\Local\cellpy\cellpy\cellpy.toml
+[cellpy] (setup migrate) done - the old file is kept untouched.
+
+❯ cellpy info
+[cellpy] version: 2.1.1.post8.dev1+fad801ac
+[cellpy] -> C:\Users\jepe\.cellpy_prms_jepe.conf     # ← stale, nothing reads this
+```
+
+Root cause: `_configloc()` (`cellpy/cli_api.py:1276`) calls `prmreader.get_user_dir_and_dst()`, which composes `~/.cellpy_prms_<user>.conf` unconditionally and never consults `cellpy.config.loader.user_config_path()`.
+
+Three surfaces are affected, and two are worse than a wrong printout:
+
+- **`cellpy info` / `cellpy info --configloc`** — names a file that no longer has any effect.
+- **`cellpy edit config`** (`cli_api.py:1876`) — opens the stale `.conf`, so the user edits a file that is silently ignored. Most damaging: the edit appears to succeed and changes nothing.
+- **`cellpy info --check`** (`_check_config_file`, `cli_api.py:999-1011`) — validates the stale YAML via `_read_prm_file_without_updating`, so it checks paths the runtime is not using.
+
+`cellpy info --show-config` is already correct — it goes through `config.get_config()` with provenance (`_dump_config_resolved`, `cli_api.py:1223`).
+
+## Spec
+
+- Resolve the *active* config file with the same precedence as `load_config`: user `cellpy.toml` → legacy `.conf` → none. Put this in one helper (e.g. `cellpy.config.loader.active_config_file()`) so the CLI and the loader cannot drift apart again.
+- `_configloc()` reports that file. When a legacy `.conf` exists but is shadowed by a TOML, say so explicitly, e.g.
+  `[cellpy] (legacy C:\Users\jepe\.cellpy_prms_jepe.conf is ignored — cellpy.toml takes precedence)`.
+- `cellpy edit config` opens the active file.
+- `_check_config_file` validates the active file; for a TOML, check it through the config models rather than the YAML reader.
+
+## Acceptance criteria
+
+- With a `cellpy.toml` present, `cellpy info` prints the TOML path and mentions the shadowed legacy file when one exists.
+- With no TOML, output is unchanged from today (legacy path).
+- `cellpy edit config` opens the TOML when it exists.
+- `cellpy info --check` passes/fails based on the TOML's paths, not the legacy YAML's.
+- Tests cover all three states: TOML only, legacy only, both (TOML wins + shadow notice). Marked `essential` — this is the "which config am I actually using" question and it must stay honest.
+
+## Out of scope
+
+- Changing precedence itself, or deprecating/deleting the legacy `.conf`.
+- `cellpy setup migrate` behaviour (it works correctly).
+- Project-level `cellpy.toml` discovery (`find_project_config_file`) — worth a follow-up, since a project file also outranks the user file and `info` will not mention it either.

--- a/.issueflows/01-current-issues/issue851_plan.md
+++ b/.issueflows/01-current-issues/issue851_plan.md
@@ -1,0 +1,134 @@
+# Issue #851 — plan: CLI must report the *active* config file
+
+Source: https://github.com/jepegit/cellpy/issues/851
+Milestone: v.2.1.2 · Labels: bug, v2
+
+## Goal
+
+`cellpy info`, `cellpy edit config`, and `cellpy info --check` must all act on the
+config file the loader actually uses (`cellpy.toml` when present, else the legacy
+`.cellpy_prms_*.conf`), and say when a legacy file is being shadowed.
+
+## Constraints
+
+- **Precedence is not up for debate** — `load_config` already does it right
+  ([`config/loader.py:203-213`](../../cellpy/config/loader.py)): user TOML wins,
+  legacy YAML only when no TOML loaded. This issue changes *reporting*, not
+  resolution.
+- **One code path, or it will drift again.** The bug exists because `_configloc`
+  re-derives a filename (`prmreader.get_user_dir_and_dst()` →
+  `~/.cellpy_prms_<user>.conf`) instead of asking the loader. A second parallel
+  "which file?" implementation would rot the same way, so `load_config` itself
+  must consume the new helper rather than merely agreeing with it.
+- **Legacy-only setups must be unchanged** — no TOML present ⇒ byte-identical
+  output to today.
+- Do not touch `cellpy setup migrate`, and do not deprecate or delete the legacy
+  `.conf` (it keeps working through the v2.0 deprecation window).
+- `cellpy info --show-config` is already correct; leave it alone.
+
+### Prior art
+
+- `.issueflows/00-tools/README.md` — nothing config-related; no reuse.
+- `config/loader.py`: `user_config_path()`, `find_project_config_file()`,
+  `CONFIG_FILENAME = "cellpy.toml"` — the pieces the helper composes.
+- `config/legacy.py`: `find_legacy_yaml_file()` — legacy discovery, already the
+  function `load_config` calls. Reuse as-is.
+- `cli_api.py:1223 _dump_config_resolved()` — the one surface that already reads
+  through `config.get_config()` + `sources()`. It is the model to follow.
+- `cli_api.py:1285 _envloc()` — same shape for the env file; out of scope, but
+  worth a glance if it turns out to have the same defect.
+- Docs already document the commands in
+  `docs/getting_started/configuration.md:50-57`.
+
+## Approach
+
+1. **`config/loader.py` — one resolver.** Add a frozen dataclass and a function:
+
+   ```python
+   @dataclass(frozen=True)
+   class ActiveConfigFile:
+       path: Path | None            # what load_config uses for the user layer
+       kind: str                    # "toml" | "legacy" | "none"
+       shadowed_legacy: Path | None # legacy file present but outranked
+
+   def active_config_file(options: LoadOptions | None = None) -> ActiveConfigFile:
+   ```
+
+   TOML at `user_config_path()` (or `opts.user_config_file`) wins; else the
+   legacy file from `find_legacy_yaml_file()` (or `opts.legacy_yaml_file`); else
+   `kind="none"`. `shadowed_legacy` is set only when a legacy file exists *and* a
+   TOML won.
+
+2. **Rewire `load_config` through it.** Its user-layer branch calls
+   `active_config_file(opts)` and switches on `kind`, so the CLI and the loader
+   cannot disagree by construction. Merge/secret handling per layer stays exactly
+   as it is today (`_reject_secrets_from_file` for TOML,
+   `_drop_legacy_secrets` for YAML).
+
+3. **`_configloc()`** reports `result.path`, and adds one line when
+   `shadowed_legacy` is set:
+
+   ```
+   [cellpy] -> C:\...\AppData\Local\cellpy\cellpy\cellpy.toml
+   [cellpy] (legacy C:\Users\jepe\.cellpy_prms_jepe.conf is ignored - cellpy.toml takes precedence)
+   ```
+
+   `kind="none"` keeps today's "File does not exist!" + `None` return, so
+   callers that branch on `None` are unaffected.
+
+4. **`cellpy edit config`** needs no change of its own — it opens whatever
+   `_configloc()` returns (`cli_api.py:1876`). This also fixes a worse case than
+   the issue described: on a **TOML-only** install (fresh `cellpy setup` with no
+   legacy file) `_configloc()` returns `None` today, so `cellpy edit config`
+   currently answers "could not find the config file" and opens nothing at all.
+
+5. **`_check_config_file()`** stops parsing the raw legacy YAML
+   (`prmreader._read_prm_file_without_updating`, which cannot read TOML) and
+   checks the **resolved** `config.paths` instead, printing the active file for
+   context. One code path covers both formats, and it validates what the runtime
+   will really use. The per-path listing, the `OTHERPATHS` skip, the
+   `db_filename` check, and the missing-count return value all stay.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `cellpy/config/loader.py` | add `ActiveConfigFile` + `active_config_file()`; `load_config` user layer routes through it |
+| `cellpy/cli_api.py` | `_configloc()` reports the active file + shadow notice; `_check_config_file()` validates resolved `config.paths` |
+| `tests/test_config.py` | new: helper precedence for the three states (TOML only / legacy only / both) |
+| `tests/test_cellpy_cmd.py` | `test_info_configloc` currently asserts `"conf" in result.output`, which a `.toml` path fails — make it format-agnostic; add a shadow-notice case |
+| `tests/test_cli_api.py` | extend `test_config_path_returns_a_path_or_none` for the TOML case |
+| `docs/getting_started/configuration.md` | note that `--configloc` names the winning file and flags a shadowed legacy one |
+
+## Test strategy
+
+Runner: `uv run pytest` (the documented conda env `cellpy_dev_313` currently has
+a broken `pyarrow` DLL — see #845 status notes). Merge gate:
+`uv run pytest -m essential`. Targeted:
+`uv run pytest tests/test_config.py tests/test_cellpy_cmd.py tests/test_cli_api.py -m ""`.
+
+Drive the three states through `LoadOptions(user_config_file=..., legacy_yaml_file=...)`
+with `tmp_path`, so nothing depends on the developer's real `$HOME`:
+
+1. TOML only → `kind == "toml"`, `shadowed_legacy is None`.
+2. Legacy only → `kind == "legacy"`, path is the `.conf`.
+3. Both → `kind == "toml"`, `shadowed_legacy` is the `.conf`, and `cellpy info`
+   prints the notice.
+4. Neither → `kind == "none"`, `_configloc()` returns `None`.
+5. Anti-drift: with both files present, assert the layer `load_config` recorded
+   comes from the TOML (a value set only there wins), proving helper and loader
+   agree.
+
+Mark 1–3 `essential`: "which config am I using" must not silently regress.
+
+## Decisions (confirmed 2026-08-09)
+
+1. **`_check_config_file` validates the resolved `config.paths`**, not the active
+   file's own contents. Format-agnostic and it checks what the runtime will really
+   use. Accepted cost: env-var and project-file layers are folded in, so `--check`
+   no longer validates the user file in isolation.
+   Rejected: per-format parsing of the active file, which keeps the check
+   file-local but reintroduces two parsers to keep in step.
+2. **`_envloc()`** — investigate during build; fix here only if it is literally the
+   same self-derived-path defect. Otherwise file a follow-up.
+3. Shadow-notice wording as drafted above.

--- a/.issueflows/01-current-issues/issue851_status.md
+++ b/.issueflows/01-current-issues/issue851_status.md
@@ -1,0 +1,95 @@
+# Issue #851 — status
+
+- [x] Done
+
+Branch: `851-configloc-active-file` · Issue: https://github.com/jepegit/cellpy/issues/851
+
+## What was done
+
+**One resolver, consumed by both sides.** `cellpy/config/loader.py` gained
+`ActiveConfigFile` (frozen dataclass: `path`, `kind`, `shadowed_legacy`) and
+`active_config_file(options)`. `load_config` no longer decides the user layer
+itself — it calls the helper and switches on `kind`, so a reporting command and
+the loader cannot disagree about which file wins. That was the actual defect:
+`_configloc()` re-derived `~/.cellpy_prms_<user>.conf` via
+`prmreader.get_user_dir_and_dst()` and never asked the loader.
+
+**`_configloc()`** reports the winning file and names a shadowed legacy one:
+
+```
+[cellpy] -> C:\Users\jepe\AppData\Local\cellpy\cellpy\cellpy.toml
+[cellpy] (legacy C:\Users\jepe\.cellpy_prms_jepe.conf is ignored - cellpy.toml takes precedence)
+```
+
+With no config at all it keeps the old "File does not exist!" + `None` return, so
+callers that branch on `None` are unaffected.
+
+**`cellpy edit config`** needed no change of its own (it opens whatever
+`_configloc()` returns). Verified: `cli_api.config_path()` now returns the TOML.
+This also fixes a case worse than the one reported — on a **TOML-only** install
+`_configloc()` used to return `None`, so `cellpy edit config` answered "could not
+find the config file" and opened nothing at all.
+
+**`_check_config_file()`** stopped parsing the raw legacy YAML
+(`prmreader._read_prm_file_without_updating`, which cannot read TOML) and now
+checks the resolved `config.paths`. Per-path listing, the `OTHERPATHS` skip, the
+`db_filename` check and the return value are unchanged.
+
+**`_envloc()` was investigated and left alone** — it reads
+`config.paths.env_file` through the resolved config
+(`prmreader.get_env_file_name`), so it never had the self-derived-path defect. No
+follow-up needed.
+
+Exported `active_config_file` / `ActiveConfigFile` from `cellpy.config`.
+
+## Verified on the reporting machine
+
+The setup that produced the bug report (migrated: both files on disk):
+
+```
+[cellpy] -> C:\Users\jepe\AppData\Local\cellpy\cellpy\cellpy.toml
+[cellpy] (legacy C:\Users\jepe\.cellpy_prms_jepe.conf is ignored - cellpy.toml takes precedence)
+```
+
+`cellpy info --check` now reads the TOML's paths — "Succeeded 3 out of 3 checks."
+
+## Tests
+
+New, in `tests/test_config.py` (three `essential`): TOML wins / legacy-only
+fallback / shadowed-legacy flagged / neither file present, plus an anti-drift test
+asserting the helper and `load_config` pick the same file when both exist.
+In `tests/test_cellpy_cmd.py` (both `essential`): `--configloc` reports the TOML,
+and prints the shadow notice.
+
+`tests/test_cellpy_cmd.py::test_info_configloc` asserted `"conf" in result.output`,
+which a `cellpy.toml` path fails — made format-agnostic (`"[cellpy] ->"`).
+
+Runner: `uv run pytest` (the documented conda env `cellpy_dev_313` has a broken
+`pyarrow` DLL, as noted under #845).
+
+- `uv run pytest -m essential` → **684 passed**, 1 skipped.
+- `uv run pytest` (full) → **1532 passed**, 3 failed.
+- Those 3 (`test_cell_readers.py::test_search_for_files`,
+  `test_filefinder.py::test_search_for_files_with_dirs`,
+  `::test_search_for_files_recursive`) are **pre-existing**: re-confirmed failing
+  on a stashed clean tree. They depend on the developer's real `rawdatadir`, an
+  unreachable `scp://` remote.
+- `black`: added code is clean; the files carry pre-existing reformat
+  suggestions that were deliberately left untouched to keep the diff small.
+
+## Files touched
+
+- `cellpy/config/loader.py` — `ActiveConfigFile`, `active_config_file()`;
+  `load_config` routes its user layer through it
+- `cellpy/config/__init__.py` — re-export
+- `cellpy/cli_api.py` — `_configloc()`, `_check_config_file()`
+- `tests/test_config.py`, `tests/test_cellpy_cmd.py`
+- `docs/getting_started/configuration.md` — document the shadow notice
+- `HISTORY.md`, `.issueflows/04-designs-and-guides/test-registry.md`
+
+## Remaining work
+
+None for this issue. Deliberately out of scope, worth a follow-up if it bites:
+a **project-level** `cellpy.toml` (`find_project_config_file`) also outranks the
+user file, and `--configloc` still does not mention it. `--config` / `-C` already
+shows per-field provenance, so the information is reachable today.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -43,6 +43,12 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |
 | tests/test_cellpy_file_v9.py::test_incomplete_archive_is_rejected_before_replace | yes | yes | v9._verify_members | #845 | missing zip member never replaces a good file |
 | tests/test_cellpy_file_v9.py::test_failed_hdf5_resave_keeps_the_old_file | no | no | cellpy_file.write.save (v8/HDF5) | #845 | same guard for the legacy writer; unmarked to keep Tier 1 fast |
+| tests/test_config.py::test_active_config_file_prefers_toml | yes | yes | config.loader.active_config_file | #851 | "which config am I using" must stay honest |
+| tests/test_config.py::test_active_config_file_falls_back_to_legacy | yes | yes | config.loader.active_config_file | #851 | legacy-only setups unchanged |
+| tests/test_config.py::test_active_config_file_flags_shadowed_legacy | yes | yes | config.loader.active_config_file | #851 | migrated user: .conf on disk but ignored |
+| tests/test_config.py::test_active_config_file_agrees_with_load_config | no | yes | config.loader.active_config_file / load_config | #851 | anti-drift: helper and loader pick the same file |
+| tests/test_cellpy_cmd.py::test_info_configloc_reports_the_toml | yes | yes | cli_api._configloc | #851 | CLI reports the winning file |
+| tests/test_cellpy_cmd.py::test_info_configloc_flags_shadowed_legacy_file | yes | yes | cli_api._configloc | #851 | never point at the dead .conf |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- ``cellpy info``, ``cellpy edit config`` and ``cellpy info --check`` now act on the config file that is actually loaded (``cellpy.toml`` before a legacy ``.conf``), and name a shadowed legacy file instead of pointing at it. (#851)
 - Atomic ``.cellpy`` / ``.h5`` writes: ``save`` stages next to the destination and replaces it only when complete, so an interrupted save no longer corrupts or destroys the file. (#845)
 - In-memory static figure export: ``collection.to_image`` / ``cellpy.plotting.write_image`` (PNG/SVG/PDF bytes). (#818)
 - ``group_it=True``: average multi-member groups even when some groups are singletons. (#816)

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1008,9 +1008,13 @@ def _check_config_file():
         _say(" You can create one by running 'cellpy setup'")
         return False
 
-    prm_dict = prmreader._read_prm_file_without_updating(prm_file_name)
+    # Check the *resolved* paths rather than re-parsing the file: those are the
+    # ones cellpy will use, and it works for both cellpy.toml and legacy YAML
+    # (the YAML reader cannot read TOML at all) -- see #851.
+    from cellpy import config as cellpy_config
+
     try:
-        prm_paths = prm_dict["Paths"]
+        prm_paths = cellpy_config.get_config().paths.model_dump()
         required_dirs = [
             "cellpydatadir",
             "examplesdir",
@@ -1274,12 +1278,20 @@ def _version():
 
 
 def _configloc():
-    _, config_file_name = prmreader.get_user_dir_and_dst()
-    _say(f"[cellpy] -> {config_file_name}")
-    if not os.path.isfile(config_file_name):
+    """Report the config file cellpy actually reads (``None`` when there is none)."""
+    from cellpy.config.loader import CONFIG_FILENAME, active_config_file
+
+    active = active_config_file()
+    if active.path is None:
+        _, config_file_name = prmreader.get_user_dir_and_dst()
+        _say(f"[cellpy] -> {config_file_name}")
         _say("[cellpy] File does not exist!")
-    else:
-        return config_file_name
+        return None
+
+    _say(f"[cellpy] -> {active.path}")
+    if active.shadowed_legacy is not None:
+        _say(f"[cellpy] (legacy {active.shadowed_legacy} is ignored - {CONFIG_FILENAME} takes precedence)")
+    return active.path
 
 
 def _envloc():

--- a/cellpy/config/__init__.py
+++ b/cellpy/config/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from cellpy.config.loader import LoadOptions
+from cellpy.config.loader import ActiveConfigFile, LoadOptions, active_config_file
 from cellpy.config.models import CellpyConfig
 from cellpy.config.session import (
     get_config,
@@ -35,8 +35,10 @@ _SECTION_NAMES = frozenset(
 )
 
 __all__ = [
+    "ActiveConfigFile",
     "CellpyConfig",
     "LoadOptions",
+    "active_config_file",
     "get_config",
     "override",
     "reload",

--- a/cellpy/config/loader.py
+++ b/cellpy/config/loader.py
@@ -53,6 +53,57 @@ def user_config_path() -> Path:
     return Path(platformdirs.user_config_dir("cellpy")) / CONFIG_FILENAME
 
 
+@dataclass(frozen=True)
+class ActiveConfigFile:
+    """Which user-level config file wins, and what it shadows.
+
+    Attributes:
+        path: The file ``load_config`` reads for the user layer, or ``None``.
+        kind: ``"toml"``, ``"legacy"`` or ``"none"``.
+        shadowed_legacy: A legacy ``.conf`` that exists but is outranked by a
+            ``cellpy.toml``. ``None`` when nothing is shadowed.
+    """
+
+    path: Path | None
+    kind: str
+    shadowed_legacy: Path | None = None
+
+
+def active_config_file(options: LoadOptions | None = None) -> ActiveConfigFile:
+    """Resolve the user-level config file, ``cellpy.toml`` before legacy YAML.
+
+    ``load_config`` calls this for its own user layer, so anything that reports a
+    config location (``cellpy info``, ``cellpy edit config``) can ask here and
+    stay in step with what is actually loaded (#851).
+
+    Args:
+        options: Same hooks ``load_config`` takes; only the file overrides and
+            ``skip_files`` are consulted.
+
+    Returns:
+        ActiveConfigFile: The winning file, plus any shadowed legacy file.
+    """
+
+    from cellpy.config.legacy import find_legacy_yaml_file
+
+    opts = options or LoadOptions()
+    if opts.skip_files:
+        return ActiveConfigFile(path=None, kind="none")
+
+    legacy = opts.legacy_yaml_file or find_legacy_yaml_file()
+    if legacy is not None and not legacy.is_file():
+        legacy = None
+
+    user_file = opts.user_config_file or user_config_path()
+    if user_file.is_file():
+        return ActiveConfigFile(path=user_file, kind="toml", shadowed_legacy=legacy)
+
+    if legacy is not None:
+        return ActiveConfigFile(path=legacy, kind="legacy")
+
+    return ActiveConfigFile(path=None, kind="none")
+
+
 def find_project_config_file(start: Path | None = None) -> Path | None:
     """Walk up from ``start`` (default cwd) looking for ``cellpy.toml``."""
 
@@ -196,28 +247,23 @@ def load_config(
 
     user_file_path: Path | None = None
     if not opts.skip_files:
-        from cellpy.config.legacy import find_legacy_yaml_file, load_legacy_yaml_dict
+        from cellpy.config.legacy import load_legacy_yaml_dict
 
-        user_file = opts.user_config_file or user_config_path()
-        user_toml_loaded = False
-        if user_file.is_file():
-            user_file_path = user_file
-            user_toml_loaded = True
-            user_data = _read_toml(user_file)
-            _reject_secrets_from_file(user_data, user_file)
+        active = active_config_file(opts)
+        if active.kind == "toml":
+            user_file_path = active.path
+            user_data = _read_toml(user_file_path)
+            _reject_secrets_from_file(user_data, user_file_path)
             merged = _deep_merge(merged, user_data)
             _record_layer(registry, SourceLayer.USER_FILE, user_data)
-
-        if not user_toml_loaded:
-            legacy_path = opts.legacy_yaml_file or find_legacy_yaml_file()
-            if legacy_path is not None and legacy_path.is_file():
-                legacy_data = load_legacy_yaml_dict(legacy_path)
-                # A legacy YAML may legitimately carry the old plain-text
-                # SQL_PWD; drop it with a warning rather than refusing to load
-                # a file the user did not write in this format.
-                _drop_legacy_secrets(legacy_data, legacy_path)
-                merged = _deep_merge(merged, legacy_data)
-                _record_layer(registry, SourceLayer.USER_FILE, legacy_data)
+        elif active.kind == "legacy":
+            legacy_data = load_legacy_yaml_dict(active.path)
+            # A legacy YAML may legitimately carry the old plain-text
+            # SQL_PWD; drop it with a warning rather than refusing to load
+            # a file the user did not write in this format.
+            _drop_legacy_secrets(legacy_data, active.path)
+            merged = _deep_merge(merged, legacy_data)
+            _record_layer(registry, SourceLayer.USER_FILE, legacy_data)
 
         project_file = opts.project_config_file
         if project_file is None and not opts.skip_files:

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -56,6 +56,15 @@ cellpy info --config
 `--configloc` / `-l` prints the path; `--config` / `-C` dumps resolved values
 with provenance (which layer each setting came from).
 
+`--configloc` names the file cellpy actually reads. If you migrated from cellpy 1
+and kept the old `.cellpy_prms_<user>.conf`, it says so explicitly — the legacy
+file is still on disk but no longer has any effect:
+
+```text
+[cellpy] -> C:\Users\you\AppData\Local\cellpy\cellpy\cellpy.toml
+[cellpy] (legacy C:\Users\you\.cellpy_prms_you.conf is ignored - cellpy.toml takes precedence)
+```
+
 ## Configuration layers
 
 Settings resolve later-over-earlier:

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -81,7 +81,49 @@ def test_info_configloc():
     print()
     print(result.output)
     assert result.exit_code == 0
-    assert "conf" in result.output
+    # Format-agnostic: the reported file may be cellpy.toml or a legacy .conf,
+    # depending on what the machine running the tests has (#851).
+    assert "[cellpy] ->" in result.output
+
+
+def _fake_active_config_file(monkeypatch, active):
+    from cellpy.config import loader
+
+    monkeypatch.setattr(loader, "active_config_file", lambda *a, **kw: active)
+
+
+@pytest.mark.essential
+def test_info_configloc_reports_the_toml(monkeypatch, tmp_path):
+    from cellpy.config.loader import ActiveConfigFile
+
+    toml_file = tmp_path / "cellpy.toml"
+    toml_file.write_text("", encoding="utf-8")
+    _fake_active_config_file(monkeypatch, ActiveConfigFile(path=toml_file, kind="toml"))
+    result = CliRunner().invoke(cli.cli, ["info", "--configloc"])
+    assert result.exit_code == 0
+    assert str(toml_file) in result.output
+    assert "is ignored" not in result.output
+
+
+@pytest.mark.essential
+def test_info_configloc_flags_shadowed_legacy_file(monkeypatch, tmp_path):
+    """After migration, `cellpy info` must not name the dead .conf (#851)."""
+    from cellpy.config.loader import ActiveConfigFile
+
+    toml_file = tmp_path / "cellpy.toml"
+    toml_file.write_text("", encoding="utf-8")
+    legacy = tmp_path / ".cellpy_prms_tester.conf"
+    legacy.write_text("", encoding="utf-8")
+    _fake_active_config_file(
+        monkeypatch,
+        ActiveConfigFile(path=toml_file, kind="toml", shadowed_legacy=legacy),
+    )
+    result = CliRunner().invoke(cli.cli, ["info", "--configloc"])
+    assert result.exit_code == 0
+    assert f"[cellpy] -> {toml_file}" in result.output
+    assert str(legacy) in result.output
+    assert "is ignored" in result.output
+    assert "cellpy.toml takes precedence" in result.output
 
 
 def test_info_no_option():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ import tomllib
 from cellpycore.units import CellpyUnits
 
 from cellpy.config import LoadOptions, override, reload, reset_session, set_load_options, sources
-from cellpy.config.loader import load_config, write_toml
+from cellpy.config.loader import active_config_file, load_config, write_toml
 from cellpy.config.migrate import convert_yaml_to_toml_dict
 from cellpy.config.models import UnitsConfig
 from cellpy.config.sources import SourceLayer
@@ -148,6 +148,88 @@ def test_toml_roundtrip_smoke(tmp_path):
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     assert data["reader"]["cycle_mode"] == "cathode"
     assert data["reader"]["auto_dirs"] is False
+
+
+LEGACY_YAML = """
+Reader:
+  cycle_mode: cathode
+"""
+
+
+def _legacy_file(tmp_path: Path) -> Path:
+    path = tmp_path / ".cellpy_prms_tester.conf"
+    path.write_text(LEGACY_YAML, encoding="utf-8")
+    return path
+
+
+@pytest.mark.essential
+def test_active_config_file_prefers_toml(tmp_path):
+    user_file = tmp_path / "cellpy.toml"
+    write_toml(user_file, {"reader": {"cycle_mode": "lithium"}})
+    active = active_config_file(
+        LoadOptions(
+            user_config_file=user_file,
+            legacy_yaml_file=tmp_path / "nothing-here.conf",
+        )
+    )
+    assert active.kind == "toml"
+    assert active.path == user_file
+    assert active.shadowed_legacy is None
+
+
+@pytest.mark.essential
+def test_active_config_file_falls_back_to_legacy(tmp_path):
+    legacy = _legacy_file(tmp_path)
+    active = active_config_file(
+        LoadOptions(
+            user_config_file=tmp_path / "cellpy.toml",
+            legacy_yaml_file=legacy,
+        )
+    )
+    assert active.kind == "legacy"
+    assert active.path == legacy
+    assert active.shadowed_legacy is None
+
+
+@pytest.mark.essential
+def test_active_config_file_flags_shadowed_legacy(tmp_path):
+    """A migrated user keeps the old .conf; it must be named as ignored (#851)."""
+
+    user_file = tmp_path / "cellpy.toml"
+    write_toml(user_file, {"reader": {"cycle_mode": "lithium"}})
+    legacy = _legacy_file(tmp_path)
+    active = active_config_file(LoadOptions(user_config_file=user_file, legacy_yaml_file=legacy))
+    assert active.kind == "toml"
+    assert active.path == user_file
+    assert active.shadowed_legacy == legacy
+
+
+def test_active_config_file_without_any_file(tmp_path):
+    active = active_config_file(
+        LoadOptions(
+            user_config_file=tmp_path / "cellpy.toml",
+            legacy_yaml_file=tmp_path / "nothing-here.conf",
+        )
+    )
+    assert active.kind == "none"
+    assert active.path is None
+
+
+def test_active_config_file_agrees_with_load_config(tmp_path):
+    """Guard against the helper and the loader drifting apart again (#851)."""
+
+    user_file = tmp_path / "cellpy.toml"
+    write_toml(user_file, {"reader": {"cycle_mode": "lithium"}})
+    legacy = _legacy_file(tmp_path)
+    options = LoadOptions(
+        user_config_file=user_file,
+        legacy_yaml_file=legacy,
+        cwd=tmp_path,
+        skip_env=True,
+    )
+    assert active_config_file(options).path == user_file
+    # ``lithium`` lives only in the TOML, ``cathode`` only in the legacy YAML.
+    assert load_config(options=options).config.reader.cycle_mode == "lithium"
 
 
 def test_yaml_to_toml_converter_minimal():


### PR DESCRIPTION
Closes #851.

## Summary

After `cellpy setup migrate`, the loader correctly preferred the new
`cellpy.toml` but the CLI kept naming the legacy `.cellpy_prms_<user>.conf`:

```
❯ cellpy info
[cellpy] -> C:\Users\jepe\.cellpy_prms_jepe.conf     # ← nothing reads this
```

Root cause: `_configloc()` re-derived the legacy filename via
`prmreader.get_user_dir_and_dst()` instead of asking the loader. Three surfaces
shared it, and two were worse than a wrong printout — `cellpy edit config`
opened the dead file (edits silently did nothing), and `cellpy info --check`
validated the stale YAML's paths.

The fix is one resolver that **both** sides use, so they cannot drift apart
again: `active_config_file()` in `config/loader.py`, which `load_config` now
calls for its own user layer.

- `cellpy info` / `--configloc` reports the winning file and names a shadowed
  legacy one:
  `[cellpy] (legacy ...\.cellpy_prms_jepe.conf is ignored - cellpy.toml takes precedence)`
- `cellpy edit config` opens the live file. This also fixes a **TOML-only**
  install, where `_configloc()` returned `None` and nothing was opened at all.
- `cellpy info --check` validates the resolved `config.paths` — format-agnostic,
  and it is what the runtime actually uses. Accepted trade-off: env/project
  layers are folded in, so `--check` no longer inspects the user file alone.
- `_envloc()` was checked and left alone; it already reads through the resolved
  config.

Precedence itself is unchanged, and legacy-only setups behave exactly as before.

## Test plan

- [x] New in `tests/test_config.py` (3 `essential`): TOML wins, legacy-only
      fallback, shadowed legacy flagged, neither file present, plus an
      anti-drift test that the helper and `load_config` pick the same file.
- [x] New in `tests/test_cellpy_cmd.py` (2 `essential`): `--configloc` reports
      the TOML and prints the shadow notice.
- [x] `test_info_configloc` asserted `"conf" in output`, which a `.toml` path
      fails — now format-agnostic.
- [x] `uv run pytest -m essential` → 684 passed.
- [x] `uv run pytest` → 1532 passed, 3 failed. The 3 (`test_search_for_files*`)
      are pre-existing and re-confirmed failing on a stashed clean tree; they
      need the developer's real `rawdatadir` (an unreachable `scp://` remote).
- [x] Verified end-to-end on the machine that reported it (both files on disk):
      `info` names the TOML, `info --check` succeeds 3/3.

Made with [Cursor](https://cursor.com)