### PR TITLE
perf(cellpy-file): write v9 parquet with zstd

### DIFF
--- a/.issueflows/03-solved-issues/issue912_original.md
+++ b/.issueflows/03-solved-issues/issue912_original.md
@@ -1,0 +1,45 @@
+# Issue #912: Use zstd for v9 parquet members
+
+Source: https://github.com/jepegit/cellpy/issues/912
+
+## Original issue text
+
+## Problem / context
+
+#898 stopped zip-DEFLATE on parquet members (`ZIP_STORED`). Save dropped ~3.8 s → ~0.9 s on a 526k-row cell. Files grew ~22 MB → ~34 MB because pandas/pyarrow `to_parquet` still defaults to **snappy**, and snappy is fast, not dense.
+
+The right place to compress is the parquet codec, not the zip. Bake-off on the same raw frame (pyarrow 25, this machine):
+
+| Codec | Encode | Decode | Size |
+| --- | ---: | ---: | ---: |
+| snappy (current) | 0.36 s | 0.026 s | 33.3 MB |
+| zstd:3 | 0.45 s | 0.026 s | 21.3 MB |
+| zstd:7 | 1.00 s | 0.025 s | 20.9 MB |
+| brotli | 4.7 s | 0.050 s | 19.7 MB |
+| gzip | 15.7 s | 0.037 s | 22.4 MB |
+
+`zstd:3` gets the old on-disk size back (slightly better) without the zip-DEFLATE CPU tax. Decode matches snappy. Writer: `cellpy/readers/cellpy_file/v9.py` (`_frame_to_parquet_bytes`). Tests: `tests/test_cellpy_file_v9.py`. Notes: `dev/speed-test-01/NOTES.md`.
+
+## Spec
+
+- Write parquet members with **`compression="zstd"`** and **`compression_level=3`**.
+- Keep `ZIP_STORED` for parquet members; `meta.json` may stay `ZIP_DEFLATED`.
+- Do not bump the on-disk schema version. Old snappy v9 files must still load.
+- Keep atomic write + member verify. Do not change column translation.
+
+## Acceptance criteria
+
+- [ ] `_frame_to_parquet_bytes` (or the write path it feeds) uses zstd level 3.
+- [ ] New or extended test writes a v9 file and asserts the parquet member is zstd (footer / pyarrow metadata), not snappy.
+- [ ] Existing `tests/test_cellpy_file_v9.py` stays green, including load of a pre-existing snappy fixture if one is in-tree.
+- [ ] No zip-level compressor on parquet members.
+
+## Goal
+
+New v9 files are ~snappy-speed to write and ~old-DEFLATE size on disk; old v9 files still open.
+
+## Out of scope
+
+Zip BZIP2/LZMA/DEFLATE on parquet. brotli/gzip. Changing the default file format (v9 stays). Dropping `Data.copy()` / `to_native`.
+
+Follow-up to #898. Same milestone as epic #896.

