### PR TITLE
feat(cli): output vocabulary for CLI feedback (#891)

### DIFF
--- a/.issueflows/01-current-issues/issue891_original.md
+++ b/.issueflows/01-current-issues/issue891_original.md
@@ -1,0 +1,23 @@
+# Issue #891: Improve feedback during cli sessions
+
+Source: https://github.com/jepegit/cellpy/issues/891
+
+Milestone: v.2.1.3
+
+## Original issue text
+
+Some of the stuff cellpy outputs when running CLI commands are not very well
+thought through. Both with respect to content and visual impression. Let's make
+it better.
+
+## Session framing (agreed with the maintainer)
+
+The issue text is deliberately open. The scope settled at the start of the
+session:
+
+- **Visual treatment:** restrained — colour plus a symbol column, width-aware
+  rules, aligned key/value detail lines. No rich `Panel`s, no `Table`s for
+  prose output.
+- **Included:** global `--quiet` / `--verbose` / `--no-color`, and making the
+  existing per-command `--silent` actually silence.
+- **Deferred:** progress feedback for long `cellpy run` batch jobs (own issue).

--- a/.issueflows/01-current-issues/issue891_plan.md
+++ b/.issueflows/01-current-issues/issue891_plan.md
@@ -1,0 +1,148 @@
+# Plan — #891: CLI feedback
+
+## Goal
+
+Make `cellpy <command>` output look and read like one deliberate program:
+colour and a symbol column instead of a repeated `[cellpy]` prefix, one line per
+real action instead of debug dumps, failures on stderr with sane exit codes, and
+`--quiet` / `--verbose` / `--no-color` that actually work.
+
+## Findings (what is wrong today)
+
+Everything prints through `_say` in [cli_api.py](../../cellpy/cli_api.py), whose
+docstring states the problem: *"colour kwargs from old typer.echo are ignored"*
+(`cli_api.py:490`). `rich` is already a dependency but only Typer's **help**
+renderer uses it — hence tidy boxed help screens and flat grey command output.
+
+| # | Problem | Evidence |
+| --- | --- | --- |
+| 1 | Developer debug output shown to users | `setup --dry-run`: `Create custom init filename and get user_dir and destination`, `Got the following parameters:` + internal names (`init_filename`, `dst_file`, `not_relative`) |
+| 2 | Raw Python reprs leak | `info --check`: `Found these: ['Microsoft Access Driver (*.mdb, *.accdb)']` |
+| 3 | Stray dev prints in shipped paths | `print("RUNNING SOMETHING ELSE")`, `say("RUNNING LINUX")` (`cli_api.py:470-476`) |
+| 4 | Same fact twice, two formats | `*** dry-run: skipping actual saving of X ***` then `[cellpy] (setup) dry-run: would write X (not written)` |
+| 5 | Literal f-string bug in the **failure** message | `_say("f[cellpy] -> failed!!!!")` (`cli_api.py:1083`) |
+| 6 | `--silent` does not silence | `cellpy setup --dry-run --silent` emits ~25 lines |
+| 7 | Errors are not errors | `cellpy run` hand-rolls Typer's usage text to **stdout** (`cli.py:382-387`) while `convert` gets the real rendered error; nothing uses stderr; exit codes split `sys.exit(-1)` vs `typer.Exit(2)` |
+| 8 | Hard-coded 80-column rules | `80 * "-"`, `" [cellpy] WARNING! ".center(80, "-")`, `=== results ===` |
+| 9 | Apologetic / vague tone, typos | `Sorry. This did not work as expected!` ×3, `OK - but this directory already exists!`, `skipping check ... (for now)`, `could not deiced what is the new project` |
+| 10 | No global switches | root command exposes only `--help` |
+| 11 | Long jobs give no feedback | `run -j` prints `running journal X` then nothing — **deferred**, see Out of scope |
+
+## Constraints
+
+- **The CLI surface is a contract** ([test_cli_surface.py](../../tests/test_cli_surface.py)
+  against `tests/data/cli_surface.json`). It pins commands and flags, **not**
+  message text — so the copy work is free, but the new global flags require
+  `uv run python dev/snapshot_cli_surface.py` in the *same* commit.
+- `cli_api` functions are callable as a library with `echo=` and are **quiet by
+  default** (`_silent`). That stays: the reporter becomes the default for the
+  CLI entry points only, never for library callers.
+- Do not restructure `cli.py` / `cli_api.py` beyond what the output work needs.
+  No new commands, no renamed flags.
+- Keep `_say` working — private helpers all over `cli_api` call it.
+- Do not add progress bars / spinners in this issue.
+- `rich` markup is a footgun on user data (a Windows path with `[` gets parsed):
+  print with `markup=False` and pass styles as arguments.
+
+### Prior art
+
+- `_say` / `_using_echo` / `_echo_var` / `_resolve_echo` — `cli_api.py:486-500`.
+  **Extend, do not replace:** `_say` keeps its signature; the bound echo gains
+  levels.
+- `_silent` default echo — keeps library calls quiet. **Unchanged.**
+- Typer already renders usage errors well (`convert` proves it). **Delete the
+  hand-rolled block in `run` and let Typer do it.**
+- `tests/test_cli_api.py` asserts on a handful of message strings
+  (`"number of batch-files located: N"`, `"does not exist"`,
+  `"Could not import cookiecutter"`, `"Content of"` / `"No batch-files"`).
+  Those move with the copy pass, in the same PR.
+- `cellpy/libs/local_fastnda/cli.py` is a vendored third-party CLI. **Out of
+  scope, do not touch.**
+
+## Approach
+
+### New module `cellpy/cli_ui.py`
+
+A thin reporter over `rich.console.Console` (rich already handles TTY
+detection, `NO_COLOR`, and legacy Windows consoles):
+
+```python
+ui = Reporter(level=Level.NORMAL, color=None)   # color=None -> auto
+
+ui.title("cellpy 2.1.2 - checking your setup")
+ui.ok("odbc driver", "Microsoft Access Driver (*.mdb, *.accdb)")
+ui.fail("configuration", "no cellpy.toml found")
+ui.hint("run  cellpy setup")
+ui.detail("rawdatadir", "scp://.../projects", note="remote, not checked")
+ui.step("writing cellpy.toml")
+ui.warn("legacy .conf found", hint="cellpy setup migrate")
+ui.rule()                    # terminal width, not 80
+ui.summary(passed=3, total=3)
+```
+
+Vocabulary (the whole visual language — nothing else gets invented ad hoc):
+
+| Call | Renders | Colour | Stream |
+| --- | --- | --- | --- |
+| `title` | plain heading + blank line | default, bold | stdout |
+| `ok` | `  ✓ label   detail` | green symbol | stdout |
+| `warn` | `  ! label   detail` | yellow symbol | stdout |
+| `fail` | `  ✗ label   detail` | red symbol | **stderr** |
+| `step` | `  · doing thing` | dim | stdout |
+| `detail` | `      key   value   (note)` aligned | dim key | stdout |
+| `hint` | `      hint: …` | cyan | follows its parent |
+| `rule` | width-aware horizontal rule | dim | stdout |
+
+- **Symbols:** unicode when the stream encoding can encode them, ASCII
+  (`v` / `!` / `x` / `-`) when it cannot. Decided by probing `stream.encoding`,
+  not by guessing the platform.
+- **Colour off** when: `--no-color`, `NO_COLOR` set (any value), stdout is not a
+  TTY, or `TERM=dumb`. Piped output stays plain and greppable.
+- **Levels:** `QUIET` (failures only, plus explicitly-requested payload such as
+  `info --version`), `NORMAL`, `VERBOSE`.
+
+### Global flags
+
+Add a root Typer callback carrying `--quiet/-q`, `--verbose`, `--no-color`.
+**No `-v` short flag** — `info -v` already means `--version`, and reusing it
+across levels would be a trap. Per-command `--silent` maps to `QUIET` and
+`--debug` to `VERBOSE` (+ DEBUG logging), so those existing flags finally mean
+something.
+
+### Exit codes
+
+`0` success · `1` runtime failure · `2` usage error (Typer's own). Drop
+`sys.exit(-1)`, which surfaces as 255.
+
+## Staging (one PR each, off `master`)
+
+1. **`cli_ui` reporter + tests.** Nothing wired yet; no user-visible change.
+2. **Global flags, streams, exit codes.** Root callback + snapshot regen; map
+   `--silent` / `--debug`; failures to stderr; delete the hand-rolled usage
+   block in `run`.
+3. **`info` / `info --check`.** Banner soup → aligned check list with a summary
+   line; no raw list reprs.
+4. **`setup`.** Kill the parameter dump, one line per action, single dry-run
+   statement, `--silent` genuinely silent.
+5. **Copy pass.** Remaining commands (`edit`, `new`, `pull`, `serve`,
+   `convert`, `run --list`), the `f[cellpy]` and `deiced` bugs, the stray
+   `print()` calls, and the apology strings. Update the pinned strings in
+   `tests/test_cli_api.py`.
+
+## Tests
+
+- New `tests/test_cli_ui.py`: colour suppressed under `NO_COLOR` / non-TTY;
+  ASCII fallback when the stream cannot encode `✓`; level gating (`QUIET` hides
+  `ok`/`step`, keeps `fail`); `fail` goes to stderr.
+- `tests/test_cli_api.py`: updated assertions for the rewritten messages.
+- `tests/test_cli_surface.py`: regenerated snapshot in PR 2 only, so the surface
+  change is visible in review.
+- `uv run pytest -m essential` green before each PR.
+
+## Out of scope
+
+- Progress feedback for long `cellpy run` batch jobs → follow-up issue.
+- rich `Table` / `Panel` layouts (explicitly ruled out this round).
+- Restructuring `cli.py` / `cli_api.py`; new commands or renamed flags.
+- `cellpy/libs/local_fastnda/cli.py` (vendored).
+- Library-side logging configuration (`cellpy.log`).

--- a/.issueflows/01-current-issues/issue891_status.md
+++ b/.issueflows/01-current-issues/issue891_status.md
@@ -1,0 +1,42 @@
+# Issue #891 — status
+
+- [ ] Done
+
+## What's done
+
+- Survey of the current CLI output recorded in
+  [issue891_plan.md](issue891_plan.md) (11 numbered defects with evidence).
+- Plan accepted 2026-08-15: restrained visual treatment (colour + symbols, no
+  panels/tables), global `--quiet` / `--verbose` / `--no-color` included,
+  long-job progress deferred.
+- **PR 1 — `cellpy/cli_ui.py` reporter + tests.** The output vocabulary
+  (`title` / `ok` / `warn` / `fail` / `step` / `detail` / `hint` / `rule` /
+  `summary` / `payload` / `debug`), automatic colour, ASCII symbol fallback,
+  stderr for failures, `Level` gating, and an `as_echo()` seam for incremental
+  migration. Nothing is wired to a command yet, so there is no user-visible
+  change and no HISTORY entry.
+
+## Remaining work
+
+- [ ] PR 2 — global flags (`--quiet` / `--verbose` / `--no-color`), failures to
+      stderr, exit codes 0/1/2, delete the hand-rolled usage block in `run`;
+      regenerate `tests/data/cli_surface.json` in the same commit.
+- [ ] PR 3 — `info` / `info --check`.
+- [ ] PR 4 — `setup` (drop the parameter dump, make `--silent` real).
+- [ ] PR 5 — copy pass over the remaining commands; fix the `f[cellpy]` literal
+      and the `deiced` typo; remove the stray `print()` calls.
+- [ ] Register the new essential tests in
+      [test-registry.md](../04-designs-and-guides/test-registry.md). Deferred
+      out of PR 1 only because the concurrent #912 session has uncommitted rows
+      in that file; staging it would have swept their work into this commit.
+      Rows to add (`tests/test_cli_ui.py`, essential/always, code under test
+      `cli_ui.Reporter`, issue #891) plus
+      `test_cli_light_import.py::test_importing_cli_ui_does_not_import_rich`.
+
+## Notes
+
+- A concurrent session is working #912 in this same checkout. PR 1 commits only
+  `cellpy/cli_ui.py`, `tests/test_cli_ui.py`,
+  `tests/test_cli_light_import.py` and these `.issueflows` docs; the #912
+  changes to `cellpy/readers/cellpy_file/v9.py`, `tests/test_cellpy_file_v9.py`
+  and `HISTORY.md` are left untouched in the working tree.

--- a/cellpy/cli_ui.py
+++ b/cellpy/cli_ui.py
@@ -1,0 +1,387 @@
+"""Console reporting for the cellpy CLI (#891).
+
+One small vocabulary for everything the CLI says, so output stops being a mix
+of ``[cellpy] (setup)`` prefixes, hand-drawn 80-column rules and bare
+``print()`` calls:
+
+    >>> ui = Reporter()
+    >>> ui.title("cellpy 2.1.2 - checking your setup")
+    >>> ui.ok("odbc driver", "Microsoft Access Driver")
+    >>> ui.fail("configuration", "no cellpy.toml found")
+    >>> ui.hint("run  cellpy setup")
+    >>> ui.summary(2, 3)
+
+Rules of the house:
+
+* **Failures go to stderr**, everything else to stdout, so ``cellpy ... > out``
+  keeps the errors on the terminal.
+* **Colour is automatic**: off when the stream is not a terminal, when
+  ``NO_COLOR`` is set, when ``TERM=dumb``, or when the caller passes
+  ``color=False``. Piped output stays plain and greppable.
+* **Symbols degrade to ASCII** when the stream encoding cannot represent them
+  (legacy Windows code pages), decided by probing the stream rather than
+  guessing from the platform.
+* **User data is never markup**: messages are rendered as ``rich`` ``Text``
+  objects, so a Windows path full of ``[`` is printed, not parsed.
+
+``rich`` is imported lazily so that merely importing this module stays cheap
+(#837 keeps ``cellpy info --version`` off the heavy import path).
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, TextIO
+
+__all__ = [
+    "ASCII_SYMBOLS",
+    "Level",
+    "Reporter",
+    "Symbols",
+    "UNICODE_SYMBOLS",
+    "color_enabled",
+    "make_reporter",
+    "supports_unicode",
+]
+
+# Layout constants. The label column is wide enough for the longest label the
+# CLI uses today ("cellpydatadir", "odbc driver", ...) with room to spare; a
+# longer label simply pushes its detail right instead of being truncated.
+LABEL_WIDTH = 20
+INDENT = "  "
+DETAIL_INDENT = "      "
+# ``INDENT + symbol + space`` is 4 columns; the detail indent is 6. Narrowing
+# the key column by the difference lines both value columns up.
+DETAIL_KEY_WIDTH = LABEL_WIDTH - (len(DETAIL_INDENT) - len(INDENT) - 2)
+
+STYLE_OK = "green"
+STYLE_WARN = "yellow"
+STYLE_FAIL = "red"
+STYLE_DIM = "dim"
+STYLE_HINT = "cyan"
+STYLE_TITLE = "bold"
+
+
+class Level(enum.IntEnum):
+    """How much the CLI says.
+
+    ``QUIET`` still reports problems and still prints explicitly requested
+    payload (``cellpy info --version``) - it silences progress, not answers.
+    """
+
+    QUIET = 0
+    NORMAL = 1
+    VERBOSE = 2
+
+
+@dataclass(frozen=True)
+class Symbols:
+    """The symbol column. Every symbol is one character wide, so rows align."""
+
+    ok: str
+    warn: str
+    fail: str
+    step: str
+    rule: str
+
+
+UNICODE_SYMBOLS = Symbols(ok="✓", warn="!", fail="✗", step="·", rule="─")
+ASCII_SYMBOLS = Symbols(ok="+", warn="!", fail="x", step="-", rule="-")
+
+
+def supports_unicode(stream: Any) -> bool:
+    """True when ``stream`` can encode the unicode symbol set."""
+    encoding = getattr(stream, "encoding", None)
+    if not encoding:
+        return False
+    probe = "".join(
+        (
+            UNICODE_SYMBOLS.ok,
+            UNICODE_SYMBOLS.fail,
+            UNICODE_SYMBOLS.step,
+            UNICODE_SYMBOLS.rule,
+        )
+    )
+    try:
+        probe.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def color_enabled(stream: Any, *, color: Optional[bool] = None) -> bool:
+    """Decide colour for ``stream``; ``color`` (from ``--no-color``) wins."""
+    if color is not None:
+        return bool(color)
+    # https://no-color.org - presence is the signal, whatever the value.
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    isatty = getattr(stream, "isatty", None)
+    if isatty is None:
+        return False
+    try:
+        return bool(isatty())
+    except ValueError:  # closed stream
+        return False
+
+
+class Reporter:
+    """Renders the CLI's output vocabulary.
+
+    Args:
+        level: how much to say (see :class:`Level`).
+        color: force colour on/off; ``None`` (default) decides per stream.
+        stdout / stderr: streams to write to (defaults to the real ones);
+            injectable so tests can capture without touching global state.
+    """
+
+    def __init__(
+        self,
+        *,
+        level: Level = Level.NORMAL,
+        color: Optional[bool] = None,
+        stdout: Optional[TextIO] = None,
+        stderr: Optional[TextIO] = None,
+    ) -> None:
+        self.level = Level(level)
+        self._color = color
+        self._stdout = stdout if stdout is not None else sys.stdout
+        self._stderr = stderr if stderr is not None else sys.stderr
+        self.symbols = (
+            UNICODE_SYMBOLS if supports_unicode(self._stdout) else ASCII_SYMBOLS
+        )
+        self._out_console: Any = None
+        self._err_console: Any = None
+
+    # -- plumbing ------------------------------------------------------
+
+    def _console(self, *, err: bool = False) -> Any:
+        cached = self._err_console if err else self._out_console
+        if cached is not None:
+            return cached
+        from rich.console import Console
+
+        stream = self._stderr if err else self._stdout
+        enabled = color_enabled(stream, color=self._color)
+        console = Console(
+            file=stream,
+            # force_terminal so colour survives a captured stream when the
+            # caller explicitly asked for it; no_color strips it otherwise.
+            force_terminal=True if enabled else False,
+            no_color=not enabled,
+            highlight=False,  # rich would colour numbers/paths on its own
+            markup=False,
+            emoji=False,
+            soft_wrap=True,
+        )
+        if err:
+            self._err_console = console
+        else:
+            self._out_console = console
+        return console
+
+    def _text(self) -> Any:
+        from rich.text import Text
+
+        return Text()
+
+    def _visible(self, minimum: Level) -> bool:
+        return self.level >= minimum
+
+    def _write(self, text: Any, *, err: bool = False) -> None:
+        self._console(err=err).print(text)
+
+    @property
+    def is_verbose(self) -> bool:
+        """For callers that want to emit extra detail under ``--verbose``."""
+        return self.level >= Level.VERBOSE
+
+    @property
+    def width(self) -> int:
+        return int(self._console().width)
+
+    # -- vocabulary ----------------------------------------------------
+
+    def title(self, message: str) -> None:
+        """A heading for a command that is about to report several things."""
+        if not self._visible(Level.NORMAL):
+            return
+        text = self._text()
+        text.append(message, style=STYLE_TITLE)
+        self._write(text)
+        self.blank()
+
+    def ok(self, label: str, detail: Optional[str] = None) -> None:
+        """Something worked."""
+        if not self._visible(Level.NORMAL):
+            return
+        self._write(self._row(self.symbols.ok, STYLE_OK, label, detail))
+
+    def warn(
+        self, label: str, detail: Optional[str] = None, *, hint: Optional[str] = None
+    ) -> None:
+        """Something is off but the command carries on. Survives ``--quiet``."""
+        self._write(self._row(self.symbols.warn, STYLE_WARN, label, detail))
+        if hint:
+            self._hint_line(hint)
+
+    def fail(
+        self, label: str, detail: Optional[str] = None, *, hint: Optional[str] = None
+    ) -> None:
+        """Something failed. Goes to stderr and survives ``--quiet``."""
+        self._write(self._row(self.symbols.fail, STYLE_FAIL, label, detail), err=True)
+        if hint:
+            self._hint_line(hint, err=True)
+
+    def step(self, message: str) -> None:
+        """One real action, as it happens ("writing cellpy.toml")."""
+        if not self._visible(Level.NORMAL):
+            return
+        self._write(self._row(self.symbols.step, STYLE_DIM, message, None))
+
+    def detail(self, key: str, value: str, *, note: Optional[str] = None) -> None:
+        """An aligned key/value line under whatever was just reported."""
+        if not self._visible(Level.NORMAL):
+            return
+        text = self._text()
+        text.append(DETAIL_INDENT)
+        # Narrower key column, so detail values land in the same column as the
+        # detail of the ok/warn/fail row they sit under.
+        text.append(_pad(key, DETAIL_KEY_WIDTH), style=STYLE_DIM)
+        text.append(value)
+        if note:
+            text.append(f"  ({note})", style=STYLE_DIM)
+        self._write(text)
+
+    def hint(self, message: str) -> None:
+        """What the user should do next."""
+        if not self._visible(Level.NORMAL):
+            return
+        self._hint_line(message)
+
+    def rule(self, title: Optional[str] = None) -> None:
+        """A horizontal rule at terminal width - never a hard-coded 80."""
+        if not self._visible(Level.NORMAL):
+            return
+        width = max(self.width, 10)
+        char = self.symbols.rule
+        if title:
+            label = f" {title} "
+            fill = max(width - len(label), 2)
+            left = fill // 2
+            line = char * left + label + char * (fill - left)
+        else:
+            line = char * width
+        text = self._text()
+        text.append(line, style=STYLE_DIM)
+        self._write(text)
+
+    def summary(self, passed: int, total: int, *, unit: str = "checks") -> None:
+        """The one-line verdict that closes a multi-check command."""
+        if not self._visible(Level.NORMAL):
+            return
+        self.blank()
+        text = self._text()
+        text.append(INDENT)
+        style = STYLE_OK if passed == total else STYLE_FAIL
+        text.append(f"{passed} of {total} {unit} passed", style=style)
+        self._write(text)
+
+    def blank(self) -> None:
+        if not self._visible(Level.NORMAL):
+            return
+        self._write(self._text())
+
+    def payload(self, message: str) -> None:
+        """Output the user explicitly asked for (a version, a config dump).
+
+        Printed verbatim at every level, including ``--quiet``: silencing
+        progress must not silence the answer to the question.
+        """
+        text = self._text()
+        text.append(message)
+        self._write(text)
+
+    def debug(self, message: str) -> None:
+        """Internal detail; only under ``--verbose``."""
+        if not self._visible(Level.VERBOSE):
+            return
+        text = self._text()
+        text.append(DETAIL_INDENT)
+        text.append(message, style=STYLE_DIM)
+        self._write(text)
+
+    # -- compatibility -------------------------------------------------
+
+    def as_echo(self) -> Callable[[str], None]:
+        """An ``Echo``-compatible callable for messages not yet converted.
+
+        ``cli_api`` reports through ``_say`` / ``echo=``; binding this lets the
+        conversion happen message by message instead of in one sweep. Text
+        arrives pre-formatted, so it is printed as payload.
+        """
+
+        def echo(message: str = "") -> None:
+            if not self._visible(Level.NORMAL):
+                return
+            self.payload(message)
+
+        return echo
+
+    # -- internals -----------------------------------------------------
+
+    def _row(
+        self, symbol: str, style: str, label: str, detail: Optional[str]
+    ) -> Any:
+        text = self._text()
+        text.append(INDENT)
+        text.append(symbol, style=style)
+        text.append(" ")
+        text.append(_pad(label) if detail else label)
+        if detail:
+            text.append(detail, style=STYLE_DIM)
+        return text
+
+    def _hint_line(self, message: str, *, err: bool = False) -> None:
+        text = self._text()
+        text.append(DETAIL_INDENT)
+        text.append("hint: ", style=STYLE_HINT)
+        text.append(message)
+        self._write(text, err=err)
+
+
+def _pad(value: str, width: int = LABEL_WIDTH) -> str:
+    """Left-align in a column, keeping at least two spaces after a long value."""
+    return value.ljust(width) if len(value) < width else value + "  "
+
+
+def make_reporter(
+    *,
+    quiet: bool = False,
+    verbose: bool = False,
+    no_color: bool = False,
+    stdout: Optional[TextIO] = None,
+    stderr: Optional[TextIO] = None,
+) -> Reporter:
+    """Build a :class:`Reporter` from CLI-shaped flags.
+
+    ``quiet`` wins over ``verbose`` - asking for silence and noise at once is
+    a user mistake, not a reason to be noisy.
+    """
+    if quiet:
+        level = Level.QUIET
+    elif verbose:
+        level = Level.VERBOSE
+    else:
+        level = Level.NORMAL
+    return Reporter(
+        level=level,
+        color=False if no_color else None,
+        stdout=stdout,
+        stderr=stderr,
+    )

--- a/tests/test_cli_light_import.py
+++ b/tests/test_cli_light_import.py
@@ -104,6 +104,23 @@ def test_setup_check_imports_cellreader():
 
 
 @pytest.mark.essential
+def test_importing_cli_ui_does_not_import_rich():
+    """``cli_ui`` defers rich to first output, so importing it stays cheap (#891)."""
+    completed = _run_script(
+        """
+        import sys
+
+        import cellpy.cli_ui
+
+        assert not [m for m in sys.modules if m.startswith("rich")], sorted(
+            m for m in sys.modules if m.startswith("rich")
+        )
+        """
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.essential
 def test_setup_deps_probes_optional_modules():
     """``setup --deps`` opts into optional-extra probing (#839)."""
     completed = _run_script(

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -1,0 +1,264 @@
+"""The CLI's output vocabulary (#891).
+
+``cli_ui`` decides three things a user notices immediately: whether output is
+coloured, which symbols it can print, and how much of it appears. Each of those
+is a decision about *someone else's* terminal, so they are tested against
+injected streams rather than the one running pytest.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from cellpy.cli_ui import (
+    ASCII_SYMBOLS,
+    UNICODE_SYMBOLS,
+    Level,
+    Reporter,
+    color_enabled,
+    make_reporter,
+    supports_unicode,
+)
+
+
+class _Stream(io.StringIO):
+    """A StringIO that answers the questions rich asks of a real stream."""
+
+    def __init__(self, encoding: str = "utf-8", tty: bool = False):
+        super().__init__()
+        self._encoding = encoding
+        self._tty = tty
+
+    @property
+    def encoding(self) -> str:  # type: ignore[override]
+        return self._encoding
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.fixture
+def plain_env(monkeypatch):
+    """Neutralise the ambient terminal environment for colour decisions."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+
+
+@pytest.fixture
+def streams():
+    return _Stream(), _Stream()
+
+
+def _reporter(streams, **kwargs) -> Reporter:
+    out, err = streams
+    return Reporter(stdout=out, stderr=err, **kwargs)
+
+
+# -- symbols ----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_unicode_symbols_when_the_stream_can_encode_them(plain_env, streams):
+    assert _reporter(streams).symbols is UNICODE_SYMBOLS
+
+
+@pytest.mark.essential
+def test_ascii_symbols_on_a_legacy_code_page(plain_env):
+    """A cp1252 console cannot print ✓ - fall back instead of crashing."""
+    out, err = _Stream(encoding="cp1252"), _Stream()
+    reporter = Reporter(stdout=out, stderr=err)
+
+    assert reporter.symbols is ASCII_SYMBOLS
+    reporter.ok("imports", "cellpy")
+    printed = out.getvalue()
+    assert ASCII_SYMBOLS.ok in printed
+    assert UNICODE_SYMBOLS.ok not in printed
+
+
+@pytest.mark.essential
+def test_supports_unicode_is_false_without_an_encoding():
+    assert supports_unicode(io.StringIO()) is False
+
+
+# -- colour -----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_no_colour_when_the_stream_is_not_a_terminal(plain_env, streams):
+    reporter = _reporter(streams)
+    reporter.ok("imports", "cellpy")
+
+    assert "\x1b[" not in streams[0].getvalue()
+
+
+@pytest.mark.essential
+def test_no_color_environment_variable_wins(plain_env, monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "")  # presence is the signal, not the value
+    assert color_enabled(_Stream(tty=True)) is False
+
+
+@pytest.mark.essential
+def test_dumb_terminal_gets_no_colour(plain_env, monkeypatch):
+    monkeypatch.setenv("TERM", "dumb")
+    assert color_enabled(_Stream(tty=True)) is False
+
+
+@pytest.mark.essential
+def test_a_terminal_gets_colour(plain_env):
+    assert color_enabled(_Stream(tty=True)) is True
+
+
+@pytest.mark.essential
+def test_explicit_color_flag_overrides_detection(plain_env, streams):
+    reporter = _reporter(streams, color=True)
+    reporter.ok("imports", "cellpy")
+
+    assert "\x1b[" in streams[0].getvalue()
+
+
+# -- streams ----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_failures_go_to_stderr_and_successes_to_stdout(plain_env, streams):
+    out, err = streams
+    reporter = _reporter(streams)
+
+    reporter.ok("imports", "cellpy")
+    reporter.fail("configuration", "no cellpy.toml found", hint="run  cellpy setup")
+
+    assert "imports" in out.getvalue()
+    assert "configuration" not in out.getvalue()
+    assert "configuration" in err.getvalue()
+    assert "hint: run  cellpy setup" in err.getvalue()
+
+
+# -- levels -----------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_quiet_keeps_problems_and_drops_progress(plain_env, streams):
+    out, err = streams
+    reporter = _reporter(streams, level=Level.QUIET)
+
+    reporter.title("checking your setup")
+    reporter.step("writing cellpy.toml")
+    reporter.ok("imports", "cellpy")
+    reporter.detail("rawdatadir", "/data/raw")
+    reporter.summary(3, 3)
+    reporter.warn("legacy .conf found")
+    reporter.fail("configuration", "missing")
+
+    printed = out.getvalue()
+    for silenced in (
+        "checking your setup",
+        "writing cellpy.toml",
+        "imports",
+        "rawdatadir",
+        "checks passed",
+    ):
+        assert silenced not in printed, silenced
+    # Problems are not progress: both survive --quiet, on their own streams.
+    assert "legacy .conf found" in printed
+    assert "configuration" in err.getvalue()
+
+
+@pytest.mark.essential
+def test_quiet_still_prints_requested_payload(plain_env, streams):
+    """`cellpy info --version` under --quiet must still answer."""
+    reporter = _reporter(streams, level=Level.QUIET)
+    reporter.payload("2.1.2")
+
+    assert "2.1.2" in streams[0].getvalue()
+
+
+@pytest.mark.essential
+def test_debug_only_appears_under_verbose(plain_env, streams):
+    out, _ = streams
+    _reporter(streams).debug("dst_file=/tmp/x")
+    assert out.getvalue().strip() == ""
+
+    verbose_out = _Stream()
+    Reporter(stdout=verbose_out, stderr=_Stream(), level=Level.VERBOSE).debug(
+        "dst_file=/tmp/x"
+    )
+    assert "dst_file=/tmp/x" in verbose_out.getvalue()
+
+
+@pytest.mark.essential
+def test_make_reporter_prefers_quiet_over_verbose():
+    assert make_reporter(quiet=True, verbose=True).level is Level.QUIET
+    assert make_reporter(verbose=True).level is Level.VERBOSE
+    assert make_reporter().level is Level.NORMAL
+
+
+# -- rendering --------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_user_data_is_never_parsed_as_markup(plain_env, streams):
+    """A path with brackets is data. rich must print it, not interpret it."""
+    out, _ = streams
+    reporter = _reporter(streams)
+
+    reporter.ok("cellpydatadir", r"C:\data\[bold]run[/bold]")
+
+    printed = out.getvalue()
+    assert "[bold]run[/bold]" in printed
+
+
+@pytest.mark.essential
+def test_rules_follow_the_terminal_width(plain_env, streams):
+    out, _ = streams
+    reporter = _reporter(streams)
+
+    reporter.rule()
+
+    line = out.getvalue().strip("\n")
+    assert len(line) == reporter.width
+    assert line != "-" * 80 or reporter.width == 80
+
+
+@pytest.mark.essential
+def test_summary_reports_the_score(plain_env, streams):
+    out, _ = streams
+    _reporter(streams).summary(2, 3)
+
+    assert "2 of 3 checks passed" in out.getvalue()
+
+
+@pytest.mark.essential
+def test_detail_lines_align_under_their_parent(plain_env, streams):
+    out, _ = streams
+    reporter = _reporter(streams)
+
+    reporter.ok("configuration", "cellpy.toml")
+    reporter.detail("rawdatadir", "/data/raw", note="remote, not checked")
+
+    lines = out.getvalue().splitlines()
+    assert lines[0].startswith("  ")
+    assert lines[1].startswith("      ")
+    assert "(remote, not checked)" in lines[1]
+
+
+# -- compatibility ----------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_as_echo_prints_preformatted_messages(plain_env, streams):
+    out, _ = streams
+    echo = _reporter(streams).as_echo()
+
+    echo("[cellpy] (setup) not converted yet")
+
+    assert "[cellpy] (setup) not converted yet" in out.getvalue()
+
+
+@pytest.mark.essential
+def test_as_echo_is_silent_when_quiet(plain_env, streams):
+    out, _ = streams
+    _reporter(streams, level=Level.QUIET).as_echo()("noise")
+
+    assert out.getvalue().strip() == ""


### PR DESCRIPTION
Part of #891. **PR 1 of 5** — the foundation only; nothing is wired to a command
yet, so this PR changes no output.

## Why

The CLI speaks two visual languages. `cellpy --help` is rendered by rich (boxes,
colour, terminal-aware width); every command's *output* is flat text with a
`[cellpy]` prefix repeated on 110 lines, hand-drawn `80 * "-"` rules, and bare
`print()` calls. Nothing below `_say` can style anything, because `_say` says so:

> `"""Report via the bound echo; colour kwargs from old typer.echo are ignored."""`

The survey of what's wrong (11 defects with evidence — debug dumps shown to
users, raw Python list reprs, the same fact printed twice in two formats, a
`f[cellpy]` literal in a failure message, `--silent` that doesn't silence) is
recorded in `.issueflows/01-current-issues/issue891_plan.md`.

## What this adds

`cellpy/cli_ui.py` — one vocabulary every command will speak: `title`, `ok`,
`warn`, `fail`, `step`, `detail`, `hint`, `rule`, `summary`, `payload`, `debug`.

```
cellpy 2.1.2 - checking your setup

  ✓ imports             cellpy, pandas, pyarrow
  ✓ configuration       cellpy.toml (user)
      rawdatadir          scp://…/projects  (remote, not checked)
  ! legacy config       .cellpy_prms_jepe.conf is ignored
      hint: cellpy setup migrate

  3 of 3 checks passed
```

Decisions worth reviewing:

* **Failures go to stderr**, everything else to stdout, so `cellpy … > out`
  keeps errors on the terminal. `warn` stays on stdout: it belongs to the
  narrative, and it survives `--quiet` because a problem is not progress.
* **Colour is automatic** — off for a non-terminal, `NO_COLOR` (presence, not
  value), `TERM=dumb`, or an explicit flag. Piped output stays greppable.
* **ASCII fallback is decided by probing `stream.encoding`**, not by guessing
  from the platform, so a cp1252 console degrades instead of raising on `✓`.
* **User data is never markup.** Messages are rich `Text` objects, so
  `C:\data\[bold]run` prints as written rather than being parsed.
* **`--quiet` keeps the answer.** `payload()` (a version, a config dump) prints
  at every level; silencing progress must not silence what was asked for.
* **`as_echo()`** bridges the existing `echo=` seam so PRs 3–5 can convert
  `cli_api` message by message instead of in one sweep.
* **rich is imported lazily**, so the #837 light-import path is unaffected.

## Tests

`tests/test_cli_ui.py` (19 tests) covers symbol fallback, the four colour
decisions, stream routing, level gating, markup safety, width-aware rules and
the echo bridge. `tests/test_cli_light_import.py` gains a guard that importing
`cellpy.cli_ui` does not import rich.

```
uv run pytest tests/test_cli_ui.py tests/test_cli_light_import.py tests/test_cli_api.py tests/test_cli_surface.py -q
# 64 passed
```

## Notes for the reviewer

* **No HISTORY entry.** Nothing user-visible changes yet; the entry lands with
  the global flags in PR 2.
* **No `test-registry.md` rows.** A concurrent session has uncommitted rows in
  that file for #912, and staging it would have swept their work into this
  commit. The rows to add are listed under "Remaining work" in
  `issue891_status.md` and land in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)