### PR TITLE
Put units on collected summary y-axis titles

### DIFF
--- a/.issueflows/03-solved-issues/issue947_original.md
+++ b/.issueflows/03-solved-issues/issue947_original.md
@@ -1,0 +1,37 @@
+# Issue #947: collector plots missing units
+
+Source: https://github.com/jepegit/cellpy/issues/947
+
+## Original issue text
+
+Check if this is still a problem, or if it is fixed
+
+Units on y-axis labels are missing!
+
+```python
+# pick the summary columns you want - without `columns` you get every summary
+# column, and the plot gets one facet per column
+cap_summaries = summary_collector(
+b,
+columns=[
+"charge_capacity_gravimetric",
+"discharge_capacity_gravimetric",
+"coulombic_efficiency",
+],
+group_it=True,
+custom_group_labels={
+1: "run-14",
+2: "run-15",
+},
+)
+```
+
+<img width="2297" height="1517" alt="Image" src="https://github.com/user-attachments/assets/a665d310-3aa6-42af-b317-bf2d6a12188b" />
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - Legend must use `custom_group_labels` (e.g. `run-14` / `run-15`), not bare group numbers.
+  - Confirm vertical facet order matches the `columns=` argument; document it if that order is deliberate.
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 3, last comment by @jepegit on 2026-08-25._

