### PR TITLE
fix: dash discharge half-cycle in ica_plot/dva_plot direction='both'

### DIFF
--- a/.issueflows/03-solved-issues/issue862_original.md
+++ b/.issueflows/03-solved-issues/issue862_original.md
@@ -1,0 +1,45 @@
+# Issue #862: dva_plot(direction='both') does not distinguish the half-cycles visually (ica_plotter does)
+
+Source: https://github.com/jepegit/cellpy/issues/862
+
+## Original issue text
+
+**cellpy version:** 2.1.2a3
+
+## Summary
+
+`ica_plotter` gained a visual distinction for `direction="both"` in #821 — the charge lobe is dashed (`line_dash`), so the two half-cycles are separable at a glance. `dva_plot(direction="both")` overlays both half-cycles too, but draws them **identically**: same colour, same trace name, no dash.
+
+Only the hover tells them apart. On a static export (PNG/SVG/PDF for a report) that information is gone entirely.
+
+## Reproduction
+
+```python
+import json, plotly.io as pio
+from cellpy.utils.plotutils import dva_plot
+from cellpy.utils import example_data
+
+cell = example_data.cellpy_file()
+fig = json.loads(pio.to_json(dva_plot(cell, cycles=[1], direction="both", backend="plotly")))
+for t in fig["data"]:
+    print(t["name"], t["line"], t.get("showlegend"))
+```
+
+```
+1 {'color': 'rgb(68, 1, 84)', 'width': 1.5} True
+1 {'color': 'rgb(68, 1, 84)', 'width': 1.5} False
+```
+
+Both traces: same `name`, same `legendgroup`, same colour, `dash` unset. Compare `ica_plotter(..., direction="both")`, which yields `1, charge` / `1, discharge` with `dash='dot'` on one of them.
+
+The hover *is* correct — `customdata[1]` carries `charge`/`discharge` and the template shows it — so this is purely about the visual encoding.
+
+## Why it matters for apps
+
+We're adding a DVA view to [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) next to the existing ICA view. Same "Both" control, same user expectation, but two different behaviours: ICA is readable, DVA looks like a single doubled-back curve. We'll dash the discharge half app-side for now, which is exactly the kind of divergence #821 removed for ICA.
+
+## Suggested fix
+
+Apply the #821 treatment in `dva_plot`: `line_dash` per direction (and ideally `"<cycle>, charge"` / `"<cycle>, discharge"` names, matching `ica_plotter`), so the two families stay consistent with each other.
+
+Happy to send a PR if you'd like.

