### PR TITLE
Fix Batch.drop leaving a ghost cell in the store

### DIFF
--- a/.issueflows/03-solved-issues/issue952_original.md
+++ b/.issueflows/03-solved-issues/issue952_original.md
@@ -1,0 +1,44 @@
+# Issue #952: Batch.drop leaves a ghost cell in the store so plot and summaries raise KeyError
+
+Source: https://github.com/jepegit/cellpy/issues/952
+
+## Original issue text
+
+### Problem / context
+
+`Batch.mark_as_bad(label)` only appends to `journal.session["bad_cells"]`. The cell stays in `pages`, the store, and plots.
+
+`Batch.drop(label)` (and `drop_cells_marked_bad`) removes the row from `pages` and calls `CellStore.unload(label)`, then clears the cached summaries. `unload` only evicts the cache. The label stays in `_labels` (and `_loaders` if present).
+
+After a user drops a cell on an already-loaded batch and then calls `b.plot()`, `_LegacyExperimentAdapter` iterates `store.items()` and raises `KeyError` for the ghost label. Same crash on `b.summaries`, `b.combine_summaries()`, and `b.report()`.
+
+`b.cell_names` / `b.pages` omit the cell; `list(b.cells)` can still include it. `update()` rebuilds the store and hides the bug. `batch.load(..., drop_bad_cells=True)` is safe because it drops **then** updates. Same-session `drop` → `plot` is not.
+
+`unload` should stay cache-only (reload next access). `drop` needs a real remove.
+
+### Spec
+
+1. Add `CellStore.remove(label)` (or equivalent) that drops the label from `_labels`, `_cache`, and `_loaders`. Keep `unload` as cache eviction.
+2. `Batch.drop` must call that remove, not `unload`.
+3. After `drop` on a loaded batch, `plot()`, `.summaries`, `combine_summaries()`, and `report()` work without `update()`. Remaining cells stay loaded.
+4. Tests: loaded multi-cell batch → `drop` one label → store keys / `cell_names` / `pages` agree; `summaries` and `report()` do not raise; ghost label is gone. Mark `essential`.
+5. Short user note (batch tutorial or `docs/getting_started/agents.md`):
+   - `mark_as_bad` is a session flag; `drop` / `drop_cells_marked_bad` removes now.
+   - After mark, `save()` then next `batch.load()` (default `drop_bad_cells=True`) drops before update.
+   - After same-session `drop`, plot/summaries should work immediately; `save()` still needed to persist the journal.
+
+### Acceptance criteria
+
+- [ ] `b.drop(label)` on a loaded batch: label gone from `pages`, `cell_names`, and `list(b.cells)`.
+- [ ] `b.plot()`, `b.summaries`, and `b.report()` after that drop do not raise `KeyError`.
+- [ ] `CellStore.unload` still only evicts cache (label remains, next access reloads).
+- [ ] `mark_as_bad` still only writes `session["bad_cells"]` (no silent drop).
+- [ ] Essential test covers the drop-then-summaries/report path.
+- [ ] User-facing note documents mark vs drop and the save/reload path.
+
+### Out of scope
+
+- Changing `batch.load` defaults (`drop_bad_cells=True`).
+- Making `mark_as_bad` auto-drop or flip `selected`.
+- Rewriting the plot adapter / collectors (Epic B).
+- Migrating remaining `experiment` shims.

