### PR TITLE
feat(collect): named plot family + documented collector kwargs (#924, #927)

### DIFF
--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -89,6 +89,12 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
+| tests/test_collect.py::test_summary_collector_accepts_a_named_family | yes | yes | collect.collector.summary_collector family= | #927 | same frame as family.summary_options |
+| tests/test_collect.py::test_summary_collector_y_is_an_alias_for_family | yes | yes | collect.collector.summary_collector y= | #927 | summary_plot name parity |
+| tests/test_collect.py::test_summary_collector_rejects_an_unknown_family | yes | yes | collect.collector._family_options | #927 | get_family ValueError |
+| tests/test_collect.py::test_explicit_columns_win_over_the_family | yes | yes | collect.collector.summary_collector | #927 | precedence |
+| tests/test_collect.py::test_a_family_needs_a_cell_to_resolve_its_columns | yes | yes | collect.collector._summary_headers | #927 | header-bound families |
+| tests/test_collect.py::test_collector_help_names_the_common_kwargs | yes | yes | collect.collector signatures/docstrings | #924 | Jupyter Shift-Tab contract |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+* Collector help is usable from Jupyter: `summary_collector`, `cycles_collector`,
+  `ica_collector` and `dva_collector` spell out the kwargs people actually pass
+  (`columns`, `group_it`, `custom_group_labels`, `rate`, `cycles`, `mode`,
+  `voltage_resolution`, …) in their signature and a Google-style docstring, and
+  point at `SummaryOptions` / `CurveOptions` / `IcaOptions` for the rest.
+  Shift-Tab no longer shows a one-line wrapper and `**overrides`. (#924)
+
+* `summary_collector(b, family="fullcell_standard_gravimetric")` (or `y=`, the
+  `summary_plot` alias) builds the collection from a registered plot family,
+  resolved against the first loaded cell's summary schema. Explicit `columns=`
+  / `options=` still win; an unknown name raises the same `ValueError` that
+  lists the known families. (#927)
+
 * `cellpy info` and `cellpy info --check` report rather than narrate. The check
   run is one line per check with a symbol, a short detail and a hint when it
   fails, closing with `N of M checks passed` - instead of `=== checking ===`

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -12,6 +12,7 @@ layers -- with a single options object plus a collect callable. The
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Callable
 
@@ -80,7 +81,16 @@ class BatchCollector:
         return self.collection.save(directory, **kwargs)
 
     def plot(self, **kwargs) -> Any:
-        """Draw the collection via ``cellpy.plotting``."""
+        """Draw the collection via ``cellpy.plotting``.
+
+        Args:
+            **kwargs: Forwarded to :meth:`cellpy.collect.Collection.plot` --
+                e.g. ``height``, ``backend``, ``legend_title`` or
+                ``layout`` / ``kind`` (cycles / ICA / DVA).
+
+        Returns:
+            A backend-native figure object.
+        """
         plot = getattr(self.collection, "plot", None)
         if plot is None:
             raise NotImplementedError(
@@ -95,33 +105,256 @@ class BatchCollector:
         return f"<BatchCollector {self.name!r} kind={kind} rows={rows}>"
 
 
+def _given(**candidates: Any) -> dict[str, Any]:
+    """Keep only the arguments the caller actually set (``None`` = not set).
+
+    The convenience collectors spell the common options out in their signature
+    so Jupyter's ``Shift-Tab`` shows them (#924), but the defaults live on the
+    options dataclasses -- passing ``None`` through would overwrite them.
+    """
+    return {name: value for name, value in candidates.items() if value is not None}
+
+
+def _summary_headers(batch: Any) -> Any:
+    """The summary header set (``c.schema.summary``) of the batch's first cell.
+
+    Named plot families are header-bound, so resolving one for a batch needs a
+    loaded cell (#927). Any included cell will do -- a batch mixing schemas is
+    not collectable into one frame anyway.
+    """
+    for cell in getattr(batch, "cells", {}).values():
+        schema = getattr(cell, "schema", None)
+        headers = getattr(schema, "summary", None)
+        if headers is not None:
+            return headers
+    raise ValueError(
+        "cannot resolve a plot family without a loaded cell: the family's "
+        "columns depend on the cell's summary schema. Load the batch first "
+        "(b.update() / b.load()), or pass columns= / options= directly."
+    )
+
+
+def _family_options(batch: Any, name: str) -> SummaryOptions:
+    """Build :class:`SummaryOptions` for the named family (see #927/#868)."""
+    from cellpy.plotting import get_family
+
+    return get_family(name).summary_options(_summary_headers(batch))
+
+
 def summary_collector(
-    batch: Any, options: SummaryOptions | None = None, *, autorun: bool = True, **overrides
+    batch: Any,
+    options: SummaryOptions | None = None,
+    *,
+    family: str | None = None,
+    y: str | None = None,
+    columns: Any = None,
+    group_it: bool | None = None,
+    custom_group_labels: Any = None,
+    rate: float | None = None,
+    max_cycle: int | None = None,
+    partition_by_cv: bool | None = None,
+    autorun: bool = True,
+    **overrides,
 ) -> BatchCollector:
-    """Convenience :class:`BatchCollector` bound to :func:`collect_summaries`."""
+    """Collect the per-cell summaries of a batch (cycle-life data).
+
+    Returns a :class:`BatchCollector` holding a
+    :class:`~cellpy.collect.Collection`: ``.data`` is the tidy frame, ``.plot()``
+    draws it and ``.save(dir)`` writes the frame plus its metadata.
+
+    Examples:
+        >>> caps = summary_collector(b, family="fullcell_standard_gravimetric",
+        ...                          group_it=True)
+        >>> caps.plot(height=600)
+
+    Args:
+        batch: The :class:`~cellpy.batch.Batch` to collect from.
+        options (SummaryOptions, optional): A ready options object. Wins over
+            ``family`` and is still updated by the keyword arguments below.
+        family (str, optional): Name of a registered plot family, the same
+            names ``summary_plot(y=...)`` takes (``capacities_gravimetric``,
+            ``fullcell_standard_gravimetric``, ...). Its columns and transforms
+            are resolved against the first loaded cell's summary schema. An
+            unknown name raises ``ValueError`` listing the known families;
+            ``cellpy.plotting.families()`` lists them too.
+        y (str, optional): Alias of ``family``, matching ``summary_plot(y=...)``.
+        columns (sequence of str, optional): Summary columns to keep. Wins over
+            ``family``. Journal keys (cell/group/...) are always kept.
+        group_it (bool, optional): Average per journal group -> tidy long frame
+            ``(group, cycle_num, variable, mean, std)``.
+        custom_group_labels (mapping, optional): ``group id -> display label``,
+            used for the plot legend (int or str keys both match).
+        rate (float, optional): Keep only cycles run at this C-rate (see
+            ``rate_on`` / ``rate_std`` / ``rate_inverted`` on
+            :class:`~cellpy.collect.SummaryOptions`).
+        max_cycle (int, optional): Drop cycles above this number.
+        partition_by_cv (bool, optional): Also emit ``*_non_cv`` / ``*_cv``
+            capacity contributions.
+        autorun (bool): Run the collector immediately (default ``True``).
+        **overrides: Any other field of
+            :class:`~cellpy.collect.SummaryOptions` -- ``rate_on``,
+            ``rate_std``, ``rate_inverted``, ``only_selected``, ``remove_last``,
+            ``normalize_cycles``, ``average_method``, ``transforms``, ...
+
+    Returns:
+        BatchCollector: bound to :func:`cellpy.collect.collect_summaries`.
+
+    Raises:
+        ValueError: ``family``/``y`` is not a registered family, or no loaded
+            cell is available to resolve it against.
+    """
+    name = family or y
+    if options is not None and name is not None:
+        logging.info(
+            "summary_collector: options= is explicit, ignoring family=%r", name
+        )
+    elif name is not None:
+        options = _family_options(batch, name)
+
+    overrides = {
+        **_given(
+            columns=columns,
+            group_it=group_it,
+            custom_group_labels=custom_group_labels,
+            rate=rate,
+            max_cycle=max_cycle,
+            partition_by_cv=partition_by_cv,
+        ),
+        **overrides,
+    }
     return BatchCollector(
         batch, collect_summaries, options, autorun=autorun, **overrides
     )
 
 
 def cycles_collector(
-    batch: Any, options: CurveOptions | None = None, *, autorun: bool = True, **overrides
+    batch: Any,
+    options: CurveOptions | None = None,
+    *,
+    cycles: Any = None,
+    rate: float | None = None,
+    mode: str | None = None,
+    method: str | None = None,
+    autorun: bool = True,
+    **overrides,
 ) -> BatchCollector:
-    """Convenience :class:`BatchCollector` bound to :func:`collect_cycles`."""
+    """Collect voltage-capacity curves per cell and cycle.
+
+    Returns a :class:`BatchCollector` holding a
+    :class:`~cellpy.collect.Collection`: ``.data`` is the tidy frame, ``.plot()``
+    draws it and ``.save(dir)`` writes the frame plus its metadata.
+
+    Examples:
+        >>> curves = cycles_collector(b, cycles=[1, 10, 20])
+        >>> curves.plot(layout="per_cell")  # or layout="per_cycle", kind="film"
+
+    Args:
+        batch: The :class:`~cellpy.batch.Batch` to collect from.
+        options (CurveOptions, optional): A ready options object; the keyword
+            arguments below still update it.
+        cycles (sequence of int, optional): Cycles to collect. Resolved **per
+            cell**, so a cell missing one cycle does not narrow the others.
+        rate (float, optional): Rate-based cycle selection (see ``rate_on`` /
+            ``rate_std`` / ``inverse`` on
+            :class:`~cellpy.collect.CurveOptions`).
+        mode (str, optional): Capacity mode forwarded to ``CellpyCell.get_cap``
+            (``gravimetric`` / ``areal`` / ``absolute``).
+        method (str, optional): ``forth-and-forth`` / ``back-and-forth`` /
+            ``forth``, forwarded to ``CellpyCell.get_cap``.
+        autorun (bool): Run the collector immediately (default ``True``).
+        **overrides: Any other field of
+            :class:`~cellpy.collect.CurveOptions` -- ``rate_on``, ``rate_std``,
+            ``inverse``, ``transforms``.
+
+    Returns:
+        BatchCollector: bound to :func:`cellpy.collect.collect_cycles`.
+    """
+    overrides = {
+        **_given(cycles=cycles, rate=rate, mode=mode, method=method),
+        **overrides,
+    }
     return BatchCollector(batch, collect_cycles, options, autorun=autorun, **overrides)
 
 
 def ica_collector(
-    batch: Any, options: IcaOptions | None = None, *, autorun: bool = True, **overrides
+    batch: Any,
+    options: IcaOptions | None = None,
+    *,
+    cycles: Any = None,
+    voltage_resolution: float | None = None,
+    autorun: bool = True,
+    **overrides,
 ) -> BatchCollector:
-    """Convenience :class:`BatchCollector` bound to :func:`collect_ica`."""
+    """Collect incremental-capacity (dQ/dV) curves per cell and cycle.
+
+    Returns a :class:`BatchCollector` holding a
+    :class:`~cellpy.collect.Collection`: ``.data`` is the tidy frame, ``.plot()``
+    draws it and ``.save(dir)`` writes the frame plus its metadata.
+
+    Examples:
+        >>> ica = ica_collector(b, cycles=[1, 10, 20])
+        >>> ica.plot(layout="per_cell")
+
+    Args:
+        batch: The :class:`~cellpy.batch.Batch` to collect from.
+        options (IcaOptions, optional): A ready options object; the keyword
+            arguments below still update it.
+        cycles (sequence of int, optional): Cycles to collect (resolved per
+            cell).
+        voltage_resolution (float, optional): Voltage step for the q(V)
+            interpolation dQ/dV differentiates along.
+        autorun (bool): Run the collector immediately (default ``True``).
+        **overrides: Any other field of
+            :class:`~cellpy.collect.IcaOptions` -- ``transforms``.
+
+    Returns:
+        BatchCollector: bound to :func:`cellpy.collect.collect_ica`.
+    """
+    overrides = {
+        **_given(cycles=cycles, voltage_resolution=voltage_resolution),
+        **overrides,
+    }
     return BatchCollector(batch, collect_ica, options, autorun=autorun, **overrides)
 
 
 def dva_collector(
-    batch: Any, options: IcaOptions | None = None, *, autorun: bool = True, **overrides
+    batch: Any,
+    options: IcaOptions | None = None,
+    *,
+    cycles: Any = None,
+    capacity_resolution: float | None = None,
+    autorun: bool = True,
+    **overrides,
 ) -> BatchCollector:
-    """Convenience :class:`BatchCollector` bound to :func:`collect_dva`."""
+    """Collect differential-voltage (dV/dQ) curves per cell and cycle.
+
+    Returns a :class:`BatchCollector` holding a
+    :class:`~cellpy.collect.Collection`: ``.data`` is the tidy frame, ``.plot()``
+    draws it and ``.save(dir)`` writes the frame plus its metadata.
+
+    Examples:
+        >>> dva = dva_collector(b, cycles=[1, 10, 20])
+        >>> dva.plot(layout="per_cell")
+
+    Args:
+        batch: The :class:`~cellpy.batch.Batch` to collect from.
+        options (IcaOptions, optional): A ready options object; the keyword
+            arguments below still update it.
+        cycles (sequence of int, optional): Cycles to collect (resolved per
+            cell).
+        capacity_resolution (float, optional): Capacity step for the V(q)
+            interpolation dV/dQ differentiates along.
+        autorun (bool): Run the collector immediately (default ``True``).
+        **overrides: Any other field of
+            :class:`~cellpy.collect.IcaOptions` -- ``transforms``.
+
+    Returns:
+        BatchCollector: bound to :func:`cellpy.collect.collect_dva`.
+    """
+    overrides = {
+        **_given(cycles=cycles, capacity_resolution=capacity_resolution),
+        **overrides,
+    }
     return BatchCollector(batch, collect_dva, options, autorun=autorun, **overrides)
 
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -17,6 +17,9 @@ from cellpy.collect import (
     SummaryOptions,
     collect_cycles,
     collect_summaries,
+    cycles_collector,
+    dva_collector,
+    ica_collector,
     load_collection,
     normalize_column,
     normalize_column_on_max,
@@ -535,3 +538,82 @@ def test_normalize_column_on_max_wide_and_grouped():
     assert added["std"].to_list() == pytest.approx([5.0, 10.0])
 
     assert normalize_column_on_max("nope")(wide).equals(wide)
+
+
+# ---- named plot family on the collector (#927) --------------------------
+
+
+@pytest.mark.essential
+def test_summary_collector_accepts_a_named_family(real_batch, real_cell):
+    """``family=`` must collect exactly what ``family.summary_options`` asks for."""
+    hdr = real_cell.schema.summary
+    family = registry.get("fullcell_standard_gravimetric")
+    expected = collect_summaries(real_batch, options=family.summary_options(hdr)).data
+
+    data = summary_collector(real_batch, family="fullcell_standard_gravimetric").data
+
+    assert data.columns == expected.columns
+    assert data.equals(expected)
+
+
+@pytest.mark.essential
+def test_summary_collector_y_is_an_alias_for_family(real_batch):
+    """Same names as ``summary_plot(y=...)``, so ``y=`` must work too (#927)."""
+    by_family = summary_collector(real_batch, family="capacities_gravimetric").data
+    by_y = summary_collector(real_batch, y="capacities_gravimetric").data
+    assert by_family.equals(by_y)
+
+
+@pytest.mark.essential
+def test_summary_collector_rejects_an_unknown_family(real_batch):
+    with pytest.raises(ValueError, match="unknown plot family"):
+        summary_collector(real_batch, family="not_a_family")
+
+
+@pytest.mark.essential
+def test_explicit_columns_win_over_the_family(real_batch):
+    data = summary_collector(
+        real_batch,
+        family="capacities_gravimetric",
+        columns=("charge_capacity_gravimetric",),
+    ).data
+    assert "charge_capacity_gravimetric" in data.columns
+    assert "discharge_capacity_gravimetric" not in data.columns
+
+
+@pytest.mark.essential
+def test_a_family_needs_a_cell_to_resolve_its_columns():
+    pages = pl.DataFrame({FILENAME: ["x"], "group": [1], "sub_group": [1]})
+    b = _batch_with_cells({"x": _SummaryCell([1.0, 2.0])}, pages)  # no .schema
+    with pytest.raises(ValueError, match="without a loaded cell"):
+        summary_collector(b, family="capacities_gravimetric")
+
+
+# ---- collector help lists the kwargs users actually pass (#924) ---------
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    ("collector", "expected"),
+    [
+        (
+            summary_collector,
+            ("family", "columns", "group_it", "custom_group_labels", "rate"),
+        ),
+        (cycles_collector, ("cycles", "rate", "mode", "method")),
+        (ica_collector, ("cycles", "voltage_resolution")),
+        (dva_collector, ("cycles", "capacity_resolution")),
+    ],
+    ids=["summary", "cycles", "ica", "dva"],
+)
+def test_collector_help_names_the_common_kwargs(collector, expected):
+    """Shift-Tab in Jupyter must show more than ``**overrides`` (#924)."""
+    import inspect
+
+    parameters = inspect.signature(collector).parameters
+    doc = inspect.getdoc(collector) or ""
+    for name in expected:
+        assert name in parameters, f"{collector.__name__} signature misses {name}"
+        assert f"{name} " in doc, f"{collector.__name__} docstring misses {name}"
+    # and the escape hatch to the full option set is named
+    assert "Options" in doc


### PR DESCRIPTION
Closes #927. Closes #924.

Two issues in one PR because they land on the same signature and docstring — `family=` is one of the kwargs the help has to show, so splitting them would mean writing `summary_collector` twice.

### #927 — named plot family

```python
summary_collector(b, family="fullcell_standard_gravimetric", group_it=True)
```

builds `SummaryOptions` from a registered `PlotFamily` (`y=` works too, matching `summary_plot`'s alias). The plumbing has been there since #868 — `PlotFamily.summary_options(hdr)` — this is the user-facing shortcut, so the cookiecutter notebook no longer has to spell `columns=[...]` by hand.

- Families are header-bound, so this resolves `hdr` from the first loaded cell. No loaded cell → `ValueError` that says so and points at `columns=` / `options=`.
- Explicit `columns=` / `options=` still win.
- An unknown name raises `get_family`'s own `ValueError`, which already lists the known families.
- `standard_gravimetric()` is untouched.

### #924 — usable Jupyter help

`summary_collector` / `cycles_collector` / `ica_collector` / `dva_collector` used to show

```
summary_collector(batch, options=None, *, autorun=True, **overrides) -> BatchCollector
Convenience BatchCollector bound to collect_summaries.
```

while the notebook called them with `columns`, `group_it`, `custom_group_labels`. Those now appear in the signature and in a Google-style docstring that says what comes back, how to plot and save it, and where the full option set lives (`SummaryOptions` / `CurveOptions` / `IcaOptions`).

A `None` argument means "not set" and is dropped before reaching the options dataclass, so the dataclass defaults still apply — `group_it=None` does not become `group_it=False`.

`tests/test_collect.py::test_collector_help_names_the_common_kwargs` pins the Shift-Tab contract for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)