### PR TITLE
Document batch from b = batch.load, including b.plot()

### DIFF
--- a/.issueflows/03-solved-issues/issue963_original.md
+++ b/.issueflows/03-solved-issues/issue963_original.md
@@ -1,0 +1,8 @@
+# Issue #963: Documentation of batch API is confusing and not complete enough
+
+Source: https://github.com/jepegit/cellpy/issues/963
+
+## Original issue text
+
+It is difficult to understand the facade concept vs. the Batch object itself. Most users are interested in what b can do (b = batch.load(something)). The docs should honor that better. It also looks like some methods are missing. For example, b.plot.
+Also, make sure that the facade methods have a docstring so that users get help when pressing shift+tab in jupyter lab.

--- a/.issueflows/03-solved-issues/issue963_plan.md
+++ b/.issueflows/03-solved-issues/issue963_plan.md
@@ -1,0 +1,42 @@
+# Issue #963 plan
+
+## Goal
+
+Document batch from the user's object: `b = batch.load(...)`. Stop leading
+with "facade". Give `b.plot` and other public methods Shift-Tab docstrings.
+
+## Constraints
+
+- Docs + docstrings only. No API behavior change.
+- Keep private `_Legacy*` adapters out of the published API page.
+
+### Prior art
+
+- `docs/api/batch.md` currently has a **Facade** heading → `cellpy.batch.facade`
+  (dumps adapters).
+- `Batch.plot` has no docstring.
+- `tests/test_collect.py::test_collector_help_names_the_common_kwargs` is the
+  Shift-Tab contract pattern.
+
+## Approach
+
+1. Rewrite `docs/api/batch.md` around `b = batch.load(...)` and what `b` does.
+   Document `Batch` members, filter `^_`.
+2. Expand `Batch` / `cellpy.batch` module docs; add Google-style docstrings on
+   public methods that lack them (`plot`, properties, aliases).
+3. One essential test: public methods have `__doc__`; class doc names `plot`.
+
+## Files to touch
+
+- `docs/api/batch.md`
+- `cellpy/batch/__init__.py`, `cellpy/batch/facade.py`
+- `docs/getting_started/agents.md` / `AGENTS.md` (one line: `b.plot()`)
+- `tests/test_batch_v3_facade.py`, `test-registry.md`
+
+## Test strategy
+
+`uv run pytest -m essential`. New docstring test.
+
+## Open questions
+
+None — yolo-fit, docs only.

--- a/.issueflows/03-solved-issues/issue963_status.md
+++ b/.issueflows/03-solved-issues/issue963_status.md
@@ -1,0 +1,14 @@
+# Issue #963 status
+
+- [x] Done
+
+## What's done
+
+- `docs/api/batch.md` leads with `b = batch.load(...)` and a what-`b`-can-do
+  table; API page documents `Batch`, not the facade module dump.
+- Public `Batch` methods (including `plot`) have Shift-Tab docstrings.
+- Essential test `test_batch_public_methods_have_shift_tab_docs`.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -117,6 +117,7 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_v3_runner.py::test_load_cell_fails_when_filefinder_found_nothing | yes | yes | batch.runner.load_cell | #962 | empty raw+cellpy is FAILED not empty LOADED |
 | tests/test_batch_v3_runner.py::test_load_cell_reraises_missing_files_when_not_accepting | yes | yes | batch.runner.load_cell accept_errors | #962 | |
 | tests/test_batch_v3_facade.py::test_load_warns_when_no_raw_files_were_found | yes | yes | batch.facade._finalize | #962 | batch.load warning + result.report |
+| tests/test_batch_v3_facade.py::test_batch_public_methods_have_shift_tab_docs | yes | yes | batch.facade.Batch | #963 | Shift-Tab docstrings on b.plot etc. |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,7 @@ Quick facts:
 - Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
