### PR TITLE
test(filefinder): pin the default file-name settings (#935)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,29 @@ def config_guard():
 
 
 @pytest.fixture
+def default_file_names(config_guard):
+    """Pin the ``file_names`` settings to the packaged defaults.
+
+    A test that asserts on a generated file name is otherwise reading the
+    developer's own ``cellpy.toml``: ``filefinder.search_for_files`` falls back
+    to ``config.file_names.cellpy_file_extension`` when the caller passes no
+    extension, so a machine that sets ``cellpy_file_extension = "cellpy"``
+    produced ``runA.cellpy`` where the test expected ``runA.h5``. CI has no
+    user config and stayed green, which made it look like a real regression on
+    whatever branch happened to be checked out.
+    """
+
+    from cellpy import config
+
+    config_guard("file_names")
+    section = config.file_names
+    defaults = type(section)()
+    for name in type(defaults).model_fields:
+        setattr(section, name, getattr(defaults, name))
+    return section
+
+
+@pytest.fixture
 def parameters():
     """Files, Directories, and Variables to be used in the tests."""
     return fdv

--- a/tests/test_cell_readers.py
+++ b/tests/test_cell_readers.py
@@ -297,7 +297,7 @@ def test_check64bit():
     logging.debug(f"OS 64bit? {b}")
 
 
-def test_search_for_files(parameters):
+def test_search_for_files(parameters, default_file_names):
     import os
 
     from cellpy import filefinder

--- a/tests/test_filefinder.py
+++ b/tests/test_filefinder.py
@@ -19,7 +19,7 @@ def env(parameters, config_guard):
     config.paths.db_filename = parameters.db_file_name
 
 
-def test_search_for_files_with_dirs(parameters):
+def test_search_for_files_with_dirs(parameters, default_file_names):
     import os
 
     raw_files, cellpy_file = filefinder.search_for_files(
@@ -104,13 +104,14 @@ def raw_tree(tmp_path):
     return tmp_path, cellpy_dir
 
 
-def test_search_for_files_recursive(raw_tree):
+def test_search_for_files_recursive(raw_tree, default_file_names):
     raw_dir, cellpy_dir = raw_tree
     raw_files, cellpy_file = filefinder.search_for_files(
         "runA", raw_extension="res", raw_file_dir=raw_dir, cellpy_file_dir=cellpy_dir
     )
     names = sorted(pathlib.Path(f).name for f in raw_files)
     assert names == ["runA_01.res", "runA_02.res", "runA_03.res"]
+    # the default extension, pinned by the fixture - not the developer's own
     assert cellpy_file.endswith("runA.h5")
 
 


### PR DESCRIPTION
Closes #935.

Three tests asserted on a generated cellpy file name ending in `.h5` while `filefinder.search_for_files` falls back to `config.file_names.cellpy_file_extension` when the caller passes no extension — i.e. to the developer's own `cellpy.toml`. On a machine with `cellpy_file_extension = "cellpy"` they produced `runA.cellpy` and went red; CI has no user config, got the `h5` default, and stayed green. The net effect is three failures that look like a regression on whatever branch happens to be checked out.

New `default_file_names` fixture in `tests/conftest.py` resets the `file_names` section to the packaged defaults for the duration of a test and restores it afterwards through the existing `config_guard`. The three tests take it, so they still exercise the real default-resolution path (rather than passing the extension in and asserting it comes back) without depending on the machine.

### Verified

| | `cellpy_file_extension` | result |
|---|---|---|
| this machine, before | `cellpy` | 3 failed |
| this machine, after | `cellpy` | 116 passed |
| CI-like, after | `h5` (default) | 116 passed |

Full suite on this branch: **1673 passed, 0 failed** — the first fully green local run.

### Note

Only these three tests were affected; the rest of the suite already passes under a non-default config. Auditing for other config-dependent assertions is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)