### PR TITLE
Fail batch.load cells when filefinder finds no raw files

### DIFF
--- a/.issueflows/03-solved-issues/issue962_original.md
+++ b/.issueflows/03-solved-issues/issue962_original.md
@@ -1,0 +1,7 @@
+# Issue #962: better feedback when running batch.load
+
+Source: https://github.com/jepegit/cellpy/issues/962
+
+## Original issue text
+
+The user ran batch.load using the "excel database" solution. It looked like everything went well, but it turned out that the filefinder had not found any of the raw-files. The user used external location for the raw files (OtherPath). It should be obvious for the user if some of the files were not found.

--- a/.issueflows/03-solved-issues/issue962_plan.md
+++ b/.issueflows/03-solved-issues/issue962_plan.md
@@ -1,0 +1,45 @@
+# Issue #962 plan
+
+## Goal
+
+`batch.load` must make it obvious when filefinder found no raw files. Today
+`cellpy.get()` with no paths returns an empty `CellpyCell` and the cell is
+marked `LOADED`.
+
+## Constraints
+
+- Do not change filefinder search rules or OtherPath resolution.
+- Keep `accept_errors=True` default (errors stay on `BatchResult`).
+- Do not raise the whole batch by default.
+
+### Prior art
+
+- `cellpy.get` (`filename is None` and no `cellpy_file`) returns empty cell.
+- `runner._get_kwargs` sets `source=None` when both paths are missing.
+- `_dbengine.find_files` stores `None` and continues.
+- `BatchResult.failed` / `raise_if_failed` already exist.
+
+## Approach
+
+1. `load_cell`: if `source is None`, `FAILED` + `FileNotFoundError` (re-raise
+   when `accept_errors=False`).
+2. `find_files`: `UserWarning` listing cells with no raw match.
+3. `_finalize`: after `update()`, `UserWarning` if any cell failed, pointing
+   at `batch.result.report()`.
+
+## Files to touch
+
+- `cellpy/batch/runner.py`
+- `cellpy/batch/_dbengine.py`
+- `cellpy/batch/facade.py`
+- `tests/test_batch_v3_runner.py`, `tests/test_batch.py`
+- `test-registry.md`
+
+## Test strategy
+
+`uv run pytest -m essential`. New tests for the empty-source fail and the
+find_files warning.
+
+## Open questions
+
+None — yolo-fit.

--- a/.issueflows/03-solved-issues/issue962_status.md
+++ b/.issueflows/03-solved-issues/issue962_status.md
@@ -1,0 +1,16 @@
+# Issue #962 status
+
+- [x] Done
+
+## What's done
+
+- `load_cell` fails with `FileNotFoundError` when filefinder found no raw
+  files and no local `.cellpy` exists (was an empty `LOADED` cell).
+- `find_files` warns listing unmatched cells.
+- `batch.load` `_finalize` warns on any failed cells and points at
+  `batch.result.report()`.
+- Agent docs mention the FAILED path.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -114,6 +114,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_config_secrets.py::test_describe_env_file_points_at_home_sibling | yes | yes | credentials.describe_env_file | #961 | home-named sibling hint |
 | tests/test_config_secrets.py::test_credentials_from_env_mentions_missing_env_file | yes | yes | otherpath._credentials_from_env | #961 | OtherPath auth error names env_file |
 | tests/test_config_secrets.py::test_loader_warns_when_env_file_is_missing | yes | yes | loader._collect_env_overrides | #961 | load-time warning |
