### PR TITLE
fix(otherpath): keep find -L listing when find exits 1 (#897)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,9 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* Remote `rglob(..., files_only=True)` keeps the `find -L` listing when `find`
+  exits 1 because a sibling directory was unreadable, instead of discarding it
+  and falling back to the slow SFTP walk. (#897)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -445,7 +445,12 @@ class OtherPath:
     def _remote_find_l_file_paths(self, fs: Any, root: str) -> Optional[List[str]]:
         """Bulk list files via remote ``find -L`` when Paramiko exec is available.
 
-        Returns ``None`` on any failure so callers fall back to the ls-walk.
+        ``find`` exits 1 when it could not descend into some directory (a
+        shared ``rawdatadir`` almost always has an unreadable sibling), but it
+        still prints every path it did list. Keep that listing and only fall
+        back to the ls-walk when nothing was listed (#897).
+
+        Returns ``None`` on failure so callers fall back to the ls-walk.
         """
         client = getattr(fs, "client", None)
         exec_command = getattr(client, "exec_command", None) if client is not None else None
@@ -460,14 +465,6 @@ class OtherPath:
         except (OSError, AttributeError, TypeError, ValueError) as exc:
             logging.debug("Remote find -L failed for %s: %s", root, exc)
             return None
-        if exit_status not in (0, None):
-            logging.debug(
-                "Remote find -L exit %s for %s: %s",
-                exit_status,
-                root,
-                err[:200] if isinstance(err, (bytes, bytearray)) else err,
-            )
-            return None
         if isinstance(out, (bytes, bytearray)):
             text = out.decode("utf-8", errors="replace")
         else:
@@ -477,6 +474,16 @@ class OtherPath:
             path = line.strip()
             if path:
                 paths.append(path)
+        if exit_status not in (0, None):
+            logging.debug(
+                "Remote find -L exit %s for %s (%s paths listed): %s",
+                exit_status,
+                root,
+                len(paths),
+                err[:200] if isinstance(err, (bytes, bytearray)) else err,
+            )
+            if not paths:
+                return None
         return paths
 
     def _remote_rglob_from_find(

--- a/tests/test_otherpath_symlink_rglob.py
+++ b/tests/test_otherpath_symlink_rglob.py
@@ -234,6 +234,62 @@ def test_rglob_find_l_fast_path(fake_remote):
     assert fake_remote.ls_calls == ls_before  # walk not used
 
 
+def test_rglob_find_l_keeps_listing_on_exit_1(fake_remote):
+    """Partial ``find`` (unreadable sibling -> exit 1) still lists files (#897)."""
+
+    class _Stdout:
+        def __init__(self, text: str):
+            self.channel = SimpleNamespace(recv_exit_status=lambda: 1)
+            self._text = text.encode("utf-8")
+
+        def read(self):
+            return self._text
+
+    class _Stderr:
+        def read(self):
+            return b"find: '/home/user/projects/secret': Permission denied\n"
+
+    def exec_command(cmd, timeout=None):
+        body = "\n".join(
+            [
+                "/home/user/projects/LongLife/20250709_lol079_01_cc_01.h5",
+                "/home/user/projects/plain/other.h5",
+            ]
+        )
+        return None, _Stdout(body), _Stderr()
+
+    fake_remote.client = SimpleNamespace(exec_command=exec_command)
+    ls_before = fake_remote.ls_calls
+    root = OtherPath("sftp://user@host/home/user/projects")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True, files_only=True))
+    assert names == ["20250709_lol079_01_cc_01.h5", "other.h5"]
+    assert fake_remote.ls_calls == ls_before  # walk not used
+
+
+def test_rglob_find_l_exit_1_without_output_falls_back_to_walk(fake_remote):
+    """Exit 1 and nothing listed is a real failure -> walk (#897)."""
+
+    class _Stdout:
+        def __init__(self):
+            self.channel = SimpleNamespace(recv_exit_status=lambda: 1)
+
+        def read(self):
+            return b"\n  \n"
+
+    class _Stderr:
+        def read(self):
+            return b"find: '/home/user/projects': Permission denied\n"
+
+    def exec_command(cmd, timeout=None):
+        return None, _Stdout(), _Stderr()
+
+    fake_remote.client = SimpleNamespace(exec_command=exec_command)
+    root = OtherPath("sftp://user@host/home/user/projects")
+    names = sorted(p.name for p in root.rglob("*.h5", testing=True, files_only=True))
+    assert "20250709_lol079_01_cc_01.h5" in names
+    assert fake_remote.ls_calls > 0
+
+
 def test_rglob_find_l_failure_falls_back_to_walk(fake_remote):
     def exec_command(cmd, timeout=None):
         raise OSError("no shell")


### PR DESCRIPTION
Closes #897. Part of epic #896.

## What

`OtherPath._remote_find_l_file_paths` ran `find -L <root> -type f -print` and
discarded stdout whenever the exit status was non-zero. On a shared remote
`rawdatadir` a single unreadable sibling directory makes `find` exit 1 while it
still prints everything it *could* list — measured in #895: ~18k paths in
~0.12 s, thrown away in favour of a slow SFTP `ls`-walk.

Stdout is now parsed first; a non-zero exit only forces the walk fallback when
nothing was listed. stderr is logged at debug (no full-tree dumps).

Behaviour unchanged for: `exec_command` raising (→ `None`), exit 0, and
non-zero exit with empty stdout (→ `None`, walk).

## Tests

`tests/test_otherpath_symlink_rglob.py`:

* new `test_rglob_find_l_keeps_listing_on_exit_1` — exit 1 + two paths on
  stdout + a `Permission denied` stderr line → both files returned and
  `ls_calls` unchanged (walk not used).
* new `test_rglob_find_l_exit_1_without_output_falls_back_to_walk` — exit 1 and
  blank stdout still walks.
* existing fast-path and failure-fallback tests unchanged and green.

```
uv run pytest tests/test_otherpath_symlink_rglob.py -q   # 9 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)