--- a/.issueflows/03-solved-issues/issue952_plan.md
+++ b/.issueflows/03-solved-issues/issue952_plan.md
@@ -1,0 +1,71 @@
+# Plan: #952 Batch.drop ghost cell
+
+## Goal
+
+After `Batch.drop` (or `drop_cells_marked_bad`) on a loaded batch, the store
+must forget the label so `plot` / `summaries` / `report` work without
+`update()`. Keep `CellStore.unload` as cache-only eviction.
+
+## Constraints
+
+- `mark_as_bad` stays a session flag only (no silent drop, no `selected` flip).
+- `batch.load(..., drop_bad_cells=True)` default unchanged.
+- No plot-adapter / collectors rewrite (Epic B).
+- Tests that must gate merge: `@pytest.mark.essential`; run via `uv run pytest`.
+- Public batch surface note goes in `docs/getting_started/agents.md` (and the
+  short AGENTS.md batch bullet if it stays one line).
+
+### Prior art
+
+- `CellStore.unload` — [`cellpy/batch/store.py`](../../cellpy/batch/store.py):
+  cache pop only. Keep; do not overload.
+- `Batch.drop` / `drop_cells_marked_bad` — [`cellpy/batch/facade.py`](../../cellpy/batch/facade.py):
+  pages filter + `unload`. Switch to a real store remove.
+- `test_cellstore_is_lazy` — [`tests/test_batch_v3_runner.py`](../../tests/test_batch_v3_runner.py):
+  asserts `unload` leaves the label. Extend, do not change that contract.
+- `test_mark_as_bad_and_drop` — [`tests/test_batch_v3_facade.py`](../../tests/test_batch_v3_facade.py):
+  drops an **unloaded** one-cell batch (empty store). Does not catch the ghost.
+- `_finalize` / `drop_bad_cells` — [`batch-load-orchestrator.md`](../04-designs-and-guides/batch-load-orchestrator.md):
+  load path already drops then `update()`. Same-session drop is the hole.
+- Toolbox: no helper applies. Graph: no `graphify-out/GRAPH_REPORT.md`.
+
+## Approach
+
+1. Add `CellStore.remove(label)`: pop `_cache`, `_loaders`, and the entry in
+   `_labels`. Missing label is a no-op (same as `unload`).
+2. `Batch.drop` calls `self._store.remove(label)` instead of `unload`. Still
+   filters `pages` and clears `_summaries`.
+3. Tests:
+   - Store: `unload` still keeps the key (reload on next access); `remove`
+     drops the key (`label not in store`, `__getitem__` raises).
+   - Facade: `Batch.from_cells` with two stub cells that expose `data.summary`
+     → `drop` one → `list(b.cells) == b.cell_names`, label gone from `pages`;
+     `b.summaries` and `b.report()` do not raise; remaining cell still loaded.
+     Building `b.experiment` (adapter) must not `KeyError` — that is the
+     `plot()` crash site. Do **not** require a live `b.plot()` in essential
+     (plotly / display). Mark both new tests `essential`.
+4. Docs: short mark vs drop vs save/reload note in the agents.md batch
+   recipe. One subsection on `batch-load-orchestrator.md` so the store
+   contract is recorded.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/batch/store.py` | Add `remove`. |
+| `cellpy/batch/facade.py` | `drop` → `remove`. |
+| `tests/test_batch_v3_runner.py` | `remove` vs `unload` essential test. |
+| `tests/test_batch_v3_facade.py` | Loaded two-cell drop → summaries/report/adapter. |
+| `docs/getting_started/agents.md` | Mark / drop / save recipe. |
+| `AGENTS.md` | One-line batch pointer only if it still fits. |
+| `.issueflows/04-designs-and-guides/batch-load-orchestrator.md` | Drop vs unload note. |
+
+## Test strategy
+
+```bash
+uv run pytest -m essential tests/test_batch_v3_runner.py tests/test_batch_v3_facade.py
+```
+
+## Open questions
+
+None — spec already chose `remove` + keep `unload` + docs in agents.md.

--- a/.issueflows/03-solved-issues/issue952_status.md
+++ b/.issueflows/03-solved-issues/issue952_status.md
@@ -1,0 +1,16 @@
+# Status: #952 Batch.drop ghost cell
+
+- [x] Done
+
+## What's done
+
+- Added `CellStore.remove`; `Batch.drop` calls it (`unload` stays cache-only).
+- Essential tests: store remove vs unload; loaded two-cell drop → summaries/report/adapter.
+- User note in `docs/getting_started/agents.md` and AGENTS.md batch bullet.
+- Design note on `batch-load-orchestrator.md`.
+- Registry rows for the two new essential tests.
+- `uv run pytest -m essential`: 835 passed; one unrelated Windows HDF5 lock flake (`test_v9_files_do_not_need_tables`) passed on retry.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/batch-load-orchestrator.md
+++ b/.issueflows/04-designs-and-guides/batch-load-orchestrator.md
@@ -13,6 +13,16 @@ Notebooks expected the v1 flow: resolve journal → load cells → persist.
    `cellpy_batch_{name}.json` from `journal_dir` (default **cwd**), else DB.
 2. `drop_bad_cells` (default True) removes `session["bad_cells"]`.
 3. Always `Batch.update()` (legacy `link` is a no-op in v3).
+
+### Same-session `drop` vs `unload` (#952)
+
+- `CellStore.unload` only evicts the cache; the label stays and the next
+  access reloads. That is memory management, not a journal edit.
+- `Batch.drop` / `drop_cells_marked_bad` call `CellStore.remove`, which
+  drops `_labels` / `_cache` / `_loaders`. Pages and store stay aligned so
+  `plot` / `summaries` / `report` work without a following `update()`.
+- `mark_as_bad` only appends `session["bad_cells"]`. The load path above
+  still drops those labels before `update()`.
 4. Persist journal JSON when `save_cellpy=True` (default). Rewrite `.cellpy` only for cells loaded from raw (or `NEWEST` / `recalc`); skip rewrite when already loaded from an on-disk `.cellpy`.
 
 ### Journal location

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -99,6 +99,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_progress.py::test_run_emits_cell_start_parse_done | yes | yes | batch.runner emit + on_progress | #916 | event bus + 3-arg callback |
 | tests/test_batch_progress.py::test_on_progress_still_wins_with_event_hook | yes | yes | batch.runner on_progress | #916 | BC: 3-arg hook still fires |
 | tests/test_batch_progress.py::test_tqdm_display_disable_tracks_cells | yes | yes | batch.progress.TqdmBatchProgress | #916 | overall n without TTY |
+| tests/test_batch_v3_runner.py::test_cellstore_remove_drops_label_unload_keeps_it | yes | yes | batch.store.CellStore.remove / unload | #952 | unload cache-only; remove drops key |
+| tests/test_batch_v3_facade.py::test_drop_loaded_cell_forgets_store_label | yes | yes | batch.facade.Batch.drop | #952 | ghost label after loaded drop |
 | tests/test_batch_v3_runner.py::test_dispatch_lite_saves_raw_then_strips | yes | yes | batch.runner._dispatch_lite | #920 | process worker saves raw load |
 | tests/test_batch_v3_runner.py::test_persist_skips_none_placeholder_from_processes | yes | yes | batch.facade._persist_cells / CellStore.is_loaded | #920 | None.save guard |
 | tests/test_collected_summary_groups.py (module) | yes | yes | plotting.collected.summary_plotter / Collection.plot | #923 #947 | facet order, group labels, legend title, units |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,9 @@ Quick facts:
 - Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
+  `mark_as_bad` is a session flag; `drop` / `drop_cells_marked_bad` remove now
+  (plot/summaries work without `update()`). `save()` then next `load` (default
+  `drop_bad_cells=True`) drops marked cells before update.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
   Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
 - Prefer schema-resolved names over hard-coded 1.x header strings.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* `Batch.drop` (and `drop_cells_marked_bad`) remove the cell from the store,
+  not just the cache, so `plot` / `summaries` / `report` work without a
+  following `update()`. `mark_as_bad` stays a session flag. (#952)
+
 * Collected summary y-axis titles include units
   (`Charge Capacity (mAh/g)`, `Coulombic Efficiency (%)`).
   `spread=True` legends use `custom_group_labels=`, and facet rows follow

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -330,7 +330,7 @@ class Batch:
 
     def drop(self, label: str) -> "Batch":
         self.journal.pages = self.journal.pages.filter(pl.col(FILENAME) != label)
-        self._store.unload(label)
+        self._store.remove(label)
         self._summaries = None
         return self
 

--- a/cellpy/batch/store.py
+++ b/cellpy/batch/store.py
@@ -68,8 +68,23 @@ class CellStore(Mapping):
         return self._cache.get(label) is not None
 
     def unload(self, label: str) -> None:
-        """Drop a loaded cell from the cache (explicit memory management)."""
+        """Drop a loaded cell from the cache (explicit memory management).
+
+        The label stays in the store; the next access reloads it. Use
+        :meth:`remove` to forget a cell entirely (e.g. ``Batch.drop``).
+        """
         self._cache.pop(label, None)
+
+    def remove(self, label: str) -> None:
+        """Forget a cell: drop cache, loader, and the store key.
+
+        Missing labels are a no-op. After this, ``label not in store`` and
+        ``store[label]`` raises ``KeyError``.
+        """
+        self._cache.pop(label, None)
+        self._loaders.pop(label, None)
+        if label in self._labels:
+            self._labels.remove(label)
 
     def _ipython_key_completions_(self) -> list[str]:
         """Tab completion for ``store["<TAB>"]`` -- no prefix mangling."""

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -226,6 +226,17 @@ summaries = b.summaries          # polars frame across cells
 c = b.cells["my_cell_01"]        # a CellpyCell
 ```
 
