### PR TITLE
test(cli): fix red master — check test assumed a configured machine (#891)

### DIFF
--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -45,6 +45,24 @@ def one_failing_check(monkeypatch):
     )
 
 
+@pytest.fixture
+def every_check_passes(monkeypatch):
+    """Stub all three checks green.
+
+    Whether a real machine passes them depends on what is installed and
+    configured - CI has no user config file, so the configuration check fails
+    there quite correctly. A test about the *exit code* must not depend on it.
+    """
+    for name in (
+        "_check_import_cellpy",
+        "_check_import_pyodbc",
+        "_check_config_file",
+    ):
+        monkeypatch.setattr(
+            cli_api, name, lambda: cli_api._CheckOutcome(True, "fine")
+        )
+
+
 # -- info -------------------------------------------------------------------
 
 
@@ -110,10 +128,11 @@ def test_a_failing_check_exits_non_zero(one_failing_check):
 
 
 @pytest.mark.essential
-def test_a_passing_check_exits_zero():
+def test_a_passing_check_exits_zero(every_check_passes):
     result = runner.invoke(cli, ["info", "--check"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, plain(result.output)
+    assert "3 of 3 checks passed" in plain(result.output)
 
 
 @pytest.mark.essential


### PR DESCRIPTION
**Fixes red `master`.** Follow-up to #918.

## What happened

`test_a_passing_check_exits_zero` runs a real `cellpy info --check` and asserts
exit 0. CI has no user config file, so the configuration check fails there —
correctly — and `info --check` now exits 1, which is the behaviour #918
introduced on purpose. The test encodes an assumption about the machine.

I had pushed this fix to the #918 branch, but the PR was merged first; merging
deleted the PR's merge ref, so the follow-up commit never got a CI run and the
flaw went to `master` (`4a190122`), where the `essential` gate is now failing.

## The fix

The test stubs all three checks green and asserts both the exit code and the
`3 of 3 checks passed` verdict, so it exercises the all-pass branch on any
machine. The failing-path tests already stubbed their failure, which is why
they passed in CI.

This is the same environment assumption I removed from
`tests/test_cellpy_cmd.py::test_info_check` in #918 — and then made again in a
new test. `test_info_check` asserts that the exit code *agrees with the printed
verdict*; the two approaches now cover both directions.

## Verified

```
uv run pytest tests/test_cli_info.py -q                       # 11 passed
HOME=/tmp/empty USERPROFILE=/tmp/empty uv run pytest tests/test_cli_info.py -q  # 11 passed
```

The second run approximates CI (no user config file) and is what the original
test would have failed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)