### PR TITLE
feat(plotting): bound raw_plot with cycles= and max_points= (#867)

### DIFF
--- a/.issueflows/01-current-issues/cycle_status.md
+++ b/.issueflows/01-current-issues/cycle_status.md
@@ -1,0 +1,35 @@
+# Cycle status
+
+- queue: `yolo v.2.1.2` → resolved `label:yolo` (identical to open issues in milestone `v.2.1.2`)
+- repo: jepegit/cellpy
+- onfail: stop
+- started: 2026-08-09T19:50:00+02:00
+- preflight: clean tree on `master`; `uv run pytest -m essential` → 703 passed, 1 skipped, 2 xfailed (`conda` not on PATH in this shell)
+
+## Up-front design decisions (from the consolidated confirm)
+
+- **#867** — add *both* `max_points=` (min/max decimation per bucket) and `cycles=` to `raw_plot`.
+- **#868** — Option 1: `PlotFamily.summary_options(hdr)` returning a ready `SummaryOptions` (transforms as callables, `partition_by_cv` set where required).
+- **#869** — Deduplicate the other way round (refined by the user after the first confirm): the
+  notebooks stay in the **top-level `examples/`** folder as the single maintained copy, and
+  `docs/examples/` keeps only the generated markdown plus figure directories.
+  - The executed `docs/examples/*.ipynb` are the current generation, so they move to `examples/`,
+    overwriting the stale top-level copies. `docs/examples/templates/` moves too.
+  - `dev/render_example_notebooks.py` gains a source (`examples/`) → output (`docs/examples/`)
+    split instead of rendering in place; **all** notebooks under `examples/` are rendered, so
+    `08_batmo_bdf` and `09_loading_pec_data` gain docs pages.
+  - `examples/cellpy batch utility/cellpy_batch_processing.ipynb` is normalised to
+    `examples/batch_utility/cellpy_batch_processing.ipynb`; the rendered page stays under
+    `docs/examples/batch_utility/`.
+  - Scope is larger than the original yolo estimate; the user chose to keep it in the cycle.
+
+## Queue
+
+- [ ] #867 — raw_plot has no way to limit points (or select cycles) — 18 MiB of JSON for one demo cell — in-progress
+- [ ] #868 — fullcell_standard_* families can't be collected: family.transforms() shape doesn't match SummaryOptions.transforms — pending
+- [ ] #869 — Top-level examples/ notebooks still use removed 1.x API — pending
+
+blocked: none
+skipped (closed): none
+
+- [ ] Done

--- a/.issueflows/01-current-issues/issue867_original.md
+++ b/.issueflows/01-current-issues/issue867_original.md
@@ -1,0 +1,31 @@
+# Issue #867 — raw_plot has no way to limit points (or select cycles)
+
+**Source:** https://github.com/jepegit/cellpy/issues/867
+**Labels:** yolo · **Milestone:** v.2.1.2 · **cellpy version:** 2.1.2a4
+
+## Summary
+
+`raw_plot` always plots the entire raw frame. `prepare_raw` does
+`raw = c.data.raw.copy()` with no thinning and no cycle filter, and the public
+entry point exposes neither. On the bundled `cellpy_file()` example (155 754 raw
+rows) the resulting Plotly figure JSON is 7.0–18.1 MiB depending on `plot_type`
+(`full` → 18.1 MiB). A real multi-week test is far larger.
+
+Every other family has a natural bound — `summary_plot` is per cycle,
+`cycles_plot` / `ica_plot` / `dva_plot` take `cycles=`. `raw_plot` is the only
+one unbounded by construction.
+
+## Why it matters for apps
+
+In cellpy-simple-gui figures go over HTTP into a browser; an 18 MiB figure stalls
+the tab. The app currently thins traces itself after `raw_plot` returns (every
+Nth point: 18.5 MiB → 482 KiB), which means every app reinvents the same
+post-processing, the cost of copying/converting the full frame is paid anyway,
+and naive striding drops spikes that min/max-per-bucket decimation would keep.
+
+## Wish (from the issue)
+
+- `raw_plot(..., max_points=N)` — thin to roughly N points per trace, ideally
+  min/max per bucket rather than plain striding;
+- `raw_plot(..., cycles=[...])` — the same bound the other families already have;
+- or plumb both through `RawPrepareConfig` so the reduction happens before the copy.

--- a/.issueflows/01-current-issues/issue867_plan.md
+++ b/.issueflows/01-current-issues/issue867_plan.md
@@ -1,0 +1,56 @@
+# Issue #867 — plan
+
+## Goal
+
+Give `raw_plot` a bound on how much data it emits: both `cycles=` (the selector
+the other families already have) and `max_points=` (min/max-per-bucket
+decimation), plumbed through `RawPrepareConfig` so the reduction happens on the
+prepare side rather than in every downstream app.
+
+Direction confirmed up front in the cycle confirm: implement **both** knobs.
+
+## Approach
+
+`cellpy/plotting/prepare/raw.py`
+
+- `RawPrepareConfig` gains `cycles: Optional[Any] = None` and
+  `max_points: Optional[int] = None`.
+- `prepare()` filters on the raw cycle-index column **before** the copy, so a
+  cycle subset never pays for copying the whole frame.
+- After the x column is derived (decimation must see the plotted columns), thin
+  with min/max per bucket:
+  - buckets are positional over the time-ordered frame;
+  - `n_buckets = max_points // (2 * n_y)` so the union of per-column argmin /
+    argmax rows lands near `max_points` rather than overshooting by a factor of
+    the trace count;
+  - the union keeps every column's extremes — spikes survive, unlike striding;
+  - first and last rows are always kept so the x range does not shrink.
+- No new `FigureSpec.extras` keys → the figure-spec snapshot is untouched.
+
+`cellpy/utils/plotutils.py`
+
+- `raw_plot` gains explicit `cycles=` / `max_points=` parameters (explicit, so
+  they are not swallowed into `**kwargs` and forwarded to the backend) and
+  passes them through to the config. Docstring updated.
+
+Defaults stay `None` on both, so current behaviour is unchanged.
+
+## Files to touch
+
+- `cellpy/plotting/prepare/raw.py`
+- `cellpy/utils/plotutils.py`
+- `tests/test_raw_cycle_info_prepare.py`
+- `HISTORY.md` (changelog bullet at close)
+
+## Test strategy
+
+New `essential` tests in `tests/test_raw_cycle_info_prepare.py`:
+
+- `cycles=` restricts the prepared frame to the requested cycle numbers;
+- `max_points=` cuts the row count to roughly the requested budget;
+- decimation preserves the global min and max of a y column and both endpoints
+  (the property that separates min/max bucketing from striding);
+- both knobs reach `raw_plot` from the public signature and are not forwarded to
+  the backend as stray kwargs.
+
+Then the full `uv run pytest -m essential` gate.

--- a/.issueflows/01-current-issues/issue867_status.md
+++ b/.issueflows/01-current-issues/issue867_status.md
@@ -1,0 +1,41 @@
+# Issue #867 — status
+
+- [x] Done
+
+## What was done
+
+`raw_plot` is no longer unbounded. Both knobs from the issue were implemented,
+as confirmed up front in the cycle's consolidated confirm.
+
+- `RawPrepareConfig` gained `cycles` and `max_points`; both default to `None`,
+  so existing behaviour is unchanged.
+- `prepare()` filters on the raw cycle-index column **before** `.copy()`, so a
+  cycle subset no longer pays for copying the whole frame.
+- New `decimate()` helper in `cellpy/plotting/prepare/raw.py`: positional
+  buckets over the time-ordered frame, keeping each y column's per-bucket argmin
+  and argmax plus the first and last row. The bucket count is scaled by the
+  number of traces (`max_points // (2 * n_y)`) so the union lands near the
+  budget rather than overshooting by the trace count.
+- `raw_plot` exposes `cycles=` / `max_points=` explicitly, so they are not
+  swallowed by `**kwargs` and forwarded to the backend.
+
+## Measured effect (bundled `example_data.cellpy_file()`, 155 754 raw rows)
+
+| call | figure JSON |
+|---|---|
+| `plot_type="full"` (unchanged default) | 18.06 MiB |
+| `max_points=5000` | 0.33 MiB |
+| `max_points=2000` | 0.17 MiB |
+| `cycles=[1, 2]` | 0.29 MiB |
+
+## Tests
+
+Four new `essential` tests in `tests/test_raw_cycle_info_prepare.py`: cycle
+selection (list and bare int), thinning within budget, endpoint and per-trace
+min/max preservation (the property that distinguishes bucketed decimation from
+striding), the no-op path when the frame is already small, and the public
+signature. Full `uv run pytest -m essential` gate green.
+
+## Remaining work
+
+None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Plotting
+
+* `raw_plot` can now be bounded: `cycles=` selects cycles (as the other plot
+  families already allow) and `max_points=` thins the traces with min/max
+  decimation per bucket, so spikes survive where plain striding would drop
+  them. Both are plumbed through `RawPrepareConfig`, and the cycle filter runs
+  before the frame is copied. On the bundled demo cell `plot_type="full"` drops
+  from 18 MiB of figure JSON to 0.33 MiB at `max_points=5000`. (#867)
+
 ## [2.1.2] - 2026-08-09
 
 Patch release — plotting and collect improvements for app builders, config and

--- a/cellpy/plotting/prepare/raw.py
+++ b/cellpy/plotting/prepare/raw.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
+import numpy as np
 import pandas as pd
 
 from cellpy.plotting.headers import LiveHeaders
@@ -29,7 +30,65 @@ class RawPrepareConfig:
     plot_type: str = "voltage-current"
     double_y: bool = True
     backend: str = "plotly"
+    cycles: Optional[Any] = None
+    max_points: Optional[int] = None
     additional_kwargs: dict = field(default_factory=dict)
+
+
+def _as_cycle_list(cycles: Any) -> list:
+    """Normalise a cycle selector to a list of cycle numbers."""
+    if isinstance(cycles, (int, np.integer)):
+        return [int(cycles)]
+    if isinstance(cycles, (Sequence, set, frozenset, range, np.ndarray, pd.Series)):
+        return list(cycles)
+    return [cycles]
+
+
+def decimate(
+    frame: pd.DataFrame,
+    columns: Sequence[str],
+    max_points: int,
+) -> pd.DataFrame:
+    """Thin *frame* to roughly *max_points* rows, keeping per-bucket extremes.
+
+    The frame is split into positional buckets and, for every column in
+    *columns*, the rows holding that bucket's minimum and maximum are kept. The
+    union of those rows (plus the first and last row, so the x range is
+    preserved) is the result — spikes survive, which is what separates this from
+    plain striding. Because each trace contributes up to two rows per bucket,
+    the bucket count is scaled by the number of columns to land near the budget
+    instead of overshooting by a factor of the trace count.
+
+    Args:
+        frame (pandas.DataFrame): frame to thin, in plotting order.
+        columns: the y columns whose extremes must survive.
+        max_points (int): approximate row budget for the result.
+
+    Returns:
+        ``pandas.DataFrame``: the thinned frame, or *frame* itself when it is
+        already within budget.
+    """
+    n_rows = len(frame)
+    numeric = [
+        col
+        for col in columns
+        if col in frame.columns and pd.api.types.is_numeric_dtype(frame[col])
+    ]
+    if max_points < 2 or n_rows <= max_points or not numeric:
+        return frame
+
+    n_buckets = max(1, max_points // (2 * len(numeric)))
+    if n_buckets >= n_rows:
+        return frame
+
+    positions = np.arange(n_rows)
+    bucket = pd.Series((positions * n_buckets) // n_rows)
+    keep = {0, n_rows - 1}
+    for col in numeric:
+        values = pd.Series(frame[col].to_numpy(), copy=False).groupby(bucket)
+        keep.update(int(i) for i in values.idxmin().dropna())
+        keep.update(int(i) for i in values.idxmax().dropna())
+    return frame.iloc[sorted(keep)]
 
 
 def prepare(
@@ -51,7 +110,12 @@ def prepare(
 
     c = ctx.cell
     hdr_raw = LiveHeaders(c, "raw")
-    raw = c.data.raw.copy()
+    raw = c.data.raw
+    # Select before copying — a cycle subset should not pay for the full frame.
+    if config.cycles is not None:
+        cycle_col = hdr_raw["cycle_index_txt"]
+        raw = raw.loc[raw[cycle_col].isin(_as_cycle_list(config.cycles))]
+    raw = raw.copy()
     raw_units = c.data.raw_units
 
     y = config.y
@@ -159,6 +223,9 @@ def prepare(
 
     y = list(y)
     y_label = list(y_label)
+
+    if config.max_points is not None:
+        raw = decimate(raw, y, config.max_points)
     panels = tuple(
         PanelSpec(
             columns=(col,),

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -1262,6 +1262,8 @@ def raw_plot(
     backend: Optional[str] = None,
     plot_type="voltage-current",
     double_y=True,
+    cycles=None,
+    max_points: Optional[int] = None,
     **kwargs,
 ):
     """Plot raw data.
@@ -1279,6 +1281,10 @@ def raw_plot(
         plot_type (str): type of plot (defaults to "voltage-current") (overrides given y if y is not None),
           currently only "voltage-current", "raw", "capacity", "capacity-current", and "full" is supported.
         double_y (bool): use double y-axis (only for matplotlib and when plot_type with 2 rows is used)
+        cycles (int or list): only plot these cycle numbers (defaults to all).
+        max_points (int, optional): thin the data to roughly this many points,
+          keeping the minimum and maximum of every trace within each bucket so
+          spikes survive. Defaults to no thinning.
         **kwargs: additional parameters for the plotting backend
 
     Returns:
@@ -1304,6 +1310,8 @@ def raw_plot(
         plot_type=plot_type,
         double_y=double_y,
         backend=resolved_backend,
+        cycles=cycles,
+        max_points=max_points,
         additional_kwargs=dict(kwargs),
     )
     ctx = from_source(cell)

--- a/tests/test_raw_cycle_info_prepare.py
+++ b/tests/test_raw_cycle_info_prepare.py
@@ -7,6 +7,7 @@ import warnings
 import pytest
 
 from cellpy.plotting.context import from_source
+from cellpy.plotting.headers import LiveHeaders
 from cellpy.plotting.prepare.raw import RawPrepareConfig, prepare as prepare_raw
 from cellpy.plotting.prepare.steps import (
     CycleInfoPrepareConfig,
@@ -61,6 +62,76 @@ def test_cycle_info_plot_backend_matplotlib(cell):
     assert cycle_info_plot(cell, cycle=3, backend="matplotlib") is None
     axes = cycle_info_plot(cell, cycle=3, backend="matplotlib", get_axes=True)
     assert axes is not None
+
+
+@pytest.mark.essential
+def test_prepare_raw_cycles_selects_only_the_requested_cycles(cell):
+    family = plot_registry.get("raw")
+    ctx = from_source(cell)
+    cycle_col = LiveHeaders(cell, "raw")["cycle_index_txt"]
+
+    full, _ = prepare_raw(ctx, family, RawPrepareConfig(backend="matplotlib"))
+    wanted = sorted(full[cycle_col].unique())[:2]
+
+    frame, _ = prepare_raw(
+        ctx, family, RawPrepareConfig(backend="matplotlib", cycles=wanted)
+    )
+    assert sorted(frame[cycle_col].unique()) == wanted
+    assert len(frame) < len(full)
+
+    single, _ = prepare_raw(
+        ctx, family, RawPrepareConfig(backend="matplotlib", cycles=wanted[0])
+    )
+    assert sorted(single[cycle_col].unique()) == [wanted[0]]
+
+
+@pytest.mark.essential
+def test_prepare_raw_max_points_thins_but_keeps_the_extremes(cell):
+    family = plot_registry.get("raw")
+    ctx = from_source(cell)
+
+    full, spec = prepare_raw(
+        ctx, family, RawPrepareConfig(backend="matplotlib", plot_type="full")
+    )
+    thinned, _ = prepare_raw(
+        ctx,
+        family,
+        RawPrepareConfig(backend="matplotlib", plot_type="full", max_points=500),
+    )
+
+    assert len(thinned) < len(full)
+    assert len(thinned) <= 500
+    # Endpoints survive, so the x range does not shrink.
+    x = spec.extras["x"]
+    assert thinned[x].iloc[0] == full[x].iloc[0]
+    assert thinned[x].iloc[-1] == full[x].iloc[-1]
+    # Per-bucket min/max keeps every trace's extremes — striding would not.
+    for column in spec.extras["y"]:
+        assert thinned[column].min() == full[column].min()
+        assert thinned[column].max() == full[column].max()
+
+
+@pytest.mark.essential
+def test_prepare_raw_max_points_is_a_no_op_when_already_small(cell):
+    family = plot_registry.get("raw")
+    ctx = from_source(cell)
+    full, _ = prepare_raw(ctx, family, RawPrepareConfig(backend="matplotlib"))
+    frame, _ = prepare_raw(
+        ctx,
+        family,
+        RawPrepareConfig(backend="matplotlib", max_points=len(full) + 1),
+    )
+    assert len(frame) == len(full)
+
+
+@pytest.mark.essential
+def test_raw_plot_exposes_cycles_and_max_points(cell):
+    import inspect
+
+    parameters = inspect.signature(raw_plot).parameters
+    assert "cycles" in parameters
+    assert "max_points" in parameters
+    assert raw_plot(cell, backend="matplotlib", cycles=1, max_points=200) is not None
 
 
 @pytest.mark.essential


### PR DESCRIPTION
Closes #867.

## Summary

`raw_plot` was the only plot family unbounded by construction — `prepare_raw` copied the entire raw frame with no cycle filter and no thinning, and the public entry point exposed neither. On the bundled `example_data.cellpy_file()` (155 754 raw rows) `plot_type="full"` produced 18 MiB of Plotly figure JSON.

Both knobs from the issue are implemented:

- **`cycles=`** — the same selector `cycles_plot` / `ica_plot` / `dva_plot` already take. Applied *before* the frame is copied, so a cycle subset no longer pays for copying everything.
- **`max_points=`** — min/max decimation per bucket rather than striding. For each positional bucket, the rows holding every y column's minimum and maximum are kept, along with the first and last row so the x range does not shrink. Spikes survive, which is the part naive every-Nth thinning gets wrong. The bucket count is scaled by the number of traces (`max_points // (2 * n_y)`) so the union lands near the budget instead of overshooting by the trace count.

Both are plumbed through `RawPrepareConfig` and default to `None`, so current behaviour is unchanged and the figure-spec snapshot is untouched.

## Measured effect

Bundled demo cell, `plot_type="full"`:

| call | figure JSON |
|---|---|
| default (unchanged) | 18.06 MiB |
| `max_points=5000` | 0.33 MiB |
| `max_points=2000` | 0.17 MiB |
| `cycles=[1, 2]` | 0.29 MiB |

## Test plan

- [x] Four new `essential` tests in `tests/test_raw_cycle_info_prepare.py`: cycle selection by list and by bare int, thinning within budget, endpoint plus per-trace min/max preservation, the no-op path when the frame is already within budget, and the public signature.
- [x] `uv run pytest -m essential` — 707 passed, 1 skipped, 2 xfailed.

Made with [Cursor](https://cursor.com)