### PR TITLE
perf(otherpath): reuse credentialed fs; skip pre-copy is_file (#901)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,10 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* Remote loads are cheaper: an `OtherPath` builds its credentialed filesystem
+  once and reuses it for `is_file` / `stat` / `copy`, and `from_raw` no longer
+  STATs a remote raw file it is about to copy (the copy raises if it is
+  missing). Missing local files still raise `NoDataFound`. (#901)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -165,6 +165,10 @@ class OtherPath:
         self._uri_prefix = uri_prefix
         self._location = location
         self._extra_storage_options = dict(storage_options)
+        # Credentialed UPath (and its fs) cached per instance - see
+        # _upath_with_credentials (#901).
+        self._credentialed_upath: Optional[UPath] = None
+        self._credentialed_key: Optional[Tuple[str, bool]] = None
 
     # --- cellpy metadata -------------------------------------------------
 
@@ -323,14 +327,37 @@ class OtherPath:
     # --- remote / local I/O ----------------------------------------------
 
     def _upath_with_credentials(self, *, testing: bool = False) -> UPath:
+        """Credentialed ``UPath`` for this instance (built once, then reused).
+
+        Building it resolves credentials and instantiates the filesystem, and
+        the first remote call on a fresh one pays an SSH handshake (~0.5-0.8 s
+        measured). ``is_file`` + ``stat`` + ``copy`` on the *same* instance
+        therefore share one (#901). The cache is keyed on the URI string, so a
+        path that somehow changes identity rebuilds it.
+        """
         if not self.is_external:
             return self._upath
+        url = str(self._upath)
+        cache_key = (url, bool(testing))
+        cached = getattr(self, "_credentialed_upath", None)
+        if cached is not None and self._credentialed_key == cache_key:
+            return cached
         scheme = _scheme_from_uri_prefix(self._uri_prefix)
         if f"{scheme}:" not in IMPLEMENTED_PROTOCOLS:
             raise ValueError(f"uri_prefix {scheme} not implemented yet")
         creds = _credentials_from_env(testing=testing)
         options = {**dict(self._upath.storage_options), **self._extra_storage_options, **creds}
-        return UPath(str(self._upath), **options)
+        upath = UPath(url, **options)
+        self._credentialed_upath = upath
+        self._credentialed_key = cache_key
+        return upath
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Never carry a live filesystem/SSH client into a pickle or deepcopy."""
+        state = self.__dict__.copy()
+        state["_credentialed_upath"] = None
+        state["_credentialed_key"] = None
+        return state
 
     def connection_info(self, testing: bool = False) -> Tuple[Dict[str, Any], str]:
         """Return ``(storage_options, host)`` for remote paths (empty if local)."""

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1396,7 +1396,12 @@ class CellpyCell:
             logging.debug(f"{file_name}")
             if is_a_file:
                 file_name = internals.OtherPath(file_name)
-                if not file_name.is_file():
+                # A remote raw file is about to be copied (or opened) by the
+                # loader, and that step raises if it is missing - so skip the
+                # extra pre-copy STAT, which pays an SSH handshake per cell
+                # (#901). Local paths are cheap to check and give a clearer
+                # error than the loader would.
+                if not file_name.is_external and not file_name.is_file():
                     raise NoDataFound(f"Could not find the file {file_name}")
 
             new_data = raw_file_loader(

--- a/tests/test_otherpaths.py
+++ b/tests/test_otherpaths.py
@@ -397,3 +397,115 @@ def test_remote_exists_uses_upath(monkeypatch, mock_env_cellpy_key_filename):
     )
     assert p.exists(testing=True) is True
     assert p.is_file(testing=True) is True
+
+
+# --- credentialed fs reuse / no pre-copy STAT (#901) -----------------------
+
+
+def _credentialed_upath_spy(monkeypatch, tmp_path):
+    """Fake UPath that records every construction; returns the credentialed ones."""
+    constructed = []
+
+    class _FakeFS:
+        def __init__(self):
+            self.get_calls = 0
+
+        def get(self, remote_path, local_path):
+            self.get_calls += 1
+            pathlib.Path(local_path).write_text("data")
+
+        def info(self, path):
+            return {"size": 4, "mtime": 0, "atime": 0}
+
+    class _FakeUPath:
+        def __init__(self, *args, **kwargs):
+            self._url = str(args[0])
+            self.path = "/home/jepe/file.res"
+            self.storage_options = kwargs
+            self.fs = _FakeFS()
+            self.name = "file.res"
+            self.protocol = "sftp"
+            constructed.append(kwargs)
+
+        def __str__(self):
+            return self._url
+
+        def exists(self):
+            return True
+
+        def is_file(self):
+            return True
+
+        def is_dir(self):
+            return False
+
+    monkeypatch.setattr("cellpy.internals.otherpath.UPath", _FakeUPath)
+    return constructed
+
+
+def test_remote_instance_reuses_one_credentialed_upath(
+    monkeypatch, tmp_path, mock_env_cellpy_key_filename
+):
+    """is_file + stat + copy on one instance build the credentialed fs once (#901)."""
+    constructed = _credentialed_upath_spy(monkeypatch, tmp_path)
+
+    p = cellpy.internals.connections.OtherPath(
+        "sftp://jepe@server.ife.no/home/jepe/file.res"
+    )
+    p.is_file(testing=True)
+    p.is_file(testing=True)
+    p.stat(testing=True)
+    p.copy(destination=tmp_path, testing=True)
+
+    with_credentials = [kw for kw in constructed if "key_filename" in kw]
+    assert len(with_credentials) == 1, constructed
+
+
+def test_credentialed_upath_is_not_carried_into_a_pickle(
+    monkeypatch, tmp_path, mock_env_cellpy_key_filename
+):
+    """A live fs/SSH client must not travel to a worker process (#901)."""
+    _credentialed_upath_spy(monkeypatch, tmp_path)
+
+    p = cellpy.internals.connections.OtherPath(
+        "sftp://jepe@server.ife.no/home/jepe/file.res"
+    )
+    p.is_file(testing=True)
+    assert p._credentialed_upath is not None
+    assert p.__getstate__()["_credentialed_upath"] is None
+
+
+def test_from_raw_missing_local_file_still_raises(tmp_path):
+    """Skipping the pre-copy STAT must not silence a missing local file (#901)."""
+    from cellpy import cellreader
+    from cellpy.exceptions import NoDataFound
+
+    c = cellreader.CellpyCell()
+    with pytest.raises(NoDataFound, match="Could not find the file"):
+        c.from_raw(tmp_path / "does_not_exist.res")
+
+
+def test_from_raw_does_not_stat_a_remote_file_before_copying(monkeypatch, tmp_path):
+    """from_raw leaves the existence check to the copy/loader for remote paths."""
+    from cellpy import cellreader
+    from cellpy.internals.connections import OtherPath
+
+    calls = {"is_file": 0}
+    original = OtherPath.is_file
+
+    def _counting_is_file(self, *args, **kwargs):
+        if self.is_external:
+            calls["is_file"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(OtherPath, "is_file", _counting_is_file)
+
+    def _boom(file_name, **kwargs):
+        raise RuntimeError("loader reached")
+
+    c = cellreader.CellpyCell()
+    monkeypatch.setattr(c, "loader", _boom, raising=False)
+    with pytest.raises(RuntimeError, match="loader reached"):
+        c.from_raw("sftp://jepe@server.ife.no/home/jepe/file.res")
+
+    assert calls["is_file"] == 0


### PR DESCRIPTION
Closes #901. Part of epic #896.

## What

Two extra round trips per remote cell, measured in #895 (first `is_file()`
0.55–0.81 s = SSH handshake; later calls ~0.006 s):

1. `_upath_with_credentials()` built a **new** credentialed `UPath` on every
   call, so `is_file`, `stat` and `copy` on the same path each paid their own
   handshake. It is now built once per `OtherPath` instance and cached, keyed on
   the URI string so a path that changes identity rebuilds it.
   `__getstate__` clears the cache, so a live filesystem / SSH client never
   travels into a pickle or `deepcopy` (relevant for `executor="processes"`).
2. `from_raw` always called `is_file()` on a raw path it was about to hand to
   the loader, which copies it anyway. Remote paths now go straight to the
   loader — `OtherPath.copy()` already raises
   `FileNotFoundError("Could not find file … on …")` when it is missing. Local
   paths keep the cheap check and its clearer `NoDataFound`.

No new public API, no required args, no change for local paths, no
ControlMaster / parallel SFTP / progress UI (out of scope).

## Tests

`tests/test_otherpaths.py`:

* `test_remote_instance_reuses_one_credentialed_upath` — `is_file` ×2 + `stat`
  + `copy` on one instance construct exactly **one** credentialed `UPath`.
* `test_credentialed_upath_is_not_carried_into_a_pickle` — the cached fs is
  dropped by `__getstate__`.
* `test_from_raw_missing_local_file_still_raises` — missing local path still
  raises `NoDataFound`, no silent empty cell.
* `test_from_raw_does_not_stat_a_remote_file_before_copying` — zero external
  `is_file()` calls before the loader runs.

```
uv run pytest tests/test_otherpaths.py tests/test_otherpaths_sftp.py tests/test_otherpath_symlink_rglob.py -q
# 57 passed, 6 deselected
uv run pytest -m essential -q
# 730 passed, 1 skipped, 2 xfailed, 1 xpassed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)