### PR TITLE
perf(filefinder): search_for_files uses files_only rglob (#899)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,9 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* Per-cell `search_for_files` searches sub-folders with
+  `rglob(..., files_only=True)`, so a remote search can use the single
+  `find -L` listing instead of walking the tree per cell. (#899)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/readers/filefinder.py
+++ b/cellpy/readers/filefinder.py
@@ -382,7 +382,9 @@ def search_for_files(
                 logging.debug(f"checking in folder {d}")
                 logging.debug(f"{sub_folders=}")
                 if sub_folders:
-                    _run_files = d.rglob(glob_text_raw)
+                    # files_only lets a remote search use the single find -L
+                    # listing instead of walking the tree (#899).
+                    _run_files = d.rglob(glob_text_raw, files_only=True)
 
                 else:
                     _run_files = d.glob(glob_text_raw)

--- a/tests/test_filefinder.py
+++ b/tests/test_filefinder.py
@@ -124,6 +124,60 @@ def test_search_for_files_no_sub_folders(raw_tree):
     assert names == ["runA_01.res", "runA_02.res"]
 
 
+@pytest.fixture
+def rglob_spy(monkeypatch):
+    """Record the kwargs ``search_for_files`` hands to ``OtherPath.rglob``."""
+    from cellpy.internals.connections import OtherPath
+
+    calls = []
+    original = OtherPath.rglob
+
+    def _spy(self, glob_str, *args, **kwargs):
+        calls.append(kwargs)
+        return original(self, glob_str, *args, **kwargs)
+
+    monkeypatch.setattr(OtherPath, "rglob", _spy)
+    return calls
+
+
+def test_search_for_files_recursive_uses_files_only(raw_tree, rglob_spy):
+    """Per-cell search must take the files_only / find -L path (#899)."""
+    raw_dir, cellpy_dir = raw_tree
+    raw_files, _ = filefinder.search_for_files(
+        "runA", raw_extension="res", raw_file_dir=raw_dir, cellpy_file_dir=cellpy_dir
+    )
+    assert rglob_spy, "search_for_files did not use rglob"
+    assert all(call.get("files_only") is True for call in rglob_spy)
+    names = sorted(pathlib.Path(f).name for f in raw_files)
+    assert names == ["runA_01.res", "runA_02.res", "runA_03.res"]
+
+
+def test_search_for_files_no_sub_folders_does_not_rglob(raw_tree, rglob_spy):
+    raw_dir, cellpy_dir = raw_tree
+    filefinder.search_for_files(
+        "runA",
+        raw_extension="res",
+        raw_file_dir=raw_dir,
+        cellpy_file_dir=cellpy_dir,
+        sub_folders=False,
+    )
+    assert rglob_spy == []
+
+
+def test_search_for_files_within_file_list_does_not_rglob(raw_tree, rglob_spy):
+    raw_dir, cellpy_dir = raw_tree
+    raw_files, _ = filefinder.search_for_files(
+        "runA",
+        raw_extension="res",
+        raw_file_dir=raw_dir,
+        cellpy_file_dir=cellpy_dir,
+        file_list=["runA_01.res", "runB_01.res"],
+        with_prefix=False,
+    )
+    assert raw_files == ["runA_01.res"]
+    assert rglob_spy == []
+
+
 def test_search_for_files_within_file_list(raw_tree):
     raw_dir, cellpy_dir = raw_tree
     raw_files, _ = filefinder.search_for_files(


### PR DESCRIPTION
Closes #899. Part of epic #896.

## What

`find_in_raw_file_directory` already calls `rglob(..., files_only=True)` and can
therefore take the remote `find -L` fast path (#690). The per-cell
`search_for_files` called plain `rglob()`, so it always walked the tree.

Measured in #895 on a shared remote `rawdatadir`: 25 per-cell searches ≈ 68.9 s;
the same 25 cells against a dumped list ≈ 0.014 s, project-scoped walk ≈ 0.88 s.

Only the `sub_folders=True` / `file_list is None` branch changes — it now passes
`files_only=True`. The `file_list` / `fnmatch` branch, the `sub_folders=False`
`glob` branch, and the glob text are untouched. `raw_file_dir` entries are
always coerced to `OtherPath`, whose `rglob` accepts the kwarg for both local
and remote paths, so local results are unchanged.

## Tests

`tests/test_filefinder.py`, via a new `rglob_spy` fixture:

* `test_search_for_files_recursive_uses_files_only` — recursive search calls
  `OtherPath.rglob` with `files_only=True` and still finds the same three files
  (including the one in the subdirectory).
* `test_search_for_files_no_sub_folders_does_not_rglob` — `sub_folders=False`
  never touches `rglob`.
* `test_search_for_files_within_file_list_does_not_rglob` — the `file_list`
  branch still filters with `fnmatch` and does not search the folder.

```
uv run pytest tests/test_filefinder.py -q   # 17 passed, 2 failed
```

The two failures — `test_search_for_files_with_dirs` and
`test_search_for_files_recursive` — are **pre-existing on `master`** (verified by
stashing this diff): both assert a `runA.h5` cellpy filename while the resolved
config yields `runA.cellpy`. Untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)