### PR TITLE
perf(cellpy-file): store v9 parquet members uncompressed (#898)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,9 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* v9 `.cellpy` writes its parquet members with `ZIP_STORED` instead of
+  DEFLATE-ing already-compressed parquet, cutting seconds off every `save`.
+  `meta.json` stays deflated; the file format is unchanged. (#898)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/readers/cellpy_file/v9.py
+++ b/cellpy/readers/cellpy_file/v9.py
@@ -182,13 +182,15 @@ def save(
     def verify(staged: Path) -> None:
         _verify_members(staged, required)
 
+    # Parquet members are already compressed; DEFLATE-ing them again costs
+    # seconds per save and buys almost nothing (#898). meta.json is tiny text
+    # and stays deflated. ZIP_STORED is plain zip - old readers handle it.
     with atomic_write(path, verify=verify) as staged:
-        with zipfile.ZipFile(
-            staged, mode="w", compression=zipfile.ZIP_DEFLATED
-        ) as zf:
+        with zipfile.ZipFile(staged, mode="w", compression=zipfile.ZIP_STORED) as zf:
             zf.writestr(
                 META_JSON_NAME,
                 json.dumps(meta_doc, indent=2, default=meta_archive._json_default),
+                compress_type=zipfile.ZIP_DEFLATED,
             )
             zf.writestr(V9_RAW_PARQUET, _frame_to_parquet_bytes(scratch.raw))
             zf.writestr(V9_STEPS_PARQUET, _frame_to_parquet_bytes(scratch.steps))

--- a/tests/test_cellpy_file_v9.py
+++ b/tests/test_cellpy_file_v9.py
@@ -86,6 +86,26 @@ def test_v8_to_v9_to_read_roundtrip(tmp_path):
 
 
 @pytest.mark.essential
+def test_v9_parquet_members_are_stored_not_deflated(tmp_path):
+    """Parquet is already compressed - do not DEFLATE it again (#898)."""
+    source = _require_v8_with_fids()
+    original = load_cellpy_file(source)
+
+    outfile = tmp_path / "stored.cellpy"
+    original.save(outfile)
+
+    with zipfile.ZipFile(outfile) as zf:
+        infos = {info.filename: info for info in zf.infolist()}
+    parquet_members = [name for name in infos if name.endswith(".parquet")]
+    assert V9_RAW_PARQUET in parquet_members
+    assert V9_STEPS_PARQUET in parquet_members
+    assert V9_SUMMARY_PARQUET in parquet_members
+    for name in parquet_members:
+        assert infos[name].compress_type == zipfile.ZIP_STORED, name
+    assert infos[META_JSON_NAME].compress_type == zipfile.ZIP_DEFLATED
+
+
+@pytest.mark.essential
 def test_v9_persists_extra_test_meta(tmp_path):
     """v9 round-trip keeps non-active TestMeta records (unlike v8)."""
     source = _require_v8_with_fids()


### PR DESCRIPTION
Closes #898. Part of epic #896.

## What

A v9 `.cellpy` file is a zip of parquet tables plus `meta.json`. The writer
opened that zip with `ZIP_DEFLATED`, so every parquet member was compressed a
second time. Measured in #895 on a 22 MB / 526k-row file: `CellpyCell.save`
took 3.84 s of which the parquet encode itself was only 0.74 s — about 95 s
across a 25-cell first load.

`raw.parquet`, `steps.parquet`, `summary.parquet` and `fid.parquet` are now
written `ZIP_STORED`. `meta.json` is tiny text and stays `ZIP_DEFLATED`.

`ZIP_STORED` is plain zip, so existing readers open these files unchanged —
no format-version bump, no schema or column-translation change, atomic write
and member verification untouched.

## Tests

`tests/test_cellpy_file_v9.py`:

* new `test_v9_parquet_members_are_stored_not_deflated` — every `.parquet`
  member of a freshly written file has `ZipInfo.compress_type == ZIP_STORED`,
  and `meta.json` is still deflated.
* the existing save/load parity suite (round-trip, extra test meta, atomic
  write / corruption cases) is unchanged and green.

```
uv run pytest tests/test_cellpy_file_v9.py -q   # 8 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)