### PR TITLE
Use uv for local pytest, not conda

### DIFF
--- a/.cursor/rules/this-project.mdc
+++ b/.cursor/rules/this-project.mdc
@@ -5,19 +5,29 @@ alwaysApply: true
 
 # Best practices for cellpy
 
-This project is called "cellpy". 
-It is supposed to work an many platforms.
+This project is called "cellpy". It is supposed to work on many platforms.
 
-We have several python environments
+## Toolchain
 
-conda: cellpy_dev_313
-python: .venv
+**uv is the local default.** After `uv sync`, run everything through `uv run`
+(scripts, `pytest`, CLI). Do not call bare `python`.
 
-Rember to activate it! 
+```bash
+uv sync
+uv run pytest -m essential    # merge-gate subset
+uv run pytest                 # full suite (default addopts deselects slow/local)
+```
 
-We also have uv installed. Use it if you want (uv run python).
+A `.venv` from `uv sync` is the project interpreter.
 
-I recommend using conda when running pytest. First activate the conda environment. Then run pytest.
+**Do not use conda for day-to-day pytest** (including `cellpy_dev_313` /
+`conda run -n …`). Conda env files (`environment.yml`, `environment_dev.yml`,
+`github_actions_environment.yml`) exist for conda-forge packaging and
+scheduled Tier-3 CI. Use conda only when the task is specifically to test
+conda install, feedstock, or those env files.
+
+Issue-flow's generic "if the project documents a conda environment, don't
+substitute uv" does **not** apply here — this file is the override.
 
 ## Working on issues
 

--- a/.issueflows/04-designs-and-guides/ci-tiers.md
+++ b/.issueflows/04-designs-and-guides/ci-tiers.md
@@ -27,6 +27,8 @@ when you discover a gap). See [`tests/README.md`](../../tests/README.md).
 
 **What:** full conda pytest matrix (Linux / macOS-14 / Windows with ACE), pip-install
 matrix, nbmake notebook (Linux, `continue-on-error`), conda-forge install check.
+Local day-to-day work stays on **uv**; do not run this conda matrix unless the
+issue is specifically about conda install / those env files.
 
 **Env constraints (issue #885):**
 - `sqlalchemy-access` is Windows-only on conda-forge (`__win`). Keep it out of

--- a/.issueflows/04-designs-and-guides/testing-and-coverage.md
+++ b/.issueflows/04-designs-and-guides/testing-and-coverage.md
@@ -2,6 +2,9 @@
 
 Durable guide for running cellpy's test suite and coverage locally. Established in issue #372.
 
+**Local runner is uv** (`uv run pytest`). Do not use conda for ordinary pytest.
+Conda env files are for conda-forge / scheduled Tier-3 CI only.
+
 ## Environment setup
 
 `pyproject.toml` has no `[project]` table (cellpy is a legacy `setup.py` project), so `uv sync`

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -2,12 +2,20 @@
 
 ## What this project is
 
-TODO: Summarize the project in one short paragraph. Mention what it does, who it is for, and the main outcome it produces.
+Python library + `cellpy` CLI for battery/cell cycling data (no hosted GUI).
+Researchers and other libraries ingest tester files, build step/summary tables,
+plot, and persist `.cellpy` archives.
 
 ## Stack / runtime
 
-- TODO: Primary language(s), runtime versions, package manager(s), and major frameworks.
-- TODO: External services, CLIs, or local tools that agents should know about.
+- Python 3.13, package manager **uv** (`uv.lock`, hatchling, git-tag version).
+- Local interpreter: `.venv` from `uv sync`. Always `uv run …` — never bare
+  `python`, and never conda for day-to-day pytest.
+- Conda (`environment*.yml`, `github_actions_environment.yml`, feedstock) is
+  **only** for conda-forge packaging and scheduled Tier-3 CI. Use it when the
+  issue is specifically "does conda install / that env file work?"
+- Issue-flow's generic "if conda is documented, don't substitute uv" does
+  **not** apply: this file is the toolchain source of truth.
 
 ## How to run / test
 
@@ -38,7 +46,9 @@ See also [testing-and-coverage.md](testing-and-coverage.md) and [ci-tiers.md](ci
   [`docs/getting_started/agents.md`](../../docs/getting_started/agents.md) and the
   short **Using cellpy (for agents)** section in root `AGENTS.md` in the same PR.
   Do not put long recipes inside the managed issue-flow block of `AGENTS.md`.
-- TODO: Branch, commit, formatting, typing, or review conventions beyond the above.
+- **Local pytest:** `uv run pytest` / `uv run pytest -m essential`. Do not
+  activate `cellpy_dev_313` or other conda envs unless the issue is conda
+  packaging / scheduled CI.
 
 ## Entry points
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,14 @@ Quick facts:
 - When changing public get/save/schema/CLI surface, update
   `docs/getting_started/agents.md` and this section in the same PR.
 
+## Local toolchain
+
+Day-to-day: `uv sync`, then `uv run pytest` / `uv run pytest -m essential` /
+`uv run cellpy …`. Do **not** use conda for local pytest unless the issue is
+specifically conda-forge install, `environment*.yml`, or scheduled CI conda
+jobs. That overrides the generic issue-flow "if conda is documented" block
+above. Detail: `.issueflows/04-designs-and-guides/this-project.md`.
+
 ## Cursor Cloud specific instructions
 
 Environment is already provisioned on cloud VM startup: `uv` (on PATH via


### PR DESCRIPTION
## Summary
- Local default is `uv run pytest` / `uv run pytest -m essential`. Agents should not activate `cellpy_dev_313` or other conda envs for ordinary work.
- Conda env files and scheduled Tier-3 CI stay for conda-forge packaging and “does conda work?” checks only.
- Override lives in `.cursor/rules/this-project.mdc` and `.issueflows/04-designs-and-guides/this-project.md` so issue-flow’s generic conda block does not win.

## Test plan
- [ ] Skim the five files; no code/test change.
- [ ] Confirm a later `/iflow-build` uses `uv run pytest`, not conda.


Made with [Cursor](https://cursor.com)