### PR TITLE
feat: refresh_after for meta-dependent summary columns (#846)

### DIFF
--- a/.issueflows/03-solved-issues/issue846_original.md
+++ b/.issueflows/03-solved-issues/issue846_original.md
@@ -1,0 +1,36 @@
+# Issue #846: No selective summary rebuild after metadata edits (mass/area/nom-cap/cycle mode)
+
+Source: https://github.com/jepegit/cellpy/issues/846
+
+## Original issue text
+
+## Problem
+Editing physical metadata after load — mass, active electrode area, nominal
+capacity, cycle mode — requires a **full** `cell.make_summary()`. There's no
+public API to rebuild only the dependent summary columns (e.g. gravimetric
+capacities after a mass change, C-rates after a nominal-capacity change).
+
+There's also no documented **meta → summary-column dependency map**, so an app
+can't do targeted updates or tell the user precisely what a change will affect.
+
+## How it surfaced
+cellpy-simple-gui's "Manage Cells" lets users change these knobs post-load. The
+app assigns `cell.mass` / `cell.active_electrode_area` / `cell.nominal_capacity`
+/ `cell.cycle_mode` and then always calls the full `make_summary()`. Correct,
+but opaque and potentially expensive for large cells, and easy to get subtly
+wrong (which attribute invalidates which column?).
+
+## Suggested fix (either is useful)
+1. Cheap selective-refresh helpers keyed by meta field, e.g.
+   `cell.refresh_after(("mass",))` that recomputes just the affected columns; or
+2. A small documented dependency map / note ("`nominal_capacity` affects
+   `charge_c_rate`, `discharge_c_rate`, normalized cycle index; `mass` affects
+   `*_gravimetric`; `area` affects `*_areal`; …") so GUIs can scope rebuilds
+   and messaging.
+
+Dedicated setters (vs bare attribute assignment) would also help
+discoverability of "what do I call after changing mass?".
+
+
+---
+*Found while building [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) on cellpy 2.1.1.post7. Context: [CELLPY_PAINPOINTS.md §19](https://github.com/cellpy/cellpy-simple-gui/blob/main/CELLPY_PAINPOINTS.md).*

--- a/.issueflows/03-solved-issues/issue846_plan.md
+++ b/.issueflows/03-solved-issues/issue846_plan.md
@@ -1,0 +1,54 @@
+# Plan: #846 selective summary rebuild after metadata edits
+
+## Goal
+
+Give apps (e.g. cellpy-simple-gui) a public meta→summary dependency map and a
+`refresh_after(...)` helper so post-load mass/area/nom-cap/cycle-mode edits
+do not require an opaque full `make_summary()` when a summary already exists.
+
+## Constraints
+
+- Yolo-sized: no new selective column engine; reuse existing
+  `core.add_scaled_summary_columns` seam already used by `_make_summary`.
+- Document **current** behaviour accurately: C-rate columns come from the step
+  table and are **not** derived from `nominal_capacity` (core comment).
+- Keep setters as assignment; point them at `refresh_after` in docstrings.
+- Do not change default `make_summary` behaviour.
+
+### Prior art
+
+- `_make_summary` → `core.make_core_summary` + `core.add_scaled_summary_columns`
+  (`cellpy/readers/cellreader.py`) — scaled path is already the meta-dependent half.
+- `cellpycore.summarizers.generate_specific_summary_columns` /
+  `equivalent_cycles_to_summary` — overwrite via `with_columns` (safe re-run).
+- Toolbox: none relevant.
+
+## Approach
+
+1. Add module-level `SUMMARY_META_DEPENDENCIES` (and alias map) describing what
+   each meta field invalidates / affects.
+2. Add `CellpyCell.refresh_after(fields, **kwargs)`:
+   - normalize field names (`mass`/`active_mass`, `area`/`active_electrode_area`,
+     `nom_cap`/`nominal_capacity`, `cycle_mode`);
+   - if no summary → `make_summary(**kwargs)`;
+   - else recompute `nom_cap_abs` + specific conversion factors and call
+     `core.add_scaled_summary_columns` in place (no `make_core_summary`).
+3. Docstring notes on mass / area / nom_cap / cycle_mode setters.
+4. One paragraph in `docs/getting_started/agents.md`.
+5. Unit tests for map keys + mass change updates gravimetric columns without
+   requiring a full rebuild path assertion.
+
+## Files to touch
+
+- `cellpy/readers/cellreader.py` — map + `refresh_after` + setter docs
+- `docs/getting_started/agents.md` — short usage note
+- `tests/test_refresh_after_meta.py` — new focused tests
+- `.issueflows/01-current-issues/issue846_{plan,status}.md`
+
+## Test strategy
+
+`uv run pytest tests/test_refresh_after_meta.py -q` then `uv run pytest -m essential -q`.
+
+## Open questions
+
+None — batch cycle confirm covers Accept.

--- a/.issueflows/03-solved-issues/issue846_status.md
+++ b/.issueflows/03-solved-issues/issue846_status.md
@@ -1,0 +1,13 @@
+# Status: #846
+
+- [x] Done
+
+## What's done
+
+- `SUMMARY_META_DEPENDENCIES` + `normalize_summary_meta_fields`
+- `CellpyCell.refresh_after` / `_refresh_scaled_summary_columns`
+- Setter docs; agents.md note; tests (1 essential); HISTORY bullet
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -38,6 +38,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_light_import.py::test_info_version_avoids_cellreader_import | yes | yes | cellpy.__init__ / cli / cli_api light path | #837 | subprocess; cellreader must stay out of sys.modules |
 | tests/test_cli_light_import.py::test_setup_default_avoids_cellreader_and_optional_deps | yes | yes | cli_api.setup_config default light | #839 | no cellreader / lmfit |
 | tests/test_cli_light_import.py::test_setup_check_imports_cellreader | yes | yes | cli_api.setup_config --check | #839 | opt-in check loads readers |
+| tests/test_refresh_after_meta.py::test_refresh_after_mass_updates_gravimetric | yes | yes | CellpyCell.refresh_after / SUMMARY_META_DEPENDENCIES | #846 | mass → gravimetric rescale |
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- ``refresh_after`` + ``SUMMARY_META_DEPENDENCIES``: rebuild meta-dependent summary columns after mass / area / nom-cap / cycle-mode edits without a full ``make_summary()``. (#846)
 - ``cellpy info``, ``cellpy edit config`` and ``cellpy info --check`` now act on the config file that is actually loaded (``cellpy.toml`` before a legacy ``.conf``), and name a shadowed legacy file instead of pointing at it. (#851)
 - Atomic ``.cellpy`` / ``.h5`` writes: ``save`` stages next to the destination and replaces it only when complete, so an interrupted save no longer corrupts or destroys the file. (#845)
 - In-memory static figure export: ``collection.to_image`` / ``cellpy.plotting.write_image`` (PNG/SVG/PDF bytes). (#818)

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -68,6 +68,89 @@ from cellpy.readers.cellpy_file import write as cellpy_file_write
 
 DIGITS_C_RATE = 5
 
+# Meta fields that drive scaled / equivalent-cycle summary columns (not the
+# base cycle-end summary from ``make_core_summary``). Used by apps after
+# post-load edits (mass / area / nom-cap / cycle mode) — see ``refresh_after``.
+# C-rate columns come from the step table and are independent of nom_cap.
+SUMMARY_META_DEPENDENCIES = {
+    "mass": {
+        "affects": ("*_gravimetric",),
+        "notes": (
+            "Gravimetric specific columns are absolute × (mass conversion factor). "
+            "Call refresh_after(('mass',)) after changing mass."
+        ),
+    },
+    "active_electrode_area": {
+        "affects": ("*_areal",),
+        "notes": (
+            "Areal specific columns are absolute × (area conversion factor). "
+            "Call refresh_after(('active_electrode_area',)) after changing area."
+        ),
+    },
+    "nominal_capacity": {
+        "affects": (
+            "normalized_cycle_index",
+            "equivalent_full_cycles",
+            "test_cumulated_capacity_throughput",
+        ),
+        "notes": (
+            "Absolute nominal capacity rescales equivalent-cycle / EFC columns. "
+            "charge_c_rate / discharge_c_rate come from the step table and are "
+            "not derived from nominal_capacity."
+        ),
+    },
+    "cycle_mode": {
+        "affects": (
+            "normalized_cycle_index",
+            "equivalent_full_cycles",
+        ),
+        "notes": (
+            "Inverted (anode) cycle_mode selects discharge vs charge capacity "
+            "when deriving equivalent-cycle columns. Plot charge/discharge "
+            "interpretation also depends on cycle_mode."
+        ),
+    },
+}
+
+_SUMMARY_META_FIELD_ALIASES = {
+    "mass": "mass",
+    "active_mass": "mass",
+    "active_electrode_area": "active_electrode_area",
+    "area": "active_electrode_area",
+    "nominal_capacity": "nominal_capacity",
+    "nom_cap": "nominal_capacity",
+    "cycle_mode": "cycle_mode",
+}
+
+
+def normalize_summary_meta_fields(fields=None):
+    """Normalize meta field names for ``SUMMARY_META_DEPENDENCIES`` / ``refresh_after``.
+
+    Args:
+        fields: One field name, an iterable of names, or ``None`` (all keys).
+
+    Returns:
+        tuple: Canonical field names in stable order.
+
+    Raises:
+        ValueError: If a name is not a known meta field / alias.
+    """
+    if fields is None:
+        return tuple(SUMMARY_META_DEPENDENCIES.keys())
+    if isinstance(fields, str):
+        fields = (fields,)
+    seen = []
+    for raw in fields:
+        key = _SUMMARY_META_FIELD_ALIASES.get(str(raw).strip().lower())
+        if key is None:
+            known = ", ".join(sorted(_SUMMARY_META_FIELD_ALIASES))
+            raise ValueError(
+                f"Unknown summary meta field {raw!r}. Expected one of: {known}"
+            )
+        if key not in seen:
+            seen.append(key)
+    return tuple(seen)
+
 
 # TODO: @jepe - new feature - method for assigning new cycle numbers and step numbers
 #   - Sometimes the user forgets to increment the cycle number and it would be good
@@ -409,7 +492,12 @@ class CellpyCell:
 
     @property
     def mass(self):
-        """Returns the mass"""
+        """Active-material mass.
+
+        After changing this on a cell that already has a summary, call
+        ``refresh_after(("mass",))`` (or full ``make_summary()``) so
+        gravimetric summary columns update. See ``SUMMARY_META_DEPENDENCIES``.
+        """
         return self.data.mass
 
     @mass.setter
@@ -418,7 +506,7 @@ class CellpyCell:
 
     @property
     def active_mass(self):
-        """Returns the active mass (same as mass)"""
+        """Active mass (same as ``mass``)."""
         return self.data.mass
 
     @active_mass.setter
@@ -436,7 +524,12 @@ class CellpyCell:
 
     @property
     def active_electrode_area(self):
-        """Returns the area"""
+        """Active electrode area.
+
+        After changing this on a cell that already has a summary, call
+        ``refresh_after(("active_electrode_area",))`` so areal summary
+        columns update. See ``SUMMARY_META_DEPENDENCIES``.
+        """
         return self.data.active_electrode_area
 
     @active_electrode_area.setter
@@ -445,7 +538,7 @@ class CellpyCell:
 
     @property
     def nom_cap(self):
-        """Returns the nominal capacity"""
+        """Nominal capacity (alias of ``nominal_capacity``)."""
         return self.data.nom_cap
 
     @nom_cap.setter
@@ -454,7 +547,13 @@ class CellpyCell:
 
     @property
     def nominal_capacity(self):
-        """Returns the nominal capacity"""
+        """Nominal capacity.
+
+        After changing this on a cell that already has a summary, call
+        ``refresh_after(("nominal_capacity",))`` so equivalent-cycle / EFC
+        columns update. C-rates are not derived from nom_cap — see
+        ``SUMMARY_META_DEPENDENCIES``.
+        """
         return self.data.nom_cap
 
     @nominal_capacity.setter
@@ -788,6 +887,11 @@ class CellpyCell:
     @property
     def cycle_mode(self):
         """The active test's ``cycle_mode`` (scalar).
+
+        After changing this on a cell that already has a summary, call
+        ``refresh_after(("cycle_mode",))`` so equivalent-cycle columns that
+        pick charge vs discharge capacity stay consistent. See
+        ``SUMMARY_META_DEPENDENCIES``.
 
         For per-test access on multi-test objects, use
         ``self.data.get_cycle_mode(test_id)`` / ``set_cycle_mode`` and the
@@ -3644,6 +3748,102 @@ class CellpyCell:
         return last_items
 
     # ----------making-summary------------------------------------------------------
+    def refresh_after(self, fields=None, **kwargs):
+        """Rebuild meta-dependent summary columns after editing cell metadata.
+
+        Prefer this over a full ``make_summary()`` when only mass, electrode
+        area, nominal capacity, or cycle mode changed and a summary already
+        exists. Re-runs the scaled / equivalent-cycle half of the summary
+        pipeline (``core.add_scaled_summary_columns``) without rebuilding the
+        base cycle-end table. Falls back to ``make_summary`` when no summary
+        is present.
+
+        See ``SUMMARY_META_DEPENDENCIES`` for the meta → column map apps can
+        use for messaging / UI scope.
+
+        Args:
+            fields: Meta field name(s) that changed. Accepted names and
+                aliases: ``mass`` / ``active_mass``, ``active_electrode_area``
+                / ``area``, ``nominal_capacity`` / ``nom_cap``, ``cycle_mode``.
+                If omitted, all meta-dependent scaled columns are refreshed.
+            **kwargs: Forwarded to ``make_summary`` when no summary exists yet.
+                ``normalization_cycles``, ``nom_cap``, and ``nom_cap_specifics``
+                are also honoured on the selective path.
+
+        Returns:
+            self (chainable).
+
+        Raises:
+            ValueError: If ``fields`` contains an unknown name.
+        """
+        normalize_summary_meta_fields(fields)  # validate early
+        try:
+            data = self.data
+        except NoDataFound:
+            logging.info("Empty test (no data found)")
+            return self
+
+        summary = getattr(data, "summary", None)
+        if summary is None or getattr(summary, "empty", False):
+            return self.make_summary(**kwargs)
+
+        self._refresh_scaled_summary_columns(
+            normalization_cycles=kwargs.get("normalization_cycles"),
+            nom_cap=kwargs.get("nom_cap"),
+            nom_cap_specifics=kwargs.get("nom_cap_specifics"),
+        )
+        return self
+
+    def _resolve_nom_cap_abs(self, data, nom_cap=None, nom_cap_specifics=None):
+        """Resolve absolute nominal capacity from cell meta / overrides."""
+        if nom_cap_specifics is None:
+            nom_cap_specifics = self.nom_cap_specifics
+        if nom_cap is None:
+            nom_cap = data.nom_cap
+        mass = data.mass or 1.0
+        if nom_cap_specifics == "gravimetric":
+            return self.nominal_capacity_as_absolute(nom_cap, mass, nom_cap_specifics)
+        if nom_cap_specifics == "areal":
+            return self.nominal_capacity_as_absolute(
+                nom_cap, data.active_electrode_area, nom_cap_specifics
+            )
+        if nom_cap_specifics == "absolute":
+            return self.nominal_capacity_as_absolute(nom_cap, 1.0, nom_cap_specifics)
+        if nom_cap_specifics == "volumetric":
+            return self.nominal_capacity_as_absolute(
+                nom_cap, data.volume, nom_cap_specifics
+            )
+        raise ValueError(f"Unknown nom_cap_specifics: {nom_cap_specifics!r}")
+
+    def _refresh_scaled_summary_columns(
+        self,
+        normalization_cycles=None,
+        nom_cap=None,
+        nom_cap_specifics=None,
+    ):
+        """Recompute meta-dependent summary columns in place."""
+        self._guard_mixed_cycle_modes()
+        data = self.data
+        specifics = ["gravimetric", "areal", "absolute"]
+        nom_cap_abs = self._resolve_nom_cap_abs(
+            data, nom_cap=nom_cap, nom_cap_specifics=nom_cap_specifics
+        )
+        specific_conversion_factors = {
+            mode: self.get_converter_to_specific(
+                dataset=data, mode=mode, to_units=self.cellpy_units
+            )
+            for mode in specifics
+        }
+        data = self.core.add_scaled_summary_columns(
+            data,
+            nom_cap_abs=nom_cap_abs,
+            normalization_cycles=normalization_cycles,
+            specifics=specifics,
+            specific_conversion_factors=specific_conversion_factors,
+        )
+        self.data = data
+        return data
+
     def make_summary(
         self,
         find_ir=False,
@@ -3663,6 +3863,10 @@ class CellpyCell:
         **kwargs,
     ):
         """Convenience function that makes a summary of the cycling data.
+
+        After editing mass / area / nominal capacity / cycle mode on a cell
+        that already has a summary, prefer ``refresh_after(...)`` over a full
+        rebuild when only those meta-dependent columns need updating.
 
         Args:
             find_ir (bool): if True, the internal resistance will be calculated.

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -120,6 +120,11 @@ Useful methods on `CellpyCell` (non-exhaustive):
 - `get_cycle_numbers()` — list of cycle indices
 - `get_cap(...)` / capacity–voltage style extracts (see API / examples)
 - `make_step_table()` / `make_summary()` — usually already run by `get`
+- `refresh_after(("mass",))` — after editing mass / area / `nominal_capacity` /
+  `cycle_mode` on a cell that already has a summary, rebuild only the
+  meta-dependent columns (cheaper than a full `make_summary()`). See
+  `cellpy.readers.cellreader.SUMMARY_META_DEPENDENCIES` for the map GUIs
+  can use for messaging.
 - `save` / `to_csv` / Excel helpers — persist for the user's workflow
 
 Deeper shape docs: [Data structure](../fundamentals/data_structure.md).

--- a/tests/test_refresh_after_meta.py
+++ b/tests/test_refresh_after_meta.py
@@ -1,0 +1,57 @@
+"""Tests for SUMMARY_META_DEPENDENCIES and CellpyCell.refresh_after (#846)."""
+
+import pytest
+
+from cellpy.readers.cellreader import (
+    SUMMARY_META_DEPENDENCIES,
+    normalize_summary_meta_fields,
+)
+
+
+def test_summary_meta_dependencies_keys():
+    assert set(SUMMARY_META_DEPENDENCIES) == {
+        "mass",
+        "active_electrode_area",
+        "nominal_capacity",
+        "cycle_mode",
+    }
+    for entry in SUMMARY_META_DEPENDENCIES.values():
+        assert entry["affects"]
+        assert entry["notes"]
+
+
+def test_normalize_summary_meta_fields_aliases():
+    assert normalize_summary_meta_fields("active_mass") == ("mass",)
+    assert normalize_summary_meta_fields(("area", "nom_cap")) == (
+        "active_electrode_area",
+        "nominal_capacity",
+    )
+    assert normalize_summary_meta_fields(None) == tuple(SUMMARY_META_DEPENDENCIES)
+
+
+def test_normalize_summary_meta_fields_unknown():
+    with pytest.raises(ValueError, match="Unknown summary meta field"):
+        normalize_summary_meta_fields("temperature")
+
+
+@pytest.mark.essential
+def test_refresh_after_mass_updates_gravimetric(dataset):
+    h = dataset.schema.summary
+    grav_col = f"{h.charge_capacity}_gravimetric"
+    assert grav_col in dataset.data.summary.columns
+
+    before = dataset.data.summary[grav_col].copy()
+    old_mass = float(dataset.mass)
+    dataset.mass = old_mass * 2.0
+    dataset.refresh_after(("mass",))
+
+    after = dataset.data.summary[grav_col]
+    # Doubling mass halves gravimetric capacity (factor ∝ 1/mass).
+    ratio = (before / after).dropna()
+    assert ratio.notna().any()
+    assert (ratio - 2.0).abs().max() < 1e-6
+
+
+def test_refresh_after_unknown_field_raises(dataset):
+    with pytest.raises(ValueError, match="Unknown summary meta field"):
+        dataset.refresh_after(("temperature",))


### PR DESCRIPTION
## Summary
- Add `SUMMARY_META_DEPENDENCIES` and `CellpyCell.refresh_after(...)` so post-load mass/area/nom-cap/cycle-mode edits rebuild only the scaled summary half (via `add_scaled_summary_columns`) instead of a full `make_summary()`.
- Document the map for GUI messaging; note that C-rates come from the step table and are independent of `nominal_capacity`.
- Agents docs + essential test for mass → gravimetric rescale.

Closes #846

## Test plan
- [x] `uv run pytest tests/test_refresh_after_meta.py -q`
- [x] `uv run pytest -m essential -q`

Made with [Cursor](https://cursor.com)