+Dropping cells:
+
+- `b.mark_as_bad("my_cell_01")` only writes `journal.session["bad_cells"]`.
+  The cell stays in `pages`, the store, and plots until you drop it.
+- `b.drop("my_cell_01")` (or `b.drop_cells_marked_bad()`) removes it now.
+  `b.plot()` / `b.summaries` / `b.report()` then use the remaining cells —
+  no `update()` required. Call `b.save()` to persist the thinner journal.
+- Next `batch.load(...)` (default `drop_bad_cells=True`) drops
+  `session["bad_cells"]` **before** it loads, so a saved mark is enough if
+  you reload instead of dropping in the same session.
+
 `batch.load` (and `Batch.update` / `Batch.load` under it) takes an `executor`
 and a `progress` knob:
 

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -74,6 +74,45 @@ def test_mark_as_bad_and_drop():
     assert b2.cell_names == []
 
 
+class _StubData:
+    def __init__(self, summary):
+        self.summary = summary
+        self.raw = None
+        self.steps = None
+
+
+class _StubCell:
+    def __init__(self, name):
+        self.cell_name = name
+        self.empty = False
+        self.data = _StubData(
+            pl.DataFrame(
+                {
+                    "cycle_index": [1, 2],
+                    "charge_capacity_gravimetric": [1.0, 0.9],
+                }
+            )
+        )
+
+
+@pytest.mark.essential
+def test_drop_loaded_cell_forgets_store_label():
+    b = Batch.from_cells(
+        {"keep": _StubCell("keep"), "gone": _StubCell("gone")},
+        name="t",
+        project="p",
+    )
+    assert b.cells.is_loaded("gone")
+    b.drop("gone")
+    assert b.cell_names == ["keep"]
+    assert list(b.cells) == ["keep"]
+    assert "gone" not in b.pages[FILENAME].to_list()
+    assert b.cells.is_loaded("keep")
+    assert set(b.summaries["cell"].to_list()) == {"keep"}
+    assert b.report()["cell"].to_list() == ["keep"]
+    assert b.experiment.cell_names == ["keep"]
+
+
 def test_save_roundtrip(tmp_path):
     b = _one_cell_batch()
     out = b.save(tmp_path / "j.json")

--- a/tests/test_batch_v3_runner.py
+++ b/tests/test_batch_v3_runner.py
@@ -76,6 +76,28 @@ def test_cellstore_is_lazy():
     assert not store.is_loaded("a")
 
 
+@pytest.mark.essential
+def test_cellstore_remove_drops_label_unload_keeps_it():
+    calls = []
+
+    def make(label):
+        return lambda: (calls.append(label), f"cell::{label}")[1]
+
+    store = CellStore({"a": make("a"), "b": make("b")})
+    assert store["a"] == "cell::a"
+    store.unload("a")
+    assert "a" in store
+    assert store["a"] == "cell::a"  # reloads
+    assert calls == ["a", "a"]
+
+    store.remove("a")
+    assert "a" not in store
+    assert list(store) == ["b"]
+    with pytest.raises(KeyError):
+        store["a"]
+    store.remove("missing")  # no-op
+
+
 def test_cellstore_no_label_mangling():
     """The legacy x_/lstrip accessor turned 'xenon_cell' into 'enon_cell'."""
     store = CellStore.from_cells({"xenon_cell": "X", "x_ray": "R"})


### PR DESCRIPTION
## Summary
- `CellStore.remove` drops the label from `_labels` / `_cache` / `_loaders`. `unload` stays cache-only.
- `Batch.drop` (and `drop_cells_marked_bad`) call `remove`, so `plot` / `summaries` / `report` work without a following `update()`.
- `mark_as_bad` remains a session flag. Docs in `agents.md` cover mark vs drop vs save/reload.

Closes #952

## Test plan
- [x] `uv run pytest -m essential tests/test_batch_v3_runner.py tests/test_batch_v3_facade.py`
- [x] Full `uv run pytest -m essential` (835 passed; one unrelated Windows HDF5 lock flake retried green)
- [ ] CI essential + Linux suite on the PR


Made with [Cursor](https://cursor.com)