### PR TITLE
perf(arbin_sql_h5): one HDF read; skip legacy post-process (#902)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,12 @@
 * Fix scheduled CI: keep `sqlalchemy-access` Windows-only in conda env files,
   and install `legacy-files` (PyTables) in the scheduled pip matrix. (#885)
 * Iterative fixes: document for devs how to add plots. (#892)
+* `arbin_sql_h5` two-stage load reads the export once: `parse()` caches the HDF
+  frames and the temp copy for the following `loader()`, `parse()` honours
+  `refuse_copying`, and when the harmonize prefetch succeeds the legacy
+  row-wise datetime decode (whose only product is a raw frame that is
+  discarded) is skipped. Prefetch failure still takes the full legacy path.
+  (#902)
 
 ## [2.1.2] - 2026-08-09
 

--- a/cellpy/readers/cellreader.py
+++ b/cellpy/readers/cellreader.py
@@ -1388,7 +1388,15 @@ class CellpyCell:
         ):
             # Forward loader knobs (bad_steps, data_points, …) so parse and the
             # cached Data shell see the same filters as loader() would.
-            prefetched_harmonized_raw = self._try_harmonized_raw_frame(**kwargs)
+            prefetched_harmonized_raw = self._try_harmonized_raw_frame(
+                refuse_copying=refuse_copying, **kwargs
+            )
+        if self.loader_class is not None:
+            # Loaders may skip work whose only product is the legacy raw frame
+            # that the harmonized frame replaces below (#902).
+            self.loader_class._harmonized_prefetch_ok = (
+                prefetched_harmonized_raw is not None
+            )
 
         data = None
         for file_name in self.file_names:
@@ -1507,7 +1515,7 @@ class CellpyCell:
         self.last_uploaded_at = datetime.datetime.now()
         return self
 
-    def _try_harmonized_raw_frame(self, **parse_kwargs):
+    def _try_harmonized_raw_frame(self, *, refuse_copying=False, **parse_kwargs):
         """Phase C: try ``harmonize(parse())`` for single-file raw.
 
         Returns a native pandas raw frame on success, or ``None`` to signal
@@ -1521,6 +1529,9 @@ class CellpyCell:
 
         ``parse_kwargs`` are forwarded to ``loader.parse`` (e.g. ``bad_steps``,
         ``data_points``) so the harmonized frame matches the filtered load.
+        ``refuse_copying`` is set on the loader instance (not passed as a parse
+        kwarg, which not every loader accepts) so ``parse`` does not copy a
+        local file the caller asked to read in place (#902).
         """
         if not getattr(config.reader, "use_harmonized_raw", True):
             return None
@@ -1536,6 +1547,8 @@ class CellpyCell:
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                if refuse_copying:
+                    loader.refuse_copying = True
                 vendor = loader.parse(source, **parse_kwargs)
                 declarations = loader.declarations()
                 native = harmonize(vendor, declarations, strict=False)

--- a/cellpy/readers/instruments/arbin_sql_h5.py
+++ b/cellpy/readers/instruments/arbin_sql_h5.py
@@ -42,8 +42,9 @@ normal_headers_renaming_dict = {
 
 
 def from_arbin_to_datetime(n):
-    if isinstance(n, int):
-        n = str(n)
+    if not isinstance(n, str):
+        # int, numpy.int64, ... - the export stores 100 ns ticks as integers
+        n = str(int(n))
     ms_component = n[-7:]
     date_time_component = n[:-7]
     temp = f"{date_time_component}.{ms_component}"
@@ -110,6 +111,21 @@ class DataLoader(BaseLoader):
         raw_limits["ir_change"] = 0.00001
         return raw_limits
 
+    def copy_to_temporary(self):
+        """Reuse the temp copy an earlier ``parse()`` made for the same source.
+
+        ``loader_executor`` calls this again after ``parse()`` already did, which
+        meant downloading (or copying) the same export twice (#902).
+        """
+        if (
+            self._temp_file_path is not None
+            and getattr(self, "_temp_copy_of", None) == str(self.name)
+        ):
+            logging.debug("reusing the temporary copy made by parse()")
+            return
+        super().copy_to_temporary()
+        self._temp_copy_of = str(self.name)
+
     def parse(self, source, **kwargs):
         """Vendor stage: read the h5 export into a frame with Arbin names.
 
@@ -121,9 +137,15 @@ class DataLoader(BaseLoader):
 
         ``drop_duplicates`` is kept here because it is vendor cleanup (the export
         repeats rows), so the vendor frame is what a de-duplicated read yields.
+
+        ``refuse_copying`` (kwarg here, or the instance flag set by the caller)
+        is honoured, so a local file is read where it lies (#902).
         """
         import polars as pl
 
+        refuse_copying = kwargs.pop("refuse_copying", None)
+        if refuse_copying is not None:
+            self.refuse_copying = refuse_copying
         self.name = source if isinstance(source, Path) else Path(source)
         self.copy_to_temporary()
         data_df = self._parse_h5_data()["data_df"].drop_duplicates()
@@ -204,16 +226,29 @@ class DataLoader(BaseLoader):
         data.summary = (
             pd.DataFrame()
         )  # creating an empty frame - loading summary is not implemented yet
-        data = self._post_process(data)
+        # When the two-stage prefetch succeeded, this legacy raw frame is
+        # discarded right after the load - so do not spend ~5 s converting a
+        # datetime column nobody reads (#902).
+        data = self._post_process(
+            data, skip_row_wise_datetime=self.harmonized_prefetch_ok
+        )
         data = self.identify_last_data_point(data)
         return data
 
-    def _post_process(self, data):
+    @property
+    def harmonized_prefetch_ok(self) -> bool:
+        """True when ``harmonize(parse())`` already produced the native raw.
+
+        Set by ``CellpyCell.from_raw`` before it calls the loader.
+        """
+        return bool(getattr(self, "_harmonized_prefetch_ok", False))
+
+    def _post_process(self, data, skip_row_wise_datetime=False):
         set_index = True
         rename_headers = True
         forward_fill_ir = True
-        fix_datetime = True
-        set_dtypes = True
+        fix_datetime = not skip_row_wise_datetime
+        set_dtypes = not skip_row_wise_datetime
         fix_duplicated_rows = True
         recalc_capacity = False
 
@@ -283,6 +318,12 @@ class DataLoader(BaseLoader):
 
         hdr_date_time = self.arbin_headers_normal.datetime_txt
         start = data.raw[hdr_date_time].iat[0]
+        if skip_row_wise_datetime:
+            # The column is still Arbin ticks; convert the one value we keep
+            # instead of the whole column (same result, O(1) instead of O(n)).
+            start = pd.to_datetime(
+                from_arbin_to_datetime(start), format=DATE_TIME_FORMAT
+            )
         # TODO: convert to datetime:
         data.start_datetime = start
 
@@ -293,11 +334,20 @@ class DataLoader(BaseLoader):
         date_time_col = normal_headers_renaming_dict["datetime_txt"]
         file_name = pathlib.Path(file_name)
 
+        # parse() and a following loader() read the same export; cache the
+        # frames so the HDF store is only selected once per file (#902).
+        cached = getattr(self, "_parsed_frames", None)
+        if cached is not None and getattr(self, "_parsed_frames_path", None) == file_name:
+            logging.debug("reusing the HDF frames read by parse()")
+            return cached
+
         raw_frames = {}
         with pd.HDFStore(file_name) as h5_file:
             for key in ["data_df", "info_df", "stat_df"]:
                 raw_frames[key] = h5_file.select(key)
 
+        self._parsed_frames = raw_frames
+        self._parsed_frames_path = file_name
         return raw_frames
 
 

--- a/tests/test_arbin_sql_h5_two_stage.py
+++ b/tests/test_arbin_sql_h5_two_stage.py
@@ -96,6 +96,107 @@ def test_epoch_time_utc_is_the_vendor_ticks_as_absolute_utc():
     assert difference == 0, f"epoch_time_utc is not the vendor ticks: off by {difference}"
 
 
+# --- one read, no legacy datetime work on the success path (#902) ----------
+
+
+@pytest.fixture
+def hdf_select_counter(monkeypatch):
+    """Count ``HDFStore.select`` calls."""
+    import pandas as pd
+
+    calls = []
+    original = pd.HDFStore.select
+
+    def _counting(self, key, *args, **kwargs):
+        calls.append(key)
+        return original(self, key, *args, **kwargs)
+
+    monkeypatch.setattr(pd.HDFStore, "select", _counting)
+    return calls
+
+
+@pytest.fixture
+def datetime_apply_spy(monkeypatch):
+    """Count ``from_arbin_to_datetime`` calls (the row-wise legacy decode)."""
+    from cellpy.readers.instruments import arbin_sql_h5
+
+    calls = []
+    original = arbin_sql_h5.from_arbin_to_datetime
+
+    def _spy(n):
+        calls.append(n)
+        return original(n)
+
+    monkeypatch.setattr(arbin_sql_h5, "from_arbin_to_datetime", _spy)
+    return calls
+
+
+@pytest.mark.essential
+def test_two_stage_load_reads_the_hdf_once(hdf_select_counter, datetime_apply_spy):
+    """parse() + loader() share one read, and no row-wise datetime decode (#902)."""
+    import cellpy
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cell = cellpy.get(
+            SOURCE,
+            instrument="arbin_sql_h5",
+            mass=1.0,
+            testing=True,
+            auto_summary=False,
+        )
+
+    assert cell.data.raw is not None and len(cell.data.raw)
+    # data_df / info_df / stat_df, once - not twice.
+    assert hdf_select_counter == ["data_df", "info_df", "stat_df"], hdf_select_counter
+    # Only the single start_datetime value, never the whole column.
+    assert len(datetime_apply_spy) <= 1, len(datetime_apply_spy)
+
+
+@pytest.mark.essential
+def test_prefetch_failure_still_runs_the_legacy_post_process(
+    monkeypatch, datetime_apply_spy
+):
+    """When harmonize cannot run, the legacy datetime decode is still applied."""
+    import cellpy
+    from cellpy.readers import cellreader
+
+    monkeypatch.setattr(
+        cellreader.CellpyCell,
+        "_try_harmonized_raw_frame",
+        lambda self, **kwargs: None,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cell = cellpy.get(
+            SOURCE,
+            instrument="arbin_sql_h5",
+            mass=1.0,
+            testing=True,
+            auto_summary=False,
+        )
+
+    assert cell.data.raw is not None and len(cell.data.raw)
+    assert len(datetime_apply_spy) > 1, "legacy _post_process did not run"
+
+
+@pytest.mark.essential
+def test_parse_honours_refuse_copying_for_a_local_file():
+    """``refuse_copying=True`` reads the file where it lies (#902)."""
+    import pathlib
+
+    loader = _loader()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        loader.parse(SOURCE, refuse_copying=True)
+
+    assert loader.refuse_copying is True
+    assert pathlib.Path(loader.temp_file_path).resolve() == pathlib.Path(
+        SOURCE
+    ).resolve()
+
+
 @pytest.mark.essential
 def test_two_stage_capacities_match_the_legacy_loader_stage_frame():
     import cellpy


### PR DESCRIPTION
Closes #902. Part of epic #896.

## What

With the default `use_harmonized_raw`, a load ran `harmonize(parse())` **and
then** the full legacy `loader()`. That meant a second `HDFStore.select`, a
second copy of the export to temp, and `apply(from_arbin_to_datetime)` +
`pd.to_datetime` over ~500k rows — to build a raw frame that is discarded
moments later when the harmonized frame replaces it. Measured in #895:
`apply` 2.84 s + `to_datetime` 1.90 s, legacy `loader()` 8.67 s, and
harmonize-**on** slower than off (11.8 s vs 8.8 s).

* `_parse_h5_data` caches its frames per temp path, and `copy_to_temporary` is
  overridden to reuse the copy `parse()` already made — so the export is
  fetched and read **once**.
* `parse()` honours `refuse_copying` (kwarg, or the instance flag that
  `from_raw` now sets before the prefetch), so a local file is not copied to
  temp.
* When the prefetch succeeded, `_post_process` skips the row-wise datetime
  decode and the dtype pass. `start_datetime` is decoded from the single first
  tick instead of the whole column, giving the same `Timestamp`. Everything
  else (rename, index, IR forward fill, de-dup) is unchanged, because the
  legacy frame is still handled by `_sort_data` / `identify_last_data_point`
  before it is replaced.
* Prefetch **failure** keeps today's full legacy path.
* `from_arbin_to_datetime` now accepts numpy integers — the export stores
  `int64` ticks, and the old `isinstance(n, int)` guard missed `np.int64`.

`datetime_kind="arbin_epoch"` and the `value * 100` tick decode are untouched,
as is step/summary science and every other loader.

## Tests

`tests/test_arbin_sql_h5_two_stage.py`:

* `test_two_stage_load_reads_the_hdf_once` — a full
  `cellpy.get(..., instrument="arbin_sql_h5", auto_summary=False)` produces
  exactly `["data_df", "info_df", "stat_df"]` `HDFStore.select` calls (was six),
  and at most one `from_arbin_to_datetime` call (the single `start_datetime`).
* `test_prefetch_failure_still_runs_the_legacy_post_process` — with the
  prefetch stubbed to `None`, the row-wise decode still runs.
* `test_parse_honours_refuse_copying_for_a_local_file` — `temp_file_path` is
  the source file itself.

Both new behavioural tests fail on `master` (verified by stashing the source
changes: 6 selects, `refuse_copying` False).

```
uv run pytest tests/test_arbin_variants_two_stage.py tests/test_loader_port_parity.py tests/test_arbin_sql_h5_two_stage.py -q
# 57 passed
uv run pytest -m essential -q
# 733 passed, 1 skipped, 2 xfailed, 1 xpassed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)