### PR TITLE
chore: sanitized speed harness and epic #896 plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ graphify-out/
 
 # My own notes
 notes.md
+!dev/speed-test-01/NOTES.md
 
 cellpy/utils/testscripts_ocv_rlx/lmfit_example.py
 cellpy/parametres/_cellpy_prms_devel.ini

--- a/.issueflows/05-epics/epic896_plan.md
+++ b/.issueflows/05-epics/epic896_plan.md
@@ -1,0 +1,94 @@
+# Epic #896: v2.1.3 perceived batch-load speed
+
+Anchor: https://github.com/jepegit/cellpy/issues/896
+Status: confirmed
+
+## Goal
+
+Land the measured, patch-safe first-load / reopen cuts from #895 on milestone
+`v.2.1.3`. Epoch done when every published child is closed and
+`uv run pytest -m essential` is green on `master`.
+
+## Constraints
+
+- Default `auto_use_file_list` stays false; default executor stays `serial`.
+- Do not implement #691 (v.2.2). Do not edit `cellpy_cookies`.
+- Decisions are in each GitHub issue Spec; agents do not ask the maintainer.
+- Loop budget: 2 fix-loops per child, then stop that child.
+
+## Stage 1 — isolated (yolo-fit)
+
+- Goal: four independent PRs that do not change defaults.
+
+### Issue: Keep remote find -L stdout when exit status is 1
+
+- Spec: see #897
+- Goal: `files_only` rglob uses find stdout even when exit is 1
+- Model: fast
+- Depends on: none
+- yolo: yes
+- Published: #897
+
+### Issue: Store v9 parquet zip members uncompressed
+
+- Spec: see #898
+- Goal: parquet members `ZIP_STORED`; v9 tests green
+- Model: fast
+- Depends on: none
+- yolo: yes
+- Published: #898
+
+### Issue: search_for_files uses files_only / find -L
+
+- Spec: see #899
+- Goal: per-cell remote search passes `files_only=True`
+- Model: fast
+- Depends on: none
+- yolo: yes
+- Published: #899
+
+### Issue: Docs: executor=threads and measured speed knobs
+
+- Spec: see #903
+- Goal: agents.md + load docstring document threads-for-reopen
+- Model: fast
+- Depends on: none
+- yolo: yes
+- Published: #903
+
+## Stage 2 — first-load cuts
+
+- Goal: dump-once wiring, fewer SFTP STATs, one HDF read on arbin_sql_h5.
+
+### Issue: Wire auto_use_file_list in journal_from_db / find_files
+
+- Spec: see #900
+- Goal: flag True dumps once (project-scoped when project set); False unchanged
+- Model: default
+- Depends on: none
+- yolo: no
+- Published: #900
+
+### Issue: OtherPath reuse credentialed fs; skip pre-copy is_file
+
+- Spec: see #901
+- Goal: one credentialed UPath per instance; from_raw does not STAT before copy
+- Model: deep
+- Depends on: none
+- yolo: no
+- Published: #901
+
+### Issue: arbin_sql_h5 one HDF read; skip leftover legacy post-process
+
+- Spec: see #902
+- Goal: successful two-stage load selects HDF once; no row-wise datetime apply
+- Model: deep
+- Depends on: none
+- yolo: no
+- Published: #902
+
+## Later (unstaged)
+
+- Cookie defer pandas (`cellpy_cookies`, other repo).
+- #691 project-folder fuzzy match (milestone v.2.2).
+- SSH ControlMaster / parallel SFTP.

--- a/dev/speed-test-01/.gitignore
+++ b/dev/speed-test-01/.gitignore
@@ -1,0 +1,5 @@
+_tmp/
+*.h5
+*.cellpy
+*.json
+importtime*.txt

