### PR TITLE
feat(collect): make collection figure export discoverable (#926)

### DIFF
--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -89,6 +89,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
+| tests/test_collect.py::test_batch_collector_to_image | yes | yes | collect.collector.BatchCollector.to_image | #926 | proxies Collection.to_image |
+| tests/test_collect.py::test_batch_collector_save_figure_writes_a_file | yes | yes | collect.collector.BatchCollector.save_figure | #926 | suffix defaults to .png |
+| tests/test_collect.py::test_save_help_says_data_only_and_names_the_figure_api | yes | yes | Collection.save / BatchCollector.save docstrings | #926 | `.save?` must name the figure API |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* Figure export is discoverable from a collector: `BatchCollector.to_image()`
+  returns image bytes and `BatchCollector.save_figure(path)` /
+  `Collection.save_figure(path)` write one to disk. `.save()` still writes
+  frame + `meta.json` only, and now says so and names the figure API. (#926)
+
 * `cellpy info` and `cellpy info --check` report rather than narrate. The check
   run is one line per check with a symbol, a short detail and a hint when it
   fails, closing with `N of M checks passed` - instead of `=== checking ===`

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -120,12 +120,51 @@ class Collection:
 
         return write_image(self.plot(**plot_kwargs), fmt, scale=scale)
 
+    def save_figure(
+        self, path: Path | str, *, scale: float = 1.0, **plot_kwargs
+    ) -> Path:
+        """Render via :meth:`plot` and write the figure to *path* (needs kaleido).
+
+        The image format comes from the suffix (``.png`` when there is none).
+        This is the file-writing counterpart of :meth:`to_image`;
+        :func:`cellpy.utils.plotutils.save_image_files` writes a whole
+        png/svg/json set from an existing figure instead.
+
+        Args:
+            path: Target file. A missing suffix defaults to ``.png``.
+            scale: Pixel scale factor for kaleido.
+            **plot_kwargs: Forwarded to :meth:`plot`.
+
+        Returns:
+            The path written.
+        """
+        path = Path(path)
+        if not path.suffix:
+            path = path.with_suffix(".png")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.to_image(path.suffix, scale=scale, **plot_kwargs))
+        return path
+
     def save(
         self,
         directory: Path | str | None = None,
         formats: tuple[str, ...] = ("parquet", "csv"),
     ) -> list[Path]:
-        """Save the frame (+ ``meta.json``). No cwd fallback -- ``directory`` is explicit."""
+        """Save the collected **frame** (+ ``meta.json``) -- data only, no figures.
+
+        No cwd fallback -- ``directory`` is explicit. Figures are a separate
+        product: use :meth:`save_figure` to write one to disk, :meth:`to_image`
+        for the bytes, or :func:`cellpy.utils.plotutils.save_image_files` for a
+        png/svg/json set from a figure you already have.
+
+        Args:
+            directory: Where to write ``<name>.<fmt>`` and ``<name>.meta.json``.
+            formats: Frame formats to write (``parquet``, ``csv``, ``json``,
+                ``xlsx``).
+
+        Returns:
+            The paths written.
+        """
         if directory is None:
             raise ValueError("save() needs an explicit directory (no cwd fallback)")
         directory = Path(directory)

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -76,7 +76,22 @@ class BatchCollector:
         return self.collection.data
 
     def save(self, directory: str | Path, **kwargs) -> list[Path]:
-        """Persist the collection (explicit directory, no cwd fallback)."""
+        """Persist the collected **frame** (+ ``meta.json``) -- data only.
+
+        Explicit directory, no cwd fallback. This writes no figures: use
+        :meth:`save_figure` for an image file, :meth:`to_image` for the bytes,
+        or :func:`cellpy.utils.plotutils.save_image_files` for a png/svg/json
+        set from a figure you already have.
+
+        Args:
+            directory: Where to write ``<name>.<fmt>`` and ``<name>.meta.json``.
+            **kwargs: Forwarded to
+                :meth:`cellpy.collect.Collection.save` (e.g.
+                ``formats=("parquet", "csv", "json", "xlsx")``).
+
+        Returns:
+            The paths written.
+        """
         return self.collection.save(directory, **kwargs)
 
     def plot(self, **kwargs) -> Any:
@@ -88,6 +103,37 @@ class BatchCollector:
                 "Use `.data` for the collected frame in the meantime."
             )
         return plot(**kwargs)
