### PR TITLE
feat(batch): wire auto_use_file_list in journal_from_db / find_files (#900)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,12 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* `config.batch.auto_use_file_list` is wired into `journal_from_db` /
+  `find_files`: when enabled (default stays **false**) the raw-file directory
+  is dumped once — scoped to the batch `project` by an exact join — and every
+  cell is matched against that list instead of searching the tree per cell. A
+  missing project folder raises with the joined path instead of producing an
+  empty journal. (#900)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/batch/_dbengine.py
+++ b/cellpy/batch/_dbengine.py
@@ -105,12 +105,51 @@ def create_factory():
     return instrument_factory
 
 
+def _dump_raw_file_directory(project=None, raw_file_dir=None, project_dir=None):
+    """One directory dump for ``auto_use_file_list`` (#900).
+
+    Scoped to ``project_dir`` (or the batch ``project``) by an exact join - no
+    fuzzy sibling matching (that is #691). A missing folder is an error, not an
+    empty journal.
+    """
+    from cellpy.internals.connections import OtherPath
+
+    if project_dir is None:
+        project_dir = project
+    if raw_file_dir is None:
+        raw_file_dir = config.paths.rawdatadir
+    given = raw_file_dir if isinstance(raw_file_dir, (list, tuple)) else [raw_file_dir]
+
+    roots = []
+    for d in given:
+        root = OtherPath(d)
+        if project_dir:
+            root = root / project_dir
+        if not root.is_dir():
+            raise FileNotFoundError(
+                f"auto_use_file_list is on, but the raw-file directory "
+                f"{root.full_path} does not exist. Point rawdatadir (and the "
+                "batch project) at an existing folder, or set "
+                "config.batch.auto_use_file_list = False."
+            )
+        roots.append(root)
+
+    logging.info(
+        "auto_use_file_list: dumping %s once",
+        ", ".join(r.full_path for r in roots),
+    )
+    return filefinder.find_in_raw_file_directory(
+        raw_file_dir=roots if len(roots) > 1 else roots[0]
+    )
+
+
 def find_files(
     info_dict,
     file_list=None,
     pre_path=None,
     sub_folders=None,
     skip_file_search=False,
+    project=None,
     **kwargs,
 ):
     """Find raw/cellpy files for each cell using :mod:`cellpy.filefinder`.
@@ -118,9 +157,22 @@ def find_files(
     Populates ``raw_file_names`` and ``cellpy_file_name`` in ``info_dict``.
     When ``skip_file_search`` is True the dict is returned unchanged (e.g.
     when a custom JSON db already carries the paths).
+
+    When ``config.batch.auto_use_file_list`` is True and the caller did not
+    supply ``file_list``, the raw-file directory is dumped **once** (scoped to
+    ``project_dir`` / ``project``) and every cell is matched against that list
+    instead of searching the tree per cell. The default of that setting is
+    False, so nothing changes unless it is switched on.
     """
     if skip_file_search:
         return info_dict
+
+    if file_list is None and config.batch.auto_use_file_list:
+        file_list = _dump_raw_file_directory(
+            project=project,
+            raw_file_dir=kwargs.get("raw_file_dir"),
+            project_dir=kwargs.get("project_dir"),
+        )
 
     sub_folders = sub_folders or config.file_names.sub_folders
     instrument_factory = create_factory()

--- a/cellpy/batch/db.py
+++ b/cellpy/batch/db.py
@@ -39,6 +39,9 @@ def journal_from_db(
     :func:`cellpy.batch._dbengine.simple_db_engine` /
     :func:`cellpy.batch._dbengine.find_files`. Pass ``skip_file_search=True``
     when the JSON already carries ``raw_file_names`` / ``cellpy_file_name``.
+
+    ``project`` also scopes the one-shot raw-file-directory dump used when
+    ``config.batch.auto_use_file_list`` is True (default False).
     """
     column_map = kwargs.pop("column_map", None)
     dbreader_kwargs = kwargs.pop("dbreader_kwargs", None) or {}
@@ -48,6 +51,8 @@ def journal_from_db(
     )
 
     engine_kwargs: dict[str, Any] = dict(kwargs)
+    # The batch project scopes the auto_use_file_list dump (#900).
+    engine_kwargs.setdefault("project", project)
     if raw_file_dir is not None:
         engine_kwargs["raw_file_dir"] = raw_file_dir
     if cellpy_file_dir is not None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -301,6 +301,160 @@ def test_find_files_skip_file_search():
     assert out[hdr_journal["cellpy_file_name"]] == ["/path/to/cell_a.h5"]
 
 
+# --- auto_use_file_list wiring (#900) -------------------------------------
+
+
+@pytest.fixture
+def auto_list_tree(tmp_path):
+    """A raw-file directory with one project folder holding two cells."""
+    raw_dir = tmp_path / "raw"
+    project_dir = raw_dir / "P"
+    project_dir.mkdir(parents=True)
+    (project_dir / "cell_a_01.res").touch()
+    (project_dir / "cell_b_01.res").touch()
+    # A sibling project that must not show up in a project-scoped dump.
+    other = raw_dir / "OTHER"
+    other.mkdir()
+    (other / "cell_a_02.res").touch()
+    cellpy_dir = tmp_path / "cellpyfiles"
+    cellpy_dir.mkdir()
+    return raw_dir, cellpy_dir
+
+
+@pytest.fixture
+def dump_spy(monkeypatch):
+    """Count (and record) ``find_in_raw_file_directory`` calls from find_files."""
+    from cellpy import filefinder
+
+    calls = []
+    original = filefinder.find_in_raw_file_directory
+
+    def _spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(_dbengine.filefinder, "find_in_raw_file_directory", _spy)
+    return calls
+
+
+def _info_dict(*names):
+    return {
+        hdr_journal["filename"]: list(names),
+        hdr_journal["file_name_indicator"]: list(names),
+        hdr_journal["instrument"]: ["arbin_res"] * len(names),
+    }
+
+
+def test_find_files_no_dump_when_flag_is_false(auto_list_tree, dump_spy):
+    """Default (False) must not dump the raw-file directory."""
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": False}):
+        out = _dbengine.find_files(
+            _info_dict("cell_a"),
+            project="P",
+            raw_file_dir=raw_dir,
+            cellpy_file_dir=cellpy_dir,
+        )
+    assert dump_spy == []
+    assert out[hdr_journal["raw_file_names"]][0] is not None
+
+
+def test_find_files_auto_use_file_list_dumps_once(auto_list_tree, dump_spy):
+    """One project-scoped dump feeds every cell (#900)."""
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": True}):
+        out = _dbengine.find_files(
+            _info_dict("cell_a", "cell_b"),
+            project="P",
+            raw_file_dir=raw_dir,
+            cellpy_file_dir=cellpy_dir,
+        )
+
+    assert len(dump_spy) == 1, "the directory must be dumped exactly once"
+    dumped_root = str(dump_spy[0][1]["raw_file_dir"]).replace("\\", "/")
+    assert dumped_root.endswith("/raw/P")
+
+    found = out[hdr_journal["raw_file_names"]]
+    assert [f is not None for f in found] == [True, True]
+    assert any("cell_a_01.res" in str(p) for p in found[0])
+    assert any("cell_b_01.res" in str(p) for p in found[1])
+    # The sibling project is outside the project-scoped dump.
+    assert not any("cell_a_02.res" in str(p) for p in found[0])
+
+
+def test_find_files_auto_use_file_list_missing_project_raises(auto_list_tree, dump_spy):
+    """A missing project folder is an error, not an empty journal (#900)."""
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": True}):
+        with pytest.raises(FileNotFoundError, match="NOPE"):
+            _dbengine.find_files(
+                _info_dict("cell_a"),
+                project="NOPE",
+                raw_file_dir=raw_dir,
+                cellpy_file_dir=cellpy_dir,
+            )
+
+
+def test_find_files_caller_file_list_wins(auto_list_tree, dump_spy):
+    """An explicit file_list is used as-is - no dump."""
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": True}):
+        out = _dbengine.find_files(
+            _info_dict("cell_a"),
+            file_list=["some/other/place/cell_a_01.res"],
+            project="P",
+            raw_file_dir=raw_dir,
+            cellpy_file_dir=cellpy_dir,
+        )
+    assert dump_spy == []
+    assert out[hdr_journal["raw_file_names"]][0] == [
+        "some/other/place/cell_a_01.res"
+    ]
+
+
+def test_simple_db_engine_forwards_project_to_the_dump(auto_list_tree, dump_spy):
+    """The project reaches find_files through simple_db_engine (#900)."""
+
+    class _StubReader:
+        pages_dict = {
+            hdr_journal["filename"]: ["cell_a"],
+            hdr_journal["file_name_indicator"]: ["cell_a"],
+            hdr_journal["instrument"]: ["arbin_res"],
+            hdr_journal["group"]: [1],
+        }
+
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": True}):
+        pages = _dbengine.simple_db_engine(
+            reader=_StubReader(),
+            project="P",
+            raw_file_dir=raw_dir,
+            cellpy_file_dir=cellpy_dir,
+        )
+
+    assert len(dump_spy) == 1
+    assert str(dump_spy[0][1]["raw_file_dir"]).replace("\\", "/").endswith("/raw/P")
+    raw_names = pages[hdr_journal["raw_file_names"]].iloc[0]
+    assert any("cell_a_01.res" in str(p) for p in raw_names)
+
+
+def test_journal_from_db_passes_project_to_the_engine(monkeypatch):
+    """journal_from_db hands its project to the engine (scopes the dump)."""
+    from cellpy.batch import db as batch_db
+
+    seen = {}
+
+    def _fake_engine(reader, **kwargs):
+        seen.update(kwargs)
+        return pandas.DataFrame()
+
+    monkeypatch.setattr(batch_db._dbengine, "make_db_reader", lambda **_kw: object())
+    monkeypatch.setattr(batch_db._dbengine, "simple_db_engine", _fake_engine)
+
+    batch_db.journal_from_db("my_batch", "my_project")
+    assert seen["project"] == "my_project"
+
+
 def test_reading_cell_specs(batch_instance):
     # For the simple excel dbreader, cell specs are given in the
     # columns "argument" as str.


### PR DESCRIPTION
Closes #900. Part of epic #896.

## What

`config.batch.auto_use_file_list` existed (default false) and `find_files`
already filtered a supplied `file_list` with `fnmatch`, but v3
`journal_from_db` / `simple_db_engine` never read the flag — the setting was
dead unless a caller passed `file_list=` by hand.

Measured in #895: 25 per-cell `search_for_files` calls on a shared remote
`rawdatadir` ≈ 69 s; one project dump plus 25 `fnmatch` filters < 0.5 s.

* `find_files` gains a `project` kwarg. When
  `config.batch.auto_use_file_list` is True **and** the caller did not pass
  `file_list`, it calls `find_in_raw_file_directory` **once** and hands the
  result to the existing `file_list` / `with_prefix=True` branch.
* The dump is scoped by an exact join to `project_dir` (or the batch
  `project`). No fuzzy sibling matching — that stays #691.
* A missing project folder raises `FileNotFoundError` naming the joined path,
  so a typo cannot silently produce an empty journal of "found nothing".
* `journal_from_db` forwards its `project` to the engine.
* A caller-supplied `file_list=` still wins — no dump.
* **The default stays `false`.** Existing configurations behave exactly as
  before.

## Tests

`tests/test_batch.py` (new `auto_list_tree` + `dump_spy` fixtures):

* `test_find_files_no_dump_when_flag_is_false` — flag off ⇒
  `find_in_raw_file_directory` is never called, per-cell search still finds files.
* `test_find_files_auto_use_file_list_dumps_once` — flag on + `project="P"` ⇒
  exactly one dump, rooted at `raw/P`, feeding both cells; a matching file in a
  sibling project is **not** picked up (proves the scoped list, not a walk, was used).
* `test_find_files_auto_use_file_list_missing_project_raises` — missing folder ⇒
  `FileNotFoundError` naming the joined path.
* `test_find_files_caller_file_list_wins` — explicit list ⇒ no dump.
* `test_simple_db_engine_forwards_project_to_the_dump` and
  `test_journal_from_db_passes_project_to_the_engine` — the project reaches
  `find_files` through both layers.

```
uv run pytest tests/test_filefinder.py tests/test_batch.py tests/test_batch_v3_facade.py -q
# 72 passed, 2 failed (pre-existing), 1 skipped, 4 xfailed, 1 xpassed
```

The two failures — `test_search_for_files_with_dirs` and
`test_search_for_files_recursive` — are pre-existing on `master` (they assert a
`runA.h5` cellpy filename while the resolved config yields `runA.cellpy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)