### PR TITLE
chore: ignore stray test leftovers (#855)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ tmp/
 #testdata/hdf5/20160306_snx001_10_cc_01.h5
 # testdata/batchfiles/cellpy_batch_test.json
 
+# Stray local leftovers (not essential-suite tmp_path output; do not commit) (#855)
+/cellpy_batch_test_batch.json
+/testdata/hdf5/20160805_test001_45_cc.cellpy
+
 dev_data/
 dev_data/tmp
 dev_data/bugfixing

--- a/.issueflows/03-solved-issues/issue855_original.md
+++ b/.issueflows/03-solved-issues/issue855_original.md
@@ -1,0 +1,9 @@
+# Issue #855: add test generated files to gitignore
+
+Source: https://github.com/jepegit/cellpy/issues/855
+
+## Original issue text
+
+Agent said: "Working tree still has two test-run leftovers, cellpy_batch_test_batch.json and testdata/hdf5/20160805_test001_45_cc.cellpy, left untracked; they look like .gitignore candidates if the suite regenerates them every run."
+
+Verify that agent is correct in its assumtion. If so, add to gitignore.

--- a/.issueflows/03-solved-issues/issue855_plan.md
+++ b/.issueflows/03-solved-issues/issue855_plan.md
@@ -1,0 +1,47 @@
+# Plan: #855 gitignore test leftovers
+
+## Goal
+
+Ignore the two local leftovers named in the issue if they are safe to ignore;
+document the verification outcome.
+
+## Constraints
+
+- Do **not** ignore tracked fixtures under `testdata/hdf5/*.h5` (used by
+  conftest / suite).
+- Prefer exact paths over broad globs.
+
+### Prior art / verification
+
+- `.gitignore` already has a commented “testdata that changes when running
+  tests” block (including an old `cellpy_batch_test.json` name).
+- `tests/test_batch.py::test_load_autoloads_journal_from_journal_dir` writes
+  `cellpy_batch_test_batch.json` under **`tmp_path`**, not the repo root — so
+  the root file is a **manual / stray** leftover, not every-run essential output.
+- `conftest` regenerates `testdata/hdf5/20160805_test001_45_cc.h5` (tracked) when
+  missing; a sibling `.cellpy` is not produced by that path (save infers hdf5 from
+  `.h5`). The `.cellpy` leftover is still a local artifact that must not be
+  committed.
+
+**Verdict:** Agent assumption “suite regenerates them every run” is **not**
+accurate for current essential tests, but both paths are still correct
+gitignore entries (stray local artifacts).
+
+## Approach
+
+Add explicit ignore rules for:
+- `/cellpy_batch_test_batch.json`
+- `/testdata/hdf5/20160805_test001_45_cc.cellpy`
+
+## Files to touch
+
+- `.gitignore`
+- issue tracking + HISTORY (small chore)
+
+## Test strategy
+
+No code tests; `git check-ignore -v` on the two paths.
+
+## Open questions
+
+None.

--- a/.issueflows/03-solved-issues/issue855_status.md
+++ b/.issueflows/03-solved-issues/issue855_status.md
@@ -1,0 +1,12 @@
+# Status: #855
+
+- [x] Done
+
+## What's done
+
+- Verified leftovers are stray (not essential tmp_path output); added exact
+  `.gitignore` rules; `git check-ignore` confirms.
+
+## Remaining work
+
+None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Ignore stray local leftovers ``cellpy_batch_test_batch.json`` and ``testdata/hdf5/20160805_test001_45_cc.cellpy``. (#855)
 - ``cellpy info --configloc`` names a project ``cellpy.toml`` when one applies (and outranks the user file). (#853)
 - ``config.override()`` is thread-/task-local via ``contextvars`` (no cross-talk between concurrent jobs). (#850)
 - Config file dump/load no longer persist or accept legacy Arbin ``SQL_PWD`` / ``SQL_UID`` under ``[instruments]`` (env-only credentials). (#849)


### PR DESCRIPTION
## Summary
- Verified the named leftovers are not essential-suite `tmp_path` output (batch journal uses tmp; fixture save writes `.h5`).
- Still ignore the exact stray paths so they are not committed.

Closes #855

## Test plan
- [x] `git check-ignore -v` on both paths
- [ ] CI

Made with [Cursor](https://cursor.com)