### PR TITLE
fix(batch): persist .cellpy from process workers

### DIFF
--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -80,6 +80,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_run_emits_cell_start_parse_done | yes | yes | batch.runner emit + on_progress | #916 | event bus + 3-arg callback |
 | tests/test_batch_progress.py::test_on_progress_still_wins_with_event_hook | yes | yes | batch.runner on_progress | #916 | BC: 3-arg hook still fires |
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
+| tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
+| tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* `executor="processes"` writes ``.cellpy`` in the worker on a raw load and
+  lazy-reopens on the parent, so ``batch.load(..., save_cellpy=True)`` no
+  longer crashes with ``None.save``. Cached ``None`` is not treated as
+  loaded. (#920)
 * `batch.load` / `Batch.update` show tqdm progress on a TTY or in Jupyter
   (`progress=None` auto, `False` off, `True` force, or a callable). Overall
   bar covers journal → search → cells → persist; per-cell bars cover

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -168,6 +168,8 @@ class Batch:
         ``"threads"`` mainly speeds up *reopening* cells from local ``.cellpy``
         files; a first load of remote raw files does not overlap on the wire,
         and ``"processes"`` usually loses to spawn overhead on Windows.
+        Process workers strip live cells; a raw load is written to ``.cellpy``
+        in the worker so ``save_cellpy=True`` can persist without ``None.save``.
         ``progress`` is ``None`` (auto: TTY or Jupyter), ``False`` (off),
         ``True`` (force), or a callable that receives progress events.
         ``on_progress(i, n, result)`` still wins when set (3-arg callback).
@@ -190,7 +192,7 @@ class Batch:
             self._result = run(
                 self.journal, policy, on_progress=on_progress, executor=executor
             )
-        self._store = CellStore.from_cells(self._result.cells())
+        self._store = _store_from_result(self._result, self.journal)
         self._summaries = None
         return self._result
 
@@ -521,6 +523,31 @@ def _resolve_policy(
     return replace(base, **updates) if updates else base
 
 
+def _store_from_result(result, journal: Journal) -> CellStore:
+    """Live cells when present; otherwise lazy reopen from ``.cellpy`` paths.
+
+    ``executor="processes"`` strips live objects. Workers save raw loads to
+    disk first; the parent reopens those files on first ``store[label]``.
+    """
+    from cellpy import get as cellpy_get
+
+    cells = result.cells()
+    loaders: dict[str, Any] = {}
+    paths: dict[str, Path] = {}
+    if _CELLPY_FILE_COL in journal.pages.columns:
+        for row in journal.pages.iter_rows(named=True):
+            raw = row.get(_CELLPY_FILE_COL)
+            if raw:
+                paths[row[FILENAME]] = Path(raw).with_suffix(".cellpy")
+    for item in result.loaded:
+        if item.cell is not None or item.label in cells:
+            continue
+        dest = paths.get(item.label) or _default_cellpy_path(item.label)
+        if dest.is_file():
+            loaders[item.label] = lambda p=dest: cellpy_get(cellpy_file=p)
+    return CellStore(loaders=loaders, cells=cells)
+
+
 def _default_cellpy_path(label: str) -> Path:
     """Fallback ``.cellpy`` path under ``config.paths.cellpydatadir``."""
     import cellpy.config as config
@@ -687,7 +714,10 @@ def load(
             on a TTY or in Jupyter; ``False`` disables; ``True`` forces;
             a callable receives progress events. ``executor="threads"`` speeds
             up reopening cells from local ``.cellpy`` files; a first load of
-            remote raw files stays serial on the wire. ``export_cycles`` /
+            remote raw files stays serial on the wire. ``executor="processes"``
+            cannot return live cells (pickle); raw loads are saved in the
+            worker and reopened from ``.cellpy`` so ``save_cellpy=True`` works.
+            ``export_cycles`` /
             ``export_raw`` / ``export_ica`` are accepted but ignored (warned
             once).
 

--- a/cellpy/batch/result.py
+++ b/cellpy/batch/result.py
@@ -75,7 +75,7 @@ class BatchResult:
 
     def cells(self) -> dict[str, Any]:
         """Mapping of label -> loaded cell, successful cells only."""
-        return {r.label: r.cell for r in self.loaded}
+        return {r.label: r.cell for r in self.loaded if r.cell is not None}
 
     def raise_if_failed(self) -> "BatchResult":
         """Strict mode: raise if any cell failed; otherwise return self."""

--- a/cellpy/batch/runner.py
+++ b/cellpy/batch/runner.py
@@ -136,14 +136,29 @@ def _dispatch(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
     return load_cell(spec, policy)
 
 
+def _cellpy_dest(spec: CellSpec) -> Path:
+    """Where a process worker should write ``.cellpy`` before stripping."""
+    if spec.cellpy_file:
+        return Path(spec.cellpy_file).with_suffix(".cellpy")
+    from cellpy import config
+
+    return Path(config.paths.cellpydatadir) / f"{spec.label}.cellpy"
+
+
 def _dispatch_lite(spec: CellSpec, policy: LoadPolicy, bad: frozenset) -> CellResult:
     """Process-pool worker: like :func:`_dispatch` but returns a picklable result.
 
     The live :class:`CellpyCell` is not returned across the process boundary
-    (batch plan section 7, Windows pickling); ``executor="processes"`` yields
-    outcomes/timings, and cells are re-read from their cellpy files on demand.
+    (batch plan section 7, Windows pickling). A raw load is saved to
+    ``spec.cellpy_file`` first so the parent can persist / lazy-reopen.
     """
-    return _strip_cell(_dispatch(spec, policy, bad))
+    result = _dispatch(spec, policy, bad)
+    if result.ok and result.cell is not None and result.source == "raw":
+        dest = _cellpy_dest(spec)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        result.cell.save(dest, overwrite=True)
+        emit("save", label=spec.label, n=1, total_n=1)
+    return _strip_cell(result)
 
 
 def _run_serial(specs, policy, bad, on_progress) -> list[CellResult]:

--- a/cellpy/batch/store.py
+++ b/cellpy/batch/store.py
@@ -65,7 +65,7 @@ class CellStore(Mapping):
         return self.first()
 
     def is_loaded(self, label: str) -> bool:
-        return label in self._cache
+        return self._cache.get(label) is not None
 
     def unload(self, label: str) -> None:
         """Drop a loaded cell from the cache (explicit memory management)."""

--- a/tests/test_batch_v3_runner.py
+++ b/tests/test_batch_v3_runner.py
@@ -269,6 +269,72 @@ def test_run_threads_keeps_live_cells(parameters):
     assert sorted(seen) == [1, 2]
 
 
+@pytest.mark.essential
+def test_dispatch_lite_saves_raw_then_strips(tmp_path, monkeypatch):
+    """Process worker writes .cellpy before dropping the live cell (#920)."""
+    from pathlib import Path
+
+    from cellpy.batch.runner import _dispatch_lite
+
+    dest = tmp_path / "a.cellpy"
+
+    class _Cell:
+        def save(self, path, overwrite=True):
+            Path(path).write_bytes(b"from-worker")
+
+    monkeypatch.setattr("cellpy.batch.runner._cellpy_get", lambda **kwargs: _Cell())
+    spec = CellSpec(
+        label="a",
+        cellpy_file=str(dest),
+        raw_files=["raw.h5"],
+    )
+    result = _dispatch_lite(
+        spec, LoadPolicy(source=SourcePreference.RAW_ONLY), frozenset()
+    )
+    assert result.ok
+    assert result.cell is None
+    assert dest.read_bytes() == b"from-worker"
+
+
+@pytest.mark.essential
+def test_persist_skips_none_placeholder_from_processes(tmp_path):
+    """Stripped process results must not crash persist with None.save."""
+    from cellpy.batch import Batch, Journal, LoadPolicy, SourcePreference
+    from cellpy.batch import facade as facade_mod
+    from cellpy.batch.result import BatchResult, CellOutcome, CellResult
+    from cellpy.batch.store import CellStore
+
+    dest = tmp_path / "cell_a.cellpy"
+    dest.write_bytes(b"from-worker")
+    batch = Batch(
+        Journal(
+            name="t",
+            project="p",
+            pages=pl.DataFrame(
+                {
+                    FILENAME: ["cell_a"],
+                    "cellpy_file_name": [str(dest)],
+                }
+            ),
+        )
+    )
+    batch.policy = LoadPolicy(source=SourcePreference.RAW_ONLY)
+    batch._store = CellStore.from_cells({"cell_a": None})
+    batch._result = BatchResult(
+        [
+            CellResult(
+                "cell_a",
+                CellOutcome.LOADED,
+                cell=None,
+                source="raw",
+                seconds=0.1,
+            )
+        ]
+    )
+    facade_mod._persist_cells(batch, tmp_path / "cellpy_batch_t.json")
+    assert dest.read_bytes() == b"from-worker"
+
+
 def test_run_processes_returns_outcomes(parameters):
     j = _one_cell_journal("c45", parameters.cellpy_file_path)
     br = run(j, LoadPolicy(source=SourcePreference.CELLPY_ONLY), executor="processes")


### PR DESCRIPTION
## Summary
- `executor="processes"` strips live cells (pickle). A raw load now writes `.cellpy` in the worker before that strip.
- Parent persist no longer calls `.save()` on `None` (`is_loaded` is false for a cached `None`).
- `Batch.update` lazy-reopens those files so `b.cells[label]` still works.

Closes #920

## Test plan
- [x] `test_dispatch_lite_saves_raw_then_strips`
- [x] `test_persist_skips_none_placeholder_from_processes`
- [x] existing `test_run_processes_returns_outcomes`
- [ ] Re-run the notebook: `batch.load(..., force_raw_file=True, save_cellpy=True, executor="processes")` should finish and write `.cellpy` files
- [ ] Linux CI `pytest -m essential`


Made with [Cursor](https://cursor.com)