### PR TITLE
Sync conda env pins and add xlrd to install requires

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Sync conda env files with ``pyproject.toml``: pin ``cellpycore ==0.2.4``,
+  ``sqlalchemy >= 2.0.0``, and ``xlrd >= 2.0.1``. Add ``xlrd>=2.0.1`` to
+  install requires (old ``.xls`` loaders). (#969)
+
 * Zensical API pages no longer show raw Sphinx roles (``:class:``,
   ``:meth:``, ``:func:``); library docstrings use markdown code spans. (#967)
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - python >= 3.13
-    - cellpycore ==0.2.3
+    - cellpycore ==0.2.4
     - charset-normalizer
     - cookiecutter
     - cryptography
@@ -37,13 +37,13 @@ dependencies:
     - rich
     - scipy
     - setuptools
-    - sqlalchemy
+    - sqlalchemy >= 2.0.0
     # sqlalchemy-access is Windows-only (conda-forge requires __win).
     # On Windows: conda install -c conda-forge sqlalchemy-access
     # or: python -m pip install sqlalchemy-access
     - tqdm
     - typer
-    - xlrd
+    - xlrd >= 2.0.1
     - xmltodict
     - pip:
         # Optional external fastnda; cellpy defaults to cellpy.libs.local_fastnda.

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -5,7 +5,7 @@ dependencies:
     - python=3.13
     - PyGithub
     - black
-    - cellpycore ==0.2.3
+    - cellpycore ==0.2.4
     - cookiecutter
     - coverage
     - cryptography
@@ -52,14 +52,14 @@ dependencies:
     - sphinx
     - sphinx-autoapi
     - sphinx_rtd_theme
-    - sqlalchemy
+    - sqlalchemy >= 2.0.0
     # sqlalchemy-access is Windows-only (conda-forge requires __win).
     # On Windows: conda install -c conda-forge sqlalchemy-access
     # or: python -m pip install sqlalchemy-access
     - tqdm
     - twine
     - typer
-    - xlrd
+    - xlrd >= 2.0.1
     - xmltodict
     - charset-normalizer
     - pip:

--- a/github_actions_environment.yml
+++ b/github_actions_environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - python
     - PyGithub
-    - cellpycore ==0.2.3
+    - cellpycore ==0.2.4
     - charset-normalizer
     - cookiecutter
     - coverage
@@ -40,11 +40,11 @@ dependencies:
     - rich
     - scipy
     - setuptools
-    - sqlalchemy
+    - sqlalchemy >= 2.0.0
     # sqlalchemy-access is Windows-only (__win); install in CI on Windows runners only.
     - tqdm
     - typer
-    - xlrd
+    - xlrd >= 2.0.1
     - xmltodict
     - pip:
         # Optional external fastnda; cellpy defaults to cellpy.libs.local_fastnda.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "platformdirs>=4.10.0",
     "universal-pathlib>=0.3.10",
     "paramiko>=5.0.0",
+    "xlrd>=2.0.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -376,6 +376,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "universal-pathlib" },
+    { name = "xlrd" },
     { name = "xmltodict" },
 ]
 
@@ -472,6 +473,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "universal-pathlib", specifier = ">=0.3.10" },
+    { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xmltodict" },
 ]
 provides-extras = ["all", "batch", "fit", "legacy-files"]
@@ -2589,7 +2591,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3757,9 +3759,9 @@ name = "sqlalchemy-access"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyodbc" },
-    { name = "pywin32" },
-    { name = "sqlalchemy" },
+    { name = "pyodbc", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sqlalchemy", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/e3/02801e7b150342be8b7146227beb7943723511eb2f074bb836eae05e7578/sqlalchemy_access-2.0.3.tar.gz", hash = "sha256:89174a94e0ebd6c32470282d143aef0c0fbe3aafdee2c40956cd417648cb317e", size = 18011, upload-time = "2024-09-08T14:16:16.866Z" }
 wheels = [
@@ -4134,6 +4136,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `cellpycore ==0.2.4`, `sqlalchemy >= 2.0.0`, and `xlrd >= 2.0.1` in the three conda env YAMLs so they match `pyproject.toml`.
- Add `xlrd>=2.0.1` to install requires (old `.xls` loaders already call `pandas.read_excel(..., engine="xlrd")`).
- Lockfile updated; conda-forge extras (`pytables` / `hdf5` / jupyter) stay as a feedstock UX choice.

Fixes #969.

## Test plan
- [x] `uv run pytest -m essential` (776 passed)
- [ ] Scheduled conda env install still resolves after merge (Tier-3)


Made with [Cursor](https://cursor.com)