--- a/.issueflows/03-solved-issues/issue862_plan.md
+++ b/.issueflows/03-solved-issues/issue862_plan.md
@@ -1,0 +1,90 @@
+# Plan — Issue #862: dva_plot(direction='both') does not distinguish half-cycles visually
+
+## Goal
+
+Make charge vs discharge half-cycles visually distinguishable (not just via hover) when `direction="both"` in `dva_plot` — and, since it's the same code path, in `ica_plot` too.
+
+## Investigation note (corrects the issue's framing)
+
+`ica_plot` and `dva_plot` (`cellpy/utils/plotutils.py`) both route through the same shared
+`prepare` (`cellpy/plotting/prepare/ica.py`) → `_render_ica_dva` renderer (one method per
+backend: [`PlotlyBackend._render_ica_dva`](cellpy/plotting/backends/plotly.py) and
+[`MatplotlibBackend._render_ica_dva`](cellpy/plotting/backends/mpl.py)). Reproduced with the
+example cell: **`ica_plot(direction="both")` currently has the identical bug** — both docstrings
+say outright "Line style is shared across charge and discharge." The issue's comparison is to
+`cellpy.plotting.collected.ica_plotter` (the separate `Collection.plot` family-kind path fixed
+in #821, `line_dash=direction_col` via `px.line`), not to `plotutils.ica_plot`.
+
+Net effect: this is a **one-shared-fix** — patching `_render_ica_dva` fixes both `ica_plot` and
+`dva_plot` at once, and they stay consistent with each other by construction (no per-kind
+special-casing needed).
+
+## Constraints
+
+- Keep the fix minimal: line style only (dash), not a legend/trace-naming overhaul. The issue's
+  "ideally `<cycle>, charge` / `<cycle>, discharge` names" is explicitly a nice-to-have
+  ("ideally"), and both backends currently key their legend/colorbar by **cycle** (color), grouped
+  across directions — renaming would double legend entries per cycle. Out of scope here.
+- Match the #821 convention already established in `collected.py` for consistency across the
+  codebase: charge = solid, discharge = dotted (`px.line`'s default dash sequence gives the first
+  category `"solid"`, second `"dot"`, and `"charge"` < `"discharge"` alphabetically).
+- Both backends (plotly + matplotlib) must get the fix — the issue only mentions plotly exports,
+  but the mpl backend has the identical "shared line style" bug and docstring.
+- Do not change trace/line count, names, or hover content — `tests/data/figure_specs.json`
+  (structural snapshot, #567) does not record line style, so no golden-file update is needed as
+  long as trace count/names/axes are untouched.
+
+### Prior art
+
+- `cellpy/plotting/collected.py::sequence_plotter` (#821 fix, lines ~573-580): sets
+  `plotly_arguments["line_dash"] = direction_col` when `direction == "both"`, for the *separate*
+  `Collection.plot(family_kind="ica")` path. Same convention (dash keyed by the `direction`
+  column values `"charge"` / `"discharge"` from `cellpy.ica.CHARGE` / `cellpy.ica.DISCHARGE`) is
+  reused here, but applied manually (since `_render_ica_dva` builds `go.Scatter` traces directly,
+  not through `px.line`).
+- `tests/test_collected_ica_direction.py::test_ica_line_direction_both_overlays_without_coerce` —
+  existing pattern for asserting `{tr.line.dash for tr in fig.data}` has ≥2 distinct values;
+  mirror this style for the new plotutils-level test.
+
+## Approach
+
+1. **Plotly backend** (`cellpy/plotting/backends/plotly.py::PlotlyBackend._render_ica_dva`):
+   in the `for (cycle, direction), group in frame.groupby(group_cols, ...)` loop, compute
+   `dash = "dot" if direction == DISCHARGE else "solid"` and pass `dash=dash` into the existing
+   `line=dict(color=color, width=1.5)` dict. Import `CHARGE, DISCHARGE` from `cellpy.ica`
+   (`ICA_COLS` is already imported there).
+2. **Matplotlib backend** (`cellpy/plotting/backends/mpl.py::MatplotlibBackend._render_ica_dva`):
+   in the `for (cycle, _direction), group in frame.groupby(...)` loop, rename `_direction` to
+   `direction`, compute `linestyle = ":" if direction == DISCHARGE else "-"`, pass
+   `linestyle=linestyle` to `ax.plot(...)`.
+3. **Docstrings** — update both `_render_ica_dva` docstrings' "Line style is shared across charge
+   and discharge" line to describe the new dash/linestyle behaviour.
+4. **Tests** — add to `tests/test_ica_plot_prepare.py`:
+   - `test_ica_plot_both_direction_dash_differs` (and `dva_plot` equivalent, or parametrized over
+     both) for the plotly backend: call `ica_plot`/`dva_plot(direction="both", backend="plotly")`,
+     assert `{tr.line.dash for tr in fig.data}` has at least 2 distinct values.
+   - matplotlib equivalent: assert `{line.get_linestyle() for line in fig.get_axes()[0].get_lines()}`
+     has at least 2 distinct values for `direction="both"`.
+   - A `direction="charge"` (single-direction) sanity check that dash stays `"solid"`/`"-"` for
+     both kinds, guarding against a future regression that always-dashes regardless of direction.
+
+## Files to touch
+
+- `cellpy/plotting/backends/plotly.py` — `PlotlyBackend._render_ica_dva`: add per-direction dash.
+- `cellpy/plotting/backends/mpl.py` — `MatplotlibBackend._render_ica_dva`: add per-direction linestyle.
+- `tests/test_ica_plot_prepare.py` — new direction/dash tests.
+- `HISTORY.md` (at `/iflow-close`, per project convention) — patch-level fix note.
+
+## Test strategy
+
+- `uv run pytest tests/test_ica_plot_prepare.py -m essential` for the fast path; then the
+  documented merge gate `uv run pytest -m essential` (per `AGENTS.md`).
+- Plotting tests run fine outside `MPLBACKEND=Agg` requirement here since this repo's local dev
+  loop uses conda per project rules — will run via the activated `cellpy_dev_313` env (or `uv run`
+  if conda isn't needed locally); confirm whichever is available in the close step actually runs.
+- Manually re-run the issue's repro snippet for both `ica_plot` and `dva_plot` to confirm dash
+  values differ and match before/after.
+
+## Open questions
+
+None — scope, convention (match #821), and file list are all resolved from the codebase itself.

--- a/.issueflows/03-solved-issues/issue862_status.md
+++ b/.issueflows/03-solved-issues/issue862_status.md
@@ -1,0 +1,28 @@
+# Status — Issue #862
+
+- [x] Done
+
+## What's done
+
+- Investigated and confirmed `ica_plot` and `dva_plot` share the same `_render_ica_dva`
+  renderer (plotly + mpl) and both currently lacked dash distinction for `direction="both"`
+  (the issue's "ica_plotter already does this" comparison was to the separate
+  `cellpy.plotting.collected.ica_plotter`, fixed in #821 — a different code path).
+- Plan written (`issue862_plan.md`), accepted.
+- `PlotlyBackend._render_ica_dva` (`cellpy/plotting/backends/plotly.py`): dash keyed by
+  direction (`charge` solid, `discharge` dotted) whenever both directions are overlaid in the
+  frame; single-direction plots stay solid.
+- `MatplotlibBackend._render_ica_dva` (`cellpy/plotting/backends/mpl.py`): same behaviour via
+  `linestyle` (`"-"` / `":"`).
+- Docstrings updated on both renderers.
+- New tests in `tests/test_ica_plot_prepare.py`: dash/linestyle differ for `direction="both"`
+  (both `ica_plot` and `dva_plot`, both backends), and stays solid for a single direction.
+- `uv run pytest tests/test_ica_plot_prepare.py`, related plotting tests (49 passed), and the
+  full `uv run pytest -m essential` merge gate (698 passed, 1 skipped, 2 xfailed, 1 xpassed, no
+  regressions) all green with `MPLBACKEND=Agg`.
+- `black --diff` / `flake8` on touched files: only pre-existing, unrelated findings (line-length
+  config mismatch); no new issues from this change.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -47,6 +47,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |
+| tests/test_ica_plot_prepare.py::test_ica_dva_plotly_both_direction_dash_differs | yes | yes | plotting.backends.plotly._render_ica_dva | #862 | charge solid / discharge dot |
+| tests/test_ica_plot_prepare.py::test_ica_dva_plotly_single_direction_stays_solid | yes | yes | plotting.backends.plotly._render_ica_dva | #862 | single direction stays solid |
+| tests/test_ica_plot_prepare.py::test_ica_dva_matplotlib_both_direction_linestyle_differs | yes | yes | plotting.backends.mpl._render_ica_dva | #862 | "-" / ":" linestyle |
 | tests/test_cellpy_file_v9.py::test_incomplete_archive_is_rejected_before_replace | yes | yes | v9._verify_members | #845 | missing zip member never replaces a good file |
 | tests/test_cellpy_file_v9.py::test_failed_hdf5_resave_keeps_the_old_file | no | no | cellpy_file.write.save (v8/HDF5) | #845 | same guard for the legacy writer; unmarked to keep Tier 1 fast |
 | tests/test_config.py::test_active_config_file_prefers_toml | yes | yes | config.loader.active_config_file | #851 | "which config am I using" must stay honest |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 - Pretty-print cycles collector facet strips (Cycle N / cell label, not cycle_num=). (#820)
 - Honour share_y / match_axes on collected summary spread_plot. (#817)
 - ICA plotter: honour direction for line layouts; support direction='both'. (#821)
+- ``ica_plot`` / ``dva_plot``: dash discharge (dotted) vs charge (solid) when ``direction='both'`` so the two half-cycles stay distinguishable on a static export. (#862)
 
 ## [2.1.1.post6] - 2026-08-02
 

--- a/cellpy/plotting/backends/mpl.py
+++ b/cellpy/plotting/backends/mpl.py
@@ -1229,14 +1229,18 @@ class MatplotlibBackend:
     def _render_ica_dva(self, frame: Any, spec: FigureSpec) -> Any:
         """Render ICA (dQ/dV) or DVA (dV/dQ) figures.
 
-        One series per ``(cycle, direction)``; shared line style for charge and
-        discharge. Cycle legend vs colorbar via
+        One series per ``(cycle, direction)``; color keyed by cycle. When both
+        directions are overlaid (e.g. ``direction="both"``), linestyle is
+        keyed by direction (``charge`` solid, ``discharge`` dotted — same
+        convention as the collected ICA line plots, #821) so the two
+        half-cycles stay distinguishable on a static export; a
+        single-direction plot stays solid. Cycle legend vs colorbar via
         :mod:`cellpy.plotting.cycle_legend`.
         """
         import matplotlib.pyplot as plt
         from matplotlib.colors import Normalize
 
-        from cellpy.ica import ICA_COLS
+        from cellpy.ica import DISCHARGE, ICA_COLS
         from cellpy.plotting.cycle_legend import (
             add_matplotlib_cycle_colorbar,
             pop_cycle_legend_options,
@@ -1270,19 +1274,24 @@ class MatplotlibBackend:
         use_legend = mode == "legend"
 
         shown_cycles: set[Any] = set()
-        for (cycle, _direction), group in frame.groupby(
+        # Only dash when both directions are actually overlaid (#862) — a
+        # single-direction plot has nothing to disambiguate from.
+        both_directions = frame[ICA_COLS.direction].nunique() > 1
+        for (cycle, direction), group in frame.groupby(
             [ICA_COLS.cycle, ICA_COLS.direction], sort=True
         ):
             label = None
             if use_legend and cycle not in shown_cycles:
                 label = str(cycle)
                 shown_cycles.add(cycle)
+            linestyle = ":" if both_directions and direction == DISCHARGE else "-"
             ax.plot(
                 group[x_col],
                 group[y_col],
                 color=cycle_to_color[cycle],
                 label=label,
                 linewidth=1.5,
+                linestyle=linestyle,
             )
 
         ax.set_xlabel(x_label)

--- a/cellpy/plotting/backends/plotly.py
+++ b/cellpy/plotting/backends/plotly.py
@@ -861,14 +861,18 @@ class PlotlyBackend:
         """Render ICA (dQ/dV) or DVA (dV/dQ) figures.
 
         One trace per ``(cycle, direction)`` so half-cycles are not connected;
-        color is keyed by cycle. Hover includes direction. Line style is shared
-        across charge and discharge. Cycle legend vs colorbar via
+        color is keyed by cycle. When both directions are overlaid (e.g.
+        ``direction="both"``), line dash is keyed by direction (``charge``
+        solid, ``discharge`` dotted — same convention as the collected ICA
+        line plots, #821) so the two half-cycles stay distinguishable on a
+        static export; a single-direction plot stays solid. Hover also
+        includes direction. Cycle legend vs colorbar via
         :mod:`cellpy.plotting.cycle_legend`.
         """
         import plotly.express as px
         import plotly.graph_objects as go
 
-        from cellpy.ica import ICA_COLS
+        from cellpy.ica import DISCHARGE, ICA_COLS
         from cellpy.plotting.cycle_legend import (
             add_plotly_cycle_colorbar,
             pop_cycle_legend_options,
@@ -911,11 +915,15 @@ class PlotlyBackend:
         fig = go.Figure()
         shown_cycles: set[Any] = set()
         group_cols = [ICA_COLS.cycle, ICA_COLS.direction]
+        # Only dash when both directions are actually overlaid (#862) — a
+        # single-direction plot has nothing to disambiguate from.
+        both_directions = frame[ICA_COLS.direction].nunique() > 1
         for (cycle, direction), group in frame.groupby(group_cols, sort=True):
             color = cycle_to_color[cycle]
             show_legend = use_legend and cycle not in shown_cycles
             if show_legend:
                 shown_cycles.add(cycle)
+            dash = "dot" if both_directions and direction == DISCHARGE else "solid"
             fig.add_trace(
                 go.Scatter(
                     x=group[x_col],
@@ -924,7 +932,7 @@ class PlotlyBackend:
                     name=str(cycle),
                     legendgroup=str(cycle),
                     showlegend=show_legend,
-                    line=dict(color=color, width=1.5),
+                    line=dict(color=color, width=1.5, dash=dash),
                     customdata=group[[ICA_COLS.cycle, ICA_COLS.direction]],
                     hovertemplate=(
                         f"{x_label}: %{{x}}<br>"

--- a/tests/test_ica_plot_prepare.py
+++ b/tests/test_ica_plot_prepare.py
@@ -78,3 +78,34 @@ def test_ica_dva_interactive_removed(cell):
     assert "interactive" not in inspect.signature(dva_plot).parameters
     assert ica_plot(cell, cycles=1, backend="matplotlib") is not None
     assert dva_plot(cell, cycles=1, backend="matplotlib") is not None
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("plot_fn", [ica_plot, dva_plot])
+def test_ica_dva_plotly_both_direction_dash_differs(cell, plot_fn):
+    """direction='both' must be visually distinguishable, not just via hover (#862)."""
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = plot_fn(cell, cycles=[1], direction="both", backend="plotly")
+    dashes = {trace.line.dash for trace in fig.data}
+    assert dashes == {"solid", "dot"}
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("plot_fn", [ica_plot, dva_plot])
+@pytest.mark.parametrize("direction", [CHARGE, DISCHARGE])
+def test_ica_dva_plotly_single_direction_stays_solid(cell, plot_fn, direction):
+    """A single direction has nothing to disambiguate, so it stays solid."""
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = plot_fn(cell, cycles=[1], direction=direction, backend="plotly")
+    dashes = {trace.line.dash for trace in fig.data}
+    assert dashes == {"solid"}
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("plot_fn", [ica_plot, dva_plot])
+def test_ica_dva_matplotlib_both_direction_linestyle_differs(cell, plot_fn):
+    """Matplotlib backend gets the same charge/discharge distinction (#862)."""
+    fig = plot_fn(cell, cycles=[1], direction="both", backend="matplotlib")
+    lines = fig.get_axes()[0].get_lines()
+    linestyles = {line.get_linestyle() for line in lines}
+    assert linestyles == {"-", ":"}


### PR DESCRIPTION
## Summary

`ica_plot` and `dva_plot` (`cellpy.utils.plotutils`) share the same `_render_ica_dva` renderer (plotly + matplotlib backends). When `direction="both"`, charge and discharge half-cycles were drawn identically -- same color, no dash -- so only the hover tooltip distinguished them. On a static export (PNG/SVG/PDF) that information was lost entirely.

Note: the issue's comparison to "`ica_plotter` already does this" refers to the separate `cellpy.plotting.collected.ica_plotter` (`Collection.plot` path, fixed in #821) -- `plotutils.ica_plot` had the identical bug, confirmed by reproducing the issue's snippet against it too. Since both `ica_plot` and `dva_plot` share the renderer, this is a single fix for both.

## Changes

- `PlotlyBackend._render_ica_dva`: dash keyed by direction (`charge` solid, `discharge` dotted) whenever both directions are overlaid in the frame; a single-direction plot stays solid.
- `MatplotlibBackend._render_ica_dva`: same behaviour via `linestyle` (`"-"` / `":"`).
- Convention matches the existing `#821` fix in `cellpy.plotting.collected.sequence_plotter`.
- New tests in `tests/test_ica_plot_prepare.py` covering both `ica_plot`/`dva_plot`, both backends, `direction="both"` vs single direction.

## Test plan

- `uv run pytest tests/test_ica_plot_prepare.py -v` (14 passed)
- `MPLBACKEND=Agg uv run pytest -m essential` (698 passed, 1 skipped, 2 xfailed, 1 xpassed -- no regressions)
- Manually re-ran the issue's repro snippet for both `ica_plot` and `dva_plot`; dash values now differ (`solid` / `dot`).

Closes #862

Made with [Cursor](https://cursor.com)