--- a/.issueflows/03-solved-issues/issue947_plan.md
+++ b/.issueflows/03-solved-issues/issue947_plan.md
@@ -1,0 +1,50 @@
+# Issue #947 — plan
+
+## Goal
+
+Put units on collected-summary y-axis titles, make `custom_group_labels=` the legend text on the issue's plot path, and document that facet rows follow `columns=` (top → bottom).
+
+## Constraints
+
+- Back-compat: pretty names stay (`Charge Capacity`), units go in parentheses (`Charge Capacity (mAh/g)`). Explicit `y_label_mapper=` still wins and is left untouched.
+- Session / cell `CellpyUnits` via `cellpy.units.units_label` / `with_cellpy_unit` — no new hand-rolled `f"{charge}/{specific}"` strings. Unknown variables stay unit-less (do not raise).
+- One PR; no collector redesign.
+- Tests: `conda activate cellpy_dev_313` then `pytest -m essential` (plotting extras needed for figure assertions).
+
+### Prior art
+
+- `_pretty_variable_label` / `_default_summary_y_label_mapper` in [`cellpy/plotting/collected.py`](../../../cellpy/plotting/collected.py) — already title-cases and *can* append units, but only when `units={"cellpy_units": …}` is passed. [`Collection.plot`](../../../cellpy/collect/collection.py) never forwards units, so defaults are `"Charge Capacity"` with no parenthesis ([`test_collected_app_hooks.py`](../../../tests/test_collected_app_hooks.py)).
+- `cellpy.units.units_label` / `with_cellpy_unit` — canonical label helper (single-cell plots already use it).
+- Grouped legend + facet order (#923): [`plotting-collected.md`](../04-designs-and-guides/plotting-collected.md), `summary_plotter` + [`test_collected_summary_groups.py`](../../../tests/test_collected_summary_groups.py). Line path colours by `group_label` when present. `spread_plot` still keys series by `"group"` / `"cell"` and uses `variable.unique()` (unordered) — likely leftover if the screenshot used `spread=True`.
+- Toolbox: none relevant.
+
+## Approach
+
+1. **Reproduce** the issue snippet (`summary_collector` + `group_it=True` + `custom_group_labels=` + `.plot()`) on this branch. Note whether the default (line) path already shows group labels; if only `spread=True` shows numbers, fix that path.
+2. **Y-axis units.** Default mapper always resolves units:
+   - Prefer `units=` when the caller / `FrameContext` / first batch cell supplies `CellpyUnits`.
+   - Else `get_cellpy_units()` (session default).
+   - Capacity + mode suffix → `with_cellpy_unit("Charge Capacity", "charge", "gravimetric")` (and areal / volumetric). CE → `Coulombic Efficiency (%)`. Other known quantities if cheap; else pretty name only.
+   - Keep accepting the old `{"cellpy_units": …}` dict so any leftover caller still works.
+3. **Group labels.** If line-path reproduction already matches #923 tests, add one end-to-end test through `summary_collector` with the issue's column names. If `spread_plot` still legends by group id, colour / name by `group_label` when that column is present (same fallback as `summary_plotter`).
+4. **Facet order.** Already deliberate on the line path (`order_variables` from collected `columns=`; Plotly first row on top). Document in `summary_collector` docstring + [`docs/examples/batch_utility/cellpy_batch_processing.md`](../../../docs/examples/batch_utility/cellpy_batch_processing.md) (and `agents.md` if that section lists collected knobs). If `spread_plot` ignores categorical order, sort variables by `order_variables` there too.
+5. Update [`plotting-collected.md`](../04-designs-and-guides/plotting-collected.md) one bullet: default y-titles include units.
+
+## Files to touch
+
+- `cellpy/plotting/collected.py` — default unit-aware labels; `spread_plot` group_label + facet order if still broken.
+- `cellpy/collect/collection.py` — optional: forward `units=` from kwargs / meta; docstring.
+- `cellpy/collect/collector.py` — `summary_collector` docstring: `columns=` sets top→bottom facet order.
+- `tests/test_collected_app_hooks.py` — expect `"Charge Capacity (mAh/g)"` (or session-unit equivalent).
+- `tests/test_collected_summary_groups.py` (or a small new test) — issue-shaped `summary_collector` → legend labels; spread if needed.
+- `docs/examples/batch_utility/cellpy_batch_processing.md` (+ `docs/getting_started/agents.md` if that list is the agent contract).
+- `.issueflows/04-designs-and-guides/plotting-collected.md` — units-on-default-titles note.
+
+## Test strategy
+
+- New / updated essential tests: default mapper includes units; CE gets `%`; explicit `y_label_mapper` still wins; `summary_collector(..., custom_group_labels=…)` legend names; facet order for the issue's three columns (and spread if we touch it).
+- `conda activate cellpy_dev_313 && pytest -m essential` (or the collected-summary files if the full essential set is heavy locally).
+
+## Open questions
+
+- None that block coding. Units come from session `CellpyUnits` when the collection has no cell (reload-from-disk). Override remains `units=` / `y_label_mapper=`.

--- a/.issueflows/03-solved-issues/issue947_status.md
+++ b/.issueflows/03-solved-issues/issue947_status.md
@@ -1,0 +1,17 @@
+# Issue #947 — status
+
+- [x] Done
+
+## What's done
+
+- Default collected-summary y-titles include units via `with_cellpy_unit`
+  (`Charge Capacity (mAh/g)`, `Coulombic Efficiency (%)`).
+- `spread_plot` legends by `group_label` when present; facet rows follow
+  categorical / `columns=` order.
+- Docs: `summary_collector` / `Collection.plot`, batch tutorial, `agents.md`,
+  `plotting-collected.md`.
+- Essential tests: `uv run pytest -m essential` — 834 passed, 1 skipped.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/plotting-collected.md
+++ b/.issueflows/04-designs-and-guides/plotting-collected.md
@@ -44,9 +44,10 @@ Epic #567 Stage 3 / issue #657 re-bases collectors' drawing half onto
   traces use `hoverinfo="skip"`.
 - **App chrome (#801):** `plotly_template=` overrides the default
   `plotly+{method}` combo; `layout_updates=` is a shallow
-  `fig.update_layout(**…)` after collector styling. Summary facet strips no
+  `fig.update_layout(**…)` after collector styling.   Summary facet strips no
   longer keep raw `variable=…` text by default — pretty y-axis titles are
-  built automatically (`y_label_mapper=` overrides). Height:
+  built automatically and include units (`Charge Capacity (mAh/g)`;
+  `y_label_mapper=` overrides) (#947). Height:
   `height=` (absolute) or `height_per_panel=` (alias of `sub_fig_min_height`;
   summary default 300 px/panel) plus optional `figure_border_height=`.
 - **Cycles / ICA facet chrome (#820):** Plotly `layout="per_cell"` /
@@ -117,4 +118,5 @@ collection.plot(
 - Issue #801 (theme / label / height hooks)
 - Issue #820 (cycles / ICA pretty facet strips)
 - Issue #923 (grouped summary facet order / group labels / legend title)
+- Issue #947 (default y-titles include units; spread legend uses `group_label`)
 - Issue #928 (collected cycle legend vs colorbar) — see `plotting-cycle-legend.md`

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -101,7 +101,12 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
-| tests/test_collected_summary_groups.py (module) | yes | yes | plotting.collected.summary_plotter / Collection.plot | #923 | facet order, group labels, legend title |
+| tests/test_collected_summary_groups.py (module) | yes | yes | plotting.collected.summary_plotter / Collection.plot | #923 #947 | facet order, group labels, legend title, units |
+| tests/test_collected_app_hooks.py::test_pretty_variable_label_strips_mode_suffix | yes | yes | plotting.collected._pretty_variable_label | #947 | units on default titles |
+| tests/test_collected_app_hooks.py::test_pretty_variable_label_unknown_stays_unitless | yes | yes | plotting.collected._pretty_variable_label | #947 | unknown vars stay bare |
+| tests/test_collected_summary_groups.py::test_spread_plot_legend_uses_custom_group_labels | yes | yes | plotting.collected.spread_plot | #947 | group_label in spread legend |
+| tests/test_collected_summary_groups.py::test_spread_plot_facets_follow_the_collected_column_order | yes | yes | plotting.collected.spread_plot | #947 | categorical facet order |
+| tests/test_collected_summary_groups.py::test_summary_collector_plot_uses_custom_group_labels_and_units | yes | yes | collect.collector.summary_collector + plot | #947 | issue snippet e2e |
 | tests/test_collected_backend_alias.py (module) | yes | yes | plotting.collected.collected_plot backend alias | #925 | matplotlib -> seaborn, warn_once signature |
 
 **Columns**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* Collected summary y-axis titles include units
+  (`Charge Capacity (mAh/g)`, `Coulombic Efficiency (%)`).
+  `spread=True` legends use `custom_group_labels=`, and facet rows follow
+  the collected `columns=` order top to bottom. (#947)
+
 * `Collection.plot(backend="matplotlib")` no longer raises
   `TypeError: warn_once() missing 1 required positional argument`. It keeps
   aliasing to the seaborn layout path (and now actually returns a figure -

--- a/cellpy/collect/collection.py
+++ b/cellpy/collect/collection.py
@@ -97,9 +97,10 @@ class Collection:
         ``legend_cycle_limit`` cycles (default 8) get a colorbar instead of a
         long legend, and ``force_colorbar`` / ``force_legend`` override (#928).
 
-        Summary facets follow the collected ``columns=`` order unless
-        ``order_variables=`` is given (#923); derived series (the CV split, a
-        normalized retention curve) keep their own order after them.
+        Summary facets follow the collected ``columns=`` order (top → bottom)
+        unless ``order_variables=`` is given (#923); derived series (the CV
+        split, a normalized retention curve) keep their own order after them.
+        Default y-axis titles include units (#947).
         """
         from cellpy.plotting import collected_plot
 

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -225,7 +225,9 @@ def summary_collector(
             ``cellpy.plotting.families()`` lists them too.
         y (str, optional): Alias of ``family``, matching ``summary_plot(y=...)``.
         columns (sequence of str, optional): Summary columns to keep. Wins over
-            ``family``. Journal keys (cell/group/...) are always kept.
+            ``family``. Journal keys (cell/group/...) are always kept. Plot
+            facet rows follow this order top → bottom (Plotly first row on
+            top).
         group_it (bool, optional): Average per journal group -> tidy long frame
             ``(group, cycle_num, variable, mean, std)``.
         custom_group_labels (mapping, optional): ``group id -> display label``,

--- a/cellpy/plotting/collected.py
+++ b/cellpy/plotting/collected.py
@@ -159,7 +159,7 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
     else:
         y_label_mapper = _plotly_y_label_cleaner(y_label_mapper)
 
-    selected_variables = curves["variable"].unique()
+    selected_variables = _ordered_variables(curves)
     number_of_rows = len(selected_variables)
     # TODO: change this (only temporary fix to allow height fractions to be set by spread_plot)
     height_fractions = kwargs.get(
@@ -182,9 +182,9 @@ def spread_plot(curves, plotly_arguments=None, y_label_mapper=None, **kwargs):
     else:
         mode = "lines"
 
-    # Series key: per-cell frames use "cell"; group-averaged frames are keyed by
-    # "group" and have no "cell" column (#785).
-    series_col = "cell" if "cell" in curves.columns else "group"
+    # Series key: per-cell frames use "cell"; group-averaged frames prefer
+    # ``group_label`` when present (#923 / #947), else ``group`` (#785).
+    series_col = _spread_series_column(curves)
     g = curves.groupby(series_col)
     fig = make_subplots(
         rows=number_of_rows,
@@ -1013,34 +1013,50 @@ def _pretty_print_facet_strips(fig: Any) -> None:
             fig.layout.annotations[i].text = pretty
 
 
-def _pretty_variable_label(variable: str, units: Any = None) -> str:
-    """Humanize a summary ``variable`` column name for facet / y-axis titles.
+def _ordered_variables(curves: pd.DataFrame) -> list:
+    """Return ``variable`` values in facet order (categorical, else appearance)."""
+    series = curves["variable"]
+    present = list(pd.unique(series.dropna()))
+    if isinstance(series.dtype, pd.CategoricalDtype):
+        return [v for v in series.cat.categories if v in set(present)]
+    return present
 
-    Strips specific-mode suffixes (``_gravimetric`` / ``_areal`` / …). When
-    ``units`` is the Batch-style dict used by :func:`summary_plotter`, appends
-    a parenthetical unit; otherwise returns the title-cased name alone.
-    """
+
+def _spread_series_column(curves: pd.DataFrame) -> str:
+    """Column used as the spread-plot series / legend key."""
+    label_column = hdr_journal.group_label
+    if label_column in curves.columns and curves[label_column].notna().any():
+        return label_column
+    if "cell" in curves.columns:
+        return "cell"
+    return "group"
+
+
+def _cellpy_units_from(units: Any):
+    """Resolve ``units=`` to a ``CellpyUnits`` (session default when omitted)."""
+    from cellpy.parameters.internal_settings import get_cellpy_units
+
+    if isinstance(units, dict) and units.get("cellpy_units") is not None:
+        return units["cellpy_units"]
+    if units is not None and not isinstance(units, dict):
+        return units
+    return get_cellpy_units()
+
+
+def _mode_from_variable(variable: str) -> Optional[str]:
     v = str(variable)
-    u_sub = None
-    if units:
-        cellpy_units = units["cellpy_units"]
-        if v.endswith("_areal") or v.endswith("_areal_cv"):
-            u_sub = cellpy_units.specific_areal
-        elif v.endswith("_gravimetric") or v.endswith("_gravimetric_cv"):
-            u_sub = cellpy_units.specific_gravimetric
-        elif v.endswith("_volumetric") or v.endswith("_volumetric_cv"):
-            u_sub = cellpy_units.specific_volumetric
+    if v.endswith("_areal") or v.endswith("_areal_cv"):
+        return "areal"
+    if v.endswith("_gravimetric") or v.endswith("_gravimetric_cv"):
+        return "gravimetric"
+    if v.endswith("_volumetric") or v.endswith("_volumetric_cv"):
+        return "volumetric"
+    return None
 
-    u_top = None
-    if units:
-        cellpy_units = units["cellpy_units"]
-        if "_capacity" in v:
-            u_top = cellpy_units.charge
-        if "_norm" in v:
-            u_top = "normalized"
-        if v == "coulombic_efficiency":
-            u_top = "%"
 
+def _pretty_variable_name(variable: str) -> str:
+    """Title-case a summary ``variable``, stripping mode suffixes."""
+    v = str(variable)
     parts = v.split("_")
     mode_suffixes = {"gravimetric", "areal", "volumetric"}
     if parts and parts[-1] == "cv" and len(parts) >= 2 and parts[-2] in mode_suffixes:
@@ -1050,15 +1066,42 @@ def _pretty_variable_label(variable: str, units: Any = None) -> str:
     label = " ".join(parts).title()
     if label.endswith("Cv"):
         label = label.replace("Cv", "CV")
+    return label
 
-    if not units:
+
+def _pretty_variable_label(variable: str, units: Any = None) -> str:
+    """Humanize a summary ``variable`` column name for facet / y-axis titles.
+
+    Strips specific-mode suffixes (``_gravimetric`` / ``_areal`` / …) and
+    appends a parenthetical unit from session / cell ``CellpyUnits`` (#947).
+    Unknown quantities stay unit-less. ``units`` may be a ``CellpyUnits``,
+    the legacy ``{"cellpy_units": …}`` dict, or omitted.
+    """
+    from cellpy.exceptions import UnitsError
+    from cellpy.units import with_cellpy_unit
+
+    v = str(variable)
+    label = _pretty_variable_name(v)
+    if v == "coulombic_efficiency" or v.endswith("_coulombic_efficiency"):
+        return f"{label} (%)"
+    if "_norm" in v:
+        return f"{label} (normalized)"
+
+    property_name = None
+    if "_capacity" in v:
+        property_name = "charge"
+    elif "_energy" in v:
+        property_name = "energy"
+    if property_name is None:
         return label
 
-    u = u_top or "Value"
-    if u_sub:
-        u_sub = str(u_sub).replace("**", "")
-        u = f"{u}/{u_sub}"
-    return f"{label} ({u})"
+    spec = _cellpy_units_from(units)
+    try:
+        return with_cellpy_unit(
+            label, property_name, _mode_from_variable(v), units=spec
+        )
+    except UnitsError:
+        return label
 
 
 def _default_summary_y_label_mapper(
@@ -1066,6 +1109,11 @@ def _default_summary_y_label_mapper(
 ) -> dict[str, str]:
     """Build ``variable → pretty label`` for collected summary facets (#801)."""
     return {v: _pretty_variable_label(v, units=units) for v in variables}
+
+
+def _plain_axis_title(title: str) -> str:
+    """Collapse Plotly ``<br>`` wraps so title matching ignores line breaks."""
+    return " ".join(str(title).replace("<br>", " ").split())
 
 
 def _yaxis_key_for_facet_label(fig: Any, label: str) -> Optional[str]:
@@ -1110,6 +1158,7 @@ def _yaxis_key_for_variable(
     if key is not None:
         return key
     pretty = _pretty_variable_label(variable)
+    bare = _pretty_variable_name(variable)
     for layout_key in fig.layout:
         key_s = str(layout_key)
         if not key_s.startswith("yaxis"):
@@ -1117,8 +1166,13 @@ def _yaxis_key_for_variable(
         title = getattr(fig.layout[layout_key].title, "text", None)
         if not title:
             continue
-        if title == pretty or title.startswith(f"{pretty} ") or title.startswith(
-            f"{pretty} ("
+        plain = _plain_axis_title(title)
+        if (
+            plain == pretty
+            or plain == bare
+            or plain.startswith(f"{bare} (")
+            or title == pretty
+            or title.startswith(f"{bare} (")
         ):
             return key_s
     return None
@@ -1339,8 +1393,8 @@ def summary_plotter(collected_curves, cycles_to_plot=None, backend="plotly", **k
 
     - ``plotly_template``: override the default ``plotly+summary`` template.
     - ``layout_updates``: dict passed to ``fig.update_layout`` after collector styling.
-    - ``y_label_mapper``: ``variable → label``; when omitted, pretty labels are
-      built automatically (facet ``variable=…`` strip cleared).
+    - ``y_label_mapper``: ``variable → label``; when omitted, pretty labels
+      with units are built automatically (facet ``variable=…`` strip cleared).
     - ``height`` / ``height_per_panel`` (alias of ``sub_fig_min_height``) /
       ``figure_border_height``: absolute or per-panel height control.
 
@@ -1959,7 +2013,7 @@ def collected_plot(
             control shared vs independent facet y-scales (default independent);
             ``y_ranges`` maps variable name → ``[lo, hi]`` for per-panel limits.
             App chrome (#801): ``plotly_template``, ``layout_updates``,
-            ``y_label_mapper`` (pretty labels by default), ``height`` /
+            ``y_label_mapper`` (pretty labels with units by default), ``height`` /
             ``height_per_panel`` / ``figure_border_height``.
             Cycles / ICA (#820): Plotly facet strips default to ``Cycle N`` /
             cell label (prefer ``layout=`` over legacy ``method="fig_pr_*"``).

--- a/docs/examples/batch_utility/cellpy_batch_processing.md
+++ b/docs/examples/batch_utility/cellpy_batch_processing.md
@@ -228,7 +228,7 @@ The *collectors* in `cellpy.collect` are meant to simplify plotting and exportin
     [collect API reference](../../api/collect.md).
 
 ### Summaries
-`summary_collector` collects and shows summaries, including, e.g., the option to show statistical variations in the data (`spread=True`):
+`summary_collector` collects and shows summaries, including, e.g., the option to show statistical variations in the data (`spread=True`). Facet rows follow `columns=` top → bottom; default y-axis titles include units. `custom_group_labels=` is what the legend shows when `group_it=True`:
 
 
 ```python

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -168,6 +168,8 @@ Suggested layering:
       independent y-axes (`share_y=False`). For Capacity+CE, pin CE with
       `collection.plot(y_ranges={"coulombic_efficiency": [0, 110]})`
       (Plotly). `share_y=True` / `match_axes=True` restores a shared scale.
+      Default y-axis titles include units (`Charge Capacity (mAh/g)`). Facet
+      rows follow the collected `columns=` order top → bottom.
     - **Instrument picker for free.** `cellpy.list_instruments()` returns
       `[{"id", "label", "models", "suffixes"}, ...]` and is quiet by contract
       (probe/discovery skips stay at DEBUG — no `WARNING` spam on the root

--- a/tests/test_collected_app_hooks.py
+++ b/tests/test_collected_app_hooks.py
@@ -44,9 +44,17 @@ def _summary_frame() -> pd.DataFrame:
 
 @pytest.mark.essential
 def test_pretty_variable_label_strips_mode_suffix():
-    assert _pretty_variable_label("charge_capacity_gravimetric") == "Charge Capacity"
-    assert _pretty_variable_label("coulombic_efficiency") == "Coulombic Efficiency"
-    assert _pretty_variable_label("discharge_capacity_areal_cv") == "Discharge Capacity CV"
+    assert _pretty_variable_label("charge_capacity_gravimetric") == "Charge Capacity (mAh/g)"
+    assert _pretty_variable_label("coulombic_efficiency") == "Coulombic Efficiency (%)"
+    assert (
+        _pretty_variable_label("discharge_capacity_areal_cv")
+        == "Discharge Capacity CV (mAh/cm**2)"
+    )
+
+
+@pytest.mark.essential
+def test_pretty_variable_label_unknown_stays_unitless():
+    assert _pretty_variable_label("some_custom_metric") == "Some Custom Metric"
 
 
 @pytest.mark.essential
@@ -54,8 +62,8 @@ def test_default_summary_y_label_mapper():
     mapper = _default_summary_y_label_mapper(
         ["charge_capacity_gravimetric", "coulombic_efficiency"]
     )
-    assert mapper["charge_capacity_gravimetric"] == "Charge Capacity"
-    assert mapper["coulombic_efficiency"] == "Coulombic Efficiency"
+    assert mapper["charge_capacity_gravimetric"] == "Charge Capacity (mAh/g)"
+    assert mapper["coulombic_efficiency"] == "Coulombic Efficiency (%)"
 
 
 @pytest.mark.essential
@@ -69,13 +77,15 @@ def test_summary_pretty_labels_clear_variable_facet_strip():
     assert fig is not None
     texts = [getattr(a, "text", None) or "" for a in (fig.layout.annotations or ())]
     assert not any(t.startswith("variable=") for t in texts)
+    from cellpy.plotting.collected import _plain_axis_title
+
     y_titles = [
-        fig.layout[k].title.text
+        _plain_axis_title(fig.layout[k].title.text)
         for k in fig.layout
         if str(k).startswith("yaxis") and fig.layout[k].title.text
     ]
-    assert "Charge Capacity" in y_titles
-    assert "Coulombic Efficiency" in y_titles
+    assert "Charge Capacity (mAh/g)" in y_titles
+    assert "Coulombic Efficiency (%)" in y_titles
 
 
 @pytest.mark.essential

--- a/tests/test_collected_summary_groups.py
+++ b/tests/test_collected_summary_groups.py
@@ -6,6 +6,7 @@ import polars as pl
 import pytest
 
 from cellpy.collect.collection import Collection, CollectionMeta
+from cellpy.plotting.collected import _plain_axis_title
 
 _COLUMNS = ("cap_charge", "cap_discharge", "ce")
 
@@ -61,7 +62,7 @@ def _facet_labels(fig) -> list[str]:
         for key in fig.layout
         if str(key).startswith("yaxis") and fig.layout[key].domain
     ]
-    return [title for _, title in sorted(axes, key=lambda item: -item[0])]
+    return [_plain_axis_title(title) for _, title in sorted(axes, key=lambda item: -item[0])]
 
 
 @pytest.mark.essential
@@ -116,6 +117,27 @@ def test_custom_group_labels_are_the_legend_entries():
         "my_first_group",
         "my_second_group",
     }
+
+
+@pytest.mark.essential
+def test_spread_plot_legend_uses_custom_group_labels():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    collection = _grouped_collection(labels={1: "run-14", 2: "run-15"})
+    fig = collection.plot(spread=True)
+    assert {trace.name for trace in fig.data if trace.showlegend} == {
+        "run-14",
+        "run-15",
+    }
+
+
+@pytest.mark.essential
+def test_spread_plot_facets_follow_the_collected_column_order():
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    columns = ("cap_charge", "ce", "cap_discharge")
+    fig = _grouped_collection(columns).plot(
+        spread=True, y_label_mapper=_identity_mapper(*columns)
+    )
+    assert _facet_labels(fig) == list(columns)
 
 
 @pytest.mark.essential
@@ -196,3 +218,55 @@ def test_custom_group_labels_match_int_and_str_group_ids(keys):
         custom_group_labels={first: "alpha", second: "beta"},
     )
     assert set(collection.data["group_label"].to_list()) == {"alpha", "beta"}
+
+
+@pytest.mark.essential
+def test_summary_collector_plot_uses_custom_group_labels_and_units():
+    """Issue #947 snippet: legend labels + unit-bearing y-titles."""
+    pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
+    from types import SimpleNamespace
+
+    from cellpy.batch import Batch, Journal
+    from cellpy.batch.journal import FILENAME
+    from cellpy.batch.store import CellStore
+    from cellpy.collect import summary_collector
+
+    columns = (
+        "charge_capacity_gravimetric",
+        "discharge_capacity_gravimetric",
+        "coulombic_efficiency",
+    )
+
+    class _Cell:
+        def __init__(self, scale):
+            self.data = SimpleNamespace(
+                summary=pl.DataFrame(
+                    {
+                        "cycle_num": [1, 2],
+                        "charge_capacity_gravimetric": [100.0 * scale, 99.0 * scale],
+                        "discharge_capacity_gravimetric": [98.0 * scale, 97.0 * scale],
+                        "coulombic_efficiency": [98.0, 97.5],
+                    }
+                ),
+                steps=None,
+            )
+
+    pages = pl.DataFrame(
+        {FILENAME: ["a", "b", "c", "d"], "group": [1, 1, 2, 2], "sub_group": [1, 2, 1, 2]}
+    )
+    batch = Batch(Journal(name="b", project="p", pages=pages))
+    batch._store = CellStore.from_cells(
+        {"a": _Cell(1), "b": _Cell(1.1), "c": _Cell(0.9), "d": _Cell(1.2)}
+    )
+    fig = summary_collector(
+        batch,
+        columns=list(columns),
+        group_it=True,
+        custom_group_labels={1: "run-14", 2: "run-15"},
+    ).plot()
+    assert {trace.name for trace in fig.data} == {"run-14", "run-15"}
+    assert _facet_labels(fig) == [
+        "Charge Capacity (mAh/g)",
+        "Discharge Capacity (mAh/g)",
+        "Coulombic Efficiency (%)",
+    ]


### PR DESCRIPTION
## Summary
- Default collected-summary y-axis titles now include units (`Charge Capacity (mAh/g)`, `Coulombic Efficiency (%)`) via `with_cellpy_unit`.
- `spread=True` legends use `custom_group_labels=` and facet rows follow the collected `columns=` order (top → bottom).
- Docs updated (`summary_collector`, batch tutorial, `agents.md`).

Closes #947

## Test plan
- [x] `uv run pytest tests/test_collected_app_hooks.py tests/test_collected_summary_groups.py tests/test_collected_summary_axes.py`
- [x] `uv run pytest -m essential` (834 passed)
- [ ] Confirm a `summary_collector(..., group_it=True, custom_group_labels=...)` plot shows units and legend labels


Made with [Cursor](https://cursor.com)