### PR TITLE
fix(plotting): collected backend="matplotlib" no longer raises (#925)

### DIFF
--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -89,6 +89,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
+| tests/test_collected_backend_alias.py (module) | yes | yes | plotting.collected.collected_plot backend alias | #925 | matplotlib -> seaborn, warn_once signature |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* `Collection.plot(backend="matplotlib")` no longer raises
+  `TypeError: warn_once() missing 1 required positional argument`. It keeps
+  aliasing to the seaborn layout path (and now actually returns a figure -
+  the y-label mapper crashed on the summary path). (#925)
+
 * `cellpy info` and `cellpy info --check` report rather than narrate. The check
   run is one line per check with a symbol, a short detail and a hint when it
   fails, closing with `N of M checks passed` - instead of `=== checking ===`

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -897,8 +897,23 @@ def sequence_plotter(
 
             g.set_xlabels(x_label)
             if y_label_mapper:
+                # ``y_label_mapper`` is keyed by variable name (summary_plotter
+                # builds one by default); the FacetGrid rows are in
+                # ``g.row_names`` order. Fall back to positional keys for the
+                # legacy list/dict-by-index shape (#925).
+                row_names = list(getattr(g, "row_names", None) or [])
+                mapper = y_label_mapper if isinstance(y_label_mapper, dict) else None
                 for i, ax in enumerate(g.axes.flat):
-                    ax.set_ylabel(y_label_mapper[i])
+                    label = None
+                    if mapper is not None and i < len(row_names):
+                        label = mapper.get(row_names[i])
+                    if label is None:
+                        try:
+                            label = y_label_mapper[i]
+                        except (KeyError, IndexError, TypeError):
+                            label = None
+                    if label is not None:
+                        ax.set_ylabel(label)
             g.add_legend()
             return fig
 
@@ -1896,9 +1911,13 @@ def collected_plot(
 
     backend_key = (backend or "plotly").strip().lower()
     if backend_key == "matplotlib":
+        # The collected layouts have no matplotlib engine of their own; the
+        # historical seaborn path is the best-effort stand-in (#925).
         warn_once(
-            "collected_plot: backend='matplotlib' uses the collectors seaborn "
-            "layout path (best-effort parity); prefer backend='plotly'.",
+            'collected_plot(backend="matplotlib")',
+            'backend="plotly"',
+            removal="2.3",
+            introduced="2.1",
             stacklevel=2,
         )
         backend_key = "seaborn"

--- a/tests/test_collected_backend_alias.py
+++ b/tests/test_collected_backend_alias.py
@@ -1,0 +1,77 @@
+"""``collected_plot(backend="matplotlib")`` on a collected frame (#925).
+
+The collected layouts have no matplotlib engine of their own, so the flag
+aliases to the historical seaborn path. It used to raise ``TypeError`` from
+``warn_once`` before drawing anything, and the summary path raised again on the
+y-label mapper once that was fixed, so this call had never returned a figure.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+
+def _grouped_summary_frame() -> pd.DataFrame:
+    """A group-averaged summary frame (the ``group_it=True`` long shape)."""
+    rows = []
+    for group in (1, 2):
+        for cycle in (1, 2, 3):
+            for variable in ("cap_charge", "cap_discharge", "ce"):
+                rows.append(
+                    {
+                        "group": group,
+                        "cycle": cycle,
+                        "variable": variable,
+                        "mean": 100.0 + cycle + group,
+                        "std": 1.0,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+@pytest.mark.essential
+def test_collected_summary_matplotlib_backend_returns_a_figure():
+    pytest.importorskip("seaborn", reason="plotting extras (batch) not installed")
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    from cellpy.plotting.collected import collected_plot
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        figure = collected_plot(
+            _grouped_summary_frame(),
+            family_kind="summary",
+            backend="matplotlib",
+            height=600,
+        )
+
+    assert figure is not None
+    messages = [str(w.message) for w in caught]
+    assert any('backend="matplotlib"' in message for message in messages)
+
+
+@pytest.mark.essential
+def test_the_notice_names_a_replacement():
+    """``warn_once`` takes ``(name, replacement)``, not a ready message."""
+    pytest.importorskip("seaborn", reason="plotting extras (batch) not installed")
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    from cellpy import _deprecation
+    from cellpy.plotting.collected import collected_plot
+
+    _deprecation._WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        collected_plot(
+            _grouped_summary_frame(), family_kind="summary", backend="matplotlib"
+        )
+
+    messages = [str(w.message) for w in caught]
+    assert any('use backend="plotly" instead' in message for message in messages)


### PR DESCRIPTION
Closes #925.

`cap_summaries.plot(height=600, backend="matplotlib")` died with

```
TypeError: warn_once() missing 1 required positional argument: 'replacement'
```

before drawing anything. `collected_plot` called `warn_once` the way you call `warnings.warn` — one ready message plus `stacklevel` — but `warn_once(name, replacement, ...)` builds the message itself.

Fixing that exposed a **second** crash on the same path, which is why this call had never returned a figure: `summary_plotter` always builds a `y_label_mapper` keyed by variable name (since #801), while the seaborn summary branch indexed it positionally (`y_label_mapper[i]`) — a `KeyError` on the first axis. The label is now resolved from the `FacetGrid`'s `row_names`, keeping the positional lookup as a fallback for the legacy list shape.

`backend="matplotlib"` still aliases to the historical seaborn layout path, as `plotting-collected.md` documents; the notice now names a replacement.

### Note for review

The issue asked for `warn_once(name, replacement, ...)`, whose message template reads *"… is deprecated; use X instead (removed in 2.3)"*. The collected matplotlib alias is not actually scheduled for removal, so if you do not intend to drop it, say so and I will swap this for a plain `UserWarning` — the crash fix is independent of that choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)