### PR TITLE
Add the `cellpy mcp` command group (#840)

### DIFF
--- a/cellpy/cli.py
+++ b/cellpy/cli.py
@@ -18,6 +18,7 @@ cli = typer.Typer(
 )
 
 setup_app = typer.Typer()
+mcp_app = typer.Typer()
 
 
 @cli.callback()
@@ -643,8 +644,72 @@ def serve(
     )
 
 
-# `setup` is the only group; the rest register themselves with @cli.command().
+# ----------------------- mcp ----------------------------------------
+#
+# Spelled `cellpy mcp`, not `cellpy server mcp`: `cellpy serve` already starts
+# Jupyter, and for an audience defined by not being comfortable in a terminal,
+# one letter between two unrelated commands is a trap. The server itself lives
+# in the separate `cellpy-mcp` distribution — see `cli_api` for why, and for
+# the contract these three wrap.
+
+
+@mcp_app.command("serve")
+def mcp_serve(
+    root: Annotated[
+        Optional[str],
+        typer.Option(
+            "--root",
+            "-r",
+            help="The only directory the server may read or write.",
+        ),
+    ] = None,
+):
+    """Run the MCP server over stdio (a client normally spawns this)."""
+    if cli_api.mcp_serve(root=root, echo=_echo()):
+        raise typer.Exit(code=1)
+
+
+@mcp_app.command("install")
+def mcp_install(
+    root: Annotated[
+        Optional[str],
+        typer.Option(
+            "--root",
+            "-r",
+            help="The only directory the server may read or write.",
+        ),
+    ] = None,
+    client: Annotated[
+        Optional[str],
+        typer.Option("--client", "-c", help="Which chat client to register with."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            "-dr",
+            help="Print the configuration instead of writing it.",
+        ),
+    ] = False,
+):
+    """Register the MCP server with a chat client."""
+    if cli_api.mcp_install(root=root, client=client, dry_run=dry_run, echo=_echo()):
+        raise typer.Exit(code=1)
+
+
+@mcp_app.command("status")
+def mcp_status():
+    """Report whether the MCP server is installed, and what it would serve."""
+    # Deliberately never exits non-zero: "not installed" is a true answer, and
+    # this is the command you script to find that out.
+    cli_api.mcp_status(echo=_echo(payload=True))
+
+
+# ----------------------- groups --------------------------------------
+
+# `setup` and `mcp` are the groups; the rest register with @cli.command().
 cli.add_typer(setup_app, name="setup")
+cli.add_typer(mcp_app, name="mcp", help="Run cellpy as an MCP server.")
 
 
 @cli.command()

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -2032,3 +2032,130 @@ def create_project(
             list_=list_,
             **kwargs,
         )
+
+
+# ----------------------- mcp ----------------------------------------
+#
+# `cellpy mcp` is a *shim*. The MCP server lives in a separate distribution,
+# `cellpy-mcp`, and cellpy deliberately does not depend on it: the MCP Python
+# SDK is young and moving (2.0 renamed `FastMCP` to `MCPServer` and ships two
+# `Context` classes with different attributes), and a long-lived network-facing
+# process is a security surface a data library should not carry. Keeping the
+# server out means it can move at the SDK's pace instead of cellpy's release
+# cadence — while the entry point still lives where people look for it.
+#
+# So cellpy gains a command, not a dependency. What that costs is a contract:
+#
+#   cellpy_mcp.__version__
+#   cellpy_mcp.serve(root=None)                      -> None (blocks on stdio)
+#   cellpy_mcp.install(root=None, client=None, dry_run=False) -> str
+#
+# `status` is the exception and is implemented here, because its whole job is
+# to answer "is it installed?" — a question that cannot be delegated to the
+# thing whose absence is the answer.
+
+#: The distribution to install, and the module it provides. Different strings
+#: on purpose: `pip install cellpy-mcp` gives you `import cellpy_mcp`, and a
+#: hint that prints the wrong one sends people to a 404.
+MCP_DISTRIBUTION = "cellpy-mcp"
+MCP_MODULE = "cellpy_mcp"
+
+
+def _import_mcp():
+    """The server package, or ``None`` after reporting how to install it."""
+    import importlib
+
+    try:
+        return importlib.import_module(MCP_MODULE)
+    except ImportError:
+        _ui().fail(
+            "mcp",
+            f"{MCP_DISTRIBUTION} is not installed.",
+            hint=f"python -m pip install {MCP_DISTRIBUTION}",
+        )
+        return None
+
+
+def mcp_serve(root=None, echo: Optional[Echo] = None):
+    """Run the MCP server over stdio. Returns true when it could not start.
+
+    This blocks: an MCP client spawns it as a subprocess and talks to it over
+    stdin/stdout, so there is nothing to background and nothing to connect to.
+    Running it by hand is mostly useful for seeing that it starts.
+    """
+    with _using_echo(echo):
+        module = _import_mcp()
+        if module is None:
+            return True
+        # Nothing is printed on the way up: stdout *is* the protocol channel,
+        # and a friendly banner on it is a parse error at the other end.
+        module.serve(root=root)
+        return False
+
+
+def mcp_install(
+    root=None,
+    client: Optional[str] = None,
+    dry_run: bool = False,
+    echo: Optional[Echo] = None,
+):
+    """Register the server with a chat client. Returns true on failure."""
+    with _using_echo(echo):
+        module = _import_mcp()
+        if module is None:
+            return True
+
+        ui = _ui()
+        try:
+            where = module.install(root=root, client=client, dry_run=dry_run)
+        except Exception as exc:  # noqa: BLE001 - the reason belongs on screen
+            ui.fail("mcp install", str(exc))
+            return True
+
+        ui.ok("registered" if not dry_run else "would register", str(where))
+        if not dry_run:
+            ui.hint("restart the client to pick it up")
+        return False
+
+
+def mcp_status(echo: Optional[Echo] = None):
+    """Report whether the server is installed, and what it would serve.
+
+    Answers the three questions someone actually has when a chat client says
+    it cannot see cellpy: is the package there, which cellpy would it use, and
+    which directory would it be allowed to read.
+    """
+    import importlib
+    import importlib.metadata
+
+    with _using_echo(echo):
+        from cellpy import __version__ as cellpy_version
+
+        ui = _ui()
+        ui.title("cellpy mcp")
+
+        try:
+            module = importlib.import_module(MCP_MODULE)
+        except ImportError:
+            ui.detail("server", "not installed")
+            ui.detail("cellpy", cellpy_version)
+            ui.hint(f"python -m pip install {MCP_DISTRIBUTION}")
+            # Not an error: "not installed" is a true and useful answer, and a
+            # non-zero exit would make `cellpy mcp status` unscriptable as the
+            # check it exists to be.
+            return False
+
+        try:
+            version = importlib.metadata.version(MCP_DISTRIBUTION)
+        except importlib.metadata.PackageNotFoundError:
+            # Importable but not installed as a distribution — an editable
+            # checkout on the path. Worth saying rather than guessing.
+            version = getattr(module, "__version__", "unknown (not installed)")
+
+        ui.detail("server", version)
+        ui.detail("cellpy", cellpy_version)
+        describe = getattr(module, "describe", None)
+        if callable(describe):
+            for key, value in describe().items():
+                ui.detail(key, str(value))
+        return False

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -132,6 +132,15 @@
       ]
     },
     {
+      "name": "mcp",
+      "params": [],
+      "subcommands": [
+        "install",
+        "serve",
+        "status"
+      ]
+    },
+    {
       "name": "new",
       "params": [
         {
@@ -616,6 +625,7 @@
       "convert",
       "edit",
       "info",
+      "mcp",
       "new",
       "pull",
       "run",

--- a/tests/test_cli_mcp.py
+++ b/tests/test_cli_mcp.py
@@ -1,0 +1,194 @@
+"""`cellpy mcp` — the shim over the separate `cellpy-mcp` distribution (#840).
+
+cellpy deliberately does not depend on the MCP SDK: the server lives in its own
+package so it can move at the SDK's pace, and so a long-lived network-facing
+process is not something the data library carries. What cellpy provides is the
+entry point people can find.
+
+That makes the interesting behaviour *the absence case* — what happens when the
+package is not installed — and the contract with it when it is. Both are tested
+here against a stub, because installing the real package to test the shim would
+be testing the wrong thing.
+
+Assertions read the console, not the `echo` callable: passing an `echo` is what
+switches the reporter on (a library does not print because someone imported
+it), but the reporter then writes to the console itself — successes to stdout
+and failures to stderr, which the tests check separately because for `serve`
+that separation is load-bearing.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+import pytest
+from typer.testing import CliRunner
+
+from cellpy import cli, cli_api, log
+
+log.setup_logging(default_level=logging.DEBUG, testing=True)
+
+pytestmark = pytest.mark.essential
+
+
+@pytest.fixture(autouse=True)
+def _plain_output(monkeypatch):
+    """Help and reporter output without ANSI, so substring assertions hold."""
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")
+
+
+@pytest.fixture()
+def absent(monkeypatch):
+    """`cellpy_mcp` is not importable, however the machine is actually set up."""
+    monkeypatch.delitem(sys.modules, cli_api.MCP_MODULE, raising=False)
+    real_import = __import__
+
+    def _import(name, *args, **kwargs):
+        if name == cli_api.MCP_MODULE:
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _import)
+
+
+@pytest.fixture()
+def stub(monkeypatch):
+    """A stand-in for the real package, recording what the shim passed it."""
+    module = types.ModuleType(cli_api.MCP_MODULE)
+    module.__version__ = "0.1.0"
+    module.calls = []
+
+    def serve(root=None):
+        module.calls.append(("serve", root))
+
+    def install(root=None, client=None, dry_run=False):
+        module.calls.append(("install", root, client, dry_run))
+        return "/somewhere/claude_desktop_config.json"
+
+    def describe():
+        return {"root": "/data/cells", "client": "claude-desktop"}
+
+    module.serve = serve
+    module.install = install
+    module.describe = describe
+    monkeypatch.setitem(sys.modules, cli_api.MCP_MODULE, module)
+    return module
+
+
+# -- the absence case ------------------------------------------------------------
+
+
+def test_serve_says_how_to_install_and_fails(absent, capsys):
+    """A missing optional package is a usage problem, not a traceback.
+
+    On **stderr**: a failure has to survive `cellpy mcp serve > somewhere`,
+    and stdout is the protocol channel for this command in particular.
+    """
+    assert cli_api.mcp_serve(echo=print) is True
+    printed = capsys.readouterr().err
+    assert cli_api.MCP_DISTRIBUTION in printed
+    assert f"pip install {cli_api.MCP_DISTRIBUTION}" in printed
+
+
+def test_status_reports_not_installed_and_still_succeeds(absent, capsys):
+    """`cellpy mcp status` is the command you script to find this out.
+
+    Exiting non-zero for "not installed" would make it useless as the check it
+    exists to be — the answer is true and useful, not an error.
+    """
+    assert cli_api.mcp_status(echo=print) is False
+    printed = capsys.readouterr().out
+    assert "not installed" in printed
+    assert f"pip install {cli_api.MCP_DISTRIBUTION}" in printed
+
+
+def test_the_hint_names_the_distribution_not_the_module(absent, capsys):
+    """`pip install cellpy_mcp` is a 404. The two names differ on purpose."""
+    cli_api.mcp_serve(echo=print)
+    printed = capsys.readouterr().err
+    assert "pip install cellpy-mcp" in printed
+    assert "pip install cellpy_mcp" not in printed
+
+
+# -- the contract with the package -----------------------------------------------
+
+
+def test_serve_hands_the_root_through(stub):
+    assert cli_api.mcp_serve(root="/data/cells", echo=print) is False
+    assert stub.calls == [("serve", "/data/cells")]
+
+
+def test_serve_prints_nothing(stub, capsys):
+    """stdout *is* the protocol channel — a banner on it is a parse error.
+
+    Every other command in cellpy reports what it is doing. This one must not.
+    """
+    cli_api.mcp_serve(root="/data/cells", echo=print)
+    assert capsys.readouterr().out == ""
+
+
+def test_install_passes_the_arguments_and_reports_where(stub, capsys):
+    assert (
+        cli_api.mcp_install(
+            root="/data/cells", client="claude-desktop", dry_run=True, echo=print
+        )
+        is False
+    )
+    assert stub.calls == [("install", "/data/cells", "claude-desktop", True)]
+    assert "claude_desktop_config.json" in capsys.readouterr().out
+
+
+def test_a_dry_run_does_not_tell_you_to_restart(stub, capsys):
+    cli_api.mcp_install(dry_run=True, echo=print)
+    assert "restart" not in capsys.readouterr().out.lower()
+
+    cli_api.mcp_install(dry_run=False, echo=print)
+    assert "restart" in capsys.readouterr().out.lower()
+
+
+def test_install_failure_is_reported_not_raised(stub, monkeypatch, capsys):
+    """The package raising is a message on screen and a non-zero exit."""
+
+    def boom(root=None, client=None, dry_run=False):
+        raise RuntimeError("config file is not valid json")
+
+    monkeypatch.setattr(stub, "install", boom)
+    assert cli_api.mcp_install(echo=print) is True
+    assert "not valid json" in capsys.readouterr().err
+
+
+def test_status_reports_both_versions(stub, capsys):
+    cli_api.mcp_status(echo=print)
+    printed = capsys.readouterr().out
+
+    import cellpy
+
+    assert cellpy.__version__ in printed
+    # Importable but not pip-installed (an editable checkout) still answers.
+    assert "0.1.0" in printed
+    # And whatever the package wants to add about itself.
+    assert "/data/cells" in printed
+
+
+# -- through the command line ----------------------------------------------------
+
+
+def test_the_command_group_exposes_three_verbs():
+    result = CliRunner().invoke(cli.cli, ["mcp", "--help"])
+    assert result.exit_code == 0
+    for verb in ("serve", "install", "status"):
+        assert verb in result.output
+
+
+def test_serve_exits_non_zero_when_the_package_is_missing(absent):
+    result = CliRunner().invoke(cli.cli, ["mcp", "serve"])
+    assert result.exit_code == 1
+
+
+def test_status_exits_zero_when_the_package_is_missing(absent):
+    result = CliRunner().invoke(cli.cli, ["mcp", "status"])
+    assert result.exit_code == 0
+    assert "not installed" in result.output


### PR DESCRIPTION
The entry point for the MCP server discussed in #840. The server itself lives in the separate `cellpy-mcp` distribution — **cellpy gains a command, not a dependency.**

```
cellpy mcp serve      # run over stdio — what a client spawns
cellpy mcp install    # register with a chat client
cellpy mcp status     # installed? which cellpy? which root?
```

## Why a shim rather than the server

The MCP Python SDK is young and moving — 2.0 renamed `FastMCP` to `MCPServer` and ships two `Context` classes with different attributes — and a long-lived network-facing process holding other people's data is a security surface a data library should not carry. Its own package lets it move at the SDK's pace instead of cellpy's release cadence, while the entry point still lives where people look. Absorbing it later is easy; extracting it after the fact is not.

The cost is a contract, written down in `cli_api`:

```python
cellpy_mcp.__version__
cellpy_mcp.serve(root=None)
cellpy_mcp.install(root=None, client=None, dry_run=False) -> str
cellpy_mcp.describe() -> dict            # optional, feeds `status`
```

`status` is the exception and is implemented here, because its whole job is to answer "is it installed?" — a question that cannot be delegated to the thing whose absence is the answer.

## Why `mcp` and not `server mcp`

`cellpy serve` already starts Jupyter. `cellpy server mcp` would sit one letter from it, and the audience this is for is the one least comfortable in a terminal. Settled on #840.

## Details worth review

- **`serve` prints nothing on the way up.** stdout *is* the protocol channel, and a banner on it is a parse error at the other end. Failures go to stderr; both are asserted.
- **`status` never exits non-zero.** "Not installed" is a true and useful answer, and exiting non-zero would make the command useless as the check it exists to be. `serve` and `install` do exit 1.
- **The hint names the distribution, not the module.** `pip install cellpy_mcp` is a 404. `MCP_DISTRIBUTION` and `MCP_MODULE` are separate constants and a test pins the difference.
- **`tests/data/cli_surface.json` is regenerated in the same commit**, per #569 — the new group is an intended surface change, so review sees it rather than CI hiding it.

## Testing

`tests/test_cli_mcp.py` — 12 tests covering the absence case and the contract, against a stub module; installing the real package to test the shim would be testing the wrong thing.

Full essential suite: **788 passed, 58 skipped**.

## Not in this PR

The `cellpy-mcp` package itself, the sandbox default moving from a single root to `config.paths.*`, and folding `install` into `cellpy setup` so the chat audience never types a command. Design and a working 12-tool prototype are in cellpy/cellpy-simple-gui#163.

Refs #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