--- a/.issueflows/03-solved-issues/issue912_plan.md
+++ b/.issueflows/03-solved-issues/issue912_plan.md
@@ -1,0 +1,81 @@
+# Issue #912 — plan: zstd for v9 parquet members
+
+Source: https://github.com/jepegit/cellpy/issues/912
+Milestone: v.2.1.3
+
+## Goal
+
+New v9 `.cellpy` files write parquet with **zstd level 3** so on-disk size
+returns to ~old ZIP_DEFLATED (~21 MB on the #895 cell) without putting a
+second compressor on the zip. Old snappy v9 files still load. No format-version
+bump.
+
+## Constraints
+
+- Keep `#898` `ZIP_STORED` on parquet members; `meta.json` may stay
+  `ZIP_DEFLATED`.
+- Do not bump `CELLPY_FILE_VERSION`. Reader already uses pyarrow and does not
+  pin a parquet codec.
+- Do not change column translation, atomic write, or member verify.
+- No public `get` / `save` / schema / CLI surface change — no `agents.md` update.
+- HISTORY is `/iflow-close`, not this plan.
+
+### Prior art
+
+- Toolbox (`.issueflows/00-tools/README.md`) — nothing for parquet codecs.
+- [`cellpy/readers/cellpy_file/v9.py`](../../cellpy/readers/cellpy_file/v9.py)
+  `_frame_to_parquet_bytes` — single write path; `to_parquet(..., engine="pyarrow")`
+  with no `compression=` (snappy default).
+- [`tests/test_cellpy_file_v9.py`](../../tests/test_cellpy_file_v9.py)
+  `test_v9_parquet_members_are_stored_not_deflated` — sibling essential test
+  for zip `compress_type`; mirror for codec.
+- [`dev/regenerate_goldens.py`](../../dev/regenerate_goldens.py) pins
+  `compression="snappy"` for **golden fixtures**, not `.cellpy` — leave it.
+- `cellpy/libs/local_fastnda/btsda.py` brotli export — unrelated.
+- No in-tree snappy v9 `.cellpy` fixture (testdata cellpy names are journal
+  paths). Synthesize snappy members in the test.
+- graphify community around `_frame_to_parquet_bytes` / v9 save — same module.
+
+## Approach
+
+1. In `_frame_to_parquet_bytes`, pass `compression="zstd"` and
+   `compression_level=3`. Put those two values as module constants next to the
+   helper (`PARQUET_COMPRESSION`, `PARQUET_COMPRESSION_LEVEL`) so the test
+   imports them instead of magic strings.
+2. Leave `save()` zip loop unchanged (`ZIP_STORED` parquet, DEFLATED meta).
+3. Load path unchanged — `pandas.read_parquet(..., engine="pyarrow")` already
+   decodes zstd and snappy.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/readers/cellpy_file/v9.py` | constants + `to_parquet` kwargs |
+| `tests/test_cellpy_file_v9.py` | two essential tests (codec + snappy load) |
+
+No new files. No `format.py` move (that module is HDF5/v9 **layout** keys).
+
+## Test strategy
+
+Project: conda `cellpy_dev_313` then `pytest` (or `uv run pytest`). Gate:
+
+```bash
+conda run -n cellpy_dev_313 pytest tests/test_cellpy_file_v9.py -q
+```
+
+New, `@pytest.mark.essential`, same v8-with-fids fixture as the #898 test:
+
+1. **`test_v9_parquet_members_use_zstd`** — `save` a v9 file. For each
+   `*.parquet` member: zip `compress_type == ZIP_STORED`, and
+   `pyarrow.parquet.ParquetFile` metadata reports `ZSTD` (any column / row
+   group).
+2. **`test_v9_loads_snappy_parquet_members`** — save v9, rebuild a zip that
+   swaps parquet members for the same frames encoded with `compression="snappy"`,
+   `load_cellpy_file` succeeds and frames match. Proves old #898-era files
+   still open.
+
+Existing v9 essential tests stay green (round-trip, ZIP_STORED, atomic writes).
+
+## Open questions
+
+None — codec and level are in the issue Spec.

--- a/.issueflows/03-solved-issues/issue912_status.md
+++ b/.issueflows/03-solved-issues/issue912_status.md
@@ -1,0 +1,14 @@
+# Issue #912 — status
+
+- [x] Done
+
+## What's done
+
+- `_frame_to_parquet_bytes` writes zstd level 3 (`PARQUET_COMPRESSION` / `PARQUET_COMPRESSION_LEVEL`).
+- Essential tests: new save is ZSTD + ZIP_STORED; snappy members still load.
+- `pytest tests/test_cellpy_file_v9.py` — 10 passed.
+- HISTORY + test-registry updated.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -50,6 +50,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_config.py::test_active_config_file_reports_project_toml | yes | yes | config.loader.active_config_file project_path | #853 | |
 | tests/test_cellpy_cmd.py::test_info_configloc_reports_project_toml | yes | yes | cli_api._configloc project notice | #853 | |
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
+| tests/test_cellpy_file_v9.py::test_v9_parquet_members_use_zstd | yes | yes | v9._frame_to_parquet_bytes | #912 | new writes are zstd + ZIP_STORED |
+| tests/test_cellpy_file_v9.py::test_v9_loads_snappy_parquet_members | yes | yes | v9.load / _read_parquet_member | #912 | #898-era snappy members still load |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |
 | tests/test_cellpy_file_v9.py::test_failed_first_save_leaves_no_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save | #845 | no half-written archive on a fresh path |
 | tests/test_ica_plot_prepare.py::test_ica_dva_plotly_both_direction_dash_differs | yes | yes | plotting.backends.plotly._render_ica_dva | #862 | charge solid / discharge dot |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,9 @@
 * Per-cell `search_for_files` searches sub-folders with
   `rglob(..., files_only=True)`, so a remote search can use the single
   `find -L` listing instead of walking the tree per cell. (#899)
+* v9 `.cellpy` writes parquet members with zstd level 3 so new files stay
+  near the old DEFLATE size without a second zip compressor. Snappy members
+  from #898-era files still load. (#912)
 * v9 `.cellpy` writes its parquet members with `ZIP_STORED` instead of
   DEFLATE-ing already-compressed parquet, cutting seconds off every `save`.
   `meta.json` stays deflated; the file format is unchanged. (#898)

--- a/cellpy/readers/cellpy_file/v9.py
+++ b/cellpy/readers/cellpy_file/v9.py
@@ -91,6 +91,12 @@ def _normalize_frame_nulls(frame):
     return frame.replace({None: externals.numpy.nan})
 
 
+# Parquet already compresses columns. zstd:3 matches old zip-DEFLATE size
+# without a second zip compressor (#912). Readers still accept snappy (#898).
+PARQUET_COMPRESSION = "zstd"
+PARQUET_COMPRESSION_LEVEL = 3
+
+
 def _frame_to_parquet_bytes(frame) -> bytes:
     buf = io.BytesIO()
     to_write = frame
@@ -100,7 +106,13 @@ def _frame_to_parquet_bytes(frame) -> bytes:
             to_write = frame.reset_index(drop=True)
         else:
             to_write = frame.reset_index()
-    to_write.to_parquet(buf, index=False, engine="pyarrow")
+    to_write.to_parquet(
+        buf,
+        index=False,
+        engine="pyarrow",
+        compression=PARQUET_COMPRESSION,
+        compression_level=PARQUET_COMPRESSION_LEVEL,
+    )
     return buf.getvalue()
 
 

--- a/tests/test_cellpy_file_v9.py
+++ b/tests/test_cellpy_file_v9.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import json
 import zipfile
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from cellpycore.metadata import io as core_meta_io
 from cellpycore.metadata.models import TestMeta
@@ -103,6 +105,72 @@ def test_v9_parquet_members_are_stored_not_deflated(tmp_path):
     for name in parquet_members:
         assert infos[name].compress_type == zipfile.ZIP_STORED, name
     assert infos[META_JSON_NAME].compress_type == zipfile.ZIP_DEFLATED
+
+
+def _parquet_codec(data: bytes) -> str:
+    import pyarrow.parquet as pq
+
+    pf = pq.ParquetFile(io.BytesIO(data))
+    return str(pf.metadata.row_group(0).column(0).compression)
+
+
+def _frame_to_snappy_bytes(frame) -> bytes:
+    buf = io.BytesIO()
+    to_write = frame
+    if getattr(frame, "index", None) is not None and frame.index.name is not None:
+        name = frame.index.name
+        if name in frame.columns:
+            to_write = frame.reset_index(drop=True)
+        else:
+            to_write = frame.reset_index()
+    to_write.to_parquet(buf, index=False, engine="pyarrow", compression="snappy")
+    return buf.getvalue()
+
+
+@pytest.mark.essential
+def test_v9_parquet_members_use_zstd(tmp_path):
+    """New v9 writes use zstd inside parquet; zip stays STORED (#912)."""
+    source = _require_v8_with_fids()
+    original = load_cellpy_file(source)
+
+    outfile = tmp_path / "zstd.cellpy"
+    original.save(outfile)
+
+    with zipfile.ZipFile(outfile) as zf:
+        infos = {info.filename: info for info in zf.infolist()}
+        parquet_members = [name for name in infos if name.endswith(".parquet")]
+        assert parquet_members
+        for name in parquet_members:
+            assert infos[name].compress_type == zipfile.ZIP_STORED, name
+            assert _parquet_codec(zf.read(name)) == "ZSTD", name
+
+
+@pytest.mark.essential
+def test_v9_loads_snappy_parquet_members(tmp_path):
+    """Pre-#912 snappy parquet members still load."""
+    source = _require_v8_with_fids()
+    original = load_cellpy_file(source)
+    expected = snapshot_cell_state(original)
+
+    modern = tmp_path / "modern.cellpy"
+    original.save(modern)
+    snappy_path = tmp_path / "snappy.cellpy"
+
+    with zipfile.ZipFile(modern) as src, zipfile.ZipFile(
+        snappy_path, mode="w", compression=zipfile.ZIP_STORED
+    ) as dest:
+        for info in src.infolist():
+            payload = src.read(info.filename)
+            if info.filename.endswith(".parquet"):
+                frame = pd.read_parquet(io.BytesIO(payload), engine="pyarrow")
+                payload = _frame_to_snappy_bytes(frame)
+                assert _parquet_codec(payload) == "SNAPPY", info.filename
+            dest.writestr(info.filename, payload, compress_type=info.compress_type)
+
+    reloaded = load_cellpy_file(snappy_path)
+    assert_data_frames_equal(reloaded.data.raw, expected["raw"])
+    assert_data_frames_equal(reloaded.data.steps, expected["steps"])
+    assert_data_frames_equal(reloaded.data.summary, expected["summary"])
 
 
 @pytest.mark.essential


### PR DESCRIPTION
## Summary
- New v9 `.cellpy` files write parquet members with **zstd level 3** instead of the pyarrow snappy default, so on-disk size returns to ~old ZIP_DEFLATE without putting a second compressor on the zip.
- Zip members stay `ZIP_STORED` (#898). Format version is unchanged. Existing snappy parquet members still load.

## Test plan
- [x] `pytest tests/test_cellpy_file_v9.py` (10 passed)
- [x] New essential tests: save reports ZSTD; rebuilt snappy zip still loads
- [ ] CI `pytest -m essential` (Linux; local Windows essential died in unrelated matplotlib `0xc06d007f`)

Closes #912

Made with [Cursor](https://cursor.com)