### PR TITLE
fix(plotting): validate collected layout/kind (#874)

### DIFF
--- a/.issueflows/03-solved-issues/issue874_original.md
+++ b/.issueflows/03-solved-issues/issue874_original.md
@@ -1,0 +1,41 @@
+# Issue #874: resolve_collected_layout_kind accepts any layout string silently — layout='film' draws a line plot
+
+Source: https://github.com/jepegit/cellpy/issues/874
+
+## Original issue text
+
+Found while adding dQ/dV and dV/dQ to a multi-cell "Cycles" pane in [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) (against **cellpy 2.1.2**).
+
+## What happens
+
+`Collection.plot(layout=...)` accepts *any* string. Unknown values fall through `_LAYOUT_TO_METHOD.get(layout, "fig_pr_cell")` to the line renderer, with no error and no warning:
+
+```python
+>>> from cellpy.plotting.collected import resolve_collected_layout_kind as r
+>>> r(layout="film")
+('film', 'line', 'fig_pr_cell')
+>>> r(layout="totally_bogus")
+('totally_bogus', 'line', 'fig_pr_cell')
+>>> r(kind="film")
+('per_cell', 'film', 'film')
+```
+
+## Why it bit
+
+`film` is a **kind**, not a layout — but it reads like one, it sits in `_METHOD_TO_LAYOUT` alongside `fig_pr_cell` / `fig_pr_cycle`, and `Collection.plot`'s docstring mentions only `layout=` for cycles/ICA. Passing `layout="film"` produced a perfectly plausible figure — same six `scattergl` traces as `per_cell` — so nothing indicated it was wrong. The correct spelling (`kind="film"`) gives `histogram2d`, which is the intended plot.
+
+A silently-wrong figure is worse than a traceback here: the chart looks right, so it ships.
+
+## Suggestions
+
+Any one of these would have caught it:
+
+1. **Validate** — raise on an unrecognised `layout` (and `kind`), listing the accepted values. `totally_bogus` reaching the renderer is a bug regardless of the film question.
+2. **Accept `layout="film"`** as an alias for `kind="film"`, since `_METHOD_TO_LAYOUT["film"] = "per_cell"` already implies the mapping exists.
+3. **Document `kind=`** in `Collection.plot`'s docstring — it currently names only `layout=` for the cycles/ICA path, so `kind` is easy to miss entirely.
+
+## Environment
+
+cellpy 2.1.2, Python 3.13, Windows.
+
+*(Filed from cellpy-simple-gui, which is built partly to surface this kind of app-facing rough edge. The app now translates `film` → `kind="film"` itself.)*

--- a/.issueflows/03-solved-issues/issue874_plan.md
+++ b/.issueflows/03-solved-issues/issue874_plan.md
@@ -1,0 +1,76 @@
+# Issue #874 — Plan: validate collected `layout=` / `kind=`
+
+Status: **confirmed** (2026-08-10) — Accept; Q1=(A) alias `layout="film"`; Q2=validate unknown `method=` too.
+
+## Goal
+
+Stop `resolve_collected_layout_kind` (and thus `Collection.plot` / `collected_plot`) from silently mapping unknown `layout=` strings to the line/`fig_pr_cell` path. Fail loud on garbage; optionally treat the common `layout="film"` footgun as `kind="film"`. Document `kind=` on `Collection.plot`.
+
+## Constraints
+
+- Patch-scoped (milestone **v.2.1.2**): resolver + docs/tests only — no renderer / backend rewrite.
+- Public API stays `layout=` / `kind=` / legacy `method`/`plot_type`/`spread`.
+- Prefer **raise** over warn+coerce for unknown layout/kind (silent wrong figure is the bug). ICA `direction=` still warns+coerces — different footgun; do not change that path here.
+- Design doc: [plotting-collected.md](../04-designs-and-guides/plotting-collected.md).
+
+### Prior art
+
+| Hit | Where | Relation |
+| --- | --- | --- |
+| `resolve_collected_layout_kind` | [`cellpy/plotting/collected.py`](../../cellpy/plotting/collected.py) ~L1710 | Bug: `_LAYOUT_TO_METHOD.get(layout, "fig_pr_cell")` default |
+| `_METHOD_TO_LAYOUT` / `_LAYOUT_TO_METHOD` | same file ~L1696 | Canonical allowed layout/method sets; `film` is method→layout only |
+| `collected_plot` docstring | same file | Already documents `layout` / `kind` values |
+| `Collection.plot` docstring | [`cellpy/collect/collection.py`](../../cellpy/collect/collection.py) | Mentions `layout=` only — miss that bit `kind=` |
+| `plotting-collected.md` | designs | Maps `film` → `kind="film"`; no validation note |
+| ICA invalid `direction` | collected.py (`ica_plotter`) | warn+coerce — **do not mirror** for layout/kind |
+| Toolbox / graphify | — | None needed (pure resolver) |
+
+## Approach
+
+1. **Canonical sets** (module-level frozensets or reuse map keys):
+   - layouts: `per_cell`, `per_cycle`, `summary`
+   - kinds: `line`, `film`, `spread`
+   - methods (legacy, when provided): `fig_pr_cell`, `fig_pr_cycle`, `film`, `summary`
+
+2. **`layout="film"` alias** (recommended — see Open Q1): if `layout == "film"`:
+   - treat as request for `kind="film"` / `layout="per_cell"`;
+   - if `kind` is already set and ≠ `"film"`, raise `ValueError` (conflict);
+   - then continue normal resolution.
+
+3. **Validate after defaults resolved** (or validate only user-provided non-`None` args before defaults — same effect if alias runs first):
+   - unknown `layout` → `ValueError` listing allowed layouts (+ note that `film` is a `kind`);
+   - unknown `kind` → `ValueError` listing allowed kinds;
+   - unknown explicit `method`/`plot_type` → `ValueError` listing allowed methods (keeps legacy path honest);
+   - remove the silent `.get(layout, "fig_pr_cell")` fallback — after validation, `.get` is unnecessary / use direct map.
+
+4. **Docs**
+   - `Collection.plot`: mention `kind=` (`line` / `film` / `spread`) alongside `layout=`.
+   - Bullet in `plotting-collected.md`: unknown layout/kind raise; `layout="film"` → `kind="film"` (if Q1 accepted).
+
+5. **Tests** — pure unit tests on `resolve_collected_layout_kind` (no figure / kaleido).
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| [`cellpy/plotting/collected.py`](../../cellpy/plotting/collected.py) | Alias + validate in `resolve_collected_layout_kind`; drop silent layout default |
+| [`cellpy/collect/collection.py`](../../cellpy/collect/collection.py) | Docstring: `kind=` |
+| [`.issueflows/04-designs-and-guides/plotting-collected.md`](../04-designs-and-guides/plotting-collected.md) | Validation / film-alias note |
+| `tests/test_resolve_collected_layout_kind.py` (new) | Valid / alias / raise cases; mark `essential` if cheap |
+
+## Test strategy
+
+```bash
+MPLBACKEND=Agg uv run pytest tests/test_resolve_collected_layout_kind.py -q
+MPLBACKEND=Agg uv run pytest -m essential -q
+```
+
+- Valid: `layout="per_cell"`, `kind="film"`, `method="fig_pr_cycle"`, `spread=True` → expected triples.
+- Alias: `layout="film"` → `("per_cell", "film", "film")` (if Q1 yes).
+- Raise: `layout="totally_bogus"`, `kind="nope"`, conflict `layout="film", kind="line"`.
+- Regression: `kind="film"` unchanged; default (all None) still `per_cell` / `line` / `fig_pr_cell`.
+
+## Open questions
+
+1. **`layout="film"`** — **(A) alias → `kind="film"`** (recommend; matches issue suggestion 2 + `_METHOD_TO_LAYOUT`) vs **(B) raise** like any other unknown layout (strict; forces callers to use `kind=`)?
+2. **Legacy `method=`** — validate unknown methods too (**recommend yes**) or only `layout`/`kind`?

--- a/.issueflows/03-solved-issues/issue874_status.md
+++ b/.issueflows/03-solved-issues/issue874_status.md
@@ -1,0 +1,17 @@
+# Issue #874 — Status
+
+- [x] Done
+
+## What's done
+
+- Plan confirmed (Accept; alias `layout="film"`; validate `method=`).
+- `resolve_collected_layout_kind`: validate layout/kind/method; `layout="film"` → `kind="film"`; conflict raises.
+- `Collection.plot` docstring documents `kind=` + raise behaviour.
+- `plotting-collected.md` validation bullet.
+- `tests/test_resolve_collected_layout_kind.py` (13 essential) — pass; registry row added.
+- `pytest -m essential` — 679 passed.
+- `HISTORY.md` Unreleased bullet.
+
+## Remaining work
+
+- None (close: commit / push / PR).

--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -18,6 +18,10 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   - `film` → `kind="film"`
   - `spread=True` → `kind="spread"`
   - default → `kind="line"`
+- **Validation (#874):** unknown `layout=` / `kind=` / `method=` raise
+  `ValueError` (no silent fall-through to the line/`fig_pr_cell` renderer).
+  `layout="film"` is accepted as an alias for `kind="film"`
+  (`layout` becomes `per_cell`); conflicting `kind=` raises.
 - Flow: resolve layout/kind → `FigureSpec(extras["kind"]="collected", …)` →
   `get_backend(...).render` → collected layout engines (plotly primary;
   `seaborn` / `matplotlib` → historical seaborn collector path, best-effort).

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -28,6 +28,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_collected_ica_direction.py::test_ica_line_direction_both_overlays_without_coerce | yes | yes | plotting.collected ica both line_dash | #821 | |
 | tests/test_collected_ica_direction.py::test_ica_invalid_direction_warns_and_coerces | yes | yes | plotting.collected ica_plotter warn | #821 | |
 | tests/test_collected_ica_direction.py::test_collected_plot_ica_per_cell_honours_direction | yes | yes | plotting.collected collected_plot ica | #821 | public entry |
+| tests/test_resolve_collected_layout_kind.py (module) | yes | yes | plotting.collected.resolve_collected_layout_kind | #874 | validate + film alias |
 | tests/test_batch_v3_runner.py::test_auto_uses_existing_cellpy_without_raw | yes | yes | batch.runner._get_kwargs AUTO | #825 | prefer local .cellpy |
 | tests/test_batch_v3_runner.py::test_auto_falls_back_to_raw_when_cellpy_missing | yes | yes | batch.runner._get_kwargs AUTO | #825 | |
 | tests/test_batch_v3_runner.py::test_newest_passes_both_paths | yes | yes | batch.runner._get_kwargs NEWEST | #825 | freshness check |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Validate collected `layout=` / `kind=` / `method=` (raise on unknown values);
+  `layout='film'` aliases `kind='film'` so apps no longer get a silent wrong
+  line plot. (#874)
+
 ## [2.1.2] - 2026-08-09
 
 Patch release — plotting and collect improvements for app builders, config and

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -88,8 +88,10 @@ class Collection:
         (see :func:`cellpy.plotting.collected.summary_plotter`). App chrome:
         ``plotly_template``, ``layout_updates``, ``y_label_mapper``,
         ``height`` / ``height_per_panel``. Cycles / ICA: prefer ``layout=``
-        (``per_cell`` / ``per_cycle``); Plotly facet strips are pretty-printed
-        by default (``Cycle N`` / cell label).
+        (``per_cell`` / ``per_cycle``) and ``kind=`` (``line`` / ``film`` /
+        ``spread``); ``layout="film"`` aliases ``kind="film"``. Unknown
+        layout/kind/method values raise ``ValueError``. Plotly facet strips
+        are pretty-printed by default (``Cycle N`` / cell label).
         """
         from cellpy.plotting import collected_plot
 

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -1706,6 +1706,10 @@ _LAYOUT_TO_METHOD = {
     "summary": "summary",
 }
 
+_VALID_LAYOUTS = frozenset(_LAYOUT_TO_METHOD)
+_VALID_KINDS = frozenset({"line", "film", "spread"})
+_VALID_METHODS = frozenset(_METHOD_TO_LAYOUT)
+
 
 def resolve_collected_layout_kind(
     *,
@@ -1717,13 +1721,48 @@ def resolve_collected_layout_kind(
 ) -> tuple[str, str, str]:
     """Map legacy ``method``/``plot_type``/``spread`` to ``(layout, kind, method)``.
 
+    ``layout="film"`` is accepted as an alias for ``kind="film"`` (layout
+    becomes ``per_cell``). Unknown ``layout`` / ``kind`` / ``method`` values
+    raise ``ValueError`` instead of falling through to the line renderer.
+
     Returns:
         layout: ``per_cell`` | ``per_cycle`` | ``summary``
         kind: ``line`` | ``film`` | ``spread``
         method: legacy template/method string still understood by renderers
+
+    Raises:
+        ValueError: If ``layout``, ``kind``, or ``method``/``plot_type`` is
+            unrecognised, or if ``layout="film"`` conflicts with a non-film
+            ``kind``.
     """
     if method is None and plot_type is not None:
         method = plot_type
+
+    # Common footgun: film is a kind, but it sits next to layouts in docs/maps.
+    if layout == "film":
+        if kind is not None and kind != "film":
+            raise ValueError(
+                f"layout='film' conflicts with kind={kind!r}; "
+                "use kind='film' alone, or layout='film' without kind="
+            )
+        kind = "film"
+        layout = "per_cell"
+
+    if method is not None and method not in _VALID_METHODS:
+        allowed = ", ".join(sorted(_VALID_METHODS))
+        raise ValueError(f"Unknown method={method!r}; expected one of: {allowed}")
+
+    if kind is not None and kind not in _VALID_KINDS:
+        allowed = ", ".join(sorted(_VALID_KINDS))
+        raise ValueError(f"Unknown kind={kind!r}; expected one of: {allowed}")
+
+    if layout is not None and layout not in _VALID_LAYOUTS:
+        allowed = ", ".join(sorted(_VALID_LAYOUTS))
+        raise ValueError(
+            f"Unknown layout={layout!r}; expected one of: {allowed} "
+            "(note: 'film' is a kind=, not a layout= — use kind='film' or layout='film')"
+        )
+
     if kind is None:
         if spread:
             kind = "spread"
@@ -1734,15 +1773,13 @@ def resolve_collected_layout_kind(
     if layout is None:
         if method in _METHOD_TO_LAYOUT:
             layout = _METHOD_TO_LAYOUT[method]
-        elif kind == "film":
-            layout = "per_cell"
         else:
             layout = "per_cell"
     if method is None:
         if kind == "film":
             method = "film"
         else:
-            method = _LAYOUT_TO_METHOD.get(layout, "fig_pr_cell")
+            method = _LAYOUT_TO_METHOD[layout]
     if kind == "spread":
         # spread is a summary rendering mode
         if layout not in ("summary", "per_cell"):

--- a/tests/test_resolve_collected_layout_kind.py
+++ b/tests/test_resolve_collected_layout_kind.py
@@ -1,0 +1,62 @@
+"""resolve_collected_layout_kind validation and film alias (#874)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cellpy.plotting.collected import resolve_collected_layout_kind as r
+
+
+@pytest.mark.essential
+def test_defaults_are_per_cell_line():
+    assert r() == ("per_cell", "line", "fig_pr_cell")
+
+
+@pytest.mark.essential
+def test_kind_film():
+    assert r(kind="film") == ("per_cell", "film", "film")
+
+
+@pytest.mark.essential
+def test_layout_film_aliases_kind_film():
+    assert r(layout="film") == ("per_cell", "film", "film")
+
+
+@pytest.mark.essential
+def test_layout_film_conflicts_with_other_kind():
+    with pytest.raises(ValueError, match="conflicts"):
+        r(layout="film", kind="line")
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"layout": "per_cell"}, ("per_cell", "line", "fig_pr_cell")),
+        ({"layout": "per_cycle"}, ("per_cycle", "line", "fig_pr_cycle")),
+        ({"layout": "summary"}, ("summary", "line", "summary")),
+        ({"method": "fig_pr_cycle"}, ("per_cycle", "line", "fig_pr_cycle")),
+        ({"spread": True}, ("per_cell", "spread", "fig_pr_cell")),
+        ({"kind": "spread", "layout": "summary"}, ("summary", "spread", "summary")),
+    ],
+)
+def test_valid_resolutions(kwargs, expected):
+    assert r(**kwargs) == expected
+
+
+@pytest.mark.essential
+def test_unknown_layout_raises():
+    with pytest.raises(ValueError, match="Unknown layout"):
+        r(layout="totally_bogus")
+
+
+@pytest.mark.essential
+def test_unknown_kind_raises():
+    with pytest.raises(ValueError, match="Unknown kind"):
+        r(kind="nope")
+
+
+@pytest.mark.essential
+def test_unknown_method_raises():
+    with pytest.raises(ValueError, match="Unknown method"):
+        r(method="totally_bogus")


### PR DESCRIPTION
## Summary
- `resolve_collected_layout_kind` raises `ValueError` on unknown `layout=` / `kind=` / `method=` instead of silently falling through to a line/`fig_pr_cell` plot.
- `layout="film"` aliases `kind="film"` (layout becomes `per_cell`); conflicting `kind=` raises.
- Docs: `Collection.plot` + `plotting-collected.md`; essential unit tests.

Closes #874.

## Test plan
- [x] `MPLBACKEND=Agg uv run pytest tests/test_resolve_collected_layout_kind.py -q`
- [x] `MPLBACKEND=Agg uv run pytest -m essential -q` (679 passed)
- [ ] Confirm `collection.plot(layout="film")` yields film/histogram path; `layout="totally_bogus"` raises


Made with [Cursor](https://cursor.com)