### PR TITLE
fix(plotting): restore hover on spread_plot mean traces (#875)

### DIFF
--- a/.issueflows/03-solved-issues/issue875_original.md
+++ b/.issueflows/03-solved-issues/issue875_original.md
@@ -1,0 +1,45 @@
+# Issue #875: spread_plot traces carry no hovertemplate — turning on spread loses all hover detail
+
+Source: https://github.com/jepegit/cellpy/issues/875
+
+## Original issue text
+
+Found while wiring group-averaged summary plots in [cellpy-simple-gui](https://github.com/cellpy/cellpy-simple-gui) (against **cellpy 2.1.2**).
+
+## What happens
+
+On the collected summary path, hover is informative — until `spread=True`, at which point **every trace has `hovertemplate = None`**.
+
+Same collection, same columns, three renderings:
+
+| mode | `hovertemplate` on the first trace |
+|---|---|
+| per-cell | `cellpy<br>group=1<br>sub_group=1<br>variable=coulombic_efficiency<br>Cycle (n.)=%{x}<br>value=%{y}` |
+| `group_it=True` | `group=1<br>variable=coulombic_efficiency<br>Cycle (n.)=%{x}<br>mean=%{y}` |
+| `group_it=True, spread=True` | **`None`** — on all 18 traces, mean lines included |
+
+## Why
+
+`summary_plotter` goes through plotly.express, which attaches hover from the frame. `spread_plot` builds traces directly with `go.Scatter` (`make_subplots` + add_trace) and never sets `hovertemplate` or `hoverinfo`, so the figure ships with Plotly's bare default.
+
+The docstring already flags the function as experimental — this looks like one of the gaps that implies, rather than a deliberate choice.
+
+## Why it matters for an app
+
+Spread is the mode where hover is *most* useful: the band hides the individual cells, so the tooltip is the only way to read a value. Losing group, variable, cycle and value at exactly that moment is a visible regression to a user toggling one checkbox.
+
+There is also a smaller issue underneath: the **Upper Bound / Lower Bound** traces are hoverable. They are construction artefacts (mean ± std), so a tooltip on them reads like a measurement that was never taken.
+
+## Suggestions
+
+1. Set `hovertemplate` on the mean traces in `spread_plot`, matching the `group_it` path's fields (group, variable, x, y) — ideally with the spread itself, since `mean` and `std` are both in hand at that point.
+2. Set `hoverinfo="skip"` on the band edges so only the mean is hoverable.
+3. Longer term, the docstring says plotly.express is to be replaced by this path for all summary plots — worth making hover parity part of that, since it is currently the main functional difference.
+
+## Workaround (app)
+
+cellpy-simple-gui reconstructs hover after the fact: it groups traces by subplot, takes the variable from the y-axis title and the group from the mean trace's name, derives `std` from the upper-bound trace, and skips hover on the bounds. It works, but it depends on trace naming (`"Upper Bound <group>"`) and on emission order (mean, upper, lower) — both internal details that would be better not to rely on.
+
+## Environment
+
+cellpy 2.1.2, Python 3.13, Windows.

--- a/.issueflows/03-solved-issues/issue875_plan.md
+++ b/.issueflows/03-solved-issues/issue875_plan.md
@@ -1,0 +1,59 @@
+# Issue #875 — Plan: hover on `spread_plot` mean traces
+
+Status: **confirmed** (2026-08-10) — Accept; Q1=(A) std via customdata; Q2=literal `Cycle (n.)`.
+
+## Goal
+
+Give `spread_plot` informative `hovertemplate` on mean traces (parity with `group_it` summary hover) and skip hover on Upper/Lower Bound band artefacts so spread mode is usable in apps.
+
+## Constraints
+
+- Patch-scoped (milestone **v.2.1.2**): touch `spread_plot` (+ tests/docs). No rewrite of `summary_plotter` px path; no full “replace express” migration (issue suggestion 3 = follow-up only).
+- Keep `series_col` behaviour (`cell` vs `group`, #785).
+- Prefer Plotly-native `hoverinfo="skip"` on bounds (not post-hoc app surgery).
+- Design doc: [plotting-collected.md](../04-designs-and-guides/plotting-collected.md).
+
+### Prior art
+
+| Hit | Where | Relation |
+| --- | --- | --- |
+| `spread_plot` | [`cellpy/plotting/collected.py`](../../cellpy/plotting/collected.py) ~L142 | Builds mean + upper + lower `go.Scatter`; no hover today |
+| `summary_plotter` + `group_it` | same file | px attaches hover: `group=…`, `variable=…`, `Cycle (n.)=%{x}`, `mean=%{y}` |
+| `_group_avg_summary_frame` + spread axis tests | [`tests/test_collected_summary_axes.py`](../../tests/test_collected_summary_axes.py) | Ready fixture (`mean`/`std`/`group`/`variable`/`cycle`) |
+| `hoverinfo="skip"` | [`cycle_legend.py`](../../cellpy/plotting/cycle_legend.py) | Same pattern for non-data traces |
+| Toolbox / graphify | — | None needed |
+
+## Approach
+
+1. **Mean trace** — when adding the mean `go.Scatter`, set:
+   - `customdata=sub_data["std"]` (if `std` column present; else omit std line)
+   - `hovertemplate` patterned after `group_it`, e.g.  
+     `{series_col}={cell}<br>variable={variable}<br>Cycle (n.)=%{x}<br>mean=%{y}<br>std=%{customdata}<extra></extra>`  
+     (drop the `std=` line when no std column).
+   - Use the same `series_col` label (`cell` or `group`) as the groupby key so per-cell and group-avg frames stay consistent.
+
+2. **Band traces** — on Upper Bound and Lower Bound: `hoverinfo="skip"` (keep names/legendgroup/fill as today so apps that still key off naming keep working).
+
+3. **Docs** — one bullet in `plotting-collected.md` under summary / spread: mean hover + bounds skipped.
+
+4. **Tests** — extend `test_collected_summary_axes.py` (or thin sibling): `summary_plotter(..., spread=True)` on `_group_avg_summary_frame()`; assert at least one mean-named trace has `hovertemplate` containing `mean=` and `variable=`; assert every `"Upper Bound"` / `"Lower Bound"` trace has `hoverinfo == "skip"` (or equivalent Plotly representation).
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| [`cellpy/plotting/collected.py`](../../cellpy/plotting/collected.py) | `spread_plot` hovertemplate + skip on bounds |
+| [`.issueflows/04-designs-and-guides/plotting-collected.md`](../04-designs-and-guides/plotting-collected.md) | Spread hover note |
+| [`tests/test_collected_summary_axes.py`](../../tests/test_collected_summary_axes.py) | Essential hover assertions |
+
+## Test strategy
+
+```bash
+MPLBACKEND=Agg uv run pytest tests/test_collected_summary_axes.py -q -k spread
+MPLBACKEND=Agg uv run pytest -m essential -q
+```
+
+## Open questions
+
+1. **Include `std` in mean hover?** **(A) yes via `customdata`** (recommend — spread’s point) vs **(B) mean-only** to match `group_it` px hover exactly?
+2. **X-axis label in template** — keep literal `Cycle (n.)` like px group_it (**recommend**) vs pull from `plotly_arguments["labels"]` when present?

--- a/.issueflows/03-solved-issues/issue875_status.md
+++ b/.issueflows/03-solved-issues/issue875_status.md
@@ -1,0 +1,15 @@
+# Issue #875 — Status
+
+- [x] Done
+
+## What's done
+
+- Plan confirmed (Accept; std in hover; Cycle (n.) literal).
+- `spread_plot`: mean `hovertemplate` + `customdata=std`; bounds `hoverinfo="skip"`.
+- `plotting-collected.md` + registry + HISTORY.
+- `test_spread_mean_traces_have_hovertemplate` (essential) — pass.
+- `pytest -m essential` (batch extra) — 727 passed.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -39,7 +39,9 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   limits: `y_ranges={"coulombic_efficiency": [0, 110], ...}` (variable →
   `[lo, hi]`). Non-empty `y_ranges` forces independent axes. Plotly is the
   supported backend for `y_ranges`; seaborn/matplotlib are best-effort and
-  ignore it.
+  ignore it. **Spread hover (#875):** mean traces carry a `hovertemplate`
+  (`group`/`cell`, `variable`, cycle, `mean`, `std`); Upper/Lower Bound band
+  traces use `hoverinfo="skip"`.
 - **App chrome (#801):** `plotly_template=` overrides the default
   `plotly+{method}` combo; `layout_updates=` is a shallow
   `fig.update_layout(**…)` after collector styling. Summary facet strips no

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -19,6 +19,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_collected_app_hooks.py::test_cycles_per_cell_facet_strips_are_pretty | yes | yes | plotting.collected collected_plot per_cell | #820 | no cell= strip |
 | tests/test_collected_app_hooks.py::test_cycles_per_cycle_facet_strips_are_pretty | yes | yes | plotting.collected collected_plot per_cycle | #820 | Cycle N strips |
 | tests/test_collected_summary_axes.py::test_spread_share_y_true_matches_axes | yes | yes | plotting.collected summary spread + share_y | #817 | Group avg + Spread |
+| tests/test_collected_summary_axes.py::test_spread_mean_traces_have_hovertemplate | yes | yes | plotting.collected.spread_plot hover | #875 | mean hover + bounds skip |
 | tests/test_collected_summary_axes.py::test_spread_default_independent_y_axes | yes | yes | plotting.collected summary spread default | #817 | |
 | tests/test_collected_summary_axes.py::test_spread_y_ranges_forces_independent_when_share_y_true | yes | yes | plotting.collected spread y_ranges | #817 | no re-link over limits |
 | tests/test_collected_summary_axes.py::test_collected_plot_spread_share_y | yes | yes | plotting.collected collected_plot spread | #817 | public entry |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@
 * Validate collected `layout=` / `kind=` / `method=` (raise on unknown values);
   `layout='film'` aliases `kind='film'` so apps no longer get a silent wrong
   line plot. (#874)
+* `spread_plot`: mean traces get a real `hovertemplate` (group/cell, variable,
+  cycle, mean, std); Upper/Lower Bound band traces use `hoverinfo='skip'`. (#875)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -201,17 +201,35 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
             else:
                 show_legend = False
             sub_data = data[data["variable"] == variable]
+            mean_kwargs = dict(
+                name=cell,
+                x=sub_data["cycle"],
+                y=sub_data["mean"],
+                mode=mode,
+                line=dict(color=color[0]),
+                legendgroup=cell,
+                legendgrouptitle=None,
+                showlegend=show_legend,
+            )
+            # Hover parity with group_it px path (#875); std via customdata.
+            if "std" in sub_data.columns:
+                mean_kwargs["customdata"] = sub_data["std"]
+                mean_kwargs["hovertemplate"] = (
+                    f"{series_col}={cell}<br>"
+                    f"variable={variable}<br>"
+                    "Cycle (n.)=%{x}<br>"
+                    "mean=%{y}<br>"
+                    "std=%{customdata}<extra></extra>"
+                )
+            else:
+                mean_kwargs["hovertemplate"] = (
+                    f"{series_col}={cell}<br>"
+                    f"variable={variable}<br>"
+                    "Cycle (n.)=%{x}<br>"
+                    "mean=%{y}<extra></extra>"
+                )
             fig.add_trace(
-                go.Scatter(
-                    name=cell,
-                    x=sub_data["cycle"],
-                    y=sub_data["mean"],
-                    mode=mode,
-                    line=dict(color=color[0]),
-                    legendgroup=cell,
-                    legendgrouptitle=None,
-                    showlegend=show_legend,
-                ),
+                go.Scatter(**mean_kwargs),
                 row=row_number + 1,
                 col=1,
             )
@@ -227,6 +245,7 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
                     line=dict(width=0),
                     showlegend=False,
                     legendgroup=cell,
+                    hoverinfo="skip",
                 ),
                 row=row_number + 1,
                 col=1,
@@ -245,6 +264,7 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
                     fill="tonexty",
                     showlegend=False,
                     legendgroup=cell,
+                    hoverinfo="skip",
                 ),
                 row=row_number + 1,
                 col=1,

--- a/tests/test_collected_summary_axes.py
+++ b/tests/test_collected_summary_axes.py
@@ -265,3 +265,32 @@ def test_collected_plot_spread_share_y():
     )
     assert fig is not None
     assert fig.layout.yaxis2.matches == "y"
+
+
+@pytest.mark.essential
+def test_spread_mean_traces_have_hovertemplate():
+    """Mean hover matches group_it fields + std; bounds skip hover (#875)."""
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    from cellpy.plotting import theme
+    from cellpy.plotting.collected import summary_plotter
+
+    theme.make_collector_templates()
+    fig = summary_plotter(
+        _group_avg_summary_frame(),
+        backend="plotly",
+        spread=True,
+    )
+    mean_templates = []
+    for trace in fig.data:
+        name = trace.name or ""
+        if name.startswith("Upper Bound") or name.startswith("Lower Bound"):
+            assert trace.hoverinfo == "skip"
+            continue
+        tmpl = trace.hovertemplate or ""
+        mean_templates.append(tmpl)
+        assert "mean=%{y}" in tmpl
+        assert "variable=" in tmpl
+        assert "Cycle (n.)=%{x}" in tmpl
+        assert "std=%{customdata}" in tmpl
+        assert "group=" in tmpl
+    assert mean_templates, "expected at least one mean trace with hovertemplate"


### PR DESCRIPTION
## Summary
- `spread_plot` mean traces get a `hovertemplate` (series key, variable, cycle, mean, std via `customdata`).
- Upper/Lower Bound band traces use `hoverinfo="skip"`.
- Docs + essential test.

Closes #875.

## Test plan
- [x] `MPLBACKEND=Agg uv run --extra batch pytest tests/test_collected_summary_axes.py -q -k spread`
- [x] `MPLBACKEND=Agg uv run --extra batch pytest -m essential -q`
- [ ] Toggle spread in an app and confirm hover shows mean/std; bounds not hoverable


Made with [Cursor](https://cursor.com)