### PR TITLE
fix(plotting): cycle colorbar for collected layout="per_cell" (#928)

### DIFF
--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -53,6 +53,13 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   `"per_cycle"` (and legacy `fig_pr_*` / `film`) rewrite facet strips to
   `Cycle N` / cell label by default — strips stay visible (unlike summary's
   clear→y-title path). Prefer `layout=` over `method="fig_pr_*"`.
+- **Collected cycle legend (#928):** `layout="per_cell"` colours by cycle and
+  uses `cellpy.plotting.cycle_legend` — above `legend_cycle_limit` cycles
+  (default `DEFAULT_LEGEND_CYCLE_LIMIT` = 8, the same rule as the single-cell
+  `cycles_plot`) the discrete legend is replaced by a colorbar. `force_colorbar`
+  / `force_legend` / `force_nonbar` override. The knobs are consumed in
+  `sequence_plotter`, so they never reach a backend. `layout="per_cycle"`
+  colours by cell and is untouched.
 - **ICA `direction=` (#821):** `charge` / `discharge` / `both` on line layouts
   (`layout="per_cell"|"per_cycle"`) and `kind="film"`, not only film. Default
   for collected ICA remains `charge`. `both` overlays half-cycles; on Plotly
@@ -99,3 +106,4 @@ collection.plot(
 - Issue #804 (per-panel y-limits / `share_y`)
 - Issue #801 (theme / label / height hooks)
 - Issue #820 (cycles / ICA pretty facet strips)
+- Issue #928 (collected cycle legend vs colorbar) — see `plotting-cycle-legend.md`

--- a/.issueflows/04-designs-and-guides/plotting-cycle-legend.md
+++ b/.issueflows/04-designs-and-guides/plotting-cycle-legend.md
@@ -17,6 +17,17 @@ Shared policy in `cellpy/plotting/cycle_legend.py`:
 First consumer: `ica_plot` / `dva_plot` render branches. `cycles_plot` still
 has its own threshold constant; can migrate later.
 
+Second consumer (#928): the **collected** per-cell layouts
+(`sequence_plotter`, `method="fig_pr_cell"` — reached by
+`cycles_collector(b).plot(layout="per_cell")` and the ICA/DVA line paths).
+`pop_cycle_legend_options(None, kwargs)` runs once near the top of
+`sequence_plotter`, so the knobs are consumed whatever the method and never
+leak into `px.line`. In colorbar mode the per-cycle trace colours are kept,
+every trace gets `showlegend=False`, and `add_plotly_cycle_colorbar` adds the
+scale widget. A non-numeric cycle column falls back to the legend rather than
+raising.
+
 ## Links
 
 - Issue #648, epic #567
+- Issue #928 (collected per-cell layouts) — see `plotting-collected.md`

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -89,6 +89,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
+| tests/test_collected_cycle_colorbar.py (module) | yes | yes | plotting.collected.sequence_plotter fig_pr_cell | #928 | collected cycle legend vs colorbar |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* `cycles_collector(b).plot(layout="per_cell")` follows the shared cycle
+  legend policy: more than `legend_cycle_limit` cycles (default 8, the same as
+  the single-cell `cycles_plot`) get a colorbar instead of a legend hundreds of
+  entries long. `force_colorbar` / `force_legend` override. (#928)
+
 * `cellpy info` and `cellpy info --check` report rather than narrate. The check
   run is one line per check with a symbol, a short detail and a hint when it
   fails, closing with `N of M checks passed` - instead of `=== checking ===`

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -92,6 +92,10 @@ class Collection:
         ``spread``); ``layout="film"`` aliases ``kind="film"``. Unknown
         layout/kind/method values raise ``ValueError``. Plotly facet strips
         are pretty-printed by default (``Cycle N`` / cell label).
+
+        ``layout="per_cell"`` colours by cycle: more than
+        ``legend_cycle_limit`` cycles (default 8) get a colorbar instead of a
+        long legend, and ``force_colorbar`` / ``force_legend`` override (#928).
         """
         from cellpy.plotting import collected_plot
 

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -18,6 +18,11 @@ import pandas as pd
 
 from cellpycore.config import CurveCols
 from cellpy.parameters.internal_settings import get_headers_journal
+from cellpy.plotting.cycle_legend import (
+    add_plotly_cycle_colorbar,
+    pop_cycle_legend_options,
+    resolve_cycle_legend_mode,
+)
 from cellpy.plotting.labels import legend_replacer, remove_markers
 from cellpy.plotting import theme
 from cellpy.plotting.spec import FigureSpec
@@ -412,7 +417,12 @@ def sequence_plotter(
         spread (bool): plot error-bands instead of error-bars if True.
 
         **kwargs: sent to backend (if `backend == "plotly"`, it will be
-            sent to `plotly.express` etc.)
+            sent to `plotly.express` etc.). The cycle legend-vs-colorbar knobs
+            (`legend_cycle_limit`, `force_colorbar`, `force_legend` /
+            `force_nonbar`; see :mod:`cellpy.plotting.cycle_legend`) are
+            consumed here: cycle-coloured layouts (`fig_pr_cell`) swap the
+            discrete legend for a colorbar above `legend_cycle_limit` cycles
+            (default 8, same as `cycles_plot`).
 
     Returns:
         figure object
@@ -426,6 +436,12 @@ def sequence_plotter(
         print(f" - supported backends: {supported_backends}")
         return
     curves = None
+
+    # Shared legend-vs-colorbar policy for cycle-coloured figures (#928).
+    # Popped here so the knobs never leak into a backend call, whatever the
+    # method; only the cycle-coloured layouts act on the result.
+    cycle_legend_options = pop_cycle_legend_options(None, kwargs)
+    cycle_legend_mode = "legend"
 
     # ----------------- parsing arguments -----------------------------
 
@@ -551,6 +567,12 @@ def sequence_plotter(
                 start, end = palette_range
             unique_cycle_numbers = curves[z].unique()
             number_of_colors = len(unique_cycle_numbers)
+            # Same rule (and same default limit) as the single-cell
+            # ``cycles_plot`` / ``ica_plot``: a long discrete legend becomes a
+            # colorbar (#928).
+            cycle_legend_mode = resolve_cycle_legend_mode(
+                number_of_colors, **cycle_legend_options
+            )
             if number_of_colors > 1:
                 selected_colors = px.colors.sample_colorscale(
                     palette_continuous, number_of_colors, low=start, high=end
@@ -609,6 +631,21 @@ def sequence_plotter(
                 **plotly_arguments,
                 **kwargs,
             )
+
+            if method == "fig_pr_cell" and cycle_legend_mode == "colorbar":
+                # Keep the per-cycle trace colours, drop the long legend and
+                # show the scale instead (#928).
+                try:
+                    add_plotly_cycle_colorbar(
+                        fig,
+                        cycles=sorted(unique_cycle_numbers),
+                        colormap=palette_continuous,
+                        title=z_label,
+                    )
+                except (TypeError, ValueError) as e:
+                    logging.debug(f"sequence_plotter - no cycle colorbar: {e}")
+                else:
+                    fig.update_traces(showlegend=False)
 
             if method == "fig_pr_cycle" and group_cells:
                 try:
@@ -1870,6 +1907,10 @@ def collected_plot(
             ``height_per_panel`` / ``figure_border_height``.
             Cycles / ICA (#820): Plotly facet strips default to ``Cycle N`` /
             cell label (prefer ``layout=`` over legacy ``method="fig_pr_*"``).
+            ``layout="per_cell"`` colours by cycle and follows the shared
+            legend-vs-colorbar policy (#928): more than ``legend_cycle_limit``
+            cycles (default 8) get a colorbar instead of a long legend;
+            ``force_colorbar`` / ``force_legend`` override.
 
     Returns:
         Backend-native figure object.

--- a/tests/test_collected_cycle_colorbar.py
+++ b/tests/test_collected_cycle_colorbar.py
@@ -1,0 +1,106 @@
+"""Collected per-cell layouts follow the cycle legend/colorbar policy (#928).
+
+``cycles_collector(b).plot(layout="per_cell")`` used to always colour by cycle
+with a discrete legend, so a full batch produced a legend hundreds of entries
+long. The single-cell ``cycles_plot`` has had the
+:mod:`cellpy.plotting.cycle_legend` rule since #648; these tests pin the
+collected path to the same rule and the same default limit.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from cellpy.plotting.cycle_legend import DEFAULT_LEGEND_CYCLE_LIMIT
+
+pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+
+from cellpy.plotting.collected import collected_plot  # noqa: E402
+
+
+def _curves(n_cycles: int, cells: tuple[str, ...] = ("a", "b")) -> pd.DataFrame:
+    rows = []
+    for cell in cells:
+        for cycle in range(1, n_cycles + 1):
+            for capacity, potential in ((0.0, 0.1), (float(cycle), 0.2)):
+                rows.append(
+                    {
+                        "cell": cell,
+                        "cycle_num": cycle,
+                        "capacity": capacity,
+                        "potential": potential,
+                        "group": 1,
+                        "sub_group": 1,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _legend_entries(fig) -> int:
+    return sum(1 for trace in fig.data if trace.showlegend is not False)
+
+
+def _colorbars(fig) -> int:
+    return sum(1 for trace in fig.data if getattr(trace.marker, "showscale", None))
+
+
+@pytest.mark.essential
+def test_many_cycles_get_a_colorbar_not_a_long_legend():
+    fig = collected_plot(
+        _curves(DEFAULT_LEGEND_CYCLE_LIMIT + 5), family_kind="cycles", layout="per_cell"
+    )
+    assert _colorbars(fig) == 1
+    assert _legend_entries(fig) == 0
+
+
+@pytest.mark.essential
+def test_few_cycles_keep_the_discrete_legend():
+    fig = collected_plot(
+        _curves(DEFAULT_LEGEND_CYCLE_LIMIT), family_kind="cycles", layout="per_cell"
+    )
+    assert _colorbars(fig) == 0
+    assert _legend_entries(fig) == DEFAULT_LEGEND_CYCLE_LIMIT
+
+
+@pytest.mark.essential
+def test_force_colorbar_overrides_a_short_cycle_list():
+    fig = collected_plot(
+        _curves(3), family_kind="cycles", layout="per_cell", force_colorbar=True
+    )
+    assert _colorbars(fig) == 1
+    assert _legend_entries(fig) == 0
+
+
+@pytest.mark.essential
+def test_force_legend_overrides_a_long_cycle_list():
+    fig = collected_plot(
+        _curves(DEFAULT_LEGEND_CYCLE_LIMIT + 5),
+        family_kind="cycles",
+        layout="per_cell",
+        force_legend=True,
+    )
+    assert _colorbars(fig) == 0
+    assert _legend_entries(fig) == DEFAULT_LEGEND_CYCLE_LIMIT + 5
+
+
+@pytest.mark.essential
+def test_legend_cycle_limit_raises_the_threshold():
+    n = DEFAULT_LEGEND_CYCLE_LIMIT + 5
+    fig = collected_plot(
+        _curves(n), family_kind="cycles", layout="per_cell", legend_cycle_limit=n
+    )
+    assert _colorbars(fig) == 0
+    assert _legend_entries(fig) == n
+
+
+@pytest.mark.essential
+def test_per_cycle_layout_is_untouched_by_the_cycle_policy():
+    """``per_cycle`` colours by cell, so the cycle rule must not fire (#928)."""
+    fig = collected_plot(
+        _curves(DEFAULT_LEGEND_CYCLE_LIMIT + 5),
+        family_kind="cycles",
+        layout="per_cycle",
+    )
+    assert _colorbars(fig) == 0
+    assert _legend_entries(fig) > 0


### PR DESCRIPTION
Closes #928.

`cycles_collector(b).plot(layout="per_cell")` always coloured by cycle with a discrete legend, so a full batch produced a legend hundreds of entries long and no colorbar. The single-cell `cycles_plot` / `ica_plot` have had the `cellpy.plotting.cycle_legend` policy since #648; the collected path now shares it, with the same default limit (8).

- `pop_cycle_legend_options` runs once near the top of `sequence_plotter`, so `legend_cycle_limit` / `force_colorbar` / `force_legend` / `force_nonbar` are consumed whatever the method and never leak into `px.line`.
- In colorbar mode the per-cycle trace colours are kept, every trace gets `showlegend=False`, and `add_plotly_cycle_colorbar` adds the scale widget.
- A non-numeric cycle column falls back to the legend rather than raising.
- `layout="per_cycle"` colours by cell and is untouched — `tests/test_collected_cycle_colorbar.py::test_per_cycle_layout_is_untouched_by_the_cycle_policy` guards that.

The ICA/DVA line layouts reach the same `method="fig_pr_cell"` branch, so they get the rule too, as the issue asks.

Out of scope: film/heatmap colorbars and the cookiecutter notebook copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)