+
+    def to_image(self, fmt: str = "png", *, scale: float = 1.0, **plot_kwargs) -> bytes:
+        """Render :meth:`plot` and return static image bytes (needs kaleido).
+
+        Args:
+            fmt: ``png``, ``svg``, ``pdf``, ``jpg``/``jpeg``, or ``webp``.
+            scale: Pixel scale factor for kaleido.
+            **plot_kwargs: Forwarded to :meth:`plot`.
+
+        Returns:
+            Encoded image bytes (see :meth:`save_figure` to write a file).
+        """
+        return self.collection.to_image(fmt, scale=scale, **plot_kwargs)
+
+    def save_figure(
+        self, path: str | Path, *, scale: float = 1.0, **plot_kwargs
+    ) -> Path:
+        """Render :meth:`plot` and write the figure to *path* (needs kaleido).
+
+        The image format comes from the suffix (``.png`` when there is none).
+        :meth:`save` writes the data; this writes the picture.
+
+        Args:
+            path: Target file, e.g. ``"out/cycle_life.png"``.
+            scale: Pixel scale factor for kaleido.
+            **plot_kwargs: Forwarded to :meth:`plot`.
+
+        Returns:
+            The path written.
+        """
+        return self.collection.save_figure(path, scale=scale, **plot_kwargs)
 
     def __repr__(self) -> str:  # pragma: no cover - trivial
         kind = getattr(self._collection, "kind", "?")

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -535,3 +535,48 @@ def test_normalize_column_on_max_wide_and_grouped():
     assert added["std"].to_list() == pytest.approx([5.0, 10.0])
 
     assert normalize_column_on_max("nope")(wide).equals(wide)
+
+
+# ---- figure export is discoverable from the collector (#926) ------------
+
+
+class _FakeFig:
+    def __init__(self, payload=b"IMAGE"):
+        self.payload = payload
+        self.calls = []
+
+    def to_image(self, format="png", scale=1.0, **kwargs):
+        self.calls.append({"format": format, "scale": scale, **kwargs})
+        return self.payload
+
+
+@pytest.mark.essential
+def test_batch_collector_to_image(real_batch, monkeypatch):
+    bc = summary_collector(real_batch, columns=("charge_capacity",))
+    fig = _FakeFig(b"from-collector")
+    monkeypatch.setattr(bc.collection, "plot", lambda **kwargs: fig)
+
+    assert bc.to_image("svg", scale=2.0) == b"from-collector"
+    assert fig.calls[0] == {"format": "svg", "scale": 2.0}
+
+
+@pytest.mark.essential
+def test_batch_collector_save_figure_writes_a_file(real_batch, monkeypatch, tmp_path):
+    bc = summary_collector(real_batch, columns=("charge_capacity",))
+    monkeypatch.setattr(bc.collection, "plot", lambda **kwargs: _FakeFig(b"PNGBYTES"))
+
+    written = bc.save_figure(tmp_path / "cycle_life")
+    assert written == tmp_path / "cycle_life.png"
+    assert written.read_bytes() == b"PNGBYTES"
+
+
+@pytest.mark.essential
+def test_save_help_says_data_only_and_names_the_figure_api():
+    """``.save?`` used to say nothing about figures at all (#926)."""
+    import inspect
+
+    for save in (BatchCollector.save, Collection.save):
+        doc = inspect.getdoc(save) or ""
+        assert "data only" in doc
+        assert "save_figure" in doc
+        assert "to_image" in doc


### PR DESCRIPTION
Closes #926.

`cap_summaries.save("out")` writes parquet + csv + `meta.json`, and its docstring said nothing about figures — so from the object the user is actually holding there was no route to a picture on disk. `Collection.to_image` existed but `BatchCollector` did not proxy it, and `plotutils.save_image_files` is documented in a different notebook.

- `BatchCollector.to_image()` proxies `Collection.to_image()`
- `Collection.save_figure(path)` / `BatchCollector.save_figure(path)` render and write the figure; a missing suffix defaults to `.png`
- both `save()` docstrings now say **data only** and name `save_figure`, `to_image` and `plotutils.save_image_files`

`.save()` itself is unchanged — it still writes no images, as the issue asks.

Out of scope: the cookiecutter notebook copy (jepegit/cellpy_cookies#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)