### PR TITLE
feat(cli): global --quiet/--verbose/--no-color, real usage errors (#891)

### DIFF
--- a/.issueflows/01-current-issues/issue891_status.md
+++ b/.issueflows/01-current-issues/issue891_status.md
@@ -16,27 +16,31 @@
   migration. Nothing is wired to a command yet, so there is no user-visible
   change and no HISTORY entry.
 
+- **PR 2 — global flags, streams, exit codes.** Root callback installs the
+  reporter from `--quiet` / `-q`, `--verbose`, `--no-color`; per-command
+  `--silent` / `--debug` adjust one invocation via `Reporter.with_level`.
+  `cellpy run` raises real usage errors (stderr, exit 2) instead of hand-made
+  usage text and a flag dump; `convert` reports a bad `--to` on stderr.
+  `info` echoes as payload so `--quiet` cannot silence an answer. The surface
+  snapshot now describes the **root** command too, so global options are under
+  the same contract as everything else.
+
 ## Remaining work
 
-- [ ] PR 2 — global flags (`--quiet` / `--verbose` / `--no-color`), failures to
-      stderr, exit codes 0/1/2, delete the hand-rolled usage block in `run`;
-      regenerate `tests/data/cli_surface.json` in the same commit.
 - [ ] PR 3 — `info` / `info --check`.
 - [ ] PR 4 — `setup` (drop the parameter dump, make `--silent` real).
 - [ ] PR 5 — copy pass over the remaining commands; fix the `f[cellpy]` literal
       and the `deiced` typo; remove the stray `print()` calls.
-- [ ] Register the new essential tests in
-      [test-registry.md](../04-designs-and-guides/test-registry.md). Deferred
-      out of PR 1 only because the concurrent #912 session has uncommitted rows
-      in that file; staging it would have swept their work into this commit.
-      Rows to add (`tests/test_cli_ui.py`, essential/always, code under test
-      `cli_ui.Reporter`, issue #891) plus
-      `test_cli_light_import.py::test_importing_cli_ui_does_not_import_rich`.
+- [x] Register the new essential tests in
+      [test-registry.md](../04-designs-and-guides/test-registry.md) (deferred
+      from PR 1 while #912 held uncommitted rows there; done in PR 2).
 
 ## Notes
 
-- A concurrent session is working #912 in this same checkout. PR 1 commits only
-  `cellpy/cli_ui.py`, `tests/test_cli_ui.py`,
-  `tests/test_cli_light_import.py` and these `.issueflows` docs; the #912
-  changes to `cellpy/readers/cellpy_file/v9.py`, `tests/test_cellpy_file_v9.py`
-  and `HISTORY.md` are left untouched in the working tree.
+- PR 1 was built while a concurrent session held uncommitted #912 work in the
+  same checkout, so it committed only its own paths and deferred the
+  `test-registry.md` rows. #912 has since merged (#914) and the rows landed in
+  PR 2.
+- The surface snapshot gained a `root` entry in PR 2. It is additive: the
+  existing `commands` list and every per-command assertion are unchanged, and
+  no subcommand's parameters moved when the root callback was added.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -50,6 +50,13 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_config.py::test_active_config_file_reports_project_toml | yes | yes | config.loader.active_config_file project_path | #853 | |
 | tests/test_cellpy_cmd.py::test_info_configloc_reports_project_toml | yes | yes | cli_api._configloc project notice | #853 | |
 | tests/test_cli_light_import.py::test_setup_deps_probes_optional_modules | yes | yes | cli_api.setup_config --deps | #839 | opt-in optional probe |
+| tests/test_cli_light_import.py::test_importing_cli_ui_does_not_import_rich | yes | yes | cli_ui lazy rich import | #891 | subprocess; keeps cold start off rich |
+| tests/test_cli_ui.py (whole file) | yes | yes | cli_ui.Reporter vocabulary | #891 | colour/symbol/level/stream decisions; injected streams |
+| tests/test_cli_flags.py::test_global_flags_install_the_matching_level | yes | yes | cli.main root callback -> cli_ui.Level | #891 | parametrised over -q/--verbose |
+| tests/test_cli_flags.py::test_quiet_still_answers_a_question | yes | yes | cli.info payload echo | #891 | --quiet must not silence `info` |
+| tests/test_cli_flags.py::test_usage_errors_go_to_stderr | yes | yes | cli.run usage errors | #891 | stderr + exit 2, not stdout + 255 |
+| tests/test_cli_flags.py::test_run_list_still_works_without_a_name | yes | yes | cli.run NAME optionality | #891 | guards `run --list` against a required NAME |
+| tests/test_cli_surface.py::test_the_global_options_are_unchanged | yes | yes | root CLI options | #891 | snapshot now covers root params |
 | tests/test_cellpy_file_v9.py::test_v9_parquet_members_use_zstd | yes | yes | v9._frame_to_parquet_bytes | #912 | new writes are zstd + ZIP_STORED |
 | tests/test_cellpy_file_v9.py::test_v9_loads_snappy_parquet_members | yes | yes | v9.load / _read_parquet_member | #912 | #898-era snappy members still load |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* CLI: new global `--quiet` / `-q`, `--verbose` and `--no-color` options.
+  `--quiet` reports problems and the output you asked for (`cellpy info` still
+  answers) and drops progress chatter; colour is otherwise automatic and
+  honours `NO_COLOR`. `cellpy run` without a NAME, or with a NAME but no
+  `--journal` / `--key` / `--folder` / `--cellpy-project`, is now a real usage
+  error on stderr with exit code 2 — it used to print hand-made usage text (or
+  a flag dump and an apology) to stdout and exit 255 or 0. `cellpy convert`
+  reports a rejected `--to` on stderr. (#891)
 * `Batch.export_project(destination)` writes a shareable `.cellpy` + journal
   bundle (2.x replacement for `duplicate_cellpy_files`). (#878)
 * Run the real `essential` and `full` CI gates once for every PR targeting

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Annotated, Any, Callable, Optional
 
@@ -42,6 +43,11 @@ def main(
     ] = False,
 ) -> None:
     """cellpy - command line interface."""
+    if no_color:
+        # Typer renders usage errors through its own rich console, which our
+        # reporter knows nothing about. NO_COLOR is the switch both honour, so
+        # setting it keeps the promise for every line the process prints.
+        os.environ["NO_COLOR"] = "1"
     cli_ui.set_reporter(
         cli_ui.make_reporter(quiet=quiet, verbose=verbose, no_color=no_color)
     )

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Callable, Optional
 
 import typer
+
+from cellpy import cli_ui
 
 cli = typer.Typer(
     name="cellpy",
@@ -16,6 +17,56 @@ cli = typer.Typer(
 )
 
 setup_app = typer.Typer()
+
+
+@cli.callback()
+def main(
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Only report problems and output you asked for.",
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", help="Report extra detail."),
+    ] = False,
+    no_color: Annotated[
+        bool,
+        typer.Option(
+            "--no-color",
+            help="Never colour the output (NO_COLOR is honoured too).",
+        ),
+    ] = False,
+) -> None:
+    """cellpy - command line interface."""
+    cli_ui.set_reporter(
+        cli_ui.make_reporter(quiet=quiet, verbose=verbose, no_color=no_color)
+    )
+
+
+def _echo(
+    *, silent: bool = False, debug: bool = False, payload: bool = False
+) -> Callable[[str], None]:
+    """The reporter's echo for this invocation.
+
+    A per-command ``--silent`` / ``--debug`` adjusts only this command, leaving
+    the reporter the global flags installed alone.
+
+    ``payload`` marks a command whose whole output *is* the answer the user
+    asked for (``cellpy info``): those lines survive ``--quiet``, because
+    silencing progress must not silence the answer.
+    """
+    reporter = cli_ui.current()
+    if silent:
+        reporter = reporter.with_level(cli_ui.Level.QUIET)
+    elif debug:
+        reporter = reporter.with_level(cli_ui.Level.VERBOSE)
+    if payload:
+        return reporter.payload
+    return reporter.as_echo()
 
 
 class _CliApiProxy:
@@ -145,7 +196,7 @@ def setup(
         deps=deps,
         no_deps=no_deps,
         check=check,
-        echo=typer.echo,
+        echo=_echo(),
     )
 
 
@@ -183,7 +234,7 @@ def setup_migrate(
     deprecation window); the generated TOML takes precedence once present.
     """
     cli_api.migrate_config(
-        src=src, dst=dst, dry_run=dry_run, force=force, echo=typer.echo
+        src=src, dst=dst, dry_run=dry_run, force=force, echo=_echo()
     )
 
 
@@ -245,7 +296,7 @@ def edit(
         default_editor=default_editor,
         debug=debug,
         silent=silent,
-        echo=typer.echo,
+        echo=_echo(silent=silent, debug=debug),
     )
 
 
@@ -290,7 +341,8 @@ def info(
         params=params,
         show_config=show_config,
         check=check,
-        echo=typer.echo,
+        # `info` answers a question; every line is payload, so --quiet keeps it.
+        echo=_echo(payload=True),
     )
 
 
@@ -375,27 +427,23 @@ def run(
 
     """
     if list_:
-        cli_api.list_journals(None if name == "NONE" else name, echo=typer.echo)
+        cli_api.list_journals(None if name == "NONE" else name, echo=_echo())
         return
 
     if name == "NONE":
-        typer.echo(
-            "Usage: cellpy run [OPTIONS] NAME\n"
-            "Try 'cellpy run --help' for help.\n\n"
-            "Error: Missing argument 'NAME'."
-        )
-        sys.exit(-1)
+        # Typer renders this as a real usage error on stderr, exit code 2 -
+        # the same treatment `cellpy convert` already gets for a bad path.
+        raise typer.BadParameter("give a NAME to run, or --list to see them.")
 
-    if debug:
-        typer.echo("[cellpy] (run) debug mode on")
-
+    ui = cli_ui.current()
     if silent:
-        typer.echo("[cellpy] (run) silent mode on")
-
-    typer.echo("[cellpy]\n")
+        ui = ui.with_level(cli_ui.Level.QUIET)
+    elif debug:
+        ui = ui.with_level(cli_ui.Level.VERBOSE)
+    ui.debug(f"debug mode on (running {name})")
 
     if cellpy_project:
-        cli_api.run_project(name, echo=typer.echo)
+        cli_api.run_project(name, echo=ui.as_echo())
     elif journal:
         cli_api.run_journal(
             name,
@@ -405,7 +453,7 @@ def run(
             cellpyfile=cellpyfile,
             minimal=minimal,
             nom_cap=nom_cap,
-            echo=typer.echo,
+            echo=ui.as_echo(),
         )
     elif folder:
         cli_api.run_journals(
@@ -415,7 +463,7 @@ def run(
             raw=raw,
             cellpyfile=cellpyfile,
             minimal=minimal,
-            echo=typer.echo,
+            echo=ui.as_echo(),
         )
     elif key:
         cli_api.run_from_db(
@@ -428,13 +476,15 @@ def run(
             nom_cap=nom_cap,
             batch_col=batch_col,
             project=project,
-            echo=typer.echo,
+            echo=ui.as_echo(),
         )
     else:
-        typer.echo(f"running {name}")
-        typer.echo(f" --debug [{debug}]")
-        typer.echo(f" --silent [{silent}]")
-        typer.echo("[cellpy]: sorry, I am not allowed to run this on my own")
+        # Was a flag dump plus "sorry, I am not allowed to run this on my own",
+        # printed to stdout with a success exit code.
+        raise typer.BadParameter(
+            "say what to run with NAME: --journal, --key, --folder "
+            "or --cellpy-project."
+        )
 
 
 # ----------------------- pull ---------------------------------------
@@ -468,7 +518,7 @@ def pull(
         clone=clone,
         directory=directory,
         password=password,
-        echo=typer.echo,
+        echo=_echo(),
     )
 
 
@@ -544,7 +594,7 @@ def new(
         lab=lab,
         jupyter_executable=jupyter_executable,
         list_=list_,
-        echo=typer.echo,
+        echo=_echo(),
     )
 
 
@@ -572,7 +622,7 @@ def serve(
 ):
     """Start a Jupyter server."""
     cli_api.start_jupyter(
-        lab=lab, directory=directory, executable=executable, echo=typer.echo
+        lab=lab, directory=directory, executable=executable, echo=_echo()
     )
 
 
@@ -595,11 +645,12 @@ def convert(
 ):
     """Upgrade a legacy cellpy-file to a current on-disk format."""
     try:
-        cli_api.convert(old_h5, new_h5, to=to, echo=typer.echo)
+        cli_api.convert(old_h5, new_h5, to=to, echo=_echo())
     except ValueError as exc:
-        typer.echo(f"[cellpy] (convert) {exc}")
+        # A rejected --to is a usage error: stderr, exit 2 (was stdout, exit 2).
+        cli_ui.current().fail("convert", str(exc))
         raise typer.Exit(code=2)
 
 
 if __name__ == "__main__":
-    cli_api.show_info(check=True, echo=typer.echo)
+    cli_api.show_info(check=True, echo=_echo())

--- a/cellpy/cli_ui.py
+++ b/cellpy/cli_ui.py
@@ -33,8 +33,10 @@ from __future__ import annotations
 import enum
 import os
 import sys
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, TextIO
+from typing import Any, Callable, Iterator, Optional, TextIO
 
 __all__ = [
     "ASCII_SYMBOLS",
@@ -43,8 +45,11 @@ __all__ = [
     "Symbols",
     "UNICODE_SYMBOLS",
     "color_enabled",
+    "current",
     "make_reporter",
+    "set_reporter",
     "supports_unicode",
+    "using_reporter",
 ]
 
 # Layout constants. The label column is wide enough for the longest label the
@@ -316,6 +321,19 @@ class Reporter:
         text.append(message, style=STYLE_DIM)
         self._write(text)
 
+    def with_level(self, level: Level) -> "Reporter":
+        """A copy that says more (or less), keeping colour and streams.
+
+        Lets a per-command ``--silent`` / ``--debug`` adjust one invocation
+        without mutating the reporter the rest of the process shares.
+        """
+        return Reporter(
+            level=level,
+            color=self._color,
+            stdout=self._stdout,
+            stderr=self._stderr,
+        )
+
     # -- compatibility -------------------------------------------------
 
     def as_echo(self) -> Callable[[str], None]:
@@ -358,6 +376,39 @@ class Reporter:
 def _pad(value: str, width: int = LABEL_WIDTH) -> str:
     """Left-align in a column, keeping at least two spaces after a long value."""
     return value.ljust(width) if len(value) < width else value + "  "
+
+
+# The reporter the CLI is currently speaking through. A ContextVar rather than
+# a plain global, matching ``cli_api._echo_var``, so concurrent work cannot
+# steal each other's verbosity.
+_reporter_var: ContextVar[Optional[Reporter]] = ContextVar(
+    "cellpy_cli_reporter", default=None
+)
+
+
+def current() -> Reporter:
+    """The active reporter, defaulting to a plain one on first use."""
+    reporter = _reporter_var.get()
+    if reporter is None:
+        reporter = Reporter()
+        _reporter_var.set(reporter)
+    return reporter
+
+
+def set_reporter(reporter: Optional[Reporter]) -> Optional[Reporter]:
+    """Install ``reporter`` as the active one (``None`` resets to default)."""
+    _reporter_var.set(reporter)
+    return reporter
+
+
+@contextmanager
+def using_reporter(reporter: Optional[Reporter]) -> Iterator[Optional[Reporter]]:
+    """Scope a reporter, restoring the previous one afterwards (tests)."""
+    token = _reporter_var.set(reporter)
+    try:
+        yield reporter
+    finally:
+        _reporter_var.reset(token)
 
 
 def make_reporter(

--- a/dev/snapshot_cli_surface.py
+++ b/dev/snapshot_cli_surface.py
@@ -68,9 +68,13 @@ def build_surface() -> dict:
         command = typer.main.get_command(command)
 
     return {
+        # The root's own options (--quiet, --no-color, ...) are part of the
+        # surface too: `cellpy -q info` is a call a user can have in a script,
+        # and describing only subcommands would let one vanish unnoticed (#891).
+        "root": _describe(command, "cellpy"),
         "commands": [
             _describe(sub, name) for name, sub in sorted(command.commands.items())
-        ]
+        ],
     }
 
 

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -579,5 +579,48 @@
         "migrate"
       ]
     }
-  ]
+  ],
+  "root": {
+    "name": "cellpy",
+    "params": [
+      {
+        "is_flag": true,
+        "kind": "option",
+        "multiple": false,
+        "opts": [
+          "--no-color"
+        ],
+        "required": false
+      },
+      {
+        "is_flag": true,
+        "kind": "option",
+        "multiple": false,
+        "opts": [
+          "--quiet",
+          "-q"
+        ],
+        "required": false
+      },
+      {
+        "is_flag": true,
+        "kind": "option",
+        "multiple": false,
+        "opts": [
+          "--verbose"
+        ],
+        "required": false
+      }
+    ],
+    "subcommands": [
+      "convert",
+      "edit",
+      "info",
+      "new",
+      "pull",
+      "run",
+      "serve",
+      "setup"
+    ]
+  }
 }

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -259,19 +259,26 @@ def test_run_empty():
 
 
 def test_run():
+    """A NAME with no mode is a usage error, not a successful no-op (#891).
+
+    This used to print the flags back plus "sorry, I am not allowed to run
+    this on my own" and exit 0, so `cellpy run mybatch && echo ok` reported
+    success having done nothing.
+    """
     name = "20190210_cell001_cc_01.h5"
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["run", name])
     print("\n", result.output)
-    assert result.exit_code == 0
+    assert result.exit_code == 2
 
 
 def test_run_debug():
+    """--debug does not turn the missing mode into something runnable (#891)."""
     name = "20190210_cell001_cc_01.h5"
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["run", "--debug", name])
     print("\n", result.output)
-    assert result.exit_code == 0
+    assert result.exit_code == 2
 
 
 def test_run_journal():

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,104 @@
+"""Global flags, streams and exit codes (#891).
+
+These drive the CLI the way a user or a script does — through the app — rather
+than calling ``cli_api`` directly, because what is under test is the wiring:
+which reporter a flag installs, which stream a message lands on, and what the
+process exits with.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from cellpy import cli_ui
+from cellpy.cli import cli
+from cellpy.cli_ui import Level
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def fresh_reporter():
+    """Each test starts without a reporter installed by an earlier one."""
+    with cli_ui.using_reporter(None):
+        yield
+
+
+# -- global flags map to levels --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        ([], Level.NORMAL),
+        (["--quiet"], Level.QUIET),
+        (["-q"], Level.QUIET),
+        (["--verbose"], Level.VERBOSE),
+        # Asking for silence and noise at once resolves to silence.
+        (["--quiet", "--verbose"], Level.QUIET),
+    ],
+)
+@pytest.mark.essential
+def test_global_flags_install_the_matching_level(argv, expected):
+    result = runner.invoke(cli, argv + ["info", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert cli_ui.current().level is expected
+
+
+@pytest.mark.essential
+def test_no_color_disables_colour():
+    result = runner.invoke(cli, ["--no-color", "info", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert "\x1b[" not in result.output
+
+
+@pytest.mark.essential
+def test_quiet_still_answers_a_question():
+    """`info` is payload: --quiet silences progress, never the answer."""
+    result = runner.invoke(cli, ["--quiet", "info", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert "version" in result.output
+
+
+# -- usage errors ----------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_run_without_a_name_is_a_usage_error():
+    """Was hand-rolled usage text on stdout with exit -1 (255)."""
+    result = runner.invoke(cli, ["run"])
+
+    assert result.exit_code == 2
+    assert "--list" in result.output
+
+
+@pytest.mark.essential
+def test_run_without_a_mode_is_a_usage_error():
+    """Was a flag dump plus an apology, and a success exit code."""
+    result = runner.invoke(cli, ["run", "some_batch"])
+
+    assert result.exit_code == 2
+    assert "--journal" in result.output
+
+
+@pytest.mark.essential
+def test_run_list_still_works_without_a_name(tmp_path, monkeypatch):
+    """NAME stays optional: making it required would break `run --list`."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(cli, ["run", "--list"])
+
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.essential
+def test_usage_errors_go_to_stderr():
+    """A script doing `cellpy run > out` must still see the error."""
+    result = runner.invoke(cli, ["run"])
+
+    assert result.exit_code == 2
+    assert result.stdout.strip() == ""
+    assert "--list" in result.stderr

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -8,6 +8,8 @@ process exits with.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -17,10 +19,42 @@ from cellpy.cli_ui import Level
 
 runner = CliRunner()
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+# SGR parameters that set a colour: 30-49 (basic + extended selectors) and
+# 90-107 (bright). Bold (1) and dim (2) are styling, not colour.
+_COLOUR_PARAMS = set(range(30, 50)) | set(range(90, 108))
+
+
+def plain(text: str) -> str:
+    """What a human reads: the text with styling removed.
+
+    Typer renders usage errors through rich, which highlights option tokens -
+    ``--list`` reaches the terminal as ``-`` + escapes + ``-list``, so asserting
+    on the raw capture passes only where rich happens not to colour (a legacy
+    Windows console) and fails in CI.
+    """
+    return _ANSI.sub("", text)
+
+
+def has_colour(text: str) -> bool:
+    """True if anything is actually coloured.
+
+    ``NO_COLOR`` makes rich drop colour while keeping bold and dim, so "no
+    escape codes at all" would be the wrong bar for ``--no-color``.
+    """
+    for match in _ANSI.finditer(text):
+        params = [int(p) for p in match.group()[2:-1].split(";") if p.isdigit()]
+        if any(param in _COLOUR_PARAMS for param in params):
+            return True
+    return False
+
 
 @pytest.fixture(autouse=True)
-def fresh_reporter():
-    """Each test starts without a reporter installed by an earlier one."""
+def fresh_reporter(monkeypatch):
+    """Start each test without a reporter or colour decision left by another."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
     with cli_ui.using_reporter(None):
         yield
 
@@ -61,7 +95,7 @@ def test_quiet_still_answers_a_question():
     result = runner.invoke(cli, ["--quiet", "info", "--version"])
 
     assert result.exit_code == 0, result.output
-    assert "version" in result.output
+    assert "version" in plain(result.output)
 
 
 # -- usage errors ----------------------------------------------------------
@@ -73,7 +107,7 @@ def test_run_without_a_name_is_a_usage_error():
     result = runner.invoke(cli, ["run"])
 
     assert result.exit_code == 2
-    assert "--list" in result.output
+    assert "--list" in plain(result.output)
 
 
 @pytest.mark.essential
@@ -82,7 +116,7 @@ def test_run_without_a_mode_is_a_usage_error():
     result = runner.invoke(cli, ["run", "some_batch"])
 
     assert result.exit_code == 2
-    assert "--journal" in result.output
+    assert "--journal" in plain(result.output)
 
 
 @pytest.mark.essential
@@ -101,4 +135,14 @@ def test_usage_errors_go_to_stderr():
 
     assert result.exit_code == 2
     assert result.stdout.strip() == ""
-    assert "--list" in result.stderr
+    assert "--list" in plain(result.stderr)
+
+
+@pytest.mark.essential
+def test_no_color_reaches_typers_own_error_rendering():
+    """--no-color must cover the usage errors typer renders itself."""
+    result = runner.invoke(cli, ["--no-color", "run"])
+
+    assert result.exit_code == 2
+    assert not has_colour(result.stderr)
+    assert "--list" in plain(result.stderr)

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -63,6 +63,16 @@ def test_the_command_set_is_unchanged(expected, actual):
 
 
 @pytest.mark.essential
+def test_the_global_options_are_unchanged(expected, actual):
+    """`cellpy -q info` is a call users script; the root options are surface."""
+    before = {tuple(p["opts"]) for p in expected["root"]["params"]}
+    after = {tuple(p["opts"]) for p in actual["root"]["params"]}
+
+    assert not before - after, f"lost {sorted(before - after)}"
+    assert not after - before, f"added {sorted(after - before)}"
+
+
+@pytest.mark.essential
 def test_every_command_keeps_its_flags(expected, actual):
     """The check that matters: no option silently renamed or dropped."""
     expected_by_name = {c["name"]: c for c in expected["commands"]}

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -243,6 +243,47 @@ def test_detail_lines_align_under_their_parent(plain_env, streams):
     assert "(remote, not checked)" in lines[1]
 
 
+# -- the active reporter ----------------------------------------------------
+
+
+@pytest.mark.essential
+def test_with_level_keeps_colour_and_streams(plain_env, streams):
+    out, _ = streams
+    reporter = _reporter(streams, color=True)
+
+    quiet = reporter.with_level(Level.QUIET)
+    quiet.ok("imports", "cellpy")
+    quiet.warn("legacy config")
+
+    assert quiet.level is Level.QUIET
+    assert reporter.level is Level.NORMAL, "the original must not be mutated"
+    printed = out.getvalue()
+    assert "imports" not in printed
+    assert "legacy config" in printed
+    assert "\x1b[" in printed, "colour choice should survive the level change"
+
+
+@pytest.mark.essential
+def test_current_defaults_and_can_be_replaced(plain_env, streams):
+    from cellpy import cli_ui
+
+    with cli_ui.using_reporter(None):
+        assert cli_ui.current().level is Level.NORMAL
+        installed = cli_ui.set_reporter(_reporter(streams, level=Level.QUIET))
+        assert cli_ui.current() is installed
+
+
+@pytest.mark.essential
+def test_using_reporter_restores_the_previous_one(plain_env, streams):
+    from cellpy import cli_ui
+
+    outer = _reporter(streams, level=Level.VERBOSE)
+    with cli_ui.using_reporter(outer):
+        with cli_ui.using_reporter(_reporter(streams, level=Level.QUIET)):
+            assert cli_ui.current().level is Level.QUIET
+        assert cli_ui.current() is outer
+
+
 # -- compatibility ----------------------------------------------------------
 
 


### PR DESCRIPTION
Part of #891. **PR 2 of 5** — wires the [#913](https://github.com/jepegit/cellpy/pull/913) reporter to the CLI and fixes how the CLI *fails*.

## Global options

`--quiet` / `-q`, `--verbose`, `--no-color` on the root command install the
reporter. Per-command `--silent` / `--debug` adjust a single invocation through
`Reporter.with_level`, so they finally mean something without mutating the
reporter the rest of the process shares.

`cellpy info` echoes as **payload**: `--quiet` silences progress, never the
answer to the question the user asked.

## Errors behave like errors

| Command | Before | After |
| --- | --- | --- |
| `cellpy run` (no NAME) | hand-made usage text on **stdout**, exit **255** | rendered usage error on **stderr**, exit **2** |
| `cellpy run NAME` (no mode) | flag dump + `sorry, I am not allowed to run this on my own`, exit **0** | usage error naming the four modes, exit **2** |
| `cellpy convert --to bogus` | message on **stdout**, exit 2 | message on **stderr**, exit 2 |

```
$ cellpy run ; echo "exit=$?"
Usage: cellpy run [OPTIONS] [name]
Try 'cellpy run --help' for help.
┌─ Error ──────────────────────────────────────────────────────────────┐
│ Invalid value: give a NAME to run, or --list to see them.            │
└──────────────────────────────────────────────────────────────────────┘
exit=2
```

`NAME` deliberately **stays optional** — making it required would have been the
tidier signature but would break `cellpy run --list`, which takes no name.
There's a test pinning that.

## The surface contract had a hole

`dev/snapshot_cli_surface.py` described **subcommands only**, so the new root
options would have landed completely outside the contract that exists to stop
the CLI changing by accident — the snapshot would not have moved at all.

It now describes the root command too, and `test_cli_surface.py` gained
`test_the_global_options_are_unchanged`. The regeneration is **purely
additive**: the `commands` list is byte-identical, so the diff also confirms
that adding a root callback moved no subcommand's parameters.

## Tests

New `tests/test_cli_flags.py` (11 tests): flag→level mapping (parametrised,
including `--quiet --verbose` resolving to quiet), `--no-color`, `--quiet` still
answering, both usage errors, stderr routing, and the `run --list` guard.
`tests/test_cli_ui.py` gains coverage for `with_level` (original not mutated,
colour preserved) and the active-reporter context. Registry rows for all of it
land here, including the ones deferred from PR 1.

```
uv run pytest tests/test_cli_ui.py tests/test_cli_flags.py tests/test_cli_surface.py tests/test_cli_api.py tests/test_cli_light_import.py -q
# 79 passed
uv run pytest -m essential -q
# 771 passed, 1 skipped, 2 xfailed, 1 xpassed
```

## Still to come

PRs 3–5 rewrite the message *content* (`info --check`, `setup`, then the copy
pass). Until then some output still reaches the terminal through raw `print()`
calls in `cli_api` and so ignores `--quiet` — `run --list` is the visible
example. Those are exactly what the remaining PRs convert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)