### PR TITLE
docs: promote HISTORY notes for 2.1.3.post2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,19 @@
 
 ## [Unreleased]
 
+## [2.1.3.post2] - 2026-09-02
+
+Post-release of 2.1.3 — one `IcaOptions` recipe for collect and verbs, ICA/DVA
+docs, and clearer errors for empty cycles and unknown batch labels.
+
 * `collect_ica` / `collect_dva` take the same `cellpy.ica.IcaOptions` recipe
   as `dqdv` / `dvdq` (smoothing, FWHM, normalize, …) and keep `cycles` /
   `transforms` as collect-level keyword arguments. The thinner
-  `cellpy.collect.IcaOptions` still works and warns (removal 2.3).
+  `cellpy.collect.IcaOptions` still works and warns (removal 2.3). (#987)
+
+* ICA / DVA guide documents how to construct `IcaOptions`, pass it as
+  `options=`, and use `.replace()` for one-off tweaks, plus the collect
+  verbs that share the same recipe. (#986)
 
 * `from_cells` raises `ValueError` naming every value that is not a cell (and
   the type that arrived) instead of accepting it and quietly producing a
@@ -17,15 +26,21 @@
   rather than doing nothing quietly. `drop_cells_marked_bad` stays silent about
   labels dropped in an earlier session (`bad_cells` survives `save`). (#950)
 
-* ``ica.dqdv`` / ``ica.dvdq`` raise when the cycle frame is empty (missing
+* `ica.dqdv` / `ica.dvdq` raise when the cycle frame is empty (missing
   requested cycle) instead of claiming missing curve columns. (#971)
 
-* Sync conda env files with ``pyproject.toml``: pin ``cellpycore ==0.2.4``,
-  ``sqlalchemy >= 2.0.0``, and ``xlrd >= 2.0.1``. Add ``xlrd>=2.0.1`` to
-  install requires (old ``.xls`` loaders). (#969)
+* Sync conda env files with `pyproject.toml`: pin `cellpycore ==0.2.4`,
+  `sqlalchemy >= 2.0.0`, and `xlrd >= 2.0.1`. Add `xlrd>=2.0.1` to
+  install requires (old `.xls` loaders). (#969)
 
-* Zensical API pages no longer show raw Sphinx roles (``:class:``,
-  ``:meth:``, ``:func:``); library docstrings use markdown code spans. (#967)
+* Zensical API pages no longer show raw Sphinx roles (`:class:`,
+  `:meth:`, `:func:`); library docstrings use markdown code spans. (#967)
+
+## [2.1.3] - 2026-08-16
+
+Patch release — batch load/plot/docs, CLI quietness, collect/plot polish, and
+cheaper remote `.cellpy` writes. Additive, no breaking changes. The interim
+`v2.1.3.post1` packaging tag (2026-08-25) is folded into this section.
 
 * Batch docs start from ``b = batch.load(...)`` (what ``b`` can do, including
   ``b.plot()``) instead of a "Facade" heading. Public ``Batch`` methods have


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`HISTORY.md` still had a huge `[Unreleased]` and no dated `2.1.3` / `2.1.3.post1` sections, even though those tags already shipped. This PR promotes notes so a GitHub release of `v2.1.3.post2` can tag a commit that already has the changelog.

## What moved

- Fresh empty `[Unreleased]`.
- New `## [2.1.3.post2] - 2026-09-02` with only changes after `v2.1.3.post1`:
  - `collect_ica` / `collect_dva` share `cellpy.ica.IcaOptions` (#987)
  - ICA / DVA `IcaOptions` usage docs (#986)
  - `from_cells` `ValueError` (#939 / #974)
  - `mark_as_bad` / `drop` unknown labels (#950 / #973)
  - empty cycle frame error (#971 / #972)
  - conda pins + `xlrd` (#969 / #970)
  - Zensical Sphinx roles (#967 / #968)
- New `## [2.1.3] - 2026-08-16` with the leftover Unreleased bullets that already shipped in 2.1.3 / the interim `v2.1.3.post1` packaging tag (folded, same pattern as 2.1.2).

Dependabot-only bumps stay out of the notes.

## After merge

Cut the post from the GitHub Releases page (same event as `gh release create`):

1. https://github.com/jepegit/cellpy/releases/new
2. Tag: `v2.1.3.post2` (create new tag)
3. Target: `master` (required — v2 tags must be ancestors of `origin/master`)
4. Title: `v2.1.3.post2`
5. Do **not** mark as pre-release
6. Do **not** save as draft (draft does not fire `release: published`)
7. Publish release → workflow “Publish to PyPI” runs validate → essential tests → PyPI

The `pypi` environment has no protection rules, so Publish release is enough. Do this only after this PR is on `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06384-6649-7a3d-94b2-a560b8f6a2fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06384-6649-7a3d-94b2-a560b8f6a2fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

