### PR TITLE
docs: batch.load executor=threads and measured speed knobs (#903)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,8 @@ Quick facts:
 - Ingestion form fields: `cellpy.instrument_meta_schema(instrument)` → `fields` / `units`.
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
+- Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
+  reopening local `.cellpy` files (first remote load stays serial on the wire).
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
   Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
 - Prefer schema-resolved names over hard-coded 1.x header strings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,13 @@ Ready to contribute? Here's how to set up ``cellpy`` for local development.
    can be found in the root of the repository (``environment_dev.yml``; to create the environment,
    run ``conda env create -f environment_dev.yml``).
 
+   **Do not mix pip and conda for ``pyarrow``.** A leftover pip ``pyarrow`` on top of
+   a conda ``pyarrow-core`` (or the reverse) loads the wrong DLLs and breaks reading
+   ``.cellpy`` files — the parquet import fails at load time, not at install time.
+   Pick one installer: in a conda env keep the conda build and
+   ``pip uninstall pyarrow`` any pip copy (``pip list`` and ``conda list`` will both
+   show it when both are present); in a pip/uv env install only the pip build.
+
 4. Run commands inside the environment with ``uv run``, e.g.:
 
     ```shell

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,9 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* Docs: `batch.load(..., executor="threads")` and the other measured speed
+  knobs (`auto_use_file_list`, `save_cellpy`, cold reopen) are documented for
+  agents; CONTRIBUTING warns about a mixed pip/conda `pyarrow`. (#903)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -159,6 +159,9 @@ class Batch:
         """Load every cell, caching them in the store.
 
         ``executor`` is ``"serial"`` (default), ``"threads"`` or ``"processes"``.
+        ``"threads"`` mainly speeds up *reopening* cells from local ``.cellpy``
+        files; a first load of remote raw files does not overlap on the wire,
+        and ``"processes"`` usually loses to spawn overhead on Windows.
         Known :class:`LoadPolicy` fields in ``overrides`` update the policy;
         unknown (legacy) kwargs like ``testing`` are forwarded to the loader
         (``cellpy.get``) via ``loader_kwargs``.
@@ -182,7 +185,11 @@ class Batch:
         return self._result
 
     def load(self, **overrides) -> BatchResult:
-        """Load cells (alias of :meth:`update`, kept for the legacy surface)."""
+        """Load cells (alias of :meth:`update`, kept for the legacy surface).
+
+        Takes the same ``executor`` / ``on_progress`` / policy overrides as
+        :meth:`update`, e.g. ``b.load(executor="threads")``.
+        """
         return self.update(**overrides)
 
     def recalc(self, **overrides) -> BatchResult:
@@ -660,8 +667,12 @@ def load(
         drop_bad_cells: drop ``session["bad_cells"]`` before update.
         save_cellpy: write journal JSON and any newly-needed ``.cellpy`` files (default True). Skips rewriting cells already loaded from disk.
         accept_errors / max_cycle: forwarded into the load policy.
-        **kwargs: DB engine knobs (``column_map``, ``raw_file_dir``, …) and
-            loader extras (``testing``, …). ``export_cycles`` / ``export_raw`` /
+        **kwargs: DB engine knobs (``column_map``, ``raw_file_dir``, …), load
+            knobs forwarded to :meth:`Batch.update` (``executor``,
+            ``on_progress`` and :class:`LoadPolicy` fields) and loader extras
+            (``testing``, …). ``executor="threads"`` speeds up reopening cells
+            from local ``.cellpy`` files; a first load of remote raw files
+            stays serial on the wire. ``export_cycles`` / ``export_raw`` /
             ``export_ica`` are accepted but ignored (warned once).
 
     Returns:

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -214,6 +214,54 @@ Instrument strings and formats: see
 the instruments API. Coming from cellpy 1.x:
 [migration guide](migration_v1_to_v2.md).
 
+## Recipe: loading many cells (batch) and its speed knobs
+
+```python
+from cellpy import batch
+
+b = batch.load(name="my_experiment", project="my_project")
+summaries = b.summaries          # polars frame across cells
+c = b.cells["my_cell_01"]        # a CellpyCell
+```
+
+`batch.load` (and `Batch.update` / `Batch.load` under it) takes an `executor`:
+
+```python
+b = batch.load(name="my_experiment", project="my_project", executor="threads")
+```
+
+| `executor` | When it helps |
+| --- | --- |
+| `"serial"` (default) | Always correct; the only mode that never adds overhead |
+| `"threads"` | **Reopening** cells from local `.cellpy` files — measured 25 warm cells 5.2 s → 2.0 s |
+| `"processes"` | Rarely; Windows process spawn usually eats the gain |
+
+The **first** load of remote raw files stays effectively serial on the wire —
+SFTP transfers do not overlap, so `executor="threads"` buys ~nothing there
+(measured 38.5 s serial vs 37.1 s threads for 3 remote `.h5`). Use threads for
+the reopen path, not the download path.
+
+Other measured knobs for a slow first batch load:
+
+- **File search.** Creating a journal from the database searches for each
+  cell's raw files, and on a shared remote `rawdatadir` that walks the tree
+  once per cell. `config.batch.auto_use_file_list` (default `false`) is the
+  switch for dumping the directory **once** and matching every cell against
+  that list instead (project-scoped when the batch has a `project`). Wiring it
+  into the v3 journal path is tracked in
+  [#900](https://github.com/jepegit/cellpy/issues/900); either way, pointing
+  `rawdatadir` at the project folder is the cheapest fix. See
+  [Remote paths](remote_paths.md#behaviour-notes).
+- **Saving `.cellpy` files.** First load writes one file per cell. Pass
+  `save_cellpy=False` if the app only needs the frames in memory.
+- **`pyarrow` installed twice.** A pip `pyarrow` on top of a conda
+  `pyarrow-core` (or the reverse) breaks `.cellpy` reads with a DLL error at
+  load time. Keep one installer's copy — see the environment notes in
+  [CONTRIBUTING.md](https://github.com/jepegit/cellpy/blob/master/CONTRIBUTING.md).
+- **A cold first reopen is not a decode bug.** On Windows the first read of a
+  large `.cellpy` can be slower than parsing the raw file, because of page
+  cache / antivirus, not the v9 format.
+
 ## Pitfalls agents hit
 
 - **Hard-coded column names** — use `c.schema.raw.potential` (etc.), not

--- a/docs/getting_started/remote_paths.md
+++ b/docs/getting_started/remote_paths.md
@@ -117,7 +117,15 @@ Use `cellpy.utils.helpers.check_connection()` (or
   file-only listing (`files_only`) and, when the SSH session allows it, a
   single remote `find -L … -type f` for speed, with a walk fallback. A warning
   is logged if the dump returns thousands of paths. Smarter project-scoped
-  search is tracked separately (issue #691).
+  search is tracked separately (issue #691). The default is
+  `auto_use_file_list: false`; when enabled, batch dumps the directory **once**
+  (project-scoped when the batch has a `project`) and matches every cell
+  against that list instead of searching per cell — wiring it into the v3
+  journal path is tracked in issue #900.
+- **Batch load executor.** `batch.load(..., executor="threads")` overlaps cell
+  loads and mainly helps *reopening* local `.cellpy` files; a first load of
+  remote raw files does not overlap on the wire. See
+  [Using cellpy from an agent](agents.md#recipe-loading-many-cells-batch-and-its-speed-knobs).
 
 ## Live SFTP tests (Docker)
 


### PR DESCRIPTION
Closes #903. Part of epic #896.

## What

`run(..., executor="threads"|"processes"|"serial")` exists and `batch.load`
already forwards `executor`, but no doc said so. Measured in #895: threads take
a warm 25-cell local `.cellpy` reopen from 5.2 s to 2.0 s, do **not** overlap a
first remote SFTP load (38.5 s serial vs 37.1 s threads), and processes lose to
Windows spawn (8.8 s).

Changes (docs + docstrings only — no defaults touched):

* `docs/getting_started/agents.md` — new "Recipe: loading many cells (batch) and
  its speed knobs" section: the executor table, the serial-on-the-wire caveat
  for first remote loads, `auto_use_file_list` (default false; phrased as
  "when enabled …" and linked to the still-open #900), `save_cellpy=False`, the
  pip/conda `pyarrow` DLL clash, and the cold-first-reopen caveat.
* `AGENTS.md` — one-line batch/executor pointer in the usage quick-facts.
* `docs/getting_started/remote_paths.md` — `auto_use_file_list` default and
  behaviour next to the existing `find -L` note, plus an executor cross-link.
* `cellpy/batch/facade.py` — `executor` documented on `Batch.update`,
  `Batch.load` (it was silent) and the module-level `batch.load`.
* `CONTRIBUTING.md` — paragraph on not mixing pip and conda `pyarrow`
  (searchable for `pyarrow`).

`docs/getting_started/configuration_reference.md` is auto-generated, so the
config note lives in `remote_paths.md` instead.

## Tests

```
uv run pytest tests/test_batch_v3_facade.py -q   # 14 passed
```

Plus an import check that the edited docstrings load and contain `executor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)