+  After load: `b.summaries`, `b.cells[label]`, `b.plot()`, `b.result.report()`.
   `mark_as_bad` is a session flag; `drop` / `drop_cells_marked_bad` remove now
   (plot/summaries work without `update()`). `save()` then next `load` (default
   `drop_bad_cells=True`) drops marked cells before update. Missing raw files

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Batch docs start from ``b = batch.load(...)`` (what ``b`` can do, including
+  ``b.plot()``) instead of a "Facade" heading. Public ``Batch`` methods have
+  Shift-Tab docstrings. (#963)
+
 * ``batch.load`` no longer treats a filefinder miss as success: cells with
   no raw files and no local ``.cellpy`` are ``FAILED`` (not an empty
   ``LOADED`` cell), ``find_files`` warns with the labels, and load warns

--- a/cellpy/batch/__init__.py
+++ b/cellpy/batch/__init__.py
@@ -1,14 +1,16 @@
-"""cellpy.batch -- the batch subsystem.
+"""Load and work with a set of cells.
 
-A boring, standard architecture for batch processing. ``cellpy.utils.batch``
-is a thin re-export/shim.
+Typical use::
 
-Modules:
-    journal  -- Journal model + json readers/writers
-    layout   -- BatchPaths: pure path computation + ensure_dirs
-    policy   -- LoadPolicy / CellSpec typed options
-    runner   -- load_cell / run -> BatchResult
-    ...
+    from cellpy import batch
+    b = batch.load(name="exp", project="proj")
+    b.summaries
+    b.cells["cell_01"]
+    b.plot()
+    b.result.report()
+
+``b`` is a :class:`Batch`. ``cellpy.utils.batch`` re-exports the same entry
+points.
 """
 
 from __future__ import annotations

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -1,15 +1,7 @@
-"""Batch facade.
+"""The ``Batch`` object returned by ``cellpy.batch.load``.
 
-The thin, notebook-friendly ``Batch`` class that ties the pieces together:
-journal + policy/resolve_specs + runner/result/store +
-aggregate/qc/outputs. Keeps the beloved surface the characterization net
-pinned -- ``pages``, ``cells``, ``summaries``, ``update``, ``report``,
-``save``, ``mark_as_bad``, ``drop`` -- while everything underneath is the new
-package.
-
-Plot wiring: ``plot()`` delegates to the plotting layer via a small legacy
-adapter; the full tidy-frame plot path lands with the collectors redesign
-(Epic B, batch plan section 4.7).
+Implementation module for :class:`Batch`, :func:`load`, :func:`from_journal`,
+and :func:`from_cells`. Import those from ``cellpy.batch``, not from here.
 """
 
 from __future__ import annotations
@@ -48,7 +40,26 @@ _EXPORT_KWARGS_WARNED = False
 
 
 class Batch:
-    """A batch of cells: a journal, a lazy cell store, and derived frames."""
+    """A loaded experiment: journal, cells, summaries, and a summary plot.
+
+    Typical use::
+
+        from cellpy import batch
+        b = batch.load(name="exp", project="proj")
+        b.summaries
+        b.cells["cell_01"]
+        b.plot()
+        b.result.report()
+
+    Attributes:
+        journal: The :class:`~cellpy.batch.journal.Journal` (pages + session).
+        policy: The :class:`~cellpy.batch.policy.LoadPolicy` used on the last load.
+        pages (polars.DataFrame): Journal table (filename, mass, group, …).
+        cell_names (list[str]): Labels in journal order.
+        cells: Lazy :class:`~cellpy.batch.store.CellStore` of ``CellpyCell`` objects.
+        summaries (polars.DataFrame): Combined per-cycle summaries.
+        result: :class:`~cellpy.batch.result.BatchResult` from the last ``update``.
+    """
 
     def __init__(
         self,
@@ -141,18 +152,25 @@ class Batch:
     # -- data surface ----------------------------------------------------
     @property
     def pages(self) -> pl.DataFrame:
+        """Journal table (filename, mass, group, raw_file_names, …)."""
         return self.journal.pages
 
     @property
     def cell_names(self) -> list[str]:
+        """Cell labels in journal order."""
         return self.journal.cell_names
 
     @property
     def cells(self) -> CellStore:
+        """Loaded cells, keyed by label (``b.cells['cell_01']``)."""
         return self._store
 
     @property
     def result(self) -> BatchResult | None:
+        """Per-cell load outcomes from the last ``update`` / ``load``.
+
+        Use ``b.result.report()`` for a tidy frame (outcome, source, error).
+        """
         return self._result
 
     def update(
@@ -205,15 +223,21 @@ class Batch:
         return self.update(**overrides)
 
     def recalc(self, **overrides) -> BatchResult:
+        """Reload every cell and remake step tables and summaries.
+
+        Same kwargs as :meth:`update`.
+        """
         return self.update(recalc=True, **overrides)
 
     @property
     def summaries(self) -> pl.DataFrame:
+        """Combined per-cycle summary frame across the batch (cached)."""
         if self._summaries is None:
             self._summaries = aggregate.combine_summaries(self._store, self.journal)
         return self._summaries
 
     def combine_summaries(self, **_kwargs) -> pl.DataFrame:
+        """Rebuild and return the combined summary frame (clears the cache)."""
         self._summaries = aggregate.combine_summaries(self._store, self.journal)
         return self._summaries
 
@@ -228,19 +252,32 @@ class Batch:
         return aggregate.combine_tests(self._store, self.journal)
 
     def make_summaries(self) -> pl.DataFrame:
+        """Alias of :meth:`combine_summaries`."""
         return self.combine_summaries()
 
     def report(self, check: bool = True) -> pl.DataFrame:
+        """QC-style per-cell status frame (not the same as ``result.report()``).
+
+        Args:
+            check (bool): kept for the legacy surface; the frame is always built.
+        """
         return qc.check(self._store, self.journal)
 
     # -- journal ops -----------------------------------------------------
     def save(self, path: Path | str | None = None) -> Path:
+        """Write the journal JSON (default ``cellpy_batch_<name>.json`` in cwd).
+
+        Args:
+            path: Destination file. ``None`` uses the default name from
+                ``journal.name``.
+        """
         target = Path(path) if path else Path(
             f"cellpy_batch_{self.journal.name or 'batch'}.json"
         )
         return write_journal(self.journal, target)
 
     def export_journal(self, path: Path | str | None = None) -> Path:
+        """Alias of :meth:`save`."""
         return self.save(path)
 
     def export_project(
@@ -317,18 +354,29 @@ class Batch:
         return self.journal
 
     def paginate(self) -> tuple[Path, ...]:
+        """Create the batch project folders and return their paths."""
         paths = BatchPaths.create(
             self.journal.name or "batch", self.journal.project or ""
         )
         return ensure_dirs(paths)
 
     def mark_as_bad(self, label: str) -> None:
+        """Flag ``label`` in ``journal.session['bad_cells']`` (does not drop).
+
+        Args:
+            label: Cell name as in ``b.cell_names``.
+        """
         bad = list(self.journal.session.get("bad_cells") or [])
         if label not in bad:
             bad.append(label)
         self.journal.session["bad_cells"] = bad
 
     def drop(self, label: str) -> "Batch":
+        """Remove ``label`` from the journal and the store now.
+
+        Args:
+            label: Cell name as in ``b.cell_names``.
+        """
         self.journal.pages = self.journal.pages.filter(pl.col(FILENAME) != label)
         self._store.remove(label)
         self._summaries = None
@@ -348,6 +396,16 @@ class Batch:
 
     # -- plotting (delegated; full wiring is Epic B) ---------------------
     def plot(self, backend: str | None = None, show: bool = False, **kwargs) -> Any:
+        """Plot combined summaries for this batch.
+
+        Args:
+            backend: Plotting backend (``None`` uses the configured default).
+            show: If True, display the figure immediately.
+            **kwargs: Forwarded to the summary plotter (columns, grouping, …).
+
+        Returns:
+            A figure from the plotting layer (backend-dependent).
+        """
         from cellpy.plotting.batch_summary import batch_summary_plot
 
         return batch_summary_plot(

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,24 +1,65 @@
 # Batch
 
-Run a set of cells as one job: build a journal, load/update the cells, and
-aggregate their summaries.
+Load many cells, then work with the object you get back.
 
-`cellpy.batch` is the 2.1 batch subsystem (it replaced the
-`cellpy.utils.batch_tools` machinery). `cellpy.utils.batch` remains as a thin
-re-export of the entry points below.
+```python
+from cellpy import batch
+
+b = batch.load(name="my_experiment", project="my_project")
+b.summaries
+b.cells["my_cell_01"]
+b.plot()
+b.result.report()   # per-cell load outcomes
+```
+
+`b` is a [`Batch`](#batch). You do not need a separate "facade" type —
+`cellpy.batch.facade` is only the implementation module.
+
+## What `b` can do
+
+| Want | Use |
+| --- | --- |
+| Journal table | `b.pages` |
+| Cell labels | `b.cell_names` |
+| One cell | `b.cells[label]` |
+| Combined summaries | `b.summaries` |
+| Summary plot | `b.plot()` |
+| Load / reload | `b.update()` / `b.load()` |
+| Per-cell load errors | `b.result.report()` |
+| Drop a cell | `b.drop(label)` |
+| Persist the journal | `b.save()` |
+
+`cellpy.utils.batch` is a thin re-export of the same entry points.
 
 ## Entry points
 
 ::: cellpy.batch
+    options:
+      members:
+        - load
+        - Batch
+        - from_journal
+        - from_cells
+        - Journal
+        - LoadPolicy
+        - BatchResult
 
-## Facade
+## Batch
 
-::: cellpy.batch.facade
+::: cellpy.batch.facade.Batch
+    options:
+      filters:
+        - "!^_"
+        - "!^experiment$"
 
 ## Journal
 
-::: cellpy.batch.journal
+::: cellpy.batch.journal.Journal
 
 ## Aggregation
 
 ::: cellpy.batch.aggregate
+    options:
+      members:
+        - combine_summaries
+        - combine_tests

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -224,6 +224,7 @@ from cellpy import batch
 b = batch.load(name="my_experiment", project="my_project")
 summaries = b.summaries          # polars frame across cells
 c = b.cells["my_cell_01"]        # a CellpyCell
+fig = b.plot()                   # summary plot
 # If filefinder found no raw files, those cells are FAILED (not empty
 # LOADED). Check b.result.report() / the UserWarning from load.
 ```

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -37,6 +37,21 @@ def test_facade_public_surface():
         assert hasattr(b, name), f"Batch lost `{name}`"
 
 
+@pytest.mark.essential
+def test_batch_public_methods_have_shift_tab_docs():
+    """Jupyter Shift-Tab must show help for the methods users actually call (#963)."""
+    import inspect
+
+    class_doc = inspect.getdoc(Batch) or ""
+    assert "plot" in class_doc
+    assert "batch.load" in class_doc
+    for name in FACADE_MUST_KEEP:
+        if name == "journal":
+            continue
+        obj = getattr(Batch, name)
+        assert inspect.getdoc(obj), f"Batch.{name} has no docstring"
+
+
 def test_from_journal(parameters):
     b = from_journal(parameters.journal_file_json_path)
     assert isinstance(b, Batch)


### PR DESCRIPTION
## Summary
- API docs start from `b = batch.load(...)` and list what `b` can do (including `plot`).
- Public `Batch` methods have Shift-Tab docstrings.

Closes #963

## Test plan
- [x] `uv run pytest -m essential`
- [x] `test_batch_public_methods_have_shift_tab_docs`


Made with [Cursor](https://cursor.com)