### PR TITLE
fix(config): scrub instrument SQL credentials from TOML (#849)

### DIFF
--- a/.issueflows/03-solved-issues/issue849_original.md
+++ b/.issueflows/03-solved-issues/issue849_original.md
@@ -1,0 +1,65 @@
+# Issue #849: config: model_dump_for_file() writes legacy Arbin SQL credentials in plaintext
+
+Source: https://github.com/jepegit/cellpy/issues/849
+
+## Original issue text
+
+**cellpy version:** 2.1.2a2
+
+## Summary
+
+`CellpyConfig.model_dump_for_file()` is documented as *"Dump config suitable for TOML persistence (secrets excluded)"*, and it does drop the `[secrets]` section. But `ArbinConfig` (and the other instrument models) are `model_config = ConfigDict(extra="allow")`, so the **legacy** Arbin SQL credentials — `SQL_PWD`, `SQL_UID` — pass straight through and get written to `cellpy.toml` in plaintext.
+
+The asymmetry is the dangerous part: a hand-written `[secrets]` block is correctly rejected on load, but the same credential smuggled in under `[instruments.Arbin]` is written **and** silently accepted on reload.
+
+## Reproduction
+
+```python
+import tempfile
+from pathlib import Path
+from cellpy.config.models import CellpyConfig
+from cellpy.config.loader import write_toml, load_config, LoadOptions
+
+tmp = Path(tempfile.mkdtemp())
+toml_path = tmp / "cellpy.toml"
+
+cfg = CellpyConfig.model_validate(
+    {"instruments": {"Arbin": {"SQL_PWD": "hunter2", "SQL_UID": "jepe"}}}
+)
+
+write_toml(toml_path, cfg.model_dump_for_file())      # the "secrets excluded" dump
+print("hunter2" in toml_path.read_text())             # -> True
+
+res = load_config(None, LoadOptions(user_config_file=toml_path, skip_env=True))
+print(res.config.instruments.Arbin.SQL_PWD)           # -> hunter2   (no error)
+```
+
+Output:
+
+```
+written TOML contains plaintext password: True
+['SQL_PWD = "hunter2"', 'SQL_UID = "jepe"']
+reload accepted the file (no ConfigurationError)
+value round-tripped: hunter2
+[secrets] correctly rejected: ConfigurationError
+```
+
+## Why this bites app developers
+
+This is on the realistic migration path, not a contrived one:
+
+1. A user has a legacy `.cellpy_prms_*.conf` with a real `Instruments.Arbin.SQL_PWD`.
+2. The legacy loader merges it (`_drop_legacy_secrets` only pops the top-level `secrets` key, so `instruments.Arbin.SQL_PWD` survives).
+3. Any app offering a **Settings → Save** button calls the documented secrets-safe dump…
+4. …and writes the user's database password to `%LOCALAPPDATA%\cellpy\cellpy\cellpy.toml` — a file they'd reasonably share, sync, or commit alongside a project.
+
+We hit this while designing a settings UI for [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui); we now have to scrub `instruments.*.SQL_*` ourselves before writing, which is exactly the kind of thing the `model_dump_for_file()` contract should be handling.
+
+## Suggested fixes (any one would do)
+
+- **Map on legacy load** — translate `Instruments.Arbin.SQL_PWD`/`SQL_UID`/`SQL_server` into the `secrets` section during YAML migration, so they land in the one place that already knows they're credentials.
+- **Scrub on dump** — strip known credential-ish keys (`*PWD*`, `*UID*`, `*password*`) from instrument sections in `model_dump_for_file()`.
+- **Type them** — declare `SQL_PWD` on `ArbinConfig` as `SecretStr | None` with `exclude=True` rather than letting it ride in on `extra="allow"`.
+- **Symmetric guard** — have `_reject_secrets_from_file` (or a warning) also catch credential keys in instrument sections, so a file that does contain one is not silently honoured.
+
+Happy to send a PR if you have a preference on which route.

--- a/.issueflows/03-solved-issues/issue849_plan.md
+++ b/.issueflows/03-solved-issues/issue849_plan.md
@@ -1,0 +1,46 @@
+# Plan: #849 scrub instrument credentials from file dump
+
+## Goal
+
+Honour `model_dump_for_file()` contract: never write legacy Arbin `SQL_PWD` /
+`SQL_UID` (or other credential-ish instrument keys) to `cellpy.toml`, and stop
+silently accepting them on TOML load.
+
+## Constraints
+
+- Env-only secrets stay the rule (existing `[secrets]` rejection).
+- Legacy YAML migration: drop instrument credential keys with a warning (do
+  not strand users), same spirit as `_drop_legacy_secrets`.
+- KISS: scrub/reject known keys; do not redesign `ArbinConfig` as SecretStr in
+  this issue.
+
+### Prior art
+
+- `CellpyConfig.model_dump_for_file` — pops `[secrets]` only today.
+- `_reject_secrets_from_file` / `_drop_legacy_secrets` in `loader.py`.
+- `tests/test_config_secrets.py` — essential suite for this contract.
+
+## Approach
+
+1. Shared helper listing credential-ish instrument keys (`SQL_PWD`, `SQL_UID`,
+   `*PASSWORD*`, `*_PWD` / `PWD` suffixes).
+2. `model_dump_for_file`: deep-scrub instruments before return.
+3. TOML load: reject those keys with `ConfigurationError` (symmetric to
+   `[secrets]`).
+4. Legacy YAML: pop + warn.
+5. Extend `test_config_secrets.py` with the issue reproduction.
+
+## Files to touch
+
+- `cellpy/config/models.py` — scrub in dump
+- `cellpy/config/loader.py` — reject / drop on load
+- `tests/test_config_secrets.py` — new essential cases
+- issue tracking + HISTORY
+
+## Test strategy
+
+`uv run pytest tests/test_config_secrets.py -q` then `uv run pytest -m essential -q`.
+
+## Open questions
+
+None.

--- a/.issueflows/03-solved-issues/issue849_status.md
+++ b/.issueflows/03-solved-issues/issue849_status.md
@@ -1,0 +1,13 @@
+# Status: #849
+
+- [x] Done
+
+## What's done
+
+- Scrub instrument credential keys in `model_dump_for_file`
+- Reject those keys on TOML load; drop+warn on legacy YAML
+- Essential tests + HISTORY
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -39,6 +39,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_light_import.py::test_setup_default_avoids_cellreader_and_optional_deps | yes | yes | cli_api.setup_config default light | #839 | no cellreader / lmfit |
 | tests/test_cli_light_import.py::test_setup_check_imports_cellreader | yes | yes | cli_api.setup_config --check | #839 | opt-in check loads readers |
 | tests/test_refresh_after_meta.py::test_refresh_after_mass_updates_gravimetric | yes | yes | CellpyCell.refresh_after / SUMMARY_META_DEPENDENCIES | #846 | mass → gravimetric rescale |
+| tests/test_config_secrets.py::test_legacy_arbin_sql_credentials_are_not_in_the_file_dump | yes | yes | CellpyConfig.model_dump_for_file scrub | #849 | SQL_PWD/UID stripped |
+| tests/test_config_secrets.py::test_instrument_credentials_in_a_user_toml_are_rejected | yes | yes | loader instrument credential reject | #849 | TOML load guard |
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Config file dump/load no longer persist or accept legacy Arbin ``SQL_PWD`` / ``SQL_UID`` under ``[instruments]`` (env-only credentials). (#849)
 - ``refresh_after`` + ``SUMMARY_META_DEPENDENCIES``: rebuild meta-dependent summary columns after mass / area / nom-cap / cycle-mode edits without a full ``make_summary()``. (#846)
 - ``cellpy info``, ``cellpy edit config`` and ``cellpy info --check`` now act on the config file that is actually loaded (``cellpy.toml`` before a legacy ``.conf``), and name a shadowed legacy file instead of pointing at it. (#851)
 - Atomic ``.cellpy`` / ``.h5`` writes: ``save`` stages next to the destination and replaces it only when complete, so an interrupted save no longer corrupts or destroys the file. (#845)

--- a/cellpy/config/loader.py
+++ b/cellpy/config/loader.py
@@ -16,7 +16,7 @@ import platformdirs
 # signal to re-declare it in pyproject.toml.
 from dotenv import dotenv_values
 
-from cellpy.config.models import CellpyConfig
+from cellpy.config.models import CellpyConfig, is_instrument_credential_key
 from cellpy.config.sources import ProvenanceRegistry, SourceLayer
 from cellpy.exceptions import ConfigurationError
 
@@ -214,6 +214,33 @@ def _reject_secrets_from_file(data: dict[str, Any], path: Path) -> None:
     )
 
 
+def _reject_instrument_credentials_from_file(data: dict[str, Any], path: Path) -> None:
+    """Refuse credential-ish keys under ``[instruments.*]`` in a TOML file.
+
+    Legacy Arbin ``SQL_PWD`` / ``SQL_UID`` used to ride in on ``extra=\"allow\"``
+    and round-trip through ``model_dump_for_file``. Reject them on load the
+    same way ``[secrets]`` is rejected — use ``CELLPY_PASSWORD`` / ``CELLPY_USER``.
+    """
+    instruments = data.get("instruments")
+    if not isinstance(instruments, dict):
+        return
+    found: list[str] = []
+    for name, section in instruments.items():
+        if not isinstance(section, dict):
+            continue
+        for key in section:
+            if is_instrument_credential_key(key):
+                found.append(f"instruments.{name}.{key}")
+    if not found:
+        return
+    raise ConfigurationError(
+        f"{path} contains credential keys under [instruments] "
+        f"({', '.join(sorted(found))}). Credentials are read from the "
+        f"environment only — set CELLPY_PASSWORD / CELLPY_USER (and related "
+        f"CELLPY_* vars) instead, and remove those keys from the file."
+    )
+
+
 def _drop_legacy_secrets(data: dict[str, Any], path: Path) -> None:
     """Strip credentials from a *legacy YAML* layer, in place, with a warning.
 
@@ -230,6 +257,24 @@ def _drop_legacy_secrets(data: dict[str, Any], path: Path) -> None:
             ", ".join(sorted(secrets)) if isinstance(secrets, dict) else "secrets",
             ", ".join(sorted(_LEGACY_SECRET_ENV.values())),
         )
+    instruments = data.get("instruments")
+    if isinstance(instruments, dict):
+        dropped: list[str] = []
+        for name, section in instruments.items():
+            if not isinstance(section, dict):
+                continue
+            for key in list(section):
+                if is_instrument_credential_key(key):
+                    section.pop(key, None)
+                    dropped.append(f"instruments.{name}.{key}")
+        if dropped:
+            logging.warning(
+                "%s carries instrument credentials (%s); these are ignored — "
+                "cellpy 2 reads them from the environment only (%s).",
+                path,
+                ", ".join(sorted(dropped)),
+                ", ".join(sorted(_LEGACY_SECRET_ENV.values())),
+            )
 
 
 def load_config(
@@ -254,6 +299,7 @@ def load_config(
             user_file_path = active.path
             user_data = _read_toml(user_file_path)
             _reject_secrets_from_file(user_data, user_file_path)
+            _reject_instrument_credentials_from_file(user_data, user_file_path)
             merged = _deep_merge(merged, user_data)
             _record_layer(registry, SourceLayer.USER_FILE, user_data)
         elif active.kind == "legacy":
@@ -275,6 +321,7 @@ def load_config(
         ):
             project_data = _read_toml(project_file)
             _reject_secrets_from_file(project_data, project_file)
+            _reject_instrument_credentials_from_file(project_data, project_file)
             merged = _deep_merge(merged, project_data)
             _record_layer(registry, SourceLayer.PROJECT_FILE, project_data)
 

--- a/cellpy/config/models.py
+++ b/cellpy/config/models.py
@@ -10,6 +10,45 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from cellpy.config.types import LimitLoadedCycles, OtherPathField, PathField
 
+
+def is_instrument_credential_key(key: str) -> bool:
+    """Return True for credential-ish keys under ``instruments.*``.
+
+    Legacy Arbin SQL settings (``SQL_PWD``, ``SQL_UID``) and generic password
+    keys must never persist in TOML. Host / driver / server names are not
+    credentials.
+    """
+    upper = str(key).upper()
+    if upper in {"SQL_PWD", "SQL_UID"}:
+        return True
+    if "PASSWORD" in upper:
+        return True
+    if upper.endswith("_PWD") or upper.endswith("PWD"):
+        return True
+    return False
+
+
+def scrub_instrument_credentials(data: dict[str, Any]) -> dict[str, Any]:
+    """Remove credential-ish keys from ``instruments`` sections in place.
+
+    Args:
+        data: A config dict (typically a ``model_dump`` result).
+
+    Returns:
+        The same dict, mutated.
+    """
+    instruments = data.get("instruments")
+    if not isinstance(instruments, dict):
+        return data
+    for section in instruments.values():
+        if not isinstance(section, dict):
+            continue
+        for key in list(section):
+            if is_instrument_credential_key(key):
+                section.pop(key, None)
+    return data
+
+
 class PathsConfig(BaseModel):
     """Paths used in cellpy."""
 
@@ -295,10 +334,16 @@ class CellpyConfig(BaseModel):
     secrets: SecretsConfig = Field(default_factory=SecretsConfig)
 
     def model_dump_for_file(self) -> dict[str, Any]:
-        """Dump config suitable for TOML persistence (secrets excluded)."""
+        """Dump config suitable for TOML persistence (secrets excluded).
+
+        Drops the ``[secrets]`` section and strips credential-ish keys from
+        ``instruments.*`` (legacy Arbin ``SQL_PWD`` / ``SQL_UID``, etc.) so a
+        Settings → Save path cannot write plaintext database credentials.
+        """
 
         data = self.model_dump(mode="json")
         data.pop("secrets", None)
+        scrub_instrument_credentials(data)
         return data
 
 

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -63,6 +63,34 @@ def test_password_is_not_in_the_file_dump():
 
 
 @pytest.mark.essential
+def test_legacy_arbin_sql_credentials_are_not_in_the_file_dump():
+    """extra=allow must not let SQL_PWD / SQL_UID round-trip into TOML (#849)."""
+    cfg = CellpyConfig.model_validate(
+        {"instruments": {"Arbin": {"SQL_PWD": "hunter2", "SQL_UID": "jepe", "SQL_server": "localhost"}}}
+    )
+    dumped = cfg.model_dump_for_file()
+    arbin = dumped["instruments"]["Arbin"]
+    assert "SQL_PWD" not in arbin
+    assert "SQL_UID" not in arbin
+    assert arbin.get("SQL_server") == "localhost"
+    assert "hunter2" not in str(dumped)
+
+
+@pytest.mark.essential
+def test_instrument_credentials_in_a_user_toml_are_rejected(tmp_path):
+    path = tmp_path / "cellpy.toml"
+    write_toml(path, {"instruments": {"Arbin": {"SQL_PWD": "hunter2"}}})
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        load_config(options=LoadOptions(user_config_file=path, skip_env=True))
+
+    message = str(excinfo.value)
+    assert "SQL_PWD" in message
+    assert "CELLPY_PASSWORD" in message
+    assert "hunter2" not in message
+
+
+@pytest.mark.essential
 def test_password_comes_out_on_request():
     secrets = SecretsConfig(password="hunter2")
     assert secrets.get_password() == "hunter2"


### PR DESCRIPTION
## Summary
- `model_dump_for_file()` strips credential-ish keys under `instruments.*` (legacy Arbin `SQL_PWD` / `SQL_UID`).
- TOML load rejects those keys (symmetric to `[secrets]`); legacy YAML drops them with a warning.

Closes #849

## Test plan
- [x] `uv run pytest tests/test_config_secrets.py -q`
- [ ] CI essential / full

Made with [Cursor](https://cursor.com)