### PR TITLE
fix(config): thread-local override() via contextvars (#850)

### DIFF
--- a/.issueflows/03-solved-issues/issue850_original.md
+++ b/.issueflows/03-solved-issues/issue850_original.md
@@ -1,0 +1,53 @@
+# Issue #850: config: override() is process-global and not thread-safe (cross-talk in threaded apps)
+
+Source: https://github.com/jepegit/cellpy/issues/850
+
+## Original issue text
+
+**cellpy version:** 2.1.2a2
+
+## Summary
+
+`cellpy.config.override()` reads as a scoped, reentrant context manager, but it mutates a module-level `_override_stack` and swaps the global `_session` via `reload()`. In a threaded application, one thread's "scoped" override is visible to every other thread, and the `finally: pop + reload` can land while another thread is still inside its own block.
+
+## Reproduction
+
+```python
+import time
+from concurrent.futures import ThreadPoolExecutor
+from cellpy import config
+
+def worker(mode):
+    with config.override(reader={"cycle_mode": mode}):
+        time.sleep(0.05)                       # let the two blocks interleave
+        return mode, config.get_config().reader.cycle_mode
+
+with ThreadPoolExecutor(max_workers=2) as ex:
+    print(list(ex.map(worker, ["anode", "cathode"])))
+```
+
+Result:
+
+```
+[('anode', 'anode'), ('cathode', 'anode')]
+```
+
+The `cathode` worker observes `anode` **inside its own `override()` block**. Each worker should see the value it asked for.
+
+## Why this bites app developers
+
+Any GUI/service that runs cellpy work off the request thread hits this. In [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) loads/exports run in a `ThreadPoolExecutor`, so the natural pattern — "override `reader.cycle_mode` / `units` for *this* job" — is quietly racy: two concurrent jobs can silently compute with each other's settings, and the result is wrong numbers rather than an exception. That failure mode is much worse than a crash, because nothing signals it.
+
+Our workaround is to resolve config on the main thread and pass concrete values into the job, and to treat `override()` as main-thread-only. That works, but it means the config stack can't be used for per-job policy at all.
+
+## Suggested fix
+
+Back the override stack (and ideally the session) with a **`contextvars.ContextVar`** rather than a module global:
+
+- `ContextVar` isolation is per-thread *and* per-async-task, so it fixes threaded apps and any future async usage in one move.
+- `copy_context()` semantics also make the intent ("scoped to this unit of work") actually true.
+- Worth pairing with a note in the configuration docs about which parts of the stack are process-global (`reload`, `set_load_options`) versus scoped.
+
+If a full `ContextVar` migration is too invasive for a patch release, an interim step would be documenting `override()` as process-global/not thread-safe and adding a `threading.RLock` around the stack mutation + reload, so at least the stack cannot be corrupted.
+
+Happy to send a PR if you'd like the `ContextVar` version.

--- a/.issueflows/03-solved-issues/issue850_plan.md
+++ b/.issueflows/03-solved-issues/issue850_plan.md
@@ -1,0 +1,44 @@
+# Plan: #850 thread-safe config.override via ContextVar
+
+## Goal
+
+Make `config.override()` scoped per thread / async task so concurrent jobs
+cannot observe each other's overrides.
+
+## Constraints
+
+- Keep nested LIFO stacking and existing tests in `tests/test_config.py`.
+- `reload` / `set_load_options` stay process-global (document in docstring).
+- Yolo-sized: ContextVar for override stack + active config; do not
+  ContextVar-migrate the whole session.
+
+### Prior art
+
+- `cellpy/config/session.py` — `_override_stack` + `reload()` swap global `_session`.
+- `tests/test_config.py` — nested override + essential fixture.
+
+## Approach
+
+1. Replace module `_override_stack` with `ContextVar` tuple stack +
+   `ContextVar` for the active overridden `CellpyConfig`.
+2. `get_config()` returns context config when set, else session config.
+3. `override()` pushes stack, builds config via deep-merge on
+   `session.config.model_dump()` + `CellpyConfig.model_validate`, yields it;
+   no global `_session` swap.
+4. `reload()` rebuilds global session **without** applying the override stack;
+   if currently inside an override, refresh the context-local config.
+5. Threaded regression test matching the issue reproduction.
+
+## Files to touch
+
+- `cellpy/config/session.py`
+- `tests/test_config.py`
+- HISTORY + issue tracking
+
+## Test strategy
+
+`uv run pytest tests/test_config.py -q` then `uv run pytest -m essential -q`.
+
+## Open questions
+
+None.

--- a/.issueflows/03-solved-issues/issue850_status.md
+++ b/.issueflows/03-solved-issues/issue850_status.md
@@ -1,0 +1,13 @@
+# Status: #850
+
+- [x] Done
+
+## What's done
+
+- ContextVar override stack + context-local config
+- Thread isolation essential test
+- HISTORY
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -41,6 +41,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_refresh_after_meta.py::test_refresh_after_mass_updates_gravimetric | yes | yes | CellpyCell.refresh_after / SUMMARY_META_DEPENDENCIES | #846 | mass → gravimetric rescale |
 | tests/test_config_secrets.py::test_legacy_arbin_sql_credentials_are_not_in_the_file_dump | yes | yes | CellpyConfig.model_dump_for_file scrub | #849 | SQL_PWD/UID stripped |
 | tests/test_config_secrets.py::test_instrument_credentials_in_a_user_toml_are_rejected | yes | yes | loader instrument credential reject | #849 | TOML load guard |
+| tests/test_config.py::test_config_override_is_thread_isolated | yes | yes | config.session.override ContextVar | #850 | ThreadPoolExecutor isolation |
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- ``config.override()`` is thread-/task-local via ``contextvars`` (no cross-talk between concurrent jobs). (#850)
 - Config file dump/load no longer persist or accept legacy Arbin ``SQL_PWD`` / ``SQL_UID`` under ``[instruments]`` (env-only credentials). (#849)
 - ``refresh_after`` + ``SUMMARY_META_DEPENDENCIES``: rebuild meta-dependent summary columns after mass / area / nom-cap / cycle-mode edits without a full ``make_summary()``. (#846)
 - ``cellpy info``, ``cellpy edit config`` and ``cellpy info --check`` now act on the config file that is actually loaded (``cellpy.toml`` before a legacy ``.conf``), and name a shadowed legacy file instead of pointing at it. (#851)

--- a/cellpy/config/session.py
+++ b/cellpy/config/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import deepcopy
 from typing import Any, Iterator
 
@@ -11,8 +12,17 @@ from cellpy.config.models import CellpyConfig
 from cellpy.config.sources import ProvenanceRegistry
 
 _session: LoadResult | None = None
-_override_stack: list[dict[str, Any]] = []
 _load_options: LoadOptions | None = None
+
+# Per-thread / per-async-task override state. The process-global ``_session``
+# stays the unloaded base; ``override()`` must not mutate it or concurrent
+# workers cross-talk (#850).
+_override_stack_var: ContextVar[tuple[dict[str, Any], ...]] = ContextVar(
+    "cellpy_config_override_stack", default=()
+)
+_override_config_var: ContextVar[CellpyConfig | None] = ContextVar(
+    "cellpy_config_override_config", default=None
+)
 
 
 def _get_session() -> LoadResult:
@@ -23,6 +33,9 @@ def _get_session() -> LoadResult:
 
 
 def get_config() -> CellpyConfig:
+    overridden = _override_config_var.get()
+    if overridden is not None:
+        return overridden
     return _get_session().config
 
 
@@ -39,28 +52,32 @@ def reload(
     *,
     options: LoadOptions | None = None,
 ) -> CellpyConfig:
-    """Explicit (re)load from layered sources."""
+    """Explicit (re)load from layered sources into the process-global session.
+
+    Runtime ``override()`` layers are context-local and are not baked into the
+    global session. If called while an ``override()`` block is active in this
+    context, the context-local config is rebuilt on top of the new session.
+    """
 
     global _session, _load_options
     if options is not None:
         _load_options = options
     opts = _load_options or LoadOptions()
-    merged_overrides: dict[str, Any] = {}
-    for layer in _override_stack:
-        merged_overrides = _merge_dicts(merged_overrides, layer)
-    if overrides:
-        merged_overrides = _merge_dicts(merged_overrides, overrides)
-    _session = load_config(merged_overrides or None, opts)
-    return _session.config
+    _session = load_config(overrides, opts)
+    stack = _override_stack_var.get()
+    if stack:
+        _override_config_var.set(_config_with_overrides(stack))
+    return get_config()
 
 
 def reset_session() -> None:
     """Clear cached config (tests)."""
 
-    global _session, _override_stack, _load_options
+    global _session, _load_options
     _session = None
-    _override_stack = []
     _load_options = None
+    _override_stack_var.set(())
+    _override_config_var.set(None)
 
 
 def set_load_options(options: LoadOptions | None) -> None:
@@ -70,16 +87,35 @@ def set_load_options(options: LoadOptions | None) -> None:
 
 @contextmanager
 def override(**sections: Any) -> Iterator[CellpyConfig]:
-    """Scoped runtime overrides (stacked, LIFO restore)."""
+    """Scoped runtime overrides (stacked, LIFO restore).
+
+    Isolation is per thread and per asyncio task via ``contextvars``. Nested
+    ``override()`` blocks in the same context still stack. Concurrent threads
+    each see only their own layers.
+
+    Note:
+        ``reload()`` and ``set_load_options()`` remain process-global.
+    """
 
     payload = {key: value for key, value in sections.items() if value is not None}
-    _override_stack.append(payload)
+    stack = _override_stack_var.get() + (payload,)
+    token_stack = _override_stack_var.set(stack)
+    cfg = _config_with_overrides(stack)
+    token_cfg = _override_config_var.set(cfg)
     try:
-        reload()
-        yield get_config()
+        yield cfg
     finally:
-        _override_stack.pop()
-        reload()
+        _override_config_var.reset(token_cfg)
+        _override_stack_var.reset(token_stack)
+
+
+def _config_with_overrides(stack: tuple[dict[str, Any], ...]) -> CellpyConfig:
+    """Build a CellpyConfig from the session base plus context override layers."""
+
+    data = _get_session().config.model_dump(mode="python")
+    for layer in stack:
+        data = _merge_dicts(data, layer)
+    return CellpyConfig.model_validate(data)
 
 
 def _merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,26 @@ def test_config_override_nested_stack():
         assert reader_outer.cycle_mode == "cathode"
 
 
+@pytest.mark.essential
+def test_config_override_is_thread_isolated():
+    """Concurrent override() blocks must not cross-talk (#850)."""
+
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    from cellpy import config
+
+    def worker(mode: str) -> tuple[str, str]:
+        with config.override(reader={"cycle_mode": mode}):
+            time.sleep(0.05)
+            return mode, config.get_config().reader.cycle_mode
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        results = list(ex.map(worker, ["anode", "cathode"]))
+
+    assert sorted(results) == [("anode", "anode"), ("cathode", "cathode")]
+
+
 def test_loader_user_file_overrides_default(tmp_path, monkeypatch):
     user_file = tmp_path / "cellpy.toml"
     write_toml(user_file, {"reader": {"cycle_mode": "cathode"}})


### PR DESCRIPTION
## Summary
- Back `config.override()` with `contextvars` so each thread/async task gets its own override stack and config view.
- Process-global `reload()` / `set_load_options()` stay global; documented on `override()`.

Closes #850

## Test plan
- [x] `uv run pytest tests/test_config.py -q` (includes ThreadPoolExecutor isolation)
- [ ] CI essential / full

Made with [Cursor](https://cursor.com)