### PR TITLE
fix(plotting): grouped summary facet order, group labels, legend title (#923)

### DIFF
--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -53,6 +53,16 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   `"per_cycle"` (and legacy `fig_pr_*` / `film`) rewrite facet strips to
   `Cycle N` / cell label by default — strips stay visible (unlike summary's
   clear→y-title path). Prefer `layout=` over `method="fig_pr_*"`.
+- **Grouped summary series (#923):** a group-averaged frame is coloured by
+  `group_label` when the collection carries one (from the journal or
+  `custom_group_labels=`) and by `group` otherwise; groups without a label keep
+  their id, and label keys match integer *and* string group ids. Its legend
+  title defaults to **Group** (ungrouped stays **Cell**); `legend_title=`
+  overrides. Facet order comes from `order_variables=`, which
+  `Collection.plot` fills in from the collected `columns=`; variables outside
+  that list (CV split, normalized retention) keep their own order after the
+  listed ones rather than being dropped. Plotly puts the first facet row on
+  top, so the requested order reads down the figure.
 - **ICA `direction=` (#821):** `charge` / `discharge` / `both` on line layouts
   (`layout="per_cell"|"per_cycle"`) and `kind="film"`, not only film. Default
   for collected ICA remains `charge`. `both` overlays half-cycles; on Plotly
@@ -99,3 +109,4 @@ collection.plot(
 - Issue #804 (per-panel y-limits / `share_y`)
 - Issue #801 (theme / label / height hooks)
 - Issue #820 (cycles / ICA pretty facet strips)
+- Issue #923 (grouped summary facet order / group labels / legend title)

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -89,6 +89,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
+| tests/test_collected_summary_groups.py (module) | yes | yes | plotting.collected.summary_plotter / Collection.plot | #923 | facet order, group labels, legend title |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* Grouped summary collections plot the way they were collected: facets follow
+  the `columns=` order instead of coming out alphabetical (derived series such
+  as the CV split or a normalized retention curve keep their own order after
+  the requested ones), `custom_group_labels=` reach the legend (integer *and*
+  string group ids now match; an unlabelled group keeps its id), and the legend
+  title of a grouped summary is **Group** rather than **Cell**. `legend_title=`
+  and `order_variables=` still override. (#923)
+
 * `cellpy info` and `cellpy info --check` report rather than narrate. The check
   run is one line per check with a symbol, a short detail and a hint when it
   fails, closing with `N of M checks passed` - instead of `=== checking ===`

--- a/cellpy/collect/_summary_ops.py
+++ b/cellpy/collect/_summary_ops.py
@@ -158,6 +158,54 @@ def extract_cell_summary(cell: Any, opts: Any) -> pl.DataFrame | None:
     return frame
 
 
+def resolve_group_labels(
+    frame: pl.DataFrame, group_labels: dict[Any, Any] | None
+) -> dict[Any, Any] | None:
+    """Key *group_labels* by the group values actually present in *frame*.
+
+    Journal group ids are integers while a hand-written
+    ``custom_group_labels={1: "first"}`` may arrive with either integer or
+    string keys (JSON round-trips, spreadsheet imports). Matching on the raw
+    key alone silently dropped those labels (#923), so look each present group
+    up by value *and* by its string form.
+    """
+    if not group_labels or "group" not in frame.columns:
+        return None
+    lookup: dict[Any, Any] = {}
+    for key, value in group_labels.items():
+        if value is None:
+            continue
+        lookup.setdefault(key, value)
+        lookup.setdefault(str(key), value)
+    resolved: dict[Any, Any] = {}
+    for group in frame["group"].unique().to_list():
+        if group is None:
+            continue
+        if group in lookup:
+            resolved[group] = lookup[group]
+        elif str(group) in lookup:
+            resolved[group] = lookup[str(group)]
+    return resolved or None
+
+
+def _with_group_label(
+    out: pl.DataFrame, frame: pl.DataFrame, group_labels: dict[Any, Any] | None
+) -> pl.DataFrame:
+    """Add a ``group_label`` column from *group_labels* (no-op when unmapped)."""
+    mapping = resolve_group_labels(frame, group_labels)
+    if not mapping:
+        return out
+    return out.with_columns(
+        pl.col("group")
+        .replace_strict(
+            {key: str(value) for key, value in mapping.items()},
+            default=None,
+            return_dtype=pl.Utf8,
+        )
+        .alias("group_label")
+    )
+
+
 def _numeric_value_columns(frame: pl.DataFrame, keys: tuple[str, ...]) -> list[str]:
     return [
         c
@@ -223,12 +271,7 @@ def group_average(
         agg_expr, pl.col("_v").std().alias("std")
     )
 
-    if group_labels:
-        mapping = {k: v for k, v in group_labels.items() if v is not None}
-        if mapping:
-            out = out.with_columns(
-                pl.col("group").replace(mapping, default=None).alias("group_label")
-            )
+    out = _with_group_label(out, frame, group_labels)
 
     sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
     return out.sort(sort_cols)
@@ -257,12 +300,7 @@ def singletons_as_long(
         index=id_cols, on=value_cols, variable_name="variable", value_name="mean"
     ).with_columns(pl.lit(None).cast(pl.Float64).alias("std"))
 
-    if group_labels:
-        mapping = {k: v for k, v in group_labels.items() if v is not None}
-        if mapping:
-            out = out.with_columns(
-                pl.col("group").replace(mapping, default=None).alias("group_label")
-            )
+    out = _with_group_label(out, frame, group_labels)
 
     sort_cols = [c for c in ("group", CYCLE, "variable") if c in out.columns]
     return out.sort(sort_cols)

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -92,13 +92,21 @@ class Collection:
         ``spread``); ``layout="film"`` aliases ``kind="film"``. Unknown
         layout/kind/method values raise ``ValueError``. Plotly facet strips
         are pretty-printed by default (``Cycle N`` / cell label).
+
+        Summary facets follow the collected ``columns=`` order unless
+        ``order_variables=`` is given (#923); derived series (the CV split, a
+        normalized retention curve) keep their own order after them.
         """
         from cellpy.plotting import collected_plot
 
         family = family_kind or self._FAMILY.get(self.kind, "cycles")
         frame = self.data.to_pandas()
-        if family == "summary" and "cycle_num" in frame.columns:
-            frame = frame.rename(columns={"cycle_num": "cycle"})
+        if family == "summary":
+            if "cycle_num" in frame.columns:
+                frame = frame.rename(columns={"cycle_num": "cycle"})
+            requested = (self.meta.options or {}).get("columns")
+            if requested and "order_variables" not in kwargs:
+                kwargs = {**kwargs, "order_variables": list(requested)}
         return collected_plot(frame, family_kind=family, **kwargs)
 
     def to_image(self, fmt: str = "png", *, scale: float = 1.0, **plot_kwargs) -> bytes:

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -689,24 +689,28 @@ def sequence_plotter(
                 annotations = fig.layout.annotations
                 if annotations:
                     try:
-                        for i in range(len(annotations)):
-                            row = i + 1
-                            if annotations[i].text.startswith("variable="):
-                                variable = annotations[i].text.split("=")[1]
-                                if variable in y_label_mapper:
-                                    v = y_label_mapper[variable]
-                                    fig.for_each_yaxis(
-                                        functools.partial(y_axis_replacer, label=v),
-                                        row=row,
-                                    )
+                        for annotation in annotations:
+                            text = annotation.text or ""
+                            if text.startswith("variable="):
+                                variable = text.split("=", 1)[1]
+                                label = y_label_mapper.get(variable)
                             else:
-                                for k, v in y_label_mapper.items():
-                                    if annotations[i].text.endswith(k):
-                                        fig.for_each_yaxis(
-                                            functools.partial(y_axis_replacer, label=v),
-                                            row=row,
-                                        )
-                                        break
+                                label = next(
+                                    (
+                                        v
+                                        for k, v in y_label_mapper.items()
+                                        if text.endswith(k)
+                                    ),
+                                    None,
+                                )
+                            if label is None:
+                                continue
+                            # Resolve the axis from the strip's own position
+                            # rather than assuming the annotation order lines
+                            # up with Plotly's row numbering (#923).
+                            key = _yaxis_key_for_facet_label(fig, text)
+                            if key is not None:
+                                y_axis_replacer(fig.layout[key], label)
 
                         fig.update_annotations(text="")
 
@@ -1287,6 +1291,18 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
       built automatically (facet ``variable=…`` strip cleared).
     - ``height`` / ``height_per_panel`` (alias of ``sub_fig_min_height``) /
       ``figure_border_height``: absolute or per-panel height control.
+
+    Facets and legend (#923):
+
+    - ``order_variables``: list of ``variable`` names giving the facet order.
+      Variables outside the list (derived series such as the CV split or a
+      normalized retention curve) keep their own order after the listed ones.
+      :meth:`cellpy.collect.Collection.plot` fills this in from the collected
+      ``columns=``.
+    - A grouped frame (``mean``/``std``) is coloured by ``group_label`` when the
+      collection carries one (``custom_group_labels=``), else by ``group``, and
+      its legend title defaults to ``"Group"`` instead of ``"Cell"``.
+      ``legend_title=`` still overrides.
     """
 
     # start_cell is used to determine the starting cell for the subplots (plotly)
@@ -1371,6 +1387,23 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
         # the series is the group, not the (absent) per-cell column
         if hdr_journal.group in id_vars:
             z = hdr_journal.group
+        # Journal / custom group labels beat the bare group id in the legend
+        # (#923). Groups without a label keep the id so nothing goes missing.
+        label_column = hdr_journal.group_label
+        if label_column in collected_curves.columns:
+            labels = collected_curves[label_column]
+            if labels.notna().any():
+                fallback = (
+                    collected_curves[z].astype(str)
+                    if z in collected_curves.columns
+                    else ""
+                )
+                collected_curves = collected_curves.assign(
+                    **{label_column: labels.where(labels.notna(), fallback)}
+                )
+                z = label_column
+        # A grouped summary has groups in the legend, not cells (#923).
+        kwargs.setdefault("legend_title", "Group")
 
     else:
         y = "value"
@@ -1382,8 +1415,16 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
     # order the variables by a given order:
     order_variables = kwargs.pop("order_variables", None)
     if order_variables:
+        # Variables that are not in the requested order (derived series such as
+        # the CV split or a normalized retention curve) keep their own order
+        # after the requested ones -- listing them as categories would drop
+        # their rows to NaN and lose a facet (#923).
+        present = list(pd.unique(collected_curves[g]))
+        categories = [v for v in order_variables if v in present]
+        categories += [v for v in present if v not in categories]
+        collected_curves = collected_curves.copy()
         collected_curves[g] = collected_curves[g].astype(
-            pd.CategoricalDtype(categories=order_variables, ordered=True)
+            pd.CategoricalDtype(categories=categories, ordered=True)
         )
         collected_curves = collected_curves.sort_values(by=[g, z, x])
 

--- a/tests/test_collected_summary_groups.py
+++ b/tests/test_collected_summary_groups.py
@@ -1,0 +1,198 @@
+"""Grouped summary collections: facet order, group labels, legend title (#923)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from cellpy.collect.collection import Collection, CollectionMeta
+
+_COLUMNS = ("cap_charge", "cap_discharge", "ce")
+
+
+def _grouped_collection(
+    columns: tuple[str, ...] = _COLUMNS,
+    *,
+    labels: dict | None = None,
+    extra_variable: str | None = None,
+) -> Collection:
+    """A group-averaged summary collection (the ``group_it=True`` long shape)."""
+    variables = list(columns) + ([extra_variable] if extra_variable else [])
+    rows = []
+    for group in (1, 2):
+        for cycle in (1, 2, 3):
+            for variable in variables:
+                rows.append(
+                    {
+                        "group": group,
+                        "cycle_num": cycle,
+                        "variable": variable,
+                        "mean": 100.0 + cycle + group,
+                        "std": 1.0,
+                        "group_label": (labels or {}).get(group),
+                    }
+                )
+    frame = pl.DataFrame(rows)
+    if labels is None:
+        frame = frame.drop("group_label")
+    return Collection(
+        data=frame,
+        kind="summary",
+        name="demo",
+        meta=CollectionMeta(
+            kind="summary", options={"columns": list(columns)}, grouped=True
+        ),
+    )
+
+
+def _identity_mapper(*names: str) -> dict[str, str]:
+    """A ``y_label_mapper`` that puts the variable name on the y-axis."""
+    return {name: name for name in names}
+
+
+def _facet_labels(fig) -> list[str]:
+    """Y-axis titles read down the figure.
+
+    Plotly puts the first facet row on top, so this is the order a reader sees
+    and the order ``columns=`` is supposed to set.
+    """
+    axes = [
+        (float(fig.layout[key].domain[1]), fig.layout[key].title.text)
+        for key in fig.layout
+        if str(key).startswith("yaxis") and fig.layout[key].domain
+    ]
+    return [title for _, title in sorted(axes, key=lambda item: -item[0])]
+
+
+@pytest.mark.essential
+def test_grouped_summary_facets_follow_the_collected_column_order():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    columns = ("cap_charge", "cap_discharge", "ce")
+    fig = _grouped_collection(columns).plot(y_label_mapper=_identity_mapper(*columns))
+    # The old frame was sorted by ``variable``, so the facets came out
+    # alphabetically (cap_charge, cap_discharge, ce happens to differ from the
+    # requested order below).
+    assert _facet_labels(fig) == list(columns)
+
+
+@pytest.mark.essential
+def test_grouped_summary_facet_order_is_the_requested_one_not_alphabetical():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    columns = ("cap_charge", "ce", "cap_discharge")
+    fig = _grouped_collection(columns).plot(y_label_mapper=_identity_mapper(*columns))
+    assert _facet_labels(fig) == list(columns)
+
+
+@pytest.mark.essential
+def test_order_variables_keeps_variables_outside_the_requested_list():
+    """A derived series (retention, CV split) must not lose its facet (#923)."""
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    columns = ("cap_charge", "cap_discharge")
+    collection = _grouped_collection(columns, extra_variable="cap_retention")
+    fig = collection.plot(
+        y_label_mapper=_identity_mapper(*columns, "cap_retention")
+    )
+    assert _facet_labels(fig) == ["cap_charge", "cap_discharge", "cap_retention"]
+
+
+@pytest.mark.essential
+def test_explicit_order_variables_wins_over_the_collected_columns():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = _grouped_collection().plot(
+        order_variables=["ce", "cap_charge", "cap_discharge"],
+        y_label_mapper=_identity_mapper(*_COLUMNS),
+    )
+    assert _facet_labels(fig) == ["ce", "cap_charge", "cap_discharge"]
+
+
+@pytest.mark.essential
+def test_custom_group_labels_are_the_legend_entries():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    collection = _grouped_collection(
+        labels={1: "my_first_group", 2: "my_second_group"}
+    )
+    fig = collection.plot()
+    assert {trace.name for trace in fig.data} == {
+        "my_first_group",
+        "my_second_group",
+    }
+
+
+@pytest.mark.essential
+def test_unlabelled_groups_keep_their_id_in_the_legend():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = _grouped_collection(labels={1: "labelled"}).plot()
+    assert {trace.name for trace in fig.data} == {"labelled", "2"}
+
+
+@pytest.mark.essential
+def test_grouped_summary_legend_title_is_group():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = _grouped_collection().plot()
+    assert fig.layout.legend.title.text == "Group"
+
+
+@pytest.mark.essential
+def test_explicit_legend_title_still_wins_for_a_grouped_summary():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    fig = _grouped_collection().plot(legend_title="Sample")
+    assert fig.layout.legend.title.text == "Sample"
+
+
+@pytest.mark.essential
+def test_ungrouped_summary_legend_title_stays_cell():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    frame = pl.DataFrame(
+        {
+            "cell": ["a", "a", "b", "b"],
+            "cycle_num": [1, 2, 1, 2],
+            "group": [1, 1, 2, 2],
+            "sub_group": [1, 1, 1, 1],
+            "cap_charge": [100.0, 101.0, 90.0, 91.0],
+        }
+    )
+    collection = Collection(
+        data=frame, kind="summary", name="demo", meta=CollectionMeta(kind="summary")
+    )
+    fig = collection.plot(group_cells=False)
+    assert fig.layout.legend.title.text == "Cell"
+
+
+# --- collect side: label keys that are not the journal's dtype ------------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("keys", [(1, 2), ("1", "2")], ids=["int", "str"])
+def test_custom_group_labels_match_int_and_str_group_ids(keys):
+    from types import SimpleNamespace
+
+    from cellpy.batch import Batch, Journal
+    from cellpy.batch.journal import FILENAME
+    from cellpy.batch.store import CellStore
+    from cellpy.collect import collect_summaries
+
+    class _Cell:
+        def __init__(self, scale):
+            self.data = SimpleNamespace(
+                summary=pl.DataFrame(
+                    {"cycle_num": [1, 2], "cap_charge": [10.0 * scale, 20.0 * scale]}
+                ),
+                steps=None,
+            )
+
+    pages = pl.DataFrame(
+        {FILENAME: ["a", "b", "c", "d"], "group": [1, 1, 2, 2], "sub_group": [1, 2, 1, 2]}
+    )
+    batch = Batch(Journal(name="b", project="p", pages=pages))
+    batch._store = CellStore.from_cells(
+        {"a": _Cell(1), "b": _Cell(1.1), "c": _Cell(0.9), "d": _Cell(1.2)}
+    )
+
+    first, second = keys
+    collection = collect_summaries(
+        batch,
+        group_it=True,
+        columns=("cap_charge",),
+        custom_group_labels={first: "alpha", second: "beta"},
+    )
+    assert set(collection.data["group_label"].to_list()) == {"alpha", "beta"}


### PR DESCRIPTION
Closes #923.

`summary_collector(b, columns=[charge, discharge, ce], group_it=True, custom_group_labels={1: "a", 2: "b"}).plot()` got three things wrong. All three are fixed here.

**1. Facets came out alphabetical.** The grouped frame is sorted by `variable`, and `Collection.plot` never forwarded the collected `columns=` as `order_variables`. It does now. Variables *outside* that list — the CV split, a normalized retention curve — are appended in their own order instead of being dropped to NaN, which is what listing only the requested ones as categories would have done.

**2. `custom_group_labels` never reached the legend.** The plotter coloured by `group`. A grouped frame is now coloured by `group_label` when the collection carries one, falling back per group to the group id so an unlabelled group does not go missing. On the collect side the labels are keyed by the group values actually present, matching integer and string keys both ways (a JSON round-trip or a spreadsheet import can turn `1` into `"1"`), using `replace_strict` instead of the deprecated `replace(default=)`.

**3. The legend title said "Cell".** It now defaults to **Group** for a grouped summary. `legend_title=` still overrides and ungrouped stays **Cell**.

### Also

The y-label mapper now resolves each facet's axis from the strip's own position instead of assuming the annotation order lines up with Plotly's row numbering. That is equivalent today — the two orderings happen to agree — but the new tests pin the pairing rather than the coincidence, so a future Plotly change fails loudly.

### Notes

Plotly puts the first facet row on top, so the requested `columns=` order reads down the figure. `tests/test_collected_summary_groups.py` asserts labels top-to-bottom for exactly that reason.

Out of scope, as the issue says: the cookiecutter notebook copy, and ungrouped legends (still **Cell**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)