--- a/dev/speed-test-01/NOTES.md
+++ b/dev/speed-test-01/NOTES.md
@@ -1,0 +1,122 @@
+# Speed session notes (2026-08-15)
+
+Anonymized timings from a Windows PC + remote SFTP lab store. 25-cell
+`arbin_sql_h5` batch. Cookie `batch.load` ~9 min first run. [#895](https://github.com/jepegit/cellpy/issues/895).
+
+No hostnames, usernames, project names, or cell IDs here.
+
+## Import (cookie cell 1)
+
+| Step | s |
+| --- | ---: |
+| `import cellpy` | 0.18 |
+| `import numpy` | 6.7 |
+| **`import pandas`** | **62.4** (cold); ~1 s warm |
+| `matplotlib.pyplot` | 4.0 |
+| `cellpy.config` | 5.0 |
+| `config.paths.rawdatadir` (scp URI) | 0.16 |
+| `from cellpy import batch` | 0.12 |
+| `helpers` / `plotutils` | 4.4 / 1.7 |
+
+`#837` light `import cellpy` holds. SSH at config load is not the wait. Cold
+pandas is Windows/conda cache (same class as `#837`). Cookie imports pandas/mpl
+before `batch.load` needs them.
+
+## One-cell primitives (not `batch.load` as a blob)
+
+| Step | s |
+| --- | ---: |
+| `read_journal` / `resolve_specs` | 0.03 / 0.00 |
+| `cellpy.get` local `.cellpy` 22 MB (cold) | **15.3** |
+| `load_cell` AUTO (warm) | 0.20 |
+| `OtherPath.copy` remote `.h5` 76 MB | 2.6–8.1 |
+| parse local raw, `auto_summary=False` | 5.7 |
+| `make_step_table` / `make_summary` | 0.60 / 0.13 |
+| `load_cell` RAW_ONLY | 11.0 |
+
+Morning ~9 min ≈ 25 × (copy + parse + save). Second AUTO hits local `.cellpy`.
+
+Side: pip `pyarrow==24` leftover on conda `pyarrow-core==25` broke `.cellpy`
+load (DLL). Harmonize prefetch hit `WinError 32` and fell back to legacy.
+
+## OtherPath
+
+| Step | s |
+| --- | ---: |
+| `OtherPath()` | 0.003 |
+| first `is_file()` | **0.55–0.81** (SSH handshake) |
+| later `is_file` / `stat` | ~0.006 |
+| warm `copy()` | 2.6–3.6 |
+| OpenSSH `scp` same file | 2.97 |
+
+Transfer ≈ OpenSSH (~25 MB/s). Extra cost is STATs + silence, not a 3× tax.
+`from_raw` always `is_file()` then loader `copy()`; each builds a new
+credentialed `UPath`. fsspec `get_file` also `isdir()` then `ftp.get`.
+
+## Executors (`run(..., executor=)`)
+
+Cookie / default `batch.load` does not set `executor`.
+
+| Work | serial | threads | processes |
+| --- | ---: | ---: | ---: |
+| AUTO 25 local `.cellpy` (warm) | 5.2 | **2.0** | 8.8 |
+| RAW_ONLY 3 remote `.h5` | 38.5 | 37.1 | 34.1 |
+
+Threads help **reopen**. First remote load does not overlap on the wire.
+Processes lose on Windows spawn.
+
+## Filefinder / `find -L` / `auto_use_file_list`
+
+Names: `config.batch.auto_use_file_list`; remote `find -L <root> -type f` inside
+`OtherPath.rglob(..., files_only=True)` (#690). Used by
+`find_in_raw_file_directory`, **not** by per-cell `search_for_files`.
+
+v3 `journal_from_db` never reads the flag. Cookie `batch.load` skipped
+filefinder (`raw_file_names` already in the journal).
+
+Project folder (~276 `.h5`): `find -L` 0.02 s vs walk 0.08 s. 25× `fnmatch` on
+a dump **0.014 s**; 25× project `rglob` 0.88 s.
+
+Full shared `rawdatadir`: 25× `search_for_files` no list **68.9 s**. Raw
+`find -L` listed ~18k files in 0.12 s but **exit 1** (permission on a sibling
+dir) so stdout is discarded. Dump then walks (~3.4 s, ~2k `.h5`).
+
+`search_for_files` never sets `files_only=True`.
+
+## v9 `.cellpy` I/O (22 MB zip, 526k × 18 raw)
+
+Almost all `raw.parquet` (33 MB inflated / 22 MB stored).
+
+Warm load: inflate 0.14 s, pyarrow **0.97 s**, translate ~0. Cold 15 s is page
+cache / Defender. `CellpyCell.save` v9 **3.84 s** (parquet encode 0.74 s; rest
+is `ZIP_DEFLATED` on already-compressed parquet + copies). v8 HDF5 save 1.70 s
+(18.7 MB). **25 first-load writes ≈ 95 s**.
+
+## `arbin_sql_h5` parse (76 MB, 529k × 16)
+
+`Date_Time` is `int64` 100 ns ticks.
+
+| Step | s |
+| --- | ---: |
+| HDFStore select | 0.31 |
+| drop_duplicates | 0.76 |
+| `apply(from_arbin_to_datetime)` | **2.84** |
+| `pd.to_datetime` on those strings | **1.90** |
+| `parse()` + `harmonize(arbin_epoch)` | 1.4 + **0.11** |
+| legacy `loader()` / `_post_process` | **8.67** |
+| `cellpy.get` harmonize ON | **11.8** |
+| `cellpy.get` harmonize OFF | **8.8** |
+
+Default two-stage path still runs the full legacy loader, then discards that
+raw. `parse()` does not cache HDF frames and ignores `refuse_copying=` kwargs.
+
+## Likely package cuts (not done)
+
+1. Cookie: defer pandas / mpl / `plotutils`.
+2. Cache credentialed `UPath` / `fs`; skip pre-copy `is_file`; progress on `copy()`.
+3. Document `executor="threads"` for reopen.
+4. Wire `auto_use_file_list` (prefer `project_dir=`); keep `find` stdout on exit 1;
+   `files_only` in `search_for_files`; project-scoped `rawdatadir` (#691).
+5. v9: `ZIP_STORED` for parquet members.
+6. When harmonize prefetch succeeds, skip `_post_process` / second HDF read;
+   vectorize legacy datetime if it must stay.

--- a/dev/speed-test-01/README.md
+++ b/dev/speed-test-01/README.md
@@ -1,0 +1,48 @@
+# Speed harness (#895)
+
+Diagnostic scripts from the 2026-08-15 perceived-speed session. They take
+**your** journal / paths via environment variables. Do not put hostnames,
+usernames, project names, or cell IDs in these files.
+
+Findings (anonymized): [`NOTES.md`](NOTES.md). Issue: [jepegit/cellpy#895](https://github.com/jepegit/cellpy/issues/895).
+
+Scratch copies land in `_tmp/` (gitignored).
+
+## Env
+
+| Variable | Used by | What |
+| --- | --- | --- |
+| `SPEEDTEST_JOURNAL` | most scripts | path to a batch journal JSON (keep it out of git) |
+| `SPEEDTEST_LABEL` | one-cell / OtherPath / h5 | cell label; default = first journal row |
+| `SPEEDTEST_PROJECT` | filefinder | project subfolder under `rawdatadir` |
+| `SPEEDTEST_EXT` | filefinder | raw extension without dot (default `h5`) |
+| `SPEEDTEST_CELLPY` | `time_cellpy_io.py` | one local `.cellpy` |
+| `SPEEDTEST_RAW` | OtherPath / h5 | optional raw URI override |
+| `SPEEDTEST_RAW_LOCAL` | `time_arbin_h5.py` | optional already-copied local raw |
+
+Scripts print **basenames** or redacted URIs (`scp://<host>/…`), not full lab paths.
+
+## Run
+
+Use the project env (conda `cellpy_dev_313` or `uv run`). Example (Windows cmd):
+
+```bat
+set SPEEDTEST_JOURNAL=C:\path\to\your_journal.json
+set SPEEDTEST_PROJECT=YourProject
+set SPEEDTEST_CELLPY=C:\path\to\one.cellpy
+python dev/speed-test-01/time_imports.py
+python dev/speed-test-01/time_one_cell.py
+python dev/speed-test-01/time_otherpath.py
+python dev/speed-test-01/time_otherpath.py --cold
+python dev/speed-test-01/time_executors.py
+python dev/speed-test-01/time_filefinder.py
+python dev/speed-test-01/time_cellpy_io.py
+python dev/speed-test-01/time_arbin_h5.py
+```
+
+`summarize_importtime.py` only needs a `python -X importtime` dump:
+
+```bat
+python -X importtime -c "import pandas" 2> importtime.txt
+python dev/speed-test-01/summarize_importtime.py importtime.txt
+```

--- a/dev/speed-test-01/_common.py
+++ b/dev/speed-test-01/_common.py
@@ -1,0 +1,84 @@
+"""Shared helpers for the #895 speed harness.
+
+Paths come from the environment or a local journal — never hard-coded hosts,
+usernames, or project names. Printed paths are redacted.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+HERE = Path(__file__).resolve().parent
+TMP = HERE / "_tmp"
+
+
+def env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def journal_path() -> Path:
+    raw = env("SPEEDTEST_JOURNAL")
+    if raw:
+        return Path(raw)
+    raise SystemExit(
+        "Set SPEEDTEST_JOURNAL to a batch journal JSON "
+        "(do not commit that file; it usually has remote URIs)."
+    )
+
+
+def project_name() -> str:
+    name = env("SPEEDTEST_PROJECT")
+    if not name:
+        raise SystemExit("Set SPEEDTEST_PROJECT to the project subfolder under rawdatadir.")
+    return name
+
+
+def cell_label(journal=None) -> str:
+    label = env("SPEEDTEST_LABEL")
+    if label:
+        return label
+    if journal is not None:
+        from cellpy.batch.journal import FILENAME
+
+        return journal.pages[FILENAME][0]
+    raise SystemExit("Set SPEEDTEST_LABEL or pass a journal with pages.")
+
+
+def raw_extension() -> str:
+    return env("SPEEDTEST_EXT", "h5")
+
+
+def redact(value) -> str:
+    """Hide host, user home, and AD-style user@domain path segments."""
+    text = str(value)
+    text = re.sub(r"(?i)[A-Za-z]:[\\/]Users[\\/][^\\/]+", "<home>", text)
+    text = re.sub(r"/home/[^/]+", "/home/<user>", text)
+    text = re.sub(r"(?i)\\Users\\[^\\]+", r"\\Users\\<user>", text)
+    parts = urlsplit(text)
+    if parts.scheme and parts.netloc:
+        path = parts.path
+        path = re.sub(r"/home/[^/]+", "/home/<user>", path)
+        return f"{parts.scheme}://<host>{path}"
+    return text
+
+
+def redact_name(value) -> str:
+    """Print only the basename (safe for logs)."""
+    text = str(value)
+    if not text:
+        return text
+    return Path(text.replace("\\", "/").rstrip("/")).name
+
+
+def step(label: str, fn):
+    t0 = time.perf_counter()
+    value = fn()
+    print(f"{time.perf_counter() - t0:8.3f}s  {label}", flush=True)
+    return value

--- a/dev/speed-test-01/summarize_importtime.py
+++ b/dev/speed-test-01/summarize_importtime.py
@@ -1,0 +1,37 @@
+"""Print top cumulative rows from a ``python -X importtime`` stderr dump.
+
+    python -X importtime -c "import pandas" 2> importtime.txt
+    python dev/speed-test-01/summarize_importtime.py importtime.txt
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    path = Path(sys.argv[1])
+    rows = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.startswith("import time:"):
+            continue
+        rest = line[len("import time:") :].strip()
+        parts = [x.strip() for x in rest.split("|")]
+        if len(parts) < 3:
+            continue
+        try:
+            self_us = int(parts[0])
+            cum_us = int(parts[1])
+        except ValueError:
+            continue
+        rows.append((cum_us, self_us, parts[2]))
+    rows.sort(reverse=True)
+    print(f"file={path.name} rows={len(rows)} bytes={path.stat().st_size}")
+    print("top 20 by cumulative (ms):")
+    for cum, self, name in rows[:20]:
+        print(f"{cum / 1000:10.1f}  self={self / 1000:8.1f}  {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_arbin_h5.py
+++ b/dev/speed-test-01/time_arbin_h5.py
@@ -1,0 +1,98 @@
+"""Split arbin_sql_h5 parse (local raw after one copy).
+
+    set SPEEDTEST_JOURNAL=path/to/journal.json
+    python dev/speed-test-01/time_arbin_h5.py
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from _common import TMP, cell_label, env, journal_path, redact_name, step
+
+logging.basicConfig(level=logging.WARNING)
+
+import pandas as pd
+
+import cellpy.config as config
+from cellpy.batch.journal import read_journal
+from cellpy.internals.connections import OtherPath
+from cellpy.readers.cellreader import get as cellpy_get
+from cellpy.readers.instruments import arbin_sql_h5
+from cellpy.readers.instruments.harmonize import harmonize
+
+
+def _raw_uri() -> str:
+    override = env("SPEEDTEST_RAW")
+    if override:
+        return override
+    journal = read_journal(journal_path())
+    label = cell_label(journal)
+    for row in journal.pages.iter_rows(named=True):
+        if row.get("filename") == label:
+            files = row.get("raw_file_names")
+            if files:
+                return files[0]
+    raise SystemExit(f"no raw URI for label {label}")
+
+
+def _loader_on(path: Path) -> arbin_sql_h5.DataLoader:
+    loader = arbin_sql_h5.DataLoader()
+    loader.name = path
+    loader._temp_file_path = path
+    loader._refuse_copying = True
+    return loader
+
+
+def main() -> None:
+    local = Path(env("SPEEDTEST_RAW_LOCAL") or (TMP / "raw_local.h5"))
+    local.parent.mkdir(parents=True, exist_ok=True)
+    if not local.is_file():
+        copied = step("OtherPath.copy remote raw", OtherPath(_raw_uri()).copy)
+        shutil.copy2(copied, local)
+    print(f"local={redact_name(local)}  size={local.stat().st_size / 1e6:.1f} MB", flush=True)
+
+    loader = _loader_on(local)
+    frames = step("HDFStore select data/info/stat", loader._parse_h5_data)
+    data_df = frames["data_df"]
+    print(f"  data_df shape={data_df.shape}  Date_Time dtype={data_df['Date_Time'].dtype}", flush=True)
+    step("drop_duplicates", data_df.drop_duplicates)
+    sample = data_df["Date_Time"]
+    converted = step(
+        "Series.apply(from_arbin_to_datetime)",
+        lambda: sample.apply(arbin_sql_h5.from_arbin_to_datetime),
+    )
+    step(
+        "pd.to_datetime on those strings",
+        lambda: pd.to_datetime(converted, format=arbin_sql_h5.DATE_TIME_FORMAT),
+    )
+
+    dest = local.with_name(local.stem + "_copy2.h5")
+    if dest.exists():
+        dest.unlink()
+    step("shutil.copy2 local raw", lambda: shutil.copy2(local, dest))
+
+    loader_p = arbin_sql_h5.DataLoader()
+    loader_p._refuse_copying = True
+    vendor = step("parse() refuse_copying", lambda: loader_p.parse(local))
+    decls = loader_p.declarations()
+    native = step("harmonize(vendor) arbin_epoch", lambda: harmonize(vendor, decls, strict=False))
+    step("harmonized.to_pandas()", native.to_pandas)
+    step("legacy loader()", lambda: _loader_on(local).loader(local))
+
+    step(
+        "cellpy.get auto_summary=False (harmonize ON)",
+        lambda: cellpy_get(local, instrument="arbin_sql_h5", auto_summary=False, refuse_copying=True),
+    )
+    config.reader.use_harmonized_raw = False
+    step(
+        "cellpy.get auto_summary=False (harmonize OFF)",
+        lambda: cellpy_get(local, instrument="arbin_sql_h5", auto_summary=False, refuse_copying=True),
+    )
+    config.reader.use_harmonized_raw = True
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_cellpy_io.py
+++ b/dev/speed-test-01/time_cellpy_io.py
@@ -1,0 +1,85 @@
+"""Split v9 .cellpy load and save.
+
+    set SPEEDTEST_CELLPY=path/to/one.cellpy
+    python dev/speed-test-01/time_cellpy_io.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import tempfile
+import zipfile
+from pathlib import Path
+
+from _common import env, redact_name, step
+
+logging.basicConfig(level=logging.WARNING)
+
+
+def _cellpy_path() -> Path:
+    raw = env("SPEEDTEST_CELLPY")
+    if raw:
+        return Path(raw)
+    raise SystemExit("Set SPEEDTEST_CELLPY to a local .cellpy file.")
+
+
+def main() -> None:
+    import pandas as pd
+
+    from cellpy.readers.cellpy_file import v9
+    from cellpy.readers.cellreader import get as cellpy_get
+
+    path = _cellpy_path()
+    print(f"file={redact_name(path)}  size={path.stat().st_size / 1e6:.1f} MB", flush=True)
+
+    with zipfile.ZipFile(path, "r") as zf:
+        for info in zf.infolist():
+            print(
+                f"  {info.filename:20s}  stored={info.file_size/1e6:.2f} MB  "
+                f"compress={info.compress_size/1e6:.2f} MB",
+                flush=True,
+            )
+
+    zf = zipfile.ZipFile(path, "r")
+    step("ZipFile open + namelist", zf.namelist)
+    step("read+parse meta.json", lambda: json.loads(zf.read("meta.json")))
+    raw_bytes = step("zf.read raw.parquet (inflate)", lambda: zf.read("raw.parquet"))
+    print(f"  inflated raw={len(raw_bytes)/1e6:.1f} MB", flush=True)
+    raw_df = step(
+        "pandas.read_parquet raw (pyarrow)",
+        lambda: pd.read_parquet(io.BytesIO(raw_bytes), engine="pyarrow"),
+    )
+    print(f"  raw shape={raw_df.shape}", flush=True)
+    for name in ("steps.parquet", "summary.parquet", "fid.parquet"):
+        if name in zf.namelist():
+            step(f"read+parse {name}", lambda n=name: pd.read_parquet(io.BytesIO(zf.read(n)), engine="pyarrow"))
+    zf.close()
+
+    step("v9.load", lambda: v9.load(path))
+    cell = step("cellpy.get", lambda: cellpy_get(path))
+    cell = step("cellpy.get again", lambda: cellpy_get(path))
+
+    out = Path(tempfile.gettempdir()) / "speedtest_rewrite.cellpy"
+    if out.exists():
+        out.unlink()
+    step("CellpyCell.save v9", lambda: cell.save(out, overwrite=True))
+    print(f"  wrote {out.stat().st_size / 1e6:.1f} MB", flush=True)
+    step("to_parquet bytes raw", lambda: v9._frame_to_parquet_bytes(cell.data.raw))
+    step("to_parquet bytes steps", lambda: v9._frame_to_parquet_bytes(cell.data.steps))
+    step("to_parquet bytes summary", lambda: v9._frame_to_parquet_bytes(cell.data.summary))
+
+    out_v8 = Path(tempfile.gettempdir()) / "speedtest_rewrite.h5"
+    if out_v8.exists():
+        out_v8.unlink()
+    try:
+        step("CellpyCell.save v8 hdf5", lambda: cell.save(out_v8, overwrite=True, cellpy_file_format="v8"))
+        print(f"  wrote {out_v8.stat().st_size / 1e6:.1f} MB", flush=True)
+        step("cellpy.get v8", lambda: cellpy_get(out_v8))
+    except Exception as exc:
+        print(f"  v8 save/load skipped: {type(exc).__name__}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_executors.py
+++ b/dev/speed-test-01/time_executors.py
@@ -1,0 +1,74 @@
+"""Time batch.runner.run() serial vs threads vs processes.
+
+    set SPEEDTEST_JOURNAL=path/to/journal.json
+    python dev/speed-test-01/time_executors.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from _common import journal_path
+
+logging.basicConfig(level=logging.WARNING)
+
+from cellpy.batch.journal import FILENAME, Journal, read_journal
+from cellpy.batch.policy import LoadPolicy, SourcePreference
+from cellpy.batch.runner import run
+
+
+def _subset(journal: Journal, labels: list[str]) -> Journal:
+    pages = journal.pages.filter(journal.pages[FILENAME].is_in(labels))
+    return Journal(
+        name=journal.name,
+        project=journal.project,
+        pages=pages,
+        session=journal.session,
+        meta=journal.meta,
+    )
+
+
+def _report(title: str, result, wall: float) -> None:
+    rows = list(result)
+    failed = [r for r in rows if r.outcome.value == "failed"]
+    loaded = [r for r in rows if r.outcome.value == "loaded"]
+    cell_s = [r.seconds for r in loaded]
+    print(
+        f"\n== {title}  wall={wall:.2f}s  n={len(rows)} "
+        f"loaded={len(loaded)} failed={len(failed)}",
+        flush=True,
+    )
+    if cell_s:
+        print(
+            f"   per-cell s: min={min(cell_s):.2f}  "
+            f"median={sorted(cell_s)[len(cell_s)//2]:.2f}  "
+            f"max={max(cell_s):.2f}  sum={sum(cell_s):.2f}",
+            flush=True,
+        )
+    for r in failed[:5]:
+        print(f"   FAIL {r.label}: {type(r.error).__name__}: {r.error}", flush=True)
+
+
+def _run(journal: Journal, policy: LoadPolicy, executor: str, title: str) -> None:
+    t0 = time.perf_counter()
+    result = run(journal, policy, executor=executor)
+    _report(title, result, time.perf_counter() - t0)
+
+
+def main() -> None:
+    journal = read_journal(journal_path())
+    labels = list(journal.pages[FILENAME])
+    print(f"journal cells={len(labels)}", flush=True)
+    auto = LoadPolicy(source=SourcePreference.AUTO, accept_errors=True)
+    raw = LoadPolicy(source=SourcePreference.RAW_ONLY, accept_errors=True)
+    raw_journal = _subset(journal, labels[:3])
+
+    for ex in ("serial", "threads", "processes"):
+        _run(journal, auto, ex, f"AUTO {ex} (local .cellpy)")
+    for ex in ("serial", "threads", "processes"):
+        _run(raw_journal, raw, ex, f"RAW_ONLY {ex} (first 3 raw)")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_filefinder.py
+++ b/dev/speed-test-01/time_filefinder.py
@@ -1,0 +1,132 @@
+"""Time find -L vs walk vs per-cell search_for_files.
+
+    set SPEEDTEST_JOURNAL=path/to/journal.json
+    set SPEEDTEST_PROJECT=YourProject
+    set SPEEDTEST_EXT=h5
+    python dev/speed-test-01/time_filefinder.py
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import time
+
+from _common import cell_label, journal_path, project_name, raw_extension, step
+
+logging.basicConfig(level=logging.WARNING)
+
+import cellpy.config as config
+from cellpy.batch.journal import FILENAME, read_journal
+from cellpy.internals.connections import OtherPath
+from cellpy.readers import filefinder
+
+
+def main() -> None:
+    ext = raw_extension()
+    project = project_name()
+    journal = read_journal(journal_path())
+    cells = list(journal.pages[FILENAME])
+    label = cell_label(journal)
+    root = OtherPath(config.paths.rawdatadir)
+    proj = root / project
+    print(
+        f"n_cells={len(cells)}  ext={ext}  "
+        f"auto_use_file_list={config.batch.auto_use_file_list}",
+        flush=True,
+    )
+
+    cred = proj._upath_with_credentials()
+    fs, remote_root = cred.fs, cred.path.rstrip("/") or "/"
+    bulk = step("find -L project", lambda: proj._remote_find_l_file_paths(fs, remote_root))
+    if bulk is None:
+        print("  find -L returned None", flush=True)
+    else:
+        print(f"  n={len(bulk)}  *.{ext}={sum(1 for p in bulk if p.endswith('.' + ext))}", flush=True)
+
+    orig = OtherPath._remote_rglob_from_find
+    OtherPath._remote_rglob_from_find = lambda *a, **k: None
+    try:
+        walked = step(
+            "walk project rglob files_only (find disabled)",
+            lambda: list(proj.rglob(f"*.{ext}", files_only=True)),
+        )
+        print(f"  n={len(walked)}", flush=True)
+    finally:
+        OtherPath._remote_rglob_from_find = orig
+
+    dumped = step(
+        "find_in_raw_file_directory(project, ext)",
+        lambda: filefinder.find_in_raw_file_directory(
+            raw_file_dir=root, project_dir=project, extension=ext
+        ),
+    )
+    print(f"  n={len(dumped)}", flush=True)
+
+    raw, _ = filefinder.search_for_files(
+        label, raw_extension=ext, raw_file_dir=root, file_list=dumped, with_prefix=True
+    )
+    print(f"  sample hits for first label: {len(raw)}", flush=True)
+
+    def _search_list():
+        hits = []
+        for cell in cells:
+            found, _ = filefinder.search_for_files(
+                cell, raw_extension=ext, raw_file_dir=root, file_list=dumped, with_prefix=True
+            )
+            hits.append(len(found) if found else 0)
+        return hits
+
+    hits = step(f"{len(cells)}x search + file_list", _search_list)
+    print(f"  hits={hits}", flush=True)
+
+    def _search_proj():
+        hits = []
+        for cell in cells:
+            found, _ = filefinder.search_for_files(
+                cell, raw_extension=ext, raw_file_dir=proj, file_list=None
+            )
+            hits.append(len(found) if found else 0)
+        return hits
+
+    hits = step(f"{len(cells)}x search project, no list", _search_proj)
+    print(f"  hits={hits}", flush=True)
+
+    print("--- full rawdatadir ---", flush=True)
+    root_cred = root._upath_with_credentials()
+    cmd = f"find -L {shlex.quote(root_cred.path.rstrip('/') or '/')} -type f -print"
+    t0 = time.perf_counter()
+    _stdin, stdout, stderr = root_cred.fs.client.exec_command(cmd, timeout=300)
+    exit_status = stdout.channel.recv_exit_status()
+    out = stdout.read()
+    err = stderr.read()
+    text = out.decode("utf-8", errors="replace") if isinstance(out, (bytes, bytearray)) else str(out)
+    n = sum(1 for line in text.splitlines() if line.strip())
+    err_s = err.decode("utf-8", errors="replace") if isinstance(err, (bytes, bytearray)) else str(err)
+    print(
+        f"{time.perf_counter() - t0:8.3f}s  raw find -L full tree  "
+        f"exit={exit_status}  n={n}  stderr_lines={len(err_s.splitlines())}",
+        flush=True,
+    )
+
+    dumped_all = step(
+        "find_in_raw_file_directory(full, ext)",
+        lambda: filefinder.find_in_raw_file_directory(raw_file_dir=root, extension=ext),
+    )
+    print(f"  n={len(dumped_all)}", flush=True)
+
+    def _search_full():
+        hits = []
+        for cell in cells:
+            found, _ = filefinder.search_for_files(
+                cell, raw_extension=ext, raw_file_dir=root, file_list=None
+            )
+            hits.append(len(found) if found else 0)
+        return hits
+
+    hits = step(f"{len(cells)}x search FULL rawdatadir, no list", _search_full)
+    print(f"  hits={hits}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_imports.py
+++ b/dev/speed-test-01/time_imports.py
@@ -1,0 +1,64 @@
+"""Split-time the batch-cookie import list (fresh process).
+
+    python dev/speed-test-01/time_imports.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from _common import redact
+
+PROBES = (
+    "cellpy.readers.cellreader",
+    "cellpy.batch.runner",
+    "cellpy.config.loader",
+    "plotly",
+    "paramiko",
+    "fsspec",
+)
+
+
+def _present() -> set[str]:
+    return {name for name in PROBES if name in sys.modules}
+
+
+def _step(label: str, fn) -> None:
+    before = _present()
+    t0 = time.perf_counter()
+    fn()
+    dt = time.perf_counter() - t0
+    appeared = sorted(_present() - before)
+    extra = f"  appeared={appeared}" if appeared else ""
+    print(f"{dt:8.3f}s  {label}{extra}", flush=True)
+
+
+def main() -> None:
+    print(f"python={sys.executable}", flush=True)
+
+    def import_cellpy():
+        import cellpy
+
+        print(f"  cellpy.__version__={cellpy.__version__}", flush=True)
+
+    _step("import cellpy", import_cellpy)
+    _step("import numpy", lambda: __import__("numpy"))
+    _step("import pandas", lambda: __import__("pandas"))
+    _step("import matplotlib.pyplot", lambda: __import__("matplotlib.pyplot"))
+    _step("import cellpy.config", lambda: __import__("cellpy.config"))
+
+    def touch_rawdatadir():
+        import cellpy.config as config
+
+        path = config.paths.rawdatadir
+        print(f"  rawdatadir={redact(path)}", flush=True)
+
+    _step("config.paths.rawdatadir", touch_rawdatadir)
+    _step("from cellpy import batch", lambda: __import__("cellpy.batch"))
+    _step("from cellpy.utils import helpers", lambda: __import__("cellpy.utils.helpers"))
+    _step("from cellpy.utils import plotutils", lambda: __import__("cellpy.utils.plotutils"))
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_one_cell.py
+++ b/dev/speed-test-01/time_one_cell.py
@@ -1,0 +1,74 @@
+"""Time batch primitives for one journal cell (not ``batch.load``).
+
+    set SPEEDTEST_JOURNAL=path/to/journal.json
+    set SPEEDTEST_LABEL=optional-cell-label
+    python dev/speed-test-01/time_one_cell.py
+"""
+
+from __future__ import annotations
+
+import logging
+
+from _common import cell_label, journal_path, redact_name, step
+
+logging.basicConfig(level=logging.WARNING)
+
+from cellpy.batch.journal import read_journal
+from cellpy.batch.policy import LoadPolicy, SourcePreference, resolve_specs
+from cellpy.batch.runner import load_cell
+from cellpy.internals.connections import OtherPath
+from cellpy.readers.cellreader import get as cellpy_get
+
+
+def main() -> None:
+    from pathlib import Path
+
+    journal_file = journal_path()
+    journal = step("read_journal", lambda: read_journal(journal_file))
+    label = cell_label(journal)
+    print(f"  n_cells={journal.pages.height}  label={label}", flush=True)
+
+    specs = step("resolve_specs AUTO", lambda: resolve_specs(journal, LoadPolicy()))
+    spec = next(s for s in specs if s.label == label)
+    print(
+        f"  raw={redact_name(spec.raw_files[0]) if spec.raw_files else None}  "
+        f"cellpy={redact_name(spec.cellpy_file)}  instrument={spec.instrument}",
+        flush=True,
+    )
+
+    local_cellpy = Path(spec.cellpy_file) if spec.cellpy_file else None
+    if local_cellpy and local_cellpy.is_file():
+        step("cellpy.get local .cellpy", lambda: cellpy_get(local_cellpy))
+        step("load_cell AUTO", lambda: load_cell(spec, LoadPolicy()))
+    else:
+        print("  no local .cellpy — skip those steps", flush=True)
+
+    if not spec.raw_files:
+        print("  no raw path — stop", flush=True)
+        return
+
+    remote = OtherPath(spec.raw_files[0])
+    copied = step("OtherPath.copy remote raw", remote.copy)
+    print(f"  copied size={copied.stat().st_size / 1e6:.1f} MB", flush=True)
+
+    cell = step(
+        "cellpy.get local raw auto_summary=False refuse_copying",
+        lambda: cellpy_get(
+            copied,
+            instrument=spec.instrument,
+            mass=spec.mass,
+            area=spec.area,
+            auto_summary=False,
+            refuse_copying=True,
+        ),
+    )
+    step("make_step_table", cell.make_step_table)
+    step("make_summary", cell.make_summary)
+    step(
+        "load_cell RAW_ONLY",
+        lambda: load_cell(spec, LoadPolicy(source=SourcePreference.RAW_ONLY)),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/speed-test-01/time_otherpath.py
+++ b/dev/speed-test-01/time_otherpath.py
@@ -1,0 +1,94 @@
+"""Split-time OtherPath remote ops (handshake vs transfer).
+
+    set SPEEDTEST_JOURNAL=path/to/journal.json
+    python dev/speed-test-01/time_otherpath.py
+    python dev/speed-test-01/time_otherpath.py --cold
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from _common import TMP, cell_label, journal_path, redact_name, step
+
+logging.basicConfig(level=logging.WARNING)
+
+from cellpy.batch.journal import read_journal
+from cellpy.internals.connections import OtherPath
+
+
+def _raw_uri() -> str:
+    override = __import__("os").environ.get("SPEEDTEST_RAW")
+    if override:
+        return override
+    journal = read_journal(journal_path())
+    label = cell_label(journal)
+    for row in journal.pages.iter_rows(named=True):
+        if row.get("filename") == label:
+            files = row.get("raw_file_names")
+            if files:
+                return files[0]
+    raise SystemExit(f"no raw URI for label {label}")
+
+
+def cold() -> None:
+    raw = _raw_uri()
+    out = TMP / "otherpath_cold"
+    out.mkdir(parents=True, exist_ok=True)
+    for leftover in out.iterdir():
+        leftover.unlink()
+    p = OtherPath(raw)
+    import time
+
+    t0 = time.perf_counter()
+    ok = p.is_file()
+    t1 = time.perf_counter()
+    copied = p.copy(out)
+    t2 = time.perf_counter()
+    print(f"is_file {t1 - t0:.3f}s ok={ok}", flush=True)
+    print(f"copy    {t2 - t1:.3f}s {copied.stat().st_size / 1e6:.1f} MB", flush=True)
+    print(f"total   {t2 - t0:.3f}s", flush=True)
+
+
+def warm() -> None:
+    raw = _raw_uri()
+    print(f"name={redact_name(raw)}", flush=True)
+    out = TMP / "otherpath"
+    out.mkdir(parents=True, exist_ok=True)
+    d1, d2, d3 = out / "c1", out / "c2", out / "c3"
+    for d in (d1, d2, d3):
+        d.mkdir(exist_ok=True)
+        for leftover in d.iterdir():
+            leftover.unlink()
+
+    p = step("OtherPath()", lambda: OtherPath(raw))
+    print(f"  is_external={p.is_external} name={p.name}", flush=True)
+    step("is_file() #1", p.is_file)
+    step("is_file() #2 same object", p.is_file)
+    st = step("stat()", p.stat)
+    print(f"  st_size={getattr(st, 'st_size', None)}", flush=True)
+    copied = step("copy() #1", lambda: p.copy(d1))
+    print(f"  {copied.stat().st_size / 1e6:.1f} MB", flush=True)
+    step("copy() #2 new OtherPath()", lambda: OtherPath(raw).copy(d2))
+    upath = step("_upath_with_credentials()", p._upath_with_credentials)
+    step("reuse UPath.exists()", upath.exists)
+    step("reuse fs.info()", lambda: upath.fs.info(upath.path))
+    dest3 = d3 / p.name
+    step("reuse fs.get()", lambda: upath.fs.get(upath.path, str(dest3)))
+    q = OtherPath(raw)
+    step("from_raw pattern: is_file() + copy()", lambda: (q.is_file(), q.copy(d1)))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cold", action="store_true")
+    args = parser.parse_args()
+    if args.cold:
+        cold()
+    else:
+        warm()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `dev/speed-test-01/`: env-driven timing scripts and anonymized notes from the #895 first-load session (no lab hosts, usernames, or project names).
- Record the confirmed v2.1.3 speed epoch plan at `.issueflows/05-epics/epic896_plan.md` (children #897–#903).
- Allow `dev/speed-test-01/NOTES.md` through the root `notes.md` gitignore so the write-up is tracked.

Closes nothing by itself. Evidence for #895 / #896.

## Test plan
- [x] Grep harness for lab host / AD user / project / cell IDs — clean
- [ ] Skim `dev/speed-test-01/README.md` env table
- [ ] Optional: `python dev/speed-test-01/time_imports.py` (no journal required)


Made with [Cursor](https://cursor.com)