+| tests/test_batch_v3_runner.py::test_load_cell_fails_when_filefinder_found_nothing | yes | yes | batch.runner.load_cell | #962 | empty raw+cellpy is FAILED not empty LOADED |
+| tests/test_batch_v3_runner.py::test_load_cell_reraises_missing_files_when_not_accepting | yes | yes | batch.runner.load_cell accept_errors | #962 | |
+| tests/test_batch_v3_facade.py::test_load_warns_when_no_raw_files_were_found | yes | yes | batch.facade._finalize | #962 | batch.load warning + result.report |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,8 @@ Quick facts:
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
   `mark_as_bad` is a session flag; `drop` / `drop_cells_marked_bad` remove now
   (plot/summaries work without `update()`). `save()` then next `load` (default
-  `drop_bad_cells=True`) drops marked cells before update.
+  `drop_bad_cells=True`) drops marked cells before update. Missing raw files
+  (filefinder miss) mark the cell `FAILED` and warn; see `b.result.report()`.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
   Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
 - Prefer schema-resolved names over hard-coded 1.x header strings.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* ``batch.load`` no longer treats a filefinder miss as success: cells with
+  no raw files and no local ``.cellpy`` are ``FAILED`` (not an empty
+  ``LOADED`` cell), ``find_files`` warns with the labels, and load warns
+  pointing at ``batch.result.report()``. (#962)
+
 * Missing ``env_file`` is named in the ``UnderDefined`` remote-auth error
   (and a load-time warning) instead of only mentioning ``CELLPY_PASSWORD`` /
   ``CELLPY_KEY_FILENAME``. (#961)

--- a/cellpy/batch/_dbengine.py
+++ b/cellpy/batch/_dbengine.py
@@ -189,6 +189,7 @@ def find_files(
     if hdr_journal["cellpy_file_name"] not in info_dict:
         info_dict[hdr_journal["cellpy_file_name"]] = []
 
+    missing_raw: list[str] = []
     for i, run_name in enumerate(file_name_indicators):
         try:
             instrument = info_dict[hdr_journal["instrument"]][i]
@@ -209,8 +210,18 @@ def find_files(
         )
         if not raw_files:
             raw_files = None
+            missing_raw.append(str(run_name))
         info_dict[hdr_journal["raw_file_names"]].append(raw_files)
         info_dict[hdr_journal["cellpy_file_name"]].append(cellpyfile)
+
+    if missing_raw:
+        warnings.warn(
+            f"filefinder found no raw files for {len(missing_raw)} cell(s): "
+            f"{', '.join(missing_raw)}. Check paths.rawdatadir (and OtherPath "
+            "hosts) plus the filename indicators in the database.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     return info_dict
 

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -639,6 +639,15 @@ def _finalize(
     if drop_bad_cells:
         batch.drop_cells_marked_bad()
     batch.update(**update_kwargs)
+    if batch.result is not None and batch.result.failed:
+        labels = ", ".join(item.label for item in batch.result.failed)
+        warnings.warn(
+            f"{len(batch.result.failed)} cell(s) failed to load: {labels}. "
+            "See batch.result.report() for per-cell errors "
+            "(missing raw files are a common cause).",
+            UserWarning,
+            stacklevel=2,
+        )
     batch.combine_summaries()
     if save_cellpy:
         if journal_path is None:

--- a/cellpy/batch/runner.py
+++ b/cellpy/batch/runner.py
@@ -85,6 +85,20 @@ def load_cell(spec: CellSpec, policy: LoadPolicy | None = None) -> CellResult:
     kwargs, source = _get_kwargs(spec, policy)
 
     started = time.perf_counter()
+    if source is None:
+        error = FileNotFoundError(
+            f"No raw files or cellpy file found for {spec.label!r}. "
+            "filefinder did not match any raw files and no local .cellpy exists."
+        )
+        if not policy.accept_errors:
+            raise error
+        return CellResult(
+            label=spec.label,
+            outcome=CellOutcome.FAILED,
+            source=None,
+            seconds=time.perf_counter() - started,
+            error=error,
+        )
     token = set_cell_label(spec.label)
     try:
         emit("cell_start", label=spec.label)

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -224,6 +224,8 @@ from cellpy import batch
 b = batch.load(name="my_experiment", project="my_project")
 summaries = b.summaries          # polars frame across cells
 c = b.cells["my_cell_01"]        # a CellpyCell
+# If filefinder found no raw files, those cells are FAILED (not empty
+# LOADED). Check b.result.report() / the UserWarning from load.
 ```
 
 Dropping cells:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -402,6 +402,19 @@ def test_find_files_auto_use_file_list_missing_project_raises(auto_list_tree, du
             )
 
 
+def test_find_files_warns_when_no_raw_match(auto_list_tree):
+    raw_dir, cellpy_dir = auto_list_tree
+    with config.override(batch={"auto_use_file_list": False}):
+        with pytest.warns(UserWarning, match="no raw files"):
+            out = _dbengine.find_files(
+                _info_dict("no_such_cell"),
+                project="P",
+                raw_file_dir=raw_dir,
+                cellpy_file_dir=cellpy_dir,
+            )
+    assert out[hdr_journal["raw_file_names"]][0] is None
+
+
 def test_find_files_caller_file_list_wins(auto_list_tree, dump_spy):
     """An explicit file_list is used as-is - no dump."""
     raw_dir, cellpy_dir = auto_list_tree

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -125,11 +125,24 @@ def test_load_from_frame(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     frame = pl.DataFrame({FILENAME: ["a", "b"], "mass": [1.0, 2.0]})
     # No cellpy paths on the frame; persist fills defaults under cellpydatadir.
-    b = load(name="n", project="p", frame=frame, journal_dir=tmp_path)
+    # No raw files either — load records FAILED cells and warns (#962).
+    with pytest.warns(UserWarning, match="failed to load"):
+        b = load(name="n", project="p", frame=frame, journal_dir=tmp_path)
     assert isinstance(b, Batch)
     assert b.cell_names == ["a", "b"]
     assert b.journal.name == "n" and b.journal.project == "p"
     assert (tmp_path / "cellpy_batch_n.json").is_file()
+
+
+@pytest.mark.essential
+def test_load_warns_when_no_raw_files_were_found(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    frame = pl.DataFrame({FILENAME: ["ghost"], "mass": [1.0]})
+    with pytest.warns(UserWarning, match="failed to load: ghost"):
+        b = load(name="n", project="p", frame=frame, journal_dir=tmp_path)
+    assert b.result is not None
+    assert [r.label for r in b.result.failed] == ["ghost"]
+    assert "filefinder" in str(b.result["ghost"].error)
 
 
 # ---- db path (#703) -----------------------------------------------------

--- a/tests/test_batch_v3_runner.py
+++ b/tests/test_batch_v3_runner.py
@@ -188,6 +188,27 @@ def test_load_cell_error_is_captured(tmp_path):
     assert result.error is not None
 
 
+@pytest.mark.essential
+def test_load_cell_fails_when_filefinder_found_nothing(tmp_path):
+    spec = CellSpec(
+        label="ghost",
+        cellpy_file=str(tmp_path / "missing.cellpy"),
+        raw_files=[],
+    )
+    result = load_cell(spec, LoadPolicy(source=SourcePreference.AUTO))
+    assert result.outcome == CellOutcome.FAILED
+    assert isinstance(result.error, FileNotFoundError)
+    assert "ghost" in str(result.error)
+    assert "filefinder" in str(result.error)
+
+
+@pytest.mark.essential
+def test_load_cell_reraises_missing_files_when_not_accepting(tmp_path):
+    spec = CellSpec(label="ghost", raw_files=[])
+    with pytest.raises(FileNotFoundError, match="filefinder"):
+        load_cell(spec, LoadPolicy(accept_errors=False))
+
+
 def test_load_cell_reraises_when_not_accepting(tmp_path):
     spec = CellSpec(label="bad", cellpy_file=str(tmp_path / "nope.h5"))
     with pytest.raises(Exception):


### PR DESCRIPTION
## Summary
- Cells with no raw match and no local `.cellpy` are `FAILED` instead of an empty `LOADED` cell from `cellpy.get()`.
- `find_files` warns with the unmatched labels; `batch.load` warns and points at `batch.result.report()`.

Closes #962

## Test plan
- [x] `uv run pytest -m essential`
- [x] New tests in `test_batch_v3_runner.py`, `test_batch_v3_facade.py`, `test_batch.py`


Made with [Cursor](https://cursor.com)