### PR TITLE
feat: collect_ica/dva use the same IcaOptions as dqdv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,9 +315,8 @@ Quick facts:
 - ICA/DVA: `from cellpy import ica` then `ica.dqdv(c)` / `ica.dvdq(c)`.
   Recipe: `opts = ica.IcaOptions(...)` then `options=opts` (or one-off kwargs).
   Plot: `from cellpy.utils.plotutils import ica_plot, dva_plot`.
-  Multi-cell: `cellpy.collect.collect_ica` / `collect_dva`.
-  `cellpy.ica.IcaOptions` ≠ `cellpy.collect.IcaOptions`. How-to:
-  [`docs/guides/ica.md`](docs/guides/ica.md).
+  Multi-cell: `collect_ica(batch, options=opts, cycles=...)` — same recipe.
+  How-to: [`docs/guides/ica.md`](docs/guides/ica.md).
 - Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -10,3 +10,4 @@ uv run python -m cellpy._deprecation
 | --- | --- | --- | --- |
 | `MultiCycleOcvFit.data` | `MultiCycleOcvFit.cell` | 2.1 | 2.2 |
 | `MultiCycleOcvFit.set_data` | `MultiCycleOcvFit.set_cell` | 2.1 | 2.2 |
+| `cellpy.collect.IcaOptions` | `cellpy.ica.IcaOptions plus cycles= / transforms=` | 2.1 | 2.3 |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* `collect_ica` / `collect_dva` take the same `cellpy.ica.IcaOptions` recipe
+  as `dqdv` / `dvdq` (smoothing, FWHM, normalize, …) and keep `cycles` /
+  `transforms` as collect-level keyword arguments. The thinner
+  `cellpy.collect.IcaOptions` still works and warns (removal 2.3).
+
 * `from_cells` raises `ValueError` naming every value that is not a cell (and
   the type that arrived) instead of accepting it and quietly producing a
   thinner collection later. `collect_summaries` warns and names the cells it

--- a/cellpy/_deprecation.py
+++ b/cellpy/_deprecation.py
@@ -132,6 +132,16 @@ def _seed_known_deprecations() -> None:
         introduced="2.1",
     )
 
+    # collect.IcaOptions was a thinner twin of cellpy.ica.IcaOptions
+    # (cycles + resolution only). collect_ica / collect_dva now take the
+    # real recipe and keep cycles/transforms as collect-level kwargs.
+    _register(
+        "cellpy.collect.IcaOptions",
+        "cellpy.ica.IcaOptions plus cycles= / transforms=",
+        removal="2.3",
+        introduced="2.1",
+    )
+
 
 if __name__ == "__main__":
     _seed_known_deprecations()

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -345,15 +345,15 @@ def ica_collector(
 
     Args:
         batch: The `Batch` to collect from.
-        options (IcaOptions, optional): A ready options object; the keyword
-            arguments below still update it.
+        options: A [`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions] recipe
+            (the deprecated collect-only ``IcaOptions`` is still accepted).
         cycles (sequence of int, optional): Cycles to collect (resolved per
             cell).
         voltage_resolution (float, optional): Voltage step for the q(V)
             interpolation dQ/dV differentiates along.
         autorun (bool): Run the collector immediately (default ``True``).
-        **overrides: Any other field of
-            `IcaOptions` -- ``transforms``.
+        **overrides: Other [`IcaOptions`][cellpy.ica.IcaOptions] fields, plus
+            collect-level ``transforms``.
 
     Returns:
         BatchCollector: bound to `collect_ica`.
@@ -386,15 +386,15 @@ def dva_collector(
 
     Args:
         batch: The `Batch` to collect from.
-        options (IcaOptions, optional): A ready options object; the keyword
-            arguments below still update it.
+        options: A [`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions] recipe
+            (the deprecated collect-only ``IcaOptions`` is still accepted).
         cycles (sequence of int, optional): Cycles to collect (resolved per
             cell).
         capacity_resolution (float, optional): Capacity step for the V(q)
             interpolation dV/dQ differentiates along.
         autorun (bool): Run the collector immediately (default ``True``).
-        **overrides: Any other field of
-            `IcaOptions` -- ``transforms``.
+        **overrides: Other [`IcaOptions`][cellpy.ica.IcaOptions] fields, plus
+            collect-level ``transforms``.
 
     Returns:
         BatchCollector: bound to `collect_dva`.

--- a/cellpy/collect/dva.py
+++ b/cellpy/collect/dva.py
@@ -12,84 +12,37 @@ from __future__ import annotations
 
 from typing import Any
 
-import polars as pl
-
-from cellpy.collect.cells import iter_cells
-from cellpy.collect.collection import Collection, CollectionMeta
-from cellpy.collect.options import IcaOptions
+from cellpy.collect.collection import Collection
+from cellpy.collect.ica import _collect_derivative
 
 
-def _as_polars(frame: Any) -> pl.DataFrame | None:
-    if frame is None:
-        return None
-    if isinstance(frame, pl.DataFrame):
-        return frame
-    try:
-        return pl.from_pandas(frame)
-    except (TypeError, ValueError):
-        return None
-
-
-def collect_dva(
-    batch: Any, options: IcaOptions | None = None, **overrides
-) -> Collection:
+def collect_dva(batch: Any, options: Any = None, **overrides) -> Collection:
     """Collect dV/dQ (differential voltage) curves per cell into one Collection.
+
+    ``options`` is a [`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions] recipe,
+    forwarded whole to [`dvdq`][cellpy.ica.dvdq]. When omitted, ``dvdq``'s
+    ``DVA_DEFAULTS`` (``normalize=False``) are used. ``cycles`` and
+    ``transforms`` are collect-level knobs (keyword arguments, not recipe
+    fields).
 
     Cycle selection is derived per cell from the *originally requested* cycles
     every iteration, so a cell missing a cycle never narrows the request for
     the cells after it (mirrors `collect_ica`).
+
+    Example:
+        >>> from cellpy import ica
+        >>> from cellpy.collect import collect_dva
+        >>> opts = ica.DVA_DEFAULTS.replace(capacity_resolution=5.0)
+        >>> collect_dva(batch, options=opts, cycles=(2, 3))
     """
-    from cellpy.utils import ica
+    from cellpy.ica import DVA_DEFAULTS
 
-    opts = options or IcaOptions()
-    if overrides:
-        opts = opts.replace(**overrides)
-    requested = tuple(opts.cycles) if opts.cycles is not None else None
-
-    # dV/dQ differentiates along capacity (V(q) interpolation), unlike
-    # dQ/dV's voltage_resolution (q(V) interpolation).
-    dvdq_kwargs: dict[str, Any] = {}
-    if opts.capacity_resolution is not None:
-        dvdq_kwargs["capacity_resolution"] = opts.capacity_resolution
-
-    frames: list[pl.DataFrame] = []
-    for item in iter_cells(batch):
-        cell = item.cell
-        if requested is None:
-            cycles = None
-        else:
-            available = set(cell.get_cycle_numbers())
-            cycles = [c for c in requested if c in available]
-            if not cycles:
-                continue
-
-        curve = _as_polars(ica.dvdq(cell, cycles=cycles, **dvdq_kwargs))
-        if curve is None or curve.height == 0:
-            continue
-        frames.append(
-            curve.with_columns(
-                pl.lit(item.label).alias("cell"),
-                pl.lit(item.group).alias("group"),
-                pl.lit(item.sub_group).alias("sub_group"),
-            )
-        )
-
-    data = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
-    for transform in opts.transforms:
-        data = transform(data)
-
-    meta = CollectionMeta(
+    return _collect_derivative(
+        batch,
+        options,
+        overrides,
         kind="dva",
-        batch_name=batch.journal.name,
-        options={
-            "cycles": list(requested) if requested else None,
-            "capacity_resolution": opts.capacity_resolution,
-        },
-        cells_included=list(batch.cells),
-    )
-    return Collection(
-        data=data,
-        kind="dva",
-        name=f"{batch.journal.name or 'batch'}_dva",
-        meta=meta,
+        verb="dvdq",
+        default_recipe=DVA_DEFAULTS,
+        resolution_key="capacity_resolution",
     )

--- a/cellpy/collect/ica.py
+++ b/cellpy/collect/ica.py
@@ -15,7 +15,7 @@ import polars as pl
 
 from cellpy.collect.cells import iter_cells
 from cellpy.collect.collection import Collection, CollectionMeta
-from cellpy.collect.options import IcaOptions
+from cellpy.collect.options import resolve_ica_collection
 
 
 def _as_polars(frame: Any) -> pl.DataFrame | None:
@@ -29,25 +29,23 @@ def _as_polars(frame: Any) -> pl.DataFrame | None:
         return None
 
 
-def collect_ica(
-    batch: Any, options: IcaOptions | None = None, **overrides
+def _collect_derivative(
+    batch: Any,
+    options: Any,
+    overrides: dict[str, Any],
+    *,
+    kind: str,
+    verb: str,
+    default_recipe: Any,
+    resolution_key: str,
 ) -> Collection:
-    """Collect dQ/dV (incremental capacity) curves per cell into one Collection.
+    """Per-cell ICA/DVA collection with a shared recipe + cycle isolation."""
+    from cellpy.utils import ica as ica_mod
 
-    Cycle selection is derived per cell from the *originally requested* cycles
-    every iteration, so a cell missing a cycle never narrows the request for
-    the cells after it.
-    """
-    from cellpy.utils import ica
-
-    opts = options or IcaOptions()
-    if overrides:
-        opts = opts.replace(**overrides)
-    requested = tuple(opts.cycles) if opts.cycles is not None else None
-
-    dqdv_kwargs: dict[str, Any] = {}
-    if opts.voltage_resolution is not None:
-        dqdv_kwargs["voltage_resolution"] = opts.voltage_resolution
+    recipe, requested, transforms = resolve_ica_collection(
+        options, overrides, default_recipe=default_recipe
+    )
+    verb_fn = getattr(ica_mod, verb)
 
     frames: list[pl.DataFrame] = []
     for item in iter_cells(batch):
@@ -60,7 +58,7 @@ def collect_ica(
             if not cycles:
                 continue
 
-        curve = _as_polars(ica.dqdv(cell, cycles=cycles, **dqdv_kwargs))
+        curve = _as_polars(verb_fn(cell, cycles=cycles, options=recipe))
         if curve is None or curve.height == 0:
             continue
         frames.append(
@@ -72,21 +70,51 @@ def collect_ica(
         )
 
     data = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
-    for transform in opts.transforms:
+    for transform in transforms:
         data = transform(data)
 
     meta = CollectionMeta(
-        kind="ica",
+        kind=kind,
         batch_name=batch.journal.name,
         options={
             "cycles": list(requested) if requested else None,
-            "voltage_resolution": opts.voltage_resolution,
+            resolution_key: getattr(recipe, resolution_key),
         },
         cells_included=list(batch.cells),
     )
     return Collection(
         data=data,
-        kind="ica",
-        name=f"{batch.journal.name or 'batch'}_ica",
+        kind=kind,
+        name=f"{batch.journal.name or 'batch'}_{kind}",
         meta=meta,
+    )
+
+
+def collect_ica(batch: Any, options: Any = None, **overrides) -> Collection:
+    """Collect dQ/dV (incremental capacity) curves per cell into one Collection.
+
+    ``options`` is a [`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions] recipe,
+    forwarded whole to [`dqdv`][cellpy.ica.dqdv]. ``cycles`` and ``transforms``
+    are collect-level knobs (keyword arguments, not recipe fields).
+
+    Cycle selection is derived per cell from the *originally requested* cycles
+    every iteration, so a cell missing a cycle never narrows the request for
+    the cells after it.
+
+    Example:
+        >>> from cellpy import ica
+        >>> from cellpy.collect import collect_ica
+        >>> opts = ica.IcaOptions(voltage_resolution=0.005, voltage_fwhm=0.015)
+        >>> collect_ica(batch, options=opts, cycles=(2, 3))
+    """
+    from cellpy.ica import IcaOptions as IcaRecipe
+
+    return _collect_derivative(
+        batch,
+        options,
+        overrides,
+        kind="ica",
+        verb="dqdv",
+        default_recipe=IcaRecipe(),
+        resolution_key="voltage_resolution",
     )

--- a/cellpy/collect/options.py
+++ b/cellpy/collect/options.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
+
+from cellpy._deprecation import warn_once
 
 #: A transform is a pure frame -> frame step applied after collection.
 Transform = Callable[["object"], "object"]
@@ -97,14 +99,12 @@ class CurveOptions:
 
 @dataclass(frozen=True)
 class IcaOptions:
-    """Options for dQ/dV (ICA) and dV/dQ (DVA) collection.
+    """Deprecated collect-only ICA knobs.
 
-    Shared by `collect_ica` and
-    `collect_dva` -- each forwards only the resolution
-    knob its own transform actually uses: ``dqdv`` differentiates along
-    voltage (needs ``voltage_resolution`` for the q(V) interpolation);
-    ``dvdq`` differentiates along capacity (needs ``capacity_resolution`` for
-    the V(q) interpolation).
+    Pass [`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions] as ``options=`` and
+    ``cycles=`` / ``transforms=`` as collect-level keyword arguments.
+    Kept so ``collect_ica(options=IcaOptions(cycles=..., voltage_resolution=...))``
+    still works for one release.
     """
 
     cycles: tuple[int, ...] | None = None
@@ -114,6 +114,62 @@ class IcaOptions:
 
     def replace(self, **changes) -> "IcaOptions":
         return replace(self, **changes)
+
+
+def resolve_ica_collection(
+    options: Any,
+    overrides: dict[str, Any],
+    *,
+    default_recipe: Any,
+) -> tuple[Any, tuple[int, ...] | None, tuple]:
+    """Split collect-level knobs from the ``cellpy.ica.IcaOptions`` recipe.
+
+    Returns ``(recipe, cycles, transforms)``. ``cycles`` / ``transforms`` stay
+    on this side of the collect seam; every other override is applied to the
+    recipe and forwarded whole to ``dqdv`` / ``dvdq``.
+    """
+    from cellpy.ica import IcaOptions as IcaRecipe
+
+    overrides = dict(overrides)
+    cycles = overrides.pop("cycles", None)
+    transforms = overrides.pop("transforms", None)
+
+    if options is None:
+        recipe = default_recipe
+        resolved_cycles = cycles
+        resolved_transforms = () if transforms is None else transforms
+    elif type(options) is IcaOptions:
+        warn_once(
+            "cellpy.collect.IcaOptions",
+            "cellpy.ica.IcaOptions plus cycles= / transforms=",
+            removal="2.3",
+            introduced="2.1",
+        )
+        extra = {}
+        if options.voltage_resolution is not None:
+            extra["voltage_resolution"] = options.voltage_resolution
+        if options.capacity_resolution is not None:
+            extra["capacity_resolution"] = options.capacity_resolution
+        recipe = default_recipe.replace(**extra) if extra else default_recipe
+        resolved_cycles = options.cycles if cycles is None else cycles
+        resolved_transforms = options.transforms if transforms is None else transforms
+    elif isinstance(options, IcaRecipe):
+        recipe = options
+        resolved_cycles = cycles
+        resolved_transforms = () if transforms is None else transforms
+    else:
+        raise TypeError(
+            "options must be cellpy.ica.IcaOptions (or the deprecated "
+            f"cellpy.collect.IcaOptions), got {type(options).__name__}"
+        )
+
+    if overrides:
+        recipe = recipe.replace(**overrides)
+    if resolved_cycles is not None:
+        resolved_cycles = tuple(resolved_cycles)
+    if resolved_transforms is None:
+        resolved_transforms = ()
+    return recipe, resolved_cycles, resolved_transforms
 
 
 @dataclass(frozen=True)

--- a/docs/api/ica.md
+++ b/docs/api/ica.md
@@ -45,10 +45,9 @@ wide = ica.to_wide(frame)
 | Many cells, dQ/dV | [`collect_ica`][cellpy.collect.ica.collect_ica] |
 | Many cells, dV/dQ | [`collect_dva`][cellpy.collect.dva.collect_dva] |
 
-`cellpy.collect.IcaOptions` is a **different** dataclass from
-[`cellpy.ica.IcaOptions`][cellpy.ica.IcaOptions]: it only holds the collection
-knobs (`cycles`, `voltage_resolution`, `capacity_resolution`). Do not pass one
-where the other is expected.
+`collect_ica` / `collect_dva` take the same
+[`IcaOptions`][cellpy.ica.IcaOptions] as `dqdv` / `dvdq`. `cycles` and
+`transforms` stay collect-level keyword arguments.
 
 Worked notebook: [Incremental capacity analysis](../examples/04_incremental_capacity_analysis.md).
 Short recipe: [How to compute ICA / DVA](../guides/ica.md).

--- a/docs/examples/04_incremental_capacity_analysis.ipynb
+++ b/docs/examples/04_incremental_capacity_analysis.ipynb
@@ -11215,8 +11215,8 @@
     "fig = dva_plot(c, cycles=2, direction=\"charge\")\n",
     "```\n",
     "\n",
-    "Multi-cell: `cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`.\n",
-    "`cellpy.collect.IcaOptions` is not `cellpy.ica.IcaOptions`. See the\n",
+    "Multi-cell: `collect_ica(batch, options=opts, cycles=…)` / `collect_dva(batch, …)`\n",
+    "use the same `IcaOptions` as `dqdv` / `dvdq`. See the\n",
     "[how-to](../guides/ica.md) and the [API](../api/ica.md).\n"
    ]
   }

--- a/docs/examples/04_incremental_capacity_analysis.md
+++ b/docs/examples/04_incremental_capacity_analysis.md
@@ -560,8 +560,8 @@ fig = ica_plot(c, cycles=[2, 3], voltage_resolution=0.005)
 fig = dva_plot(c, cycles=2, direction="charge")
 ```
 
-Multi-cell: `cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`.
-`cellpy.collect.IcaOptions` is not `cellpy.ica.IcaOptions`. See the
+Multi-cell: `collect_ica(batch, options=opts, cycles=…)` / `collect_dva(batch, …)`
+use the same `IcaOptions` as `dqdv` / `dvdq`. See the
 [how-to](../guides/ica.md) and the [API](../api/ica.md).
 
 
@@ -615,8 +615,8 @@ fig = ica_plot(c, cycles=[2, 3], voltage_resolution=0.005)
 fig = dva_plot(c, cycles=2, direction="charge")
 ```
 
-Multi-cell: `cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`.
-`cellpy.collect.IcaOptions` is not `cellpy.ica.IcaOptions`. See the
+Multi-cell: `collect_ica(batch, options=opts, cycles=…)` / `collect_dva(batch, …)`
+use the same `IcaOptions` as `dqdv` / `dvdq`. See the
 [how-to](../guides/ica.md) and the [API](../api/ica.md).
 
 

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -239,12 +239,12 @@ frame = ica.dqdv(c, cycles=[1, 2], options=opts.replace(pre_smoothing=True))
 fig = ica_plot(c, cycles=[1, 2], options=opts)
 ```
 
-`cellpy.ica.IcaOptions` is the transform recipe. `cellpy.collect.IcaOptions`
-is a different dataclass (cycles + resolution knobs only) for
-`collect_ica` / `collect_dva`. Do not mix them. How-to:
+`cellpy.ica.IcaOptions` is the transform recipe for `dqdv` / `dvdq` /
+`ica_plot` / `collect_ica` / `collect_dva`. Collect keeps `cycles=` (and
+`transforms=`) as its own knobs. How-to:
 [Compute ICA / DVA](../guides/ica.md).
 
-Multi-cell: `cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`.
+Multi-cell: `cellpy.collect.collect_ica(batch, options=opts, cycles=(1, 2))`.
 Worked notebook: [Incremental capacity analysis](../examples/04_incremental_capacity_analysis.md).
 API: [ICA and DVA](../api/ica.md).
 

--- a/docs/getting_started/migration_v2.0_to_2.1.md
+++ b/docs/getting_started/migration_v2.0_to_2.1.md
@@ -82,11 +82,11 @@ The 1.x ICA compatibility layer is removed.
 | the duplicate `dq` output column | the single canonical dQ/dV column |
 
 For **multi-cell** ICA / DVA collection, prefer
-`cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`
-(see the batch section below). One-cell plots:
-`cellpy.utils.plotutils.ica_plot` / `dva_plot`.
-`cellpy.ica.IcaOptions` (transform recipe) is not
-`cellpy.collect.IcaOptions` (collection knobs).
+`cellpy.collect.collect_ica(batch, options=ica.IcaOptions(...), cycles=…)` /
+`collect_dva(batch, …)` (see the batch section below). One-cell plots:
+`cellpy.utils.plotutils.ica_plot` / `dva_plot`. The collect-only
+`cellpy.collect.IcaOptions` bag is deprecated; use `cellpy.ica.IcaOptions`
+plus `cycles=`.
 
 ## Plotting
 

--- a/docs/guides/ica.md
+++ b/docs/guides/ica.md
@@ -86,24 +86,22 @@ Both accept `backend="plotly"` (default) or `"matplotlib"`. Set
 ## Many cells
 
 ```python
-from cellpy.collect import IcaOptions as CollectIcaOptions
+from cellpy import ica
 from cellpy.collect import collect_ica, collect_dva
 
-# keyword overrides (same as one-cell)
-ica_coll = collect_ica(batch, cycles=(2, 3), voltage_resolution=0.005)
-dva_coll = collect_dva(batch, cycles=(2, 3), capacity_resolution=5.0)
-
-# or a collect-side options object
-coll_opts = CollectIcaOptions(cycles=(2, 3), voltage_resolution=0.005)
-ica_coll = collect_ica(batch, options=coll_opts)
+# same IcaOptions as dqdv / dvdq; cycles stay a collect-level knob
+ica_coll = collect_ica(batch, options=opts, cycles=(2, 3))
 dva_coll = collect_dva(
-    batch, options=coll_opts.replace(capacity_resolution=5.0)
+    batch, options=ica.DVA_DEFAULTS.replace(capacity_resolution=5.0), cycles=(2, 3)
 )
+
+# one-off field overrides still work
+ica_coll = collect_ica(batch, cycles=(2, 3), voltage_resolution=0.005)
 ```
 
-`cellpy.collect.IcaOptions` is **not** `cellpy.ica.IcaOptions`. The collect
-variant only has `cycles`, `voltage_resolution`, `capacity_resolution`, and
-`transforms`. Do not pass one where the other is expected.
+`cycles` and `transforms` are collect-level keyword arguments, not fields on
+[`IcaOptions`][cellpy.ica.IcaOptions]. The old `cellpy.collect.IcaOptions`
+bag still works and warns.
 
 ## See also
 

--- a/examples/04_incremental_capacity_analysis.ipynb
+++ b/examples/04_incremental_capacity_analysis.ipynb
@@ -11215,8 +11215,8 @@
     "fig = dva_plot(c, cycles=2, direction=\"charge\")\n",
     "```\n",
     "\n",
-    "Multi-cell: `cellpy.collect.collect_ica(batch)` / `collect_dva(batch)`.\n",
-    "`cellpy.collect.IcaOptions` is not `cellpy.ica.IcaOptions`. See the\n",
+    "Multi-cell: `collect_ica(batch, options=opts, cycles=…)` / `collect_dva(batch, …)`\n",
+    "use the same `IcaOptions` as `dqdv` / `dvdq`. See the\n",
     "[how-to](../guides/ica.md) and the [API](../api/ica.md).\n"
    ]
   }

--- a/tests/test_collect_dva.py
+++ b/tests/test_collect_dva.py
@@ -21,7 +21,8 @@ from tests.test_batch import (  # noqa: F401  (imported for fixture resolution)
 
 plotly = pytest.importorskip("plotly", reason="plotting extras (batch) not installed")
 
-from cellpy.collect import IcaOptions, collect_dva, dva_collector  # noqa: E402
+from cellpy import ica  # noqa: E402
+from cellpy.collect import collect_dva, dva_collector  # noqa: E402
 
 
 def _assert_rendered(collector):
@@ -69,10 +70,13 @@ def test_collect_dva_forwards_capacity_resolution_not_voltage_resolution(
 
     monkeypatch.setattr(ica_mod, "dvdq", spy)
     col = collect_dva(
-        populated_batch, options=IcaOptions(cycles=(1,), capacity_resolution=0.01)
+        populated_batch,
+        options=ica.DVA_DEFAULTS.replace(capacity_resolution=0.01),
+        cycles=(1,),
     )
 
-    assert captured.get("capacity_resolution") == 0.01
+    assert captured["options"].capacity_resolution == 0.01
+    assert captured["options"].normalize is False
     assert "voltage_resolution" not in captured
     assert col.meta.options["capacity_resolution"] == 0.01
 

--- a/tests/test_collect_ica_options.py
+++ b/tests/test_collect_ica_options.py
@@ -1,0 +1,116 @@
+"""collect_ica / collect_dva accept cellpy.ica.IcaOptions as the recipe."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from tests.test_batch import (  # noqa: F401
+    batch_instance,
+    clean_dir,
+    populated_batch,
+)
+
+from cellpy import ica
+from cellpy._deprecation import _WARNED_SITES
+from cellpy.collect import IcaOptions as CollectIcaOptions
+from cellpy.collect import collect_dva, collect_ica
+
+
+@pytest.mark.essential
+def test_collect_ica_forwards_the_full_recipe(populated_batch, monkeypatch):
+    from cellpy.utils import ica as ica_mod
+
+    captured: dict = {}
+    original = ica_mod.dqdv
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ica_mod, "dqdv", spy)
+    opts = ica.IcaOptions(
+        voltage_resolution=0.005, voltage_fwhm=0.015, pre_smoothing=True
+    )
+    collect_ica(populated_batch, options=opts, cycles=(1,))
+
+    assert captured["options"] == opts
+    assert captured["cycles"] == [1]
+
+
+@pytest.mark.essential
+def test_collect_dva_forwards_the_full_recipe(populated_batch, monkeypatch):
+    from cellpy.utils import ica as ica_mod
+
+    captured: dict = {}
+    original = ica_mod.dvdq
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ica_mod, "dvdq", spy)
+    opts = ica.DVA_DEFAULTS.replace(capacity_resolution=0.01, post_smoothing=False)
+    collect_dva(populated_batch, options=opts, cycles=(1,))
+
+    assert captured["options"] == opts
+    assert captured["options"].normalize is False
+    assert captured["cycles"] == [1]
+
+
+@pytest.mark.essential
+def test_collect_dva_keeps_dva_defaults_when_no_recipe(populated_batch, monkeypatch):
+    from cellpy.utils import ica as ica_mod
+
+    captured: dict = {}
+    original = ica_mod.dvdq
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ica_mod, "dvdq", spy)
+    collect_dva(populated_batch, cycles=(1,), capacity_resolution=0.01)
+
+    recipe = captured["options"]
+    assert recipe.capacity_resolution == 0.01
+    assert recipe.normalize is False
+    assert "voltage_resolution" not in captured
+
+
+@pytest.mark.essential
+def test_legacy_collect_ica_options_still_works(populated_batch):
+    _WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        col = collect_ica(
+            populated_batch,
+            options=CollectIcaOptions(cycles=(1,), voltage_resolution=0.01),
+        )
+    assert col.kind == "ica"
+    assert col.data.height > 0
+    assert col.meta.options["voltage_resolution"] == 0.01
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("cellpy.collect.IcaOptions" in m for m in messages)
+
+
+@pytest.mark.essential
+def test_legacy_collect_dva_options_still_works(populated_batch):
+    _WARNED_SITES.clear()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        col = collect_dva(
+            populated_batch,
+            options=CollectIcaOptions(cycles=(1,), capacity_resolution=0.01),
+        )
+    assert col.kind == "dva"
+    assert col.meta.options["capacity_resolution"] == 0.01
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("cellpy.collect.IcaOptions" in m for m in messages)
+
+
+@pytest.mark.essential
+def test_unknown_options_type_raises(populated_batch):
+    with pytest.raises(TypeError, match="cellpy.ica.IcaOptions"):
+        collect_ica(populated_batch, options=object())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`cellpy.collect.IcaOptions` was a thinner twin of `cellpy.ica.IcaOptions` (cycles + one resolution knob). Collectors only forwarded that one knob, so smoothing / FWHM / normalize never reached `dqdv` / `dvdq`. The ICA redesign asked for one recipe object shared by the verbs and the collectors.

## What changed

- `collect_ica` / `collect_dva` take `cellpy.ica.IcaOptions` and forward it whole.
- `cycles` and `transforms` stay collect-level keyword arguments.
- DVA still defaults to `DVA_DEFAULTS` (`normalize=False`) when no recipe is passed.
- The old `cellpy.collect.IcaOptions(cycles=..., voltage_resolution=...)` still works and warns (removal 2.3).
- Docs (`docs/guides/ica.md`, agents recipe, API hub) no longer treat the two classes as something to keep apart.

```python
from cellpy import ica
from cellpy.collect import collect_ica, collect_dva

opts = ica.IcaOptions(voltage_resolution=0.005, voltage_fwhm=0.015)
collect_ica(batch, options=opts, cycles=(2, 3))
collect_dva(batch, options=ica.DVA_DEFAULTS.replace(capacity_resolution=5.0), cycles=(2, 3))
```

## How to verify

```bash
uv run pytest tests/test_collect_ica_options.py tests/test_collect_dva.py tests/test_ica_api.py -q
uv run pytest -m essential
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06384-6649-7a3d-94b2-a560b8f6a2fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06384-6649-7a3d-94b2-a560b8f6a2fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

