### PR TITLE
feat(cli): info and info --check report instead of narrating (#891)

### DIFF
--- a/.issueflows/01-current-issues/issue891_status.md
+++ b/.issueflows/01-current-issues/issue891_status.md
@@ -25,9 +25,17 @@
   snapshot now describes the **root** command too, so global options are under
   the same contract as everything else.
 
+- **PR 3 — `info` / `info --check`.** Checks return a `_CheckOutcome` (verdict,
+  short detail, hint, detail lines) instead of printing their own banner and
+  narration, so the caller renders them consistently and the probe output drops
+  to `--verbose`. `info --check` exits 1 when a check fails. A remote-capable
+  path setting holding a local value is now actually checked. `cli_api._ui()`
+  returns a silent reporter when no `echo` was passed, keeping the
+  library-quiet contract; `Reporter` resolves its streams lazily so capture and
+  redirection work.
+
 ## Remaining work
 
-- [ ] PR 3 — `info` / `info --check`.
 - [ ] PR 4 — `setup` (drop the parameter dump, make `--silent` real).
 - [ ] PR 5 — copy pass over the remaining commands; fix the `f[cellpy]` literal
       and the `deiced` typo; remove the stray `print()` calls.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -57,6 +57,13 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_flags.py::test_usage_errors_go_to_stderr | yes | yes | cli.run usage errors | #891 | stderr + exit 2, not stdout + 255 |
 | tests/test_cli_flags.py::test_run_list_still_works_without_a_name | yes | yes | cli.run NAME optionality | #891 | guards `run --list` against a required NAME |
 | tests/test_cli_surface.py::test_the_global_options_are_unchanged | yes | yes | root CLI options | #891 | snapshot now covers root params |
+| tests/test_cli_info.py::test_a_failing_check_exits_non_zero | yes | yes | cli_api._check / cli.info exit code | #891 | --check was always exit 0 |
+| tests/test_cli_info.py::test_check_does_not_shout_or_draw_banners | yes | yes | cli_api._check rendering | #891 | no ===/---/!!!! |
+| tests/test_cli_info.py::test_check_keeps_the_probe_narration_for_verbose | yes | yes | cli_api._debug gating | #891 | diagnostics only under --verbose |
+| tests/test_cli_info.py::test_quiet_reports_only_what_is_broken | yes | yes | check rendering under --quiet | #891 | failures survive quiet |
+| tests/test_cli_info.py::test_a_local_path_in_a_remote_capable_setting_is_still_checked | yes | yes | cli_api._check_config_file OTHERPATHS | #891 | local value in a remote-capable setting |
+| tests/test_cli_api.py::test_show_info_is_quiet_by_default | yes | yes | cli_api._ui / _silent binding | #891 | library prints nothing without echo |
+| tests/test_cellpy_cmd.py::test_info_check | yes | yes | cli info --check exit code | #891 | exit code must match the printed verdict |
 | tests/test_cellpy_file_v9.py::test_v9_parquet_members_use_zstd | yes | yes | v9._frame_to_parquet_bytes | #912 | new writes are zstd + ZIP_STORED |
 | tests/test_cellpy_file_v9.py::test_v9_loads_snappy_parquet_members | yes | yes | v9.load / _read_parquet_member | #912 | #898-era snappy members still load |
 | tests/test_cellpy_file_v9.py::test_failed_resave_keeps_the_old_file | yes | yes | cellpy_file.atomic.atomic_write / v9.save / CellpyCell.save | #845 | data-loss guard: interrupted re-save must not destroy the old file |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+* `cellpy info` and `cellpy info --check` report rather than narrate. The check
+  run is one line per check with a symbol, a short detail and a hint when it
+  fails, closing with `N of M checks passed` - instead of `=== checking ===`
+  banners, 80-column rules, a page of probe output per check and a
+  `failed!!!!` line that shipped with a stray `f`. The probe narration is still
+  there under `--verbose`. **`cellpy info --check` now exits 1 when a check
+  fails** (it always exited 0), so it can be used in a script. A path setting
+  that *may* be remote is now only skipped when the value actually is remote,
+  so a broken local `cellpydatadir` is reported instead of excused. Output
+  lines changed: `[cellpy] version: X` is now `cellpy X`, and
+  `[cellpy] -> <path>` is now `config   <path>`. (#891)
+
 * CLI: new global `--quiet` / `-q`, `--verbose` and `--no-color` options.
   `--quiet` reports problems and the output you asked for (`cellpy info` still
   answers) and drops progress chatter; colour is otherwise automatic and

--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -341,7 +341,7 @@ def info(
     ] = False,
 ):
     """This will give you some valuable information about your cellpy."""
-    cli_api.show_info(
+    failed = cli_api.show_info(
         version=version,
         configloc=configloc,
         params=params,
@@ -350,6 +350,10 @@ def info(
         # `info` answers a question; every line is payload, so --quiet keeps it.
         echo=_echo(payload=True),
     )
+    if failed:
+        # `cellpy info --check` is worth scripting, so a broken setup has to be
+        # visible to the shell and not only to the reader (#891).
+        raise typer.Exit(code=1)
 
 
 # ----------------------- run ----------------------------------------

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -31,6 +31,7 @@ import subprocess
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Union
 
 from cellpy._version import __version__ as VERSION
@@ -487,8 +488,40 @@ _echo_var: ContextVar[Echo] = ContextVar("cellpy_cli_api_echo", default=_silent)
 
 
 def _say(message: str, **_kwargs) -> None:
-    """Report via the bound echo; colour kwargs from old typer.echo are ignored."""
+    """Report pre-formatted text via the bound echo.
+
+    The transport for messages not yet converted to the :mod:`cellpy.cli_ui`
+    vocabulary (#891). Prefer ``_ui()`` for anything new.
+    """
     _echo_var.get()(message)
+
+
+def _debug(message: Any) -> None:
+    """A diagnostic line: shown under ``--verbose``, hidden otherwise.
+
+    The check helpers used to narrate every probe at full volume; the verdict
+    is what a user needs, the narration is what they need when it goes wrong.
+    """
+    _ui().debug(str(message))
+
+
+def _ui():
+    """The active console reporter (see :mod:`cellpy.cli_ui`).
+
+    Commands that report structure - a check list, a verdict, a path with a
+    note - use this instead of ``_say``, so what they print carries meaning
+    (stream, colour, level) rather than being a string someone formatted by
+    hand.
+
+    A caller who passed no ``echo`` gets a reporter that prints nothing: these
+    functions are a library first, and a library does not write to stdout
+    because someone imported it.
+    """
+    from cellpy import cli_ui
+
+    if _echo_var.get() is _silent:
+        return cli_ui.silent_reporter()
+    return cli_ui.current()
 
 
 @contextmanager
@@ -811,17 +844,46 @@ def _ask_about_name(q, n):
     return new_name
 
 
-def _check_import_cellpy():
+@dataclass
+class _CheckOutcome:
+    """What one ``cellpy info --check`` line reports.
+
+    The checks used to print their own verdict and a page of diagnostics.
+    Returning the outcome instead lets the caller render it consistently -
+    verdict row first, then its detail lines - and lets the diagnostics drop to
+    ``--verbose`` where they belong.
+    """
+
+    ok: bool
+    detail: str = ""
+    hint: Optional[str] = None
+    details: list = field(default_factory=list)
+
+    def add(self, key: str, value: str, note: Optional[str] = None) -> None:
+        """Record a key/value line to print underneath the verdict."""
+        self.details.append((key, value, note))
+
+
+def _as_outcome(result) -> _CheckOutcome:
+    """Accept a bare bool from any check not yet returning an outcome."""
+    if isinstance(result, _CheckOutcome):
+        return result
+    return _CheckOutcome(bool(result))
+
+
+def _check_import_cellpy() -> _CheckOutcome:
     try:
         import cellpy  # noqa: F401
         from cellpy import log  # noqa: F401
         from cellpy.readers import cellreader  # noqa: F401
 
-        return True
-    except Exception:
-        _say(" Failed to import cellpy")
-        _say(" Severity: critical")
-        return False
+        return _CheckOutcome(True, "cellpy, log, cellreader")
+    except Exception as exc:
+        return _CheckOutcome(
+            False,
+            f"cannot import cellpy ({exc})",
+            hint="reinstall cellpy, or check for a broken pyarrow/pandas install",
+        )
 
 
 def _check_import_pyodbc():
@@ -834,86 +896,94 @@ def _check_import_pyodbc():
 
     use_subprocess = config.instruments.Arbin.use_subprocess
     detect_subprocess_need = config.instruments.Arbin.detect_subprocess_need
-    _say(" This is needed for loading Arbin .res files")
-    _say(" parsing prms")
-    _say(
+    _debug(" This is needed for loading Arbin .res files")
+    _debug(" parsing prms")
+    _debug(
         " (from your configuration file if it exists, otherwise using defaults)"
     )
-    _say(f" - ODBC: {ODBC}")
-    _say(f" - SEARCH_FOR_ODBC_DRIVERS: {SEARCH_FOR_ODBC_DRIVERS}")
-    _say(f" - use_subprocess: {use_subprocess}")
-    _say(f" - detect_subprocess_need: {detect_subprocess_need}")
-    _say(f" - stated office version: {config.instruments.Arbin.office_version}")
+    _debug(f" - ODBC: {ODBC}")
+    _debug(f" - SEARCH_FOR_ODBC_DRIVERS: {SEARCH_FOR_ODBC_DRIVERS}")
+    _debug(f" - use_subprocess: {use_subprocess}")
+    _debug(f" - detect_subprocess_need: {detect_subprocess_need}")
+    _debug(f" - stated office version: {config.instruments.Arbin.office_version}")
 
-    _say(" checking system")
+    _debug(" checking system")
     is_posix = False
     is_macos = False
     if os.name == "posix":
         is_posix = True
-        _say(" - running on posix")
+        _debug(" - running on posix")
     current_platform = platform.system()
     if current_platform == "Darwin":
         is_macos = True
-        _say(" - running on a mac")
+        _debug(" - running on a mac")
 
     python_version, os_version = platform.architecture()
-    _say(f" - python version: {python_version}")
-    _say(f" - os version: {os_version}")
+    _debug(f" - python version: {python_version}")
+    _debug(f" - os version: {os_version}")
 
     if not is_posix:
         if not config.instruments.Arbin.sub_process_path:
             sub_process_path = str(prms._sub_process_path)
         else:
             sub_process_path = str(config.instruments.Arbin.sub_process_path)
-        _say(f" stated path to sub-process: {sub_process_path}")
+        _debug(f" stated path to sub-process: {sub_process_path}")
         if not os.path.isfile(sub_process_path):
-            _say(" - OBS! missing")
+            _debug(" - OBS! missing")
 
     if is_posix:
-        _say(" checking existence of mdb-export")
+        _debug(" checking existence of mdb-export")
         sub_process_path = "mdb-export"
         from subprocess import PIPE, run
 
         command = ["command", "-v", sub_process_path]
 
         try:
-            _say(f" - trying to run {command}")
+            _debug(f" - trying to run {command}")
             result = run(
                 command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True
             )
             if result.returncode == 0:
-                _say(" - found it!")
-                return True
+                _debug(" - found it!")
+                return _CheckOutcome(True, f"{sub_process_path} on PATH")
 
-            _say(f" - could not find {sub_process_path}")
+            _debug(f" - could not find {sub_process_path}")
 
             if is_macos:
                 driver = "/usr/local/lib/libmdbodbc.dylib"
-                _say(
+                _debug(
                     f" looks like you are on a mac. Searching for suitable driver: {driver})"
                 )
                 if not os.path.isfile(driver):
-                    _say(f" - could not find {driver}")
-                    _say(
+                    _debug(f" - could not find {driver}")
+                    _debug(
                         " ! If you want to load Arbin .res files you will have to install it manually."
                     )
-                    _say(" - Try installing it with brew:\n")
-                    _say("   brew install mdbtools")
-                    return False
-                _say(f" - found it: {driver}")
-                return True
+                    _debug(" - Try installing it with brew:\n")
+                    _debug("   brew install mdbtools")
+                    return _CheckOutcome(
+                        False,
+                        "no mdbtools driver",
+                        hint="brew install mdbtools",
+                    )
+                _debug(f" - found it: {driver}")
+                return _CheckOutcome(True, driver)
             else:
-                _say(
+                _debug(
                     " ! If you want to load Arbin .res files you will have to install it manually."
                 )
-                _say("   For example (for ubuntu):\n")
-                _say("   sudp apt-get update")
-                _say("   sudp apt-get install -y mdbtools")
-            return False
+                _debug("   For example (for ubuntu):\n")
+                _debug("   sudp apt-get update")
+                _debug("   sudp apt-get install -y mdbtools")
+            return _CheckOutcome(
+                False,
+                "mdbtools not installed",
+                hint="apt-get install mdbtools (see the docs for other systems)",
+            )
 
         except AssertionError:
-            _say(" - could not find any suitable driver")
-            return False
+            _debug(" - could not find any suitable driver")
+            return _CheckOutcome(False, "no suitable driver found")
 
     # not posix - checking for odbc drivers
     # 1) checking if you have defined one
@@ -921,11 +991,11 @@ def _check_import_pyodbc():
         driver = config.instruments.Arbin.odbc_driver
         if not driver:
             raise AttributeError
-        _say(" You have defined an odbc driver in your config file")
-        _say(f" - driver: {driver}")
+        _debug(" You have defined an odbc driver in your config file")
+        _debug(f" - driver: {driver}")
     except AttributeError:
-        _say(" FYI: you have not defined any odbc_driver(s)")
-        _say(
+        _debug(" FYI: you have not defined any odbc_driver(s)")
+        _debug(
             " (The name of the driver from the configuration file is "
             "used as a backup when cellpy cannot locate a driver by itself)"
         )
@@ -934,79 +1004,84 @@ def _check_import_pyodbc():
 
     if ODBC == "ado":
         use_ado = True
-        _say(" you stated that you prefer the ado loader")
-        _say(" checking if adodbapi is installed")
+        _debug(" you stated that you prefer the ado loader")
+        _debug(" checking if adodbapi is installed")
         try:
             import adodbapi as dbloader
         except ImportError:
             use_ado = False
-            _say(" Failed! Try setting pyodbc as your loader or install")
-            _say(" adodbapi (http://adodbapi.sourceforge.net/)")
+            _debug(" Failed! Try setting pyodbc as your loader or install")
+            _debug(" adodbapi (http://adodbapi.sourceforge.net/)")
 
     if not use_ado:
         if ODBC == "pyodbc":
-            _say(" you stated that you prefer the pyodbc loader")
+            _debug(" you stated that you prefer the pyodbc loader")
             try:
                 import pyodbc as dbloader
             except ImportError:
-                _say(" Failed! Could not import it.")
-                _say(" Try 'pip install pyodbc'")
+                _debug(" Failed! Could not import it.")
+                _debug(" Try 'pip install pyodbc'")
                 dbloader = None
 
         elif ODBC == "pypyodbc":
-            _say(" you stated that you prefer the pypyodbc loader")
+            _debug(" you stated that you prefer the pypyodbc loader")
             try:
                 import pypyodbc as dbloader  # type: ignore
             except ImportError:
-                _say(" Failed! Could not import it.")
-                _say(" try 'pip install pypyodbc'")
-                _say(" or set pyodbc as your loader in your prm file")
-                _say(" (and install it)")
+                _debug(" Failed! Could not import it.")
+                _debug(" try 'pip install pypyodbc'")
+                _debug(" or set pyodbc as your loader in your prm file")
+                _debug(" (and install it)")
                 dbloader = None
 
-    _say(" searching for odbc drivers")
+    _debug(" searching for odbc drivers")
     try:
         drivers = [
             driver
             for driver in dbloader.drivers()
             if "Microsoft Access Driver" in driver
         ]
-        _say(f" Found these: {drivers}")
+        _debug(f" Found these: {drivers}")
         driver = drivers[0]
-        _say(f" - odbc driver: {driver}")
-        return True
+        _debug(f" - odbc driver: {driver}")
+        return _CheckOutcome(True, driver)
 
     except IndexError:
         logging.debug(" Unfortunately, it seems the list of drivers is emtpy.")
-        _say(
+        _debug(
             "\n Could not find any odbc-drivers suitable for .res-type files. "
             "Check out the homepage of pydobc for info on installing drivers"
         )
-        _say(
+        _debug(
             " One solution that might work is downloading "
             "the Microsoft Access database engine "
             "(in correct bytes (32 or 64)) "
             "from:\n"
             "https://www.microsoft.com/en-us/download/details.aspx?id=13255"
         )
-        _say(
+        _debug(
             " Or install mdbtools and set it up (check the cellpy docs for help)"
         )
-        _say("\n")
-        return False
+        _debug("\n")
+        return _CheckOutcome(
+            False,
+            "no odbc driver for .res files",
+            hint="install the Microsoft Access Database Engine, or mdbtools",
+        )
 
 
 def _check_config_file():
-    prm_file_name = _configloc()
-    env_file_name = _envloc()
+    from cellpy.config.loader import active_config_file
 
-    if env_file_name is None:
-        _say(" FYI! Could not locate the environment file")
+    outcome = _CheckOutcome(True)
+    prm_file_name = active_config_file().path
+    env_file_name = prmreader.get_env_file_name()
+
+    if env_file_name is None or not os.path.isfile(env_file_name):
+        outcome.add("env file", str(env_file_name or "not set"), "not found")
 
     if prm_file_name is None:
-        _say(" Could not find the config file")
-        _say(" You can create one by running 'cellpy setup'")
-        return False
+        return _CheckOutcome(False, "no configuration file", hint="cellpy setup")
 
     # Check the *resolved* paths rather than re-parsing the file: those are the
     # ones cellpy will use, and it works for both cellpy.toml and legacy YAML
@@ -1026,100 +1101,86 @@ def _check_config_file():
             "templatedir",
             "db_path",
         ]
+        from cellpy.internals.otherpath import OtherPath
         from cellpy.parameters.internal_settings import OTHERPATHS
 
         missing = 0
         for k in required_dirs:
             value = prm_paths.get(k, None)
-            _say(f" - {k}: {value}")
-            # splitting this into two if-statements to make it easier to debug if OtherPath changes
-            if k in OTHERPATHS:
-                print(f" skipping check for external {k} (for now)")
-                # if not OtherPath(
-                #     value
-                # ).is_dir():  # Assuming OtherPath returns True if it is external.
-                #     missing += 1
-                #     _say("COULD NOT CONNECT!")
-                #     _say(f"({value} is not a directory)")
-            elif value and not pathlib.Path(value).is_dir():
-                missing += 1
-                _say(" COULD NOT CONNECT!")
-                _say(f" ({value} is not a directory)")
             if not value:
                 missing += 1
-                _say(" MISSING")
+                outcome.add(k, "not set", "missing")
+                continue
+            # OTHERPATHS lists the settings that *may* point somewhere remote,
+            # not the ones that do - so ask the value itself. A local path in
+            # one of those settings still gets checked, which is why a wrong
+            # cellpydatadir used to be waved through as "external".
+            if k in OTHERPATHS and OtherPath(value).is_external:
+                # Verifying a remote path costs a connection; a wrong one is
+                # reported properly by the load that needs it.
+                outcome.add(k, str(value), "remote, not checked")
+            elif not pathlib.Path(value).is_dir():
+                missing += 1
+                outcome.add(k, str(value), "not a directory")
+            else:
+                outcome.add(k, str(value))
 
         value = prm_paths.get("db_filename", None)
-        _say(f" - db_filename: {value}")
-        if not value:
+        if value:
+            outcome.add("db_filename", str(value))
+        else:
             missing += 1
-            _say(" MISSING")
+            outcome.add("db_filename", "not set", "missing")
 
         if missing:
-            return False
+            outcome.ok = False
+            outcome.detail = f"{missing} path(s) missing or unusable"
+            outcome.hint = "cellpy edit config"
         else:
-            return True
+            outcome.detail = str(prm_file_name)
+        return outcome
 
-    except Exception as e:
-        _say(" Following error occurred:")
-        _say(e)
-        return False
+    except Exception as exc:
+        return _CheckOutcome(False, f"could not read the configuration ({exc})")
 
 
-def _check(dry_run=False, full_check=True):
-    _say(" checking ".center(80, "="))
+def _check(dry_run=False, full_check=True) -> int:
+    """Report what works and what does not, one line per check (#891).
+
+    Returns:
+        How many checks failed, so a caller can exit non-zero.
+    """
+    ui = _ui()
     if dry_run:
-        _say("*** dry-run: skipping the test")
-        return
-    failed_checks = 0
-    number_of_checks = 0
+        ui.warn("dry run", "checks skipped")
+        return 0
 
-    def sub_check(check_type, check_func):
-        failed = 0
-        _say(f"[cellpy] * - Checking {check_type}")
-        if check_func():
-            _say("[cellpy] -> succeeded!")
-        else:
-            _say("f[cellpy] -> failed!!!!")
-            failed = 1
-        _say(80 * "-")
-        return failed
+    ui.title(f"cellpy {VERSION} - checking your setup")
 
-    check_types = [
-        "cellpy imports",
-        "importing pyodbc",
+    checks = [
+        ("imports", _check_import_cellpy),
+        ("arbin .res support", _check_import_pyodbc),
     ]
-    check_funcs = [
-        _check_import_cellpy,
-        _check_import_pyodbc,
-    ]
-
-    # additional checks that require loading the config file (not a part of setup)
-    additional_types = ["configuration files"]
-    additional_funcs = [_check_config_file]
+    # Reading the config is not part of `setup`, which runs before there is one.
     if full_check:
-        check_types.extend(additional_types)
-        check_funcs.extend(additional_funcs)
+        checks.append(("configuration", _check_config_file))
 
-    for ct, cf in zip(check_types, check_funcs):
+    failed = 0
+    for label, check_func in checks:
         try:
-            failed_checks += sub_check(ct, cf)
-        except Exception as e:
-            _say(f"[cellpy] check raised an exception ({e})")
-        number_of_checks += 1
-    _say(" results ".center(80, "="))
-    succeeded_checks = number_of_checks - failed_checks
+            outcome = _as_outcome(check_func())
+        except Exception as exc:
+            outcome = _CheckOutcome(False, f"the check itself raised {exc!r}")
+        if outcome.ok:
+            ui.ok(label, outcome.detail)
+        else:
+            failed += 1
+            ui.fail(label, outcome.detail, hint=outcome.hint)
+        for key, value, note in outcome.details:
+            ui.detail(key, value, note=note)
 
-    if failed_checks > 0:
-        _say(
-            "[cellpy] Some of the checks failed! This could potentially be a problem."
-        )
-        _say(f"[cellpy] Failed {failed_checks} out of {number_of_checks} checks.")
-    else:
-        _say(
-            f"[cellpy] Succeeded {succeeded_checks} out of {number_of_checks} checks."
-        )
-    _say(80 * "=")
+    ui.summary(len(checks) - failed, len(checks))
+    return failed
 
 
 def _write_config_file(user_dir, dst_file, init_filename, dry_run):
@@ -1273,32 +1334,31 @@ def _pull_examples(directory, pw):
 
 # -- version/configloc/envloc/dump_params --
 def _version():
-    version_text = "[cellpy] version: " + str(VERSION)
-    _say(version_text)
+    _ui().payload(f"cellpy {VERSION}")
 
 
 def _configloc():
     """Report the config file cellpy actually reads (``None`` when there is none)."""
     from cellpy.config.loader import CONFIG_FILENAME, active_config_file
 
+    ui = _ui()
     active = active_config_file()
     if active.path is None:
         _, config_file_name = prmreader.get_user_dir_and_dst()
-        _say(f"[cellpy] -> {config_file_name}")
-        _say("[cellpy] File does not exist!")
+        ui.fail("config", f"{config_file_name} does not exist", hint="cellpy setup")
         if active.project_path is not None:
-            _say(
-                f"[cellpy] (project {active.project_path} also applies and takes precedence)"
-            )
+            ui.detail("project config", str(active.project_path), note="takes precedence")
         return None
 
-    _say(f"[cellpy] -> {active.path}")
+    ui.payload(f"config   {active.path}")
     if active.shadowed_legacy is not None:
-        _say(f"[cellpy] (legacy {active.shadowed_legacy} is ignored - {CONFIG_FILENAME} takes precedence)")
-    if active.project_path is not None:
-        _say(
-            f"[cellpy] (project {active.project_path} also applies and takes precedence)"
+        ui.detail(
+            "legacy",
+            str(active.shadowed_legacy),
+            note=f"ignored, {CONFIG_FILENAME} wins",
         )
+    if active.project_path is not None:
+        ui.detail("project", str(active.project_path), note="takes precedence")
     return active.path
 
 
@@ -1817,13 +1877,19 @@ def show_info(
     show_config: bool = False,
     check: bool = False,
     echo: Optional[Echo] = None,
-) -> None:
-    """Library form of ``cellpy info``."""
+) -> int:
+    """Library form of ``cellpy info``.
+
+    Returns:
+        The number of failed checks (always 0 unless ``check`` is set), so the
+        CLI can exit non-zero when the setup is broken.
+    """
     with _using_echo(echo):
         complete_info = True
+        failed = 0
         if check:
             complete_info = False
-            _check()
+            failed = _check()
         if version:
             complete_info = False
             _version()
@@ -1839,6 +1905,7 @@ def show_info(
         if complete_info:
             _version()
             _configloc()
+        return failed
 
 
 def config_path(*, echo: Optional[Echo] = None):

--- a/cellpy/cli_ui.py
+++ b/cellpy/cli_ui.py
@@ -152,26 +152,47 @@ class Reporter:
         color: Optional[bool] = None,
         stdout: Optional[TextIO] = None,
         stderr: Optional[TextIO] = None,
+        enabled: bool = True,
     ) -> None:
         self.level = Level(level)
         self._color = color
-        self._stdout = stdout if stdout is not None else sys.stdout
-        self._stderr = stderr if stderr is not None else sys.stderr
-        self.symbols = (
-            UNICODE_SYMBOLS if supports_unicode(self._stdout) else ASCII_SYMBOLS
-        )
+        # A disabled reporter writes nowhere at any level - what a library call
+        # gets when the caller did not ask for output (``cli_api`` is quiet by
+        # default, and that includes failures).
+        self.enabled = enabled
+        # Streams stay unresolved when not injected: pytest's capsys, Click's
+        # CliRunner and a plain shell redirect all swap sys.stdout *after* a
+        # reporter may have been built, and a reporter that captured the old
+        # object would write into the void.
+        self._stdout = stdout
+        self._stderr = stderr
         self._out_console: Any = None
         self._err_console: Any = None
 
     # -- plumbing ------------------------------------------------------
 
+    def _stream(self, *, err: bool = False) -> Any:
+        if err:
+            return self._stderr if self._stderr is not None else sys.stderr
+        return self._stdout if self._stdout is not None else sys.stdout
+
+    @property
+    def symbols(self) -> Symbols:
+        """Unicode where the current stdout can encode it, else ASCII."""
+        return (
+            UNICODE_SYMBOLS
+            if supports_unicode(self._stream())
+            else ASCII_SYMBOLS
+        )
+
     def _console(self, *, err: bool = False) -> Any:
+        stream = self._stream(err=err)
         cached = self._err_console if err else self._out_console
-        if cached is not None:
+        # Reuse only while it still points at the stream in force.
+        if cached is not None and cached.file is stream:
             return cached
         from rich.console import Console
 
-        stream = self._stderr if err else self._stdout
         enabled = color_enabled(stream, color=self._color)
         console = Console(
             file=stream,
@@ -199,6 +220,8 @@ class Reporter:
         return self.level >= minimum
 
     def _write(self, text: Any, *, err: bool = False) -> None:
+        if not self.enabled:
+            return
         self._console(err=err).print(text)
 
     @property
@@ -332,6 +355,7 @@ class Reporter:
             color=self._color,
             stdout=self._stdout,
             stderr=self._stderr,
+            enabled=self.enabled,
         )
 
     # -- compatibility -------------------------------------------------
@@ -384,6 +408,11 @@ def _pad(value: str, width: int = LABEL_WIDTH) -> str:
 _reporter_var: ContextVar[Optional[Reporter]] = ContextVar(
     "cellpy_cli_reporter", default=None
 )
+
+
+def silent_reporter() -> Reporter:
+    """A reporter that prints nothing, for library calls that asked for quiet."""
+    return Reporter(enabled=False)
 
 
 def current() -> Reporter:

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -72,7 +72,7 @@ def test_info_version():
     result = runner.invoke(cli.cli, ["info", "--version"])
     print(result.output)
     assert result.exit_code == 0
-    assert f"[cellpy] version: {cellpy.__version__}" in result.output
+    assert f"cellpy {cellpy.__version__}" in result.output
 
 
 def test_info_configloc():
@@ -83,7 +83,7 @@ def test_info_configloc():
     assert result.exit_code == 0
     # Format-agnostic: the reported file may be cellpy.toml or a legacy .conf,
     # depending on what the machine running the tests has (#851).
-    assert "[cellpy] ->" in result.output
+    assert "config" in result.output
 
 
 def _fake_active_config_file(monkeypatch, active):
@@ -120,10 +120,10 @@ def test_info_configloc_flags_shadowed_legacy_file(monkeypatch, tmp_path):
     )
     result = CliRunner().invoke(cli.cli, ["info", "--configloc"])
     assert result.exit_code == 0
-    assert f"[cellpy] -> {toml_file}" in result.output
+    assert str(toml_file) in result.output
     assert str(legacy) in result.output
-    assert "is ignored" in result.output
-    assert "cellpy.toml takes precedence" in result.output
+    assert "ignored" in result.output
+    assert "cellpy.toml wins" in result.output
 
 
 @pytest.mark.essential
@@ -142,9 +142,9 @@ def test_info_configloc_reports_project_toml(monkeypatch, tmp_path):
     )
     result = CliRunner().invoke(cli.cli, ["info", "--configloc"])
     assert result.exit_code == 0
-    assert f"[cellpy] -> {user}" in result.output
+    assert str(user) in result.output
     assert str(project) in result.output
-    assert "also applies and takes precedence" in result.output
+    assert "takes precedence" in result.output
 
 
 def test_info_no_option():
@@ -173,10 +173,23 @@ def test_info_params():
 
 
 def test_info_check():
+    """The exit code must agree with the verdict (#891).
+
+    Not `exit_code == 0`: whether every check passes depends on the machine -
+    and on earlier tests, since some fixtures point `config.paths` at
+    directories that do not exist and never restore it. What must always hold
+    is that a reported failure is also reported to the shell.
+    """
+    import re
+
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["info", "--check"])
     print("\n", result.output)
-    assert result.exit_code == 0
+
+    verdict = re.search(r"(\d+) of (\d+) checks passed", result.output)
+    assert verdict, result.output
+    passed, total = int(verdict.group(1)), int(verdict.group(2))
+    assert result.exit_code == (0 if passed == total else 1)
 
 
 @pytest.mark.slowtest

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -292,14 +292,17 @@ def test_convert_really_upgrades_a_legacy_file(tmp_path, target):
 
 @pytest.mark.essential
 def test_show_info_is_quiet_by_default(capsys):
+    """A library call prints nothing unless the caller asks for output."""
     cli_api.show_info(version=True)
-    assert "version" not in capsys.readouterr().out
+    assert capsys.readouterr().out.strip() == ""
 
 
 @pytest.mark.essential
 def test_show_info_echoes_when_asked(capsys):
+    import cellpy
+
     cli_api.show_info(version=True, echo=print)
-    assert "version" in capsys.readouterr().out
+    assert cellpy.__version__ in capsys.readouterr().out
 
 
 @pytest.mark.essential

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -92,10 +92,12 @@ def test_no_color_disables_colour():
 @pytest.mark.essential
 def test_quiet_still_answers_a_question():
     """`info` is payload: --quiet silences progress, never the answer."""
+    import cellpy
+
     result = runner.invoke(cli, ["--quiet", "info", "--version"])
 
     assert result.exit_code == 0, result.output
-    assert "version" in plain(result.output)
+    assert cellpy.__version__ in plain(result.output)
 
 
 # -- usage errors ----------------------------------------------------------

--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -1,0 +1,185 @@
+"""What ``cellpy info`` and ``cellpy info --check`` report (#891).
+
+The check list used to be banner soup: ``=== checking ===``, a page of probe
+narration per check, ``f[cellpy] -> failed!!!!`` (the ``f`` was a typo that
+reached users), and a verdict that never reached the exit code. These tests
+pin the parts a user or a script depends on.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+import cellpy
+from cellpy import cli_api, cli_ui
+from cellpy.cli import cli
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+@pytest.fixture(autouse=True)
+def fresh_reporter(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    with cli_ui.using_reporter(None):
+        yield
+
+
+@pytest.fixture
+def one_failing_check(monkeypatch):
+    """Make the odbc check fail, without needing a machine that lacks it."""
+    monkeypatch.setattr(
+        cli_api,
+        "_check_import_pyodbc",
+        lambda: cli_api._CheckOutcome(
+            False, "no odbc driver", hint="install mdbtools"
+        ),
+    )
+
+
+# -- info -------------------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_version_is_the_program_and_the_number():
+    result = runner.invoke(cli, ["info", "--version"])
+
+    assert result.exit_code == 0
+    assert plain(result.output).strip() == f"cellpy {cellpy.__version__}"
+
+
+@pytest.mark.essential
+def test_info_reports_the_config_file_it_actually_reads():
+    result = runner.invoke(cli, ["info", "--configloc"])
+
+    assert result.exit_code == 0
+    assert "config" in plain(result.output)
+
+
+# -- info --check -----------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_check_lists_one_line_per_check_and_a_verdict():
+    result = runner.invoke(cli, ["info", "--check"])
+    output = plain(result.output)
+
+    for label in ("imports", "arbin .res support", "configuration"):
+        assert label in output, label
+    assert "checks passed" in output
+
+
+@pytest.mark.essential
+def test_check_does_not_shout_or_draw_banners():
+    """No `=== checking ===`, no 80-column rules, no `failed!!!!`."""
+    output = plain(runner.invoke(cli, ["info", "--check"]).output)
+
+    assert "=" * 20 not in output
+    assert "-" * 20 not in output
+    assert "!!!!" not in output
+    assert "f[cellpy]" not in output
+
+
+@pytest.mark.essential
+def test_check_keeps_the_probe_narration_for_verbose():
+    """The diagnostics are useful when a check fails - and only then."""
+    normal = plain(runner.invoke(cli, ["info", "--check"]).output)
+    verbose = plain(runner.invoke(cli, ["--verbose", "info", "--check"]).output)
+
+    assert len(verbose.splitlines()) > len(normal.splitlines())
+    assert "checking system" in verbose or "parsing prms" in verbose
+    assert "parsing prms" not in normal
+
+
+@pytest.mark.essential
+def test_a_failing_check_exits_non_zero(one_failing_check):
+    """`cellpy info --check` is worth scripting, so it has to fail loudly."""
+    result = runner.invoke(cli, ["info", "--check"])
+
+    assert result.exit_code == 1
+    assert "no odbc driver" in plain(result.output)
+    assert "install mdbtools" in plain(result.output)
+
+
+@pytest.mark.essential
+def test_a_passing_check_exits_zero():
+    result = runner.invoke(cli, ["info", "--check"])
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.essential
+def test_failures_reach_stderr(one_failing_check):
+    """A broken setup must survive `cellpy info --check > report.txt`."""
+    result = runner.invoke(cli, ["info", "--check"])
+
+    assert "no odbc driver" in plain(result.stderr)
+
+
+@pytest.mark.essential
+def test_quiet_reports_only_what_is_broken(one_failing_check):
+    """--quiet drops the passing rows and keeps the problem."""
+    result = runner.invoke(cli, ["--quiet", "info", "--check"])
+    output = plain(result.output)
+
+    assert "no odbc driver" in output
+    assert "checks passed" not in output
+    assert "imports" not in output
+
+
+# -- the check helpers ------------------------------------------------------
+
+
+@pytest.mark.essential
+def test_a_check_that_raises_is_reported_not_propagated(monkeypatch):
+    def boom():
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(cli_api, "_check_import_cellpy", boom)
+    result = runner.invoke(cli, ["info", "--check"])
+
+    assert result.exit_code == 1
+    assert "probe exploded" in plain(result.output)
+
+
+@pytest.mark.essential
+def test_a_local_path_in_a_remote_capable_setting_is_still_checked(monkeypatch):
+    """`cellpydatadir` may be remote, so it used to be waved through entirely.
+
+    A local path in one of those settings is checkable, and a wrong one should
+    be reported rather than excused as "external".
+    """
+    from cellpy import config as cellpy_config
+
+    real = cellpy_config.get_config()
+    broken = real.paths.model_dump()
+    broken["cellpydatadir"] = "/definitely/not/a/directory"
+
+    # Delegate everything except the one dump we want to poison, so the rest of
+    # the config (env_file, ...) keeps working.
+    class _Paths:
+        def __getattr__(self, name):
+            return getattr(real.paths, name)
+
+        def model_dump(self):
+            return broken
+
+    class _Config:
+        paths = _Paths()
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr(cellpy_config, "get_config", lambda: _Config())
+
+    outcome = cli_api._check_config_file()
+    assert outcome.ok is False
+    assert "missing or unusable" in outcome.detail

--- a/tests/test_cli_light_import.py
+++ b/tests/test_cli_light_import.py
@@ -37,7 +37,7 @@ def test_info_version_avoids_cellreader_import():
 
         result = CliRunner().invoke(cellpy.cli.cli, ["info", "--version"])
         assert result.exit_code == 0, result.output
-        assert "[cellpy] version:" in result.output
+        assert "cellpy " in result.output
         assert "cellpy.readers.cellreader" not in sys.modules, sorted(
             m for m in sys.modules if m.startswith("cellpy")
         )


### PR DESCRIPTION
Part of #891. **PR 3 of 5** — the first PR that changes what the CLI *says*.

## Before

`cellpy info --check` printed a `=== checking ===` banner; then per check a
header, a page of probe narration, a verdict and an 80-column rule; then a
`=== results ===` block. A raw Python list repr leaked into it
(`Found these: ['Microsoft Access Driver (*.mdb, *.accdb)']`), the failure line
read `f[cellpy] -> failed!!!!` (that `f` shipped), and none of it reached the
exit code — a broken setup exited **0**.

## After

```
cellpy 2.1.2 - checking your setup

  ✓ imports             cellpy, log, cellreader
  ✓ arbin .res support  Microsoft Access Driver (*.mdb, *.accdb)
  ✗ configuration       2 path(s) missing or unusable
      hint: cellpy edit config
      examplesdir       ...\testdata\examples  (not a directory)
      rawdatadir        scp://…/projects  (remote, not checked)

  2 of 3 checks passed
```

Checks return a `_CheckOutcome` (verdict, short detail, hint, detail lines)
instead of printing their own; `_check` renders them consistently. The probe
narration becomes `_debug()` — still there under `--verbose`, which is when
anyone wants it.

## Behaviour fixes that fell out

* **`info --check` exits 1 when a check fails**, so it can be scripted. It
  always exited 0.
* **A remote-*capable* setting holding a local path is now actually checked.**
  `OTHERPATHS` lists settings that *may* be remote; the old code skipped all of
  them, so a wrong local `cellpydatadir` was waved through as "external". Now
  the value itself is asked.
* **`cli_api._ui()` returns a silent reporter when no `echo` was passed.**
  Without this the reporter wrote to stdout on library calls, breaking the
  quiet-by-default contract `_say` already honoured. `test_show_info_is_quiet_by_default`
  had been passing for the wrong reason and now asserts no output at all.
* **`Reporter` resolves its streams at write time.** Binding `sys.stdout` at
  construction breaks under `capsys`, `CliRunner` and shell redirection.

## Changed output (tests move with it)

`[cellpy] version: X` → `cellpy X`; `[cellpy] -> <path>` → `config   <path>`.

## Tests

New `tests/test_cli_info.py` (11): the shape of the check list, absence of the
banners/`!!!!`, `--verbose` restoring the narration, `--quiet` reporting only
what is broken, failures on stderr, exit codes both ways, a raising check being
reported rather than propagated, and the local-path-in-a-remote-setting case.

```
uv run pytest -q          # full suite, in a clean worktree
# 3 failed, 1485 passed — the 3 are pre-existing local-config failures
# (search_for_files expecting .h5 where this machine resolves .cellpy);
# CI has been green on them throughout.
```

## Note for the reviewer

`tests/test_cellpy_cmd.py::test_info_check` asserted `exit_code == 0`. That
became order-dependent once the exit code became real: `tests/test_batch.py`'s
`batch_instance` fixture points `config.paths.examplesdir` / `templatedir` at
directories that do not exist and never restores the global config, so
`info --check` legitimately fails after that module runs. The test now asserts
that the exit code **agrees with the printed verdict**, which holds on any
machine. The fixture leak is a separate pre-existing bug and is being fixed
elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)