### PR TITLE
Name a missing env_file in OtherPath credential errors

### DIFF
--- a/.issueflows/03-solved-issues/issue961_original.md
+++ b/.issueflows/03-solved-issues/issue961_original.md
@@ -1,0 +1,8 @@
+# Issue #961: need more detailed error messages for OtherPath
+
+Source: https://github.com/jepegit/cellpy/issues/961
+
+## Original issue text
+
+A user had env_file = ".env_cellpy" in the cellpy.toml file. His .env_cellpy file was located on C:\users\<username>\. And cellpy could not find it. However, the error message he got was "UnderDefined: You must define either CELLPY_PASSWORD or CELLPY_KEY_FILENAME environment variables."
+This did not help the user finding out that the .env_cellpy file was not found.

--- a/.issueflows/03-solved-issues/issue961_plan.md
+++ b/.issueflows/03-solved-issues/issue961_plan.md
@@ -1,0 +1,47 @@
+# Issue #961 plan
+
+## Goal
+
+When an `env_file` from `cellpy.toml` is missing, `OtherPath` remote auth must
+say so. Today the user only sees `UnderDefined` about `CELLPY_PASSWORD` /
+`CELLPY_KEY_FILENAME`.
+
+## Constraints
+
+- Do not change env-file *resolution* (no silent home fallback). Messages only.
+- Keep the existing `UnderDefined` exception type.
+- Relative `env_file` values stay cwd-relative; the message names the resolved
+  path and, if present, a same-named file under the home directory.
+
+### Prior art
+
+- `cellpy.internals.otherpath._credentials_from_env` — raises `UnderDefined`.
+- `cellpy.internals.connections.check_connection` — prints the same text.
+- `cellpy.config.loader._collect_env_overrides` — skips a missing file silently.
+- `cellpy.parameters.prmreader._load_env_file` — debug-only "No .env file found";
+  already tries `home / name` as a fallback (legacy path only).
+
+## Approach
+
+1. Shared helper that builds the credential-missing message plus an env-file
+   hint (configured path, resolved absolute, exists?, home-named sibling).
+2. Use it in `_credentials_from_env` and the `check_connection` print.
+3. `logging.warning` in `_collect_env_overrides` when the configured file is
+   absent (load-time, before any remote access).
+
+## Files to touch
+
+- `cellpy/internals/otherpath.py` — helper + richer `UnderDefined`.
+- `cellpy/internals/connections.py` — same message text.
+- `cellpy/config/loader.py` — warn when env file missing.
+- `tests/test_otherpaths.py` or `tests/test_config.py` — cover the hint.
+- `.issueflows/04-designs-and-guides/test-registry.md` — new essential row.
+
+## Test strategy
+
+`uv run pytest -m essential` (PR gate). New unit tests for the missing-file
+hint and the loader warning. Mark the hint test essential.
+
+## Open questions
+
+None — yolo-fit, messages only.

--- a/.issueflows/03-solved-issues/issue961_status.md
+++ b/.issueflows/03-solved-issues/issue961_status.md
@@ -1,0 +1,15 @@
+# Issue #961 status
+
+- [x] Done
+
+## What's done
+
+- `credentials.describe_env_file` / `missing_remote_credentials_message` name
+  the configured env file (resolved path, home-named sibling when present).
+- `OtherPath._credentials_from_env` and `check_connection` use that text.
+- Loader warns at load time when the configured env file is missing.
+- Essential tests in `tests/test_config_secrets.py`; registry updated.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -110,6 +110,10 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_collected_summary_groups.py::test_spread_plot_facets_follow_the_collected_column_order | yes | yes | plotting.collected.spread_plot | #947 | categorical facet order |
 | tests/test_collected_summary_groups.py::test_summary_collector_plot_uses_custom_group_labels_and_units | yes | yes | collect.collector.summary_collector + plot | #947 | issue snippet e2e |
 | tests/test_collected_backend_alias.py (module) | yes | yes | plotting.collected.collected_plot backend alias | #925 | matplotlib -> seaborn, warn_once signature |
+| tests/test_config_secrets.py::test_describe_env_file_names_a_missing_path | yes | yes | credentials.describe_env_file | #961 | missing env_file in UnderDefined |
+| tests/test_config_secrets.py::test_describe_env_file_points_at_home_sibling | yes | yes | credentials.describe_env_file | #961 | home-named sibling hint |
+| tests/test_config_secrets.py::test_credentials_from_env_mentions_missing_env_file | yes | yes | otherpath._credentials_from_env | #961 | OtherPath auth error names env_file |
+| tests/test_config_secrets.py::test_loader_warns_when_env_file_is_missing | yes | yes | loader._collect_env_overrides | #961 | load-time warning |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Missing ``env_file`` is named in the ``UnderDefined`` remote-auth error
+  (and a load-time warning) instead of only mentioning ``CELLPY_PASSWORD`` /
+  ``CELLPY_KEY_FILENAME``. (#961)
+
 * `Batch.drop` (and `drop_cells_marked_bad`) remove the cell from the store,
   not just the cache, so `plot` / `summaries` / `report` work without a
   following `update()`. `mark_as_bad` stays a session flag. (#952)

--- a/cellpy/config/credentials.py
+++ b/cellpy/config/credentials.py
@@ -24,6 +24,7 @@ Credentials are never read from a config file: the loader refuses a
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from cellpy.config.models import SecretsConfig
 
@@ -52,6 +53,59 @@ def _resolve(field: str) -> str | None:
     if value:
         return value
     return os.getenv(ENV_VARS[field]) or None
+
+
+def describe_env_file(env_file: Path | str | None) -> str:
+    """Status of a configured env file for error and warning text.
+
+    Empty string when ``env_file`` is unset. Otherwise names the resolved
+    path and, if that path is missing, a same-named file under the home
+    directory when one exists.
+    """
+    if env_file is None or env_file == "":
+        return ""
+    configured = Path(env_file).expanduser()
+    resolved = configured.resolve()
+    if resolved.is_file():
+        return (
+            f"Configured env_file {resolved} was found but does not set "
+            f"{ENV_VARS['password']} or {ENV_VARS['key_filename']}."
+        )
+    parts = [f"Configured env_file {configured} resolved to {resolved} and was not found."]
+    home_candidate = Path.home() / configured.name
+    try:
+        home_same = home_candidate.resolve() == resolved
+    except OSError:
+        home_same = False
+    if home_candidate.is_file() and not home_same:
+        parts.append(
+            f"A file named {configured.name} exists at {home_candidate}; "
+            "set paths.env_file to that absolute path."
+        )
+    else:
+        parts.append(
+            "Create that file (or run `cellpy setup`) so those variables can be loaded."
+        )
+    return " ".join(parts)
+
+
+def missing_remote_credentials_message(env_file: Path | str | None = None) -> str:
+    """``UnderDefined`` text when neither password nor key file is set."""
+    base = (
+        f"You must define either {ENV_VARS['password']} "
+        f"or {ENV_VARS['key_filename']} environment variables."
+    )
+    if env_file is None:
+        try:
+            from cellpy.config.session import get_config
+
+            env_file = get_config().paths.env_file
+        except Exception:
+            env_file = None
+    hint = describe_env_file(env_file)
+    if not hint:
+        return base
+    return f"{base} {hint}"
 
 
 def get_password() -> str | None:

--- a/cellpy/config/loader.py
+++ b/cellpy/config/loader.py
@@ -177,6 +177,10 @@ def _collect_env_overrides(env_file: Path | None) -> dict[str, Any]:
     raw: dict[str, str | None] = {}
     if env_file and env_file.is_file():
         raw.update({k: v for k, v in dotenv_values(env_file).items() if v is not None})
+    elif env_file:
+        from cellpy.config.credentials import describe_env_file
+
+        logging.warning(describe_env_file(env_file))
     for key, value in os.environ.items():
         if key.startswith("CELLPY_"):
             raw[key] = value

--- a/cellpy/internals/connections.py
+++ b/cellpy/internals/connections.py
@@ -76,10 +76,7 @@ def check_connection(
 
     key_filename = credentials.get_key_filename()
     if password is None and key_filename is None:
-        print(
-            f"   - You must define either {ENV_VAR_CELLPY_PASSWORD} "
-            f"or {ENV_VAR_CELLPY_KEY_FILENAME} environment variables."
-        )
+        print(f"   - {credentials.missing_remote_credentials_message()}")
     if key_filename is not None:
         key_path = pathlib.Path(key_filename).expanduser().resolve()
         info["key_filename"] = str(key_path)

--- a/cellpy/internals/otherpath.py
+++ b/cellpy/internals/otherpath.py
@@ -112,10 +112,7 @@ def _credentials_from_env(*, testing: bool = False) -> Dict[str, Any]:
     password = credentials.get_password()
     key_filename = credentials.get_key_filename()
     if password is None and key_filename is None:
-        raise UnderDefined(
-            f"You must define either {ENV_VAR_CELLPY_PASSWORD} "
-            f"or {ENV_VAR_CELLPY_KEY_FILENAME} environment variables."
-        )
+        raise UnderDefined(credentials.missing_remote_credentials_message())
     if key_filename is not None:
         key_path = pathlib.Path(key_filename).expanduser().resolve()
         if not testing and not key_path.is_file():

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -252,3 +252,50 @@ def test_configuration_reference_documents_secrets_without_values():
     assert "CELLPY_PASSWORD" in rendered
     # The secrets section documents the env var, never a default value.
     assert "ChangeMe123" not in rendered
+
+
+@pytest.mark.essential
+def test_describe_env_file_names_a_missing_path(tmp_path):
+    missing = tmp_path / "no-such.env"
+    text = credentials.describe_env_file(missing)
+    assert str(missing.resolve()) in text.replace("\\", "/") or str(missing.resolve()) in text
+    assert "was not found" in text
+    msg = credentials.missing_remote_credentials_message(missing)
+    assert "CELLPY_PASSWORD" in msg
+    assert "was not found" in msg
+
+
+@pytest.mark.essential
+def test_describe_env_file_points_at_home_sibling(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    sibling = home / ".env_cellpy"
+    sibling.write_text("CELLPY_PASSWORD=x\n", encoding="utf-8")
+    monkeypatch.setattr(credentials.Path, "home", staticmethod(lambda: home))
+    text = credentials.describe_env_file(tmp_path / ".env_cellpy")
+    assert "was not found" in text
+    assert str(sibling) in text or str(sibling.resolve()) in text
+    assert "absolute path" in text
+
+
+@pytest.mark.essential
+def test_credentials_from_env_mentions_missing_env_file(tmp_path, hermetic_session, monkeypatch):
+    from cellpy.exceptions import UnderDefined
+    from cellpy.internals import otherpath
+
+    missing = tmp_path / "gone.env"
+    with hermetic_session.override(paths={"env_file": missing}):
+        monkeypatch.delenv("CELLPY_PASSWORD", raising=False)
+        monkeypatch.delenv("CELLPY_KEY_FILENAME", raising=False)
+        with pytest.raises(UnderDefined, match="was not found") as exc:
+            otherpath._credentials_from_env()
+    assert "CELLPY_PASSWORD" in str(exc.value)
+    assert "gone.env" in str(exc.value)
+
+
+@pytest.mark.essential
+def test_loader_warns_when_env_file_is_missing(tmp_path, caplog):
+    missing = tmp_path / "missing.env"
+    caplog.set_level(logging.WARNING)
+    load_config(options=LoadOptions(skip_files=True, skip_env=False, env_file=missing))
+    assert any("was not found" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- When remote `OtherPath` auth has no `CELLPY_PASSWORD` / `CELLPY_KEY_FILENAME`, the `UnderDefined` message now also names the configured `env_file`, the path that was resolved, and a same-named file under the home directory when one exists.
- Config load logs a warning if `paths.env_file` is set but missing, so the problem is visible before a remote access.

Closes #961

## Test plan
- [x] `uv run pytest -m essential`
- [x] New tests in `tests/test_config_secrets.py` for the hint, home-sibling, `_credentials_from_env`, and loader warning


Made with [Cursor](https://cursor.com)