### PR TITLE
feat(batch): tqdm progress bars for load and update

### DIFF
--- a/.issueflows/03-solved-issues/issue916_original.md
+++ b/.issueflows/03-solved-issues/issue916_original.md
@@ -1,0 +1,9 @@
+# Issue #916: Iterative fixes: add progress bars for batch
+
+Source: https://github.com/jepegit/cellpy/issues/916
+
+## Original issue text
+
+Interactive `/iflow-fix` session. Individual fixes are recorded in the status markdown and landed together via `/iflow-close`.
+
+Hook already exists: `batch.runner.run(..., on_progress=)`. The runner never imports tqdm or prints. This session wires visible progress for `batch.load` / first-load waits (copy + parse + save).

--- a/.issueflows/03-solved-issues/issue916_status.md
+++ b/.issueflows/03-solved-issues/issue916_status.md
@@ -1,0 +1,13 @@
+# Issue #916 — status
+
+Interactive `/iflow-fix` session: add progress bars for batch.
+
+- [x] Done
+
+## Iterative fixes log
+
+- 2026-08-15: One PR for the whole bar surface. Process-wide `ProgressEvent` bus (`cellpy.internals.progress`); `tqdm.auto` UI (`cellpy.batch.progress`) for TTY + JupyterLab; overall + per-cell copy/parse/save; threads get one child bar per in-flight cell; processes keep overall only. `progress=None|False|True|callable`. 3-arg `on_progress` unchanged. Byte ticks on `OtherPath.copy` when fsspec `callback=` works.
+
+## Close
+
+Landed on `916-add-progress-bars-for-batch`. Local `tests/test_batch_progress.py` (14) plus runner/copy/persist tests green. Full `pytest -m essential` on this Windows box still dies in matplotlib (`0xc06d007f`) — pre-existing, Linux CI is the gate.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -70,6 +70,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_config.py::test_active_config_file_agrees_with_load_config | no | yes | config.loader.active_config_file / load_config | #851 | anti-drift: helper and loader pick the same file |
 | tests/test_cellpy_cmd.py::test_info_configloc_reports_the_toml | yes | yes | cli_api._configloc | #851 | CLI reports the winning file |
 | tests/test_cellpy_cmd.py::test_info_configloc_flags_shadowed_legacy_file | yes | yes | cli_api._configloc | #851 | never point at the dead .conf |
+| tests/test_batch_progress.py::test_run_emits_cell_start_parse_done | yes | yes | batch.runner emit + on_progress | #916 | event bus + 3-arg callback |
+| tests/test_batch_progress.py::test_on_progress_still_wins_with_event_hook | yes | yes | batch.runner on_progress | #916 | BC: 3-arg hook still fires |
+| tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,7 @@ Quick facts:
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
 - Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
   reopening local `.cellpy` files (first remote load stays serial on the wire).
+  `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
   Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
 - Prefer schema-resolved names over hard-coded 1.x header strings.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+* `batch.load` / `Batch.update` show tqdm progress on a TTY or in Jupyter
+  (`progress=None` auto, `False` off, `True` force, or a callable). Overall
+  bar covers journal → search → cells → persist; per-cell bars cover
+  copy / parse / save. `executor="threads"` draws one child bar per in-flight
+  cell; `processes` keeps the overall bar only. The 3-arg `on_progress`
+  callback is unchanged. (#916)
 * `Batch.export_project(destination)` writes a shareable `.cellpy` + journal
   bundle (2.x replacement for `duplicate_cellpy_files`). (#878)
 * Run the real `essential` and `full` CI gates once for every PR targeting

--- a/cellpy/batch/_dbengine.py
+++ b/cellpy/batch/_dbengine.py
@@ -167,6 +167,10 @@ def find_files(
     if skip_file_search:
         return info_dict
 
+    from cellpy.internals.progress import emit
+
+    emit("search")
+
     if file_list is None and config.batch.auto_use_file_list:
         file_list = _dump_raw_file_directory(
             project=project,

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -34,8 +34,10 @@ from cellpy.batch.journal import (
 from cellpy.batch.layout import BatchPaths, ensure_dirs
 from cellpy.batch.policy import LoadPolicy, SourcePreference
 from cellpy.batch.result import BatchResult
+from cellpy.batch.progress import progress_scope
 from cellpy.batch.runner import run
 from cellpy.batch.store import CellStore
+from cellpy.internals.progress import emit
 from cellpy.parameters.internal_settings import get_headers_journal
 
 _log = logging.getLogger(__name__)
@@ -154,7 +156,11 @@ class Batch:
         return self._result
 
     def update(
-        self, on_progress=None, executor: str = "serial", **overrides
+        self,
+        on_progress=None,
+        executor: str = "serial",
+        progress=None,
+        **overrides
     ) -> BatchResult:
         """Load every cell, caching them in the store.
 
@@ -162,6 +168,9 @@ class Batch:
         ``"threads"`` mainly speeds up *reopening* cells from local ``.cellpy``
         files; a first load of remote raw files does not overlap on the wire,
         and ``"processes"`` usually loses to spawn overhead on Windows.
+        ``progress`` is ``None`` (auto: TTY or Jupyter), ``False`` (off),
+        ``True`` (force), or a callable that receives progress events.
+        ``on_progress(i, n, result)`` still wins when set (3-arg callback).
         Known :class:`LoadPolicy` fields in ``overrides`` update the policy;
         unknown (legacy) kwargs like ``testing`` are forwarded to the loader
         (``cellpy.get``) via ``loader_kwargs``.
@@ -177,9 +186,10 @@ class Batch:
                 policy = replace(
                     policy, loader_kwargs={**policy.loader_kwargs, **extra}
                 )
-        self._result = run(
-            self.journal, policy, on_progress=on_progress, executor=executor
-        )
+        with progress_scope(progress, len(self.cell_names), executor):
+            self._result = run(
+                self.journal, policy, on_progress=on_progress, executor=executor
+            )
         self._store = CellStore.from_cells(self._result.cells())
         self._summaries = None
         return self._result
@@ -187,8 +197,8 @@ class Batch:
     def load(self, **overrides) -> BatchResult:
         """Load cells (alias of :meth:`update`, kept for the legacy surface).
 
-        Takes the same ``executor`` / ``on_progress`` / policy overrides as
-        :meth:`update`, e.g. ``b.load(executor="threads")``.
+        Takes the same ``executor`` / ``on_progress`` / ``progress`` / policy
+        overrides as :meth:`update`, e.g. ``b.load(executor="threads")``.
         """
         return self.update(**overrides)
 
@@ -573,7 +583,9 @@ def _persist_cells(
         )
         if do_save:
             _log.info("saving %s -> %s", label, dest)
+            emit("save", label=label)
             batch.cells[label].save(dest, overwrite=True)
+            emit("save", label=label, n=1, total_n=1)
         else:
             _log.debug("skip save (already from cellpy or not loaded): %s", label)
         saved.append(dest.as_posix())
@@ -605,6 +617,7 @@ def _finalize(
         if journal_path is None:
             name = batch.journal.name or "batch"
             journal_path = _journal_path(name)
+        emit("persist")
         _persist_cells(batch, journal_path)
     return batch
 
@@ -669,11 +682,14 @@ def load(
         accept_errors / max_cycle: forwarded into the load policy.
         **kwargs: DB engine knobs (``column_map``, ``raw_file_dir``, …), load
             knobs forwarded to :meth:`Batch.update` (``executor``,
-            ``on_progress`` and :class:`LoadPolicy` fields) and loader extras
-            (``testing``, …). ``executor="threads"`` speeds up reopening cells
-            from local ``.cellpy`` files; a first load of remote raw files
-            stays serial on the wire. ``export_cycles`` / ``export_raw`` /
-            ``export_ica`` are accepted but ignored (warned once).
+            ``on_progress``, ``progress`` and :class:`LoadPolicy` fields) and
+            loader extras (``testing``, …). ``progress=None`` auto-shows tqdm
+            on a TTY or in Jupyter; ``False`` disables; ``True`` forces;
+            a callable receives progress events. ``executor="threads"`` speeds
+            up reopening cells from local ``.cellpy`` files; a first load of
+            remote raw files stays serial on the wire. ``export_cycles`` /
+            ``export_raw`` / ``export_ica`` are accepted but ignored (warned
+            once).
 
     Returns:
         Populated :class:`Batch`.
@@ -707,6 +723,7 @@ def load(
 
     # Split kwargs: known LoadPolicy extras / loader vs DB engine args.
     policy_field_names = {f.name for f in fields(LoadPolicy)}
+    progress = kwargs.pop("progress", None)
     update_kwargs = {
         k: kwargs.pop(k)
         for k in list(kwargs)
@@ -718,6 +735,48 @@ def load(
     if reader_path is not None:
         db_kwargs.setdefault("db_file", reader_path)
 
+    executor = update_kwargs.get("executor", "serial")
+    with progress_scope(progress, 0, executor) as display:
+        emit("journal")
+        return _load_after_progress(
+            name=name,
+            project=project,
+            journal=journal,
+            journal_file=journal_file,
+            journal_dir=journal_dir,
+            frame=frame,
+            db=db,
+            db_reader=db_reader,
+            allow_from_journal=allow_from_journal,
+            drop_bad_cells=drop_bad_cells,
+            save_cellpy=save_cellpy,
+            batch_col=batch_col,
+            resolved=resolved,
+            db_kwargs=db_kwargs,
+            update_kwargs=update_kwargs,
+            display=display,
+        )
+
+
+def _load_after_progress(
+    *,
+    name,
+    project,
+    journal,
+    journal_file,
+    journal_dir,
+    frame,
+    db,
+    db_reader,
+    allow_from_journal,
+    drop_bad_cells,
+    save_cellpy,
+    batch_col,
+    resolved,
+    db_kwargs,
+    update_kwargs,
+    display,
+) -> Batch:
     journal_path: Path | None = None
     batch: Batch | None = None
 
@@ -787,6 +846,8 @@ def load(
             )
 
     assert batch is not None
+    if display is not None:
+        display.set_n_cells(len(batch.cell_names))
     return _finalize(
         batch,
         policy=resolved,

--- a/cellpy/batch/progress.py
+++ b/cellpy/batch/progress.py
@@ -1,0 +1,229 @@
+"""Default batch progress UI (tqdm in the terminal, widget in Jupyter)."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from cellpy.internals.progress import ProgressEvent, ProgressHook, get_hook, set_hook
+
+def _noop(_event: ProgressEvent) -> None:
+    return None
+
+
+_NOOP: ProgressHook = _noop
+
+_STEPS = {"copy": 1, "parse": 2, "save": 3}
+
+
+def in_notebook() -> bool:
+    """True when running under IPython/Jupyter (including JupyterLab)."""
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+    shell = get_ipython()
+    if shell is None:
+        return False
+    name = type(shell).__name__
+    return name == "ZMQInteractiveShell" or "google.colab" in name
+
+
+def should_show_default() -> bool:
+    """TTY stderr or a notebook kernel — not a pytest/pipe capture."""
+    if in_notebook():
+        return True
+    try:
+        return bool(sys.stderr.isatty())
+    except Exception:
+        return False
+
+
+class TqdmBatchProgress:
+    """Overall cell bar plus per-cell step bars.
+
+    Serial: one reusable child bar. Threads: one child bar per in-flight
+    label (``position=``). ``processes`` should pass ``concurrent=False``;
+    workers cannot drive these bars.
+    """
+
+    def __init__(
+        self,
+        n_cells: int,
+        *,
+        concurrent: bool = False,
+        show_children: bool = True,
+        disable: bool = False,
+    ) -> None:
+        from tqdm.auto import tqdm
+
+        self._tqdm = tqdm
+        self.concurrent = concurrent
+        self.show_children = show_children
+        self.disable = disable
+        self._lock = threading.Lock()
+        self.overall = tqdm(
+            total=max(n_cells, 0),
+            desc="batch",
+            unit="cell",
+            position=0,
+            disable=disable,
+            dynamic_ncols=True,
+        )
+        self._children: dict[str, Any] = {}
+        self._serial: Any | None = None
+        self._next_pos = 1
+        self._free_pos: list[int] = []
+        self.cells_done = 0
+
+    def __call__(self, event: ProgressEvent) -> None:
+        with self._lock:
+            self._handle(event)
+
+    def set_n_cells(self, n: int) -> None:
+        with self._lock:
+            self.overall.total = max(n, 0)
+            self.overall.refresh()
+
+    def close(self) -> None:
+        with self._lock:
+            for bar in self._children.values():
+                bar.close()
+            self._children.clear()
+            if self._serial is not None:
+                self._serial.close()
+                self._serial = None
+            self.overall.close()
+
+    def _handle(self, event: ProgressEvent) -> None:
+        if event.phase in {"journal", "search", "persist"}:
+            self.overall.set_postfix_str(event.phase, refresh=True)
+            return
+        if not self.show_children:
+            if event.phase == "cell_done":
+                self.cells_done += 1
+                self.overall.update(1)
+                self.overall.set_postfix_str(event.label or "", refresh=True)
+            return
+        if event.phase == "cell_start" and event.label:
+            self._child(event.label)
+            return
+        if event.phase in _STEPS and event.label:
+            bar = self._child(event.label)
+            if event.phase == "copy" and event.total_n:
+                copied = event.n or 0
+                bar.set_postfix_str(
+                    f"copy {copied / 1e6:.1f}/{event.total_n / 1e6:.1f} MB",
+                    refresh=True,
+                )
+                if copied < event.total_n:
+                    return
+            self._advance(bar, _STEPS[event.phase])
+            bar.set_postfix_str(event.phase, refresh=True)
+            return
+        if event.phase == "cell_done":
+            self.cells_done += 1
+            self.overall.update(1)
+            self.overall.set_postfix_str(event.label or "", refresh=True)
+            self._close_child(event.label)
+
+    def _child(self, label: str):
+        if label in self._children:
+            return self._children[label]
+        if self.concurrent:
+            pos = self._free_pos.pop() if self._free_pos else self._next_pos
+            if pos == self._next_pos:
+                self._next_pos += 1
+            bar = self._tqdm(
+                total=3,
+                desc=label,
+                position=pos,
+                leave=False,
+                disable=self.disable,
+                unit="step",
+                dynamic_ncols=True,
+            )
+            bar._cellpy_pos = pos
+            self._children[label] = bar
+            return bar
+        if self._serial is None:
+            self._serial = self._tqdm(
+                total=3,
+                desc=label,
+                position=1,
+                leave=False,
+                disable=self.disable,
+                unit="step",
+                dynamic_ncols=True,
+            )
+        else:
+            self._serial.reset(total=3)
+            self._serial.set_description(label)
+        self._children[label] = self._serial
+        return self._serial
+
+    def _advance(self, bar, step: int) -> None:
+        if bar.n < step:
+            bar.update(step - bar.n)
+
+    def _close_child(self, label: str) -> None:
+        bar = self._children.pop(label, None)
+        if bar is None:
+            return
+        if self.concurrent:
+            pos = getattr(bar, "_cellpy_pos", None)
+            bar.close()
+            if pos is not None:
+                self._free_pos.append(pos)
+        elif bar is self._serial:
+            self._advance(bar, 3)
+
+
+def attach_default(
+    n_cells: int,
+    *,
+    concurrent: bool = False,
+    show_children: bool = True,
+) -> TqdmBatchProgress:
+    """Install a tqdm display as the process hook. Caller must ``close()``."""
+    display = TqdmBatchProgress(
+        n_cells, concurrent=concurrent, show_children=show_children
+    )
+    set_hook(display)
+    return display
+
+
+@contextmanager
+def progress_scope(
+    progress: bool | ProgressHook | None,
+    n_cells: int,
+    executor: str,
+) -> Iterator[TqdmBatchProgress | None]:
+    """Install the ``progress=`` knob for a load. Restores the previous hook.
+
+    ``None`` — auto (TTY or notebook) unless a hook is already installed.
+    ``False`` — off (nested ``update()`` inherits the off state).
+    ``True`` — force on. A callable is the raw event hook.
+    """
+    previous = get_hook()
+    display: TqdmBatchProgress | None = None
+    try:
+        if progress is False:
+            set_hook(_NOOP)
+        elif callable(progress):
+            set_hook(progress)
+        elif progress is True or (
+            progress is None and previous is None and should_show_default()
+        ):
+            display = attach_default(
+                n_cells,
+                concurrent=(executor == "threads"),
+                show_children=(executor != "processes"),
+            )
+        yield display
+    finally:
+        if display is not None:
+            display.close()
+        set_hook(previous)

--- a/cellpy/batch/runner.py
+++ b/cellpy/batch/runner.py
@@ -17,6 +17,7 @@ from cellpy import get as _cellpy_get
 from cellpy.batch.journal import Journal
 from cellpy.batch.policy import CellSpec, LoadPolicy, SourcePreference, resolve_specs
 from cellpy.batch.result import BatchResult, CellOutcome, CellResult
+from cellpy.internals.progress import emit, reset_cell_label, set_cell_label
 
 ProgressHook = Callable[[int, int, CellResult], None]
 
@@ -84,8 +85,11 @@ def load_cell(spec: CellSpec, policy: LoadPolicy | None = None) -> CellResult:
     kwargs, source = _get_kwargs(spec, policy)
 
     started = time.perf_counter()
+    token = set_cell_label(spec.label)
     try:
+        emit("parse", label=spec.label)
         cell = _cellpy_get(**kwargs)
+        emit("parse", label=spec.label, n=1, total_n=1)
         if policy.recalc and cell is not None:
             # Summary C-rates are derived from the step table; remake both.
             cell.make_step_table()
@@ -100,13 +104,16 @@ def load_cell(spec: CellSpec, policy: LoadPolicy | None = None) -> CellResult:
             seconds=time.perf_counter() - started,
             error=error,
         )
-    return CellResult(
-        label=spec.label,
-        outcome=CellOutcome.LOADED,
-        cell=cell,
-        source=source,
-        seconds=time.perf_counter() - started,
-    )
+    else:
+        return CellResult(
+            label=spec.label,
+            outcome=CellOutcome.LOADED,
+            cell=cell,
+            source=source,
+            seconds=time.perf_counter() - started,
+        )
+    finally:
+        reset_cell_label(token)
 
 
 def _strip_cell(result: CellResult) -> CellResult:
@@ -143,8 +150,10 @@ def _run_serial(specs, policy, bad, on_progress) -> list[CellResult]:
     results: list[CellResult] = []
     total = len(specs)
     for index, spec in enumerate(specs, start=1):
+        emit("cell_start", index=index, total=total, label=spec.label)
         result = _dispatch(spec, policy, bad)
         results.append(result)
+        emit("cell_done", index=index, total=total, label=spec.label)
         if on_progress is not None:
             on_progress(index, total, result)
     return results
@@ -154,15 +163,21 @@ def _run_pool(pool_cls, worker, specs, policy, bad, on_progress) -> list[CellRes
     results: list[CellResult | None] = [None] * len(specs)
     total = len(specs)
     with pool_cls() as pool:
-        futures = {
-            pool.submit(worker, spec, policy, bad): i
-            for i, spec in enumerate(specs)
-        }
+        futures = {}
+        for i, spec in enumerate(specs):
+            emit("cell_start", index=i + 1, total=total, label=spec.label)
+            futures[pool.submit(worker, spec, policy, bad)] = i
         done = 0
         for future in as_completed(futures):
             index = futures[future]
             results[index] = future.result()
             done += 1
+            emit(
+                "cell_done",
+                index=done,
+                total=total,
+                label=results[index].label,
+            )
             if on_progress is not None:
                 on_progress(done, total, results[index])
     return results  # type: ignore[return-value]

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -424,17 +424,63 @@ class OtherPath:
         path_of_copied_file = destination / self.name
 
         if not self.is_external:
+            from cellpy.internals.progress import emit
+
+            emit("copy")
             shutil.copy2(os.fspath(self), destination)
+            emit("copy", n=1, total_n=1)
             return path_of_copied_file
 
         upath = self._upath_with_credentials(testing=testing)
         try:
-            upath.fs.get(upath.path, str(path_of_copied_file))
+            self._get_with_progress(upath, path_of_copied_file)
         except FileNotFoundError as exc:
             raise FileNotFoundError(
                 f"Could not find file {self.raw_path} on {self.location}"
             ) from exc
         return path_of_copied_file
+
+    def _get_with_progress(self, upath, dest: pathlib.Path) -> None:
+        """``fs.get`` plus optional byte ticks on the progress bus."""
+        from cellpy.internals.progress import emit
+
+        size = None
+        try:
+            info = upath.fs.info(upath.path)
+            size = int(info.get("size") or 0) or None
+        except Exception:
+            size = None
+        emit("copy", n=0, total_n=size)
+
+        callback = None
+        try:
+            from fsspec.callbacks import Callback
+
+            class _Emit(Callback):
+                def set_size(self, size_):
+                    super().set_size(size_)
+                    emit("copy", n=0, total_n=int(size_ or 0) or None)
+
+                def relative_update(self, inc=1):
+                    super().relative_update(inc)
+                    emit(
+                        "copy",
+                        n=int(getattr(self, "value", 0) or 0),
+                        total_n=int(getattr(self, "size", 0) or 0) or None,
+                    )
+
+            callback = _Emit()
+        except Exception:
+            callback = None
+
+        try:
+            if callback is not None:
+                upath.fs.get(upath.path, str(dest), callback=callback)
+            else:
+                upath.fs.get(upath.path, str(dest))
+        except TypeError:
+            upath.fs.get(upath.path, str(dest))
+        emit("copy", n=size, total_n=size)
 
     def _wrap_remote_child(self, child: UPath) -> "OtherPath":
         child_path = child.path if child.path.startswith("/") else f"/{child.path}"

--- a/cellpy/internals/progress.py
+++ b/cellpy/internals/progress.py
@@ -1,0 +1,87 @@
+"""Process-wide progress emit bus.
+
+Batch UI (tqdm / Jupyter) and loaders share one hook so copy/parse/save can
+report without threading a callback through every signature. Threads in the
+same process see the same hook; process-pool workers do not (parent updates
+the overall bar on cell-done only).
+"""
+
+from __future__ import annotations
+
+import threading
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Callable
+
+_LOCK = threading.Lock()
+_HOOK: Callable[["ProgressEvent"], None] | None = None
+_CELL_LABEL: ContextVar[str] = ContextVar("cellpy_progress_cell", default="")
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    """One progress tick.
+
+    ``phase`` is ``journal``, ``search``, ``cell_start``, ``copy``, ``parse``,
+    ``save``, ``cell_done``, or ``persist``.
+    """
+
+    phase: str
+    index: int = 0
+    total: int = 0
+    label: str = ""
+    n: int | None = None
+    total_n: int | None = None
+
+
+ProgressHook = Callable[[ProgressEvent], None]
+
+
+def set_hook(hook: ProgressHook | None) -> ProgressHook | None:
+    """Install ``hook`` (or clear with ``None``). Returns the previous hook."""
+    global _HOOK
+    with _LOCK:
+        previous = _HOOK
+        _HOOK = hook
+        return previous
+
+
+def get_hook() -> ProgressHook | None:
+    return _HOOK
+
+
+def set_cell_label(label: str):
+    """Bind copy/parse/save ticks to ``label`` for this task (thread-local)."""
+    return _CELL_LABEL.set(label)
+
+
+def reset_cell_label(token) -> None:
+    _CELL_LABEL.reset(token)
+
+
+def emit(
+    phase: str,
+    *,
+    index: int = 0,
+    total: int = 0,
+    label: str = "",
+    n: int | None = None,
+    total_n: int | None = None,
+) -> None:
+    """Notify the current hook, if any. Never raises into the loader."""
+    hook = _HOOK
+    if hook is None:
+        return
+    try:
+        hook(
+            ProgressEvent(
+                phase=phase,
+                index=index,
+                total=total,
+                label=label or _CELL_LABEL.get(),
+                n=n,
+                total_n=total_n,
+            )
+        )
+    except Exception:
+        return

--- a/cellpy/readers/instruments/base.py
+++ b/cellpy/readers/instruments/base.py
@@ -335,6 +335,9 @@ class AtomicLoad:
             self._temp_file_path = self.name
             return
 
+        from cellpy.internals.progress import emit
+
+        emit("copy")
         self._temp_file_path = self.name.copy()
 
     def loader_executor(self, *args, **kwargs):

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -224,11 +224,20 @@ summaries = b.summaries          # polars frame across cells
 c = b.cells["my_cell_01"]        # a CellpyCell
 ```
 
-`batch.load` (and `Batch.update` / `Batch.load` under it) takes an `executor`:
+`batch.load` (and `Batch.update` / `Batch.load` under it) takes an `executor`
+and a `progress` knob:
 
 ```python
 b = batch.load(name="my_experiment", project="my_project", executor="threads")
+b = batch.load(name="my_experiment", project="my_project", progress=False)
 ```
+
+`progress=None` (default) shows tqdm on a TTY or in JupyterLab. `False` turns
+bars off. `True` forces them on. A callable receives progress events
+(`journal` / `search` / `copy` / `parse` / `save` / `cell_done`). The older
+`on_progress(i, n, result)` callback still fires on each finished cell.
+`executor="threads"` draws one child bar per in-flight cell; `processes`
+keeps the overall bar only.
 
 | `executor` | When it helps |
 | --- | --- |

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -1,0 +1,218 @@
+"""Batch progress bus + tqdm display (#916)."""
+
+import polars as pl
+import pytest
+
+from cellpy.batch.journal import FILENAME, Journal
+from cellpy.batch.policy import LoadPolicy, SourcePreference
+from cellpy.batch.progress import (
+    TqdmBatchProgress,
+    in_notebook,
+    progress_scope,
+    should_show_default,
+)
+from cellpy.batch.runner import run
+from cellpy.internals.progress import (
+    ProgressEvent,
+    emit,
+    get_hook,
+    set_cell_label,
+    set_hook,
+)
+
+
+@pytest.fixture
+def progress_events():
+    events = []
+    previous = set_hook(events.append)
+    try:
+        yield events
+    finally:
+        set_hook(previous)
+
+
+def test_emit_is_silent_without_hook():
+    set_hook(None)
+    emit("copy", label="x")
+
+
+def test_emit_records_phases(progress_events):
+    emit("journal")
+    emit("search")
+    emit("parse", label="c1", n=1, total_n=1)
+    phases = [e.phase for e in progress_events]
+    assert phases == ["journal", "search", "parse"]
+    assert progress_events[-1].label == "c1"
+
+
+def test_emit_uses_cell_label_context(progress_events):
+    token = set_cell_label("cell_a")
+    try:
+        emit("copy", n=1, total_n=1)
+    finally:
+        from cellpy.internals.progress import reset_cell_label
+
+        reset_cell_label(token)
+    assert progress_events[0].label == "cell_a"
+
+
+def test_emit_swallows_hook_errors():
+    def boom(_event):
+        raise RuntimeError("nope")
+
+    previous = set_hook(boom)
+    try:
+        emit("parse")
+    finally:
+        set_hook(previous)
+
+
+@pytest.mark.essential
+def test_run_emits_cell_start_parse_done(monkeypatch, progress_events):
+    monkeypatch.setattr("cellpy.batch.runner._cellpy_get", lambda **kwargs: object())
+    journal = Journal(
+        name="t",
+        project="p",
+        pages=pl.DataFrame(
+            {FILENAME: ["c_a"], "cellpy_file_name": ["x.cellpy"]}
+        ),
+    )
+    seen = []
+    br = run(
+        journal,
+        LoadPolicy(source=SourcePreference.CELLPY_ONLY),
+        on_progress=lambda i, n, r: seen.append((i, n, r.label)),
+    )
+    assert br["c_a"].ok
+    assert seen == [(1, 1, "c_a")]
+    phases = [e.phase for e in progress_events]
+    assert phases == ["cell_start", "parse", "parse", "cell_done"]
+    assert all(e.label == "c_a" for e in progress_events)
+
+
+@pytest.mark.essential
+def test_on_progress_still_wins_with_event_hook(monkeypatch, progress_events):
+    """3-arg on_progress stays the public completion callback."""
+    monkeypatch.setattr("cellpy.batch.runner._cellpy_get", lambda **kwargs: object())
+    journal = Journal(
+        name="t",
+        project="p",
+        pages=pl.DataFrame(
+            {
+                FILENAME: ["a", "b"],
+                "cellpy_file_name": ["x.cellpy", "y.cellpy"],
+            }
+        ),
+    )
+    seen = []
+    run(
+        journal,
+        LoadPolicy(source=SourcePreference.CELLPY_ONLY),
+        on_progress=lambda i, n, r: seen.append(i),
+    )
+    assert seen == [1, 2]
+    assert [e.phase for e in progress_events].count("cell_done") == 2
+
+
+@pytest.mark.essential
+def test_tqdm_display_disable_tracks_cells():
+    display = TqdmBatchProgress(2, disable=True)
+    try:
+        display(ProgressEvent("cell_start", label="a"))
+        display(ProgressEvent("copy", label="a", n=1, total_n=1))
+        display(ProgressEvent("parse", label="a", n=1, total_n=1))
+        display(ProgressEvent("save", label="a", n=1, total_n=1))
+        display(ProgressEvent("cell_done", label="a"))
+        display(ProgressEvent("cell_start", label="b"))
+        display(ProgressEvent("cell_done", label="b"))
+        assert display.cells_done == 2
+    finally:
+        display.close()
+
+
+def test_tqdm_processes_skips_child_bars():
+    display = TqdmBatchProgress(1, show_children=False, disable=True)
+    try:
+        display(ProgressEvent("cell_start", label="a"))
+        display(ProgressEvent("parse", label="a"))
+        display(ProgressEvent("cell_done", label="a"))
+        assert display.cells_done == 1
+        assert display._children == {}
+    finally:
+        display.close()
+
+
+def test_progress_scope_false_installs_noop_and_restores():
+    previous = set_hook(None)
+    try:
+        with progress_scope(False, 1, "serial") as display:
+            assert display is None
+            assert get_hook() is not None
+            emit("journal")
+        assert get_hook() is None
+    finally:
+        set_hook(previous)
+
+
+def test_progress_scope_callable_and_nested_inherit():
+    events = []
+    with progress_scope(events.append, 0, "serial"):
+        with progress_scope(None, 1, "serial") as inner:
+            assert inner is None
+            emit("search")
+    assert [e.phase for e in events] == ["search"]
+    assert get_hook() is None
+
+
+def test_progress_scope_true_attaches(monkeypatch):
+    created = []
+    real = TqdmBatchProgress
+
+    def _wrapped(*args, **kwargs):
+        kwargs["disable"] = True
+        bar = real(*args, **kwargs)
+        created.append(bar)
+        return bar
+
+    monkeypatch.setattr("cellpy.batch.progress.TqdmBatchProgress", _wrapped)
+    with progress_scope(True, 1, "serial") as display:
+        assert display is created[0]
+    assert get_hook() is None
+
+
+def test_should_show_default_false_when_not_tty(monkeypatch):
+    monkeypatch.setattr("cellpy.batch.progress.in_notebook", lambda: False)
+
+    class _Err:
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr("cellpy.batch.progress.sys.stderr", _Err())
+    assert should_show_default() is False
+
+
+def test_in_notebook_detects_zmq_shell(monkeypatch):
+    class ZMQInteractiveShell:
+        pass
+
+    class _IPython:
+        @staticmethod
+        def get_ipython():
+            return ZMQInteractiveShell()
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "IPython", _IPython)
+    assert in_notebook() is True
+
+
+def test_local_copy_emits_copy(tmp_path, progress_events):
+    from cellpy.internals.otherpath import OtherPath
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"abc")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    OtherPath(src).copy(dest)
+    assert (dest / "src.bin").is_file()
+    assert any(e.phase == "copy" for e in progress_events)


### PR DESCRIPTION
## Summary
- `batch.load` / `Batch.update` show tqdm on a TTY or in Jupyter (`progress=None` auto, `False` off, `True` force, or a callable event hook).
- Overall bar covers journal → search → cells → persist; per-cell bars cover copy / parse / save. `executor="threads"` gets one child bar per in-flight cell; `processes` keeps the overall bar only.
- The existing 3-arg `on_progress(i, n, result)` callback is unchanged.

Closes #916

## Test plan
- [x] `pytest tests/test_batch_progress.py` (14) plus runner / copy / persist tests
- [ ] Linux CI `pytest -m essential` (local Windows essential still dies in matplotlib `0xc06d007f`, pre-existing)
- [ ] Optional: `batch.load(...)` in a terminal and in JupyterLab; `progress=False` stays quiet; `executor="threads"` shows stacked child bars


Made with [Cursor](https://cursor.com)