### PR TITLE
Add cli_api.list_templates() returning the batch templates as data

### DIFF
--- a/.issueflows/01-current-issues/cycle_status.md
+++ b/.issueflows/01-current-issues/cycle_status.md
@@ -10,8 +10,8 @@
 
 ## Queue (ordered)
 
-- [ ] #990 — cellpy new: honour no_input when the project directory does not exist — pending
-- [ ] #991 — Add cli_api.list_templates() returning the batch templates as data — pending
+- [x] #990 — cellpy new: honour no_input when the project directory does not exist — merged https://github.com/jepegit/cellpy/pull/994
+- [ ] #991 — Add cli_api.list_templates() returning the batch templates as data — in-progress
 - [ ] #993 — Docstring cross-references lost their module paths in #968, making them unresolvable — pending
 
 Blocked: none. Skipped (closed): none.

--- a/.issueflows/03-solved-issues/issue991_original.md
+++ b/.issueflows/03-solved-issues/issue991_original.md
@@ -1,0 +1,40 @@
+# Issue #991: Add cli_api.list_templates() returning the batch templates as data
+
+Source: https://github.com/jepegit/cellpy/issues/991
+
+## Original issue text
+
+`cellpy new --list` prints the available templates through the UI and returns
+nothing, so any non-CLI caller — a GUI, a script, an MCP tool — has to reach
+into `cellpy.utils.template_registry.REGISTERED_TEMPLATES` plus the private
+`cli_api._get_default_template()` and `cli_api._read_local_templates()` to
+offer the same choice.
+
+Every other `cellpy new` capability already has a library form
+(`cli_api.create_project`); listing is the one that does not.
+
+### Acceptance criteria
+
+- Add `cli_api.list_templates()` returning the templates as data, e.g.
+
+  ```python
+  {
+      "default": "standard",
+      "registered": {"standard": "<location>", "ife": "...", "single": "..."},
+      "local": {},                       # from config.paths.templatedir
+      "templatedir": "/path/to/templates",
+  }
+  ```
+
+  Exact key names are open to preference; the requirement is that a caller can
+  name every template, say which is the default, and distinguish registered
+  from local without importing a private helper.
+- The `list_` branch of `_new()` renders its output from that return value, so
+  the printed listing and the data cannot drift apart.
+- `cellpy new --list` output is unchanged.
+- A test in `tests/test_cli_api.py` asserting the returned shape and that the
+  default appears among the registered templates.
+
+Found while prototyping an MCP server for cellpy (#840), whose `list_templates`
+tool currently reads the registry and two private helpers directly. Related:
+#990.

--- a/.issueflows/03-solved-issues/issue991_plan.md
+++ b/.issueflows/03-solved-issues/issue991_plan.md
@@ -1,0 +1,36 @@
+# Issue #991 — plan
+
+## Goal
+
+Give `cellpy new --list` a library form: `cli_api.list_templates()` returning
+the templates as data, so a GUI / script / MCP tool does not have to import
+`REGISTERED_TEMPLATES` plus the private `_get_default_template()` and
+`_read_local_templates()`.
+
+## Approach
+
+- New public `cli_api.list_templates()` returning
+  `{"default": str, "registered": {name: location}, "local": {name: location},
+  "templatedir": str}`, with locations flattened through the existing
+  `_template_location()` helper. No cookiecutter import needed.
+- The `list_` branch of `_new()` renders its `ui` output **from that return
+  value** and returns it, so printed listing and data cannot drift.
+  `cellpy new --list` output stays byte-identical (same labels, same
+  `local (<templatedir>)` line); the CLI ignores the return value.
+
+## Files to touch
+
+- `cellpy/cli_api.py` — new `list_templates()` (public section, next to
+  `create_project`) plus the rewritten `list_` branch of `_new()`.
+- `tests/test_cli_api.py` — one new essential test.
+
+## Test strategy
+
+Test asserts the returned shape (four keys, dict types), that `default` names a
+template present in `registered`, and that `create_project(list_=True)` renders
+the same data (default label appears in the echoed output).
+
+## Constraints
+
+`_new()`'s list branch previously returned `None`; it now returns the dict.
+Update its docstring `Returns:` accordingly.

--- a/.issueflows/03-solved-issues/issue991_status.md
+++ b/.issueflows/03-solved-issues/issue991_status.md
@@ -1,0 +1,19 @@
+# Issue #991 — status
+
+- [x] Done
+
+## What's done
+
+- Added public `cli_api.list_templates()` returning
+  `{"default", "registered", "local", "templatedir"}` — locations flattened
+  through `_template_location()`, no cookiecutter import needed.
+- The `list_` branch of `_new()` now renders its output from that dict and
+  returns it (so `create_project(list_=True)` hands the data back too);
+  `cellpy new --list` output verified unchanged.
+- Two essential tests in `tests/test_cli_api.py` (shape contract + the printed
+  listing being rendered from the data), registered in
+  `04-designs-and-guides/test-registry.md`.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -131,6 +131,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_collect.py::test_collect_summaries_warns_about_cells_it_leaves_out | yes | yes | collect.summary.collect_summaries | #939 | narrowed collection names the dropped cells |
 | tests/test_collect.py::test_collect_summaries_is_quiet_when_every_cell_contributes | yes | yes | collect.summary._warn_left_out | #939 | noise guard: healthy batch must not warn |
 | tests/test_cli_api.py::test_create_project_with_no_input_creates_the_project_dir | yes | yes | cli_api._new project-dir branch | #990 | no_input must not read stdin (scriptable `cellpy new`) |
+| tests/test_cli_api.py::test_list_templates_returns_the_templates_as_data | yes | yes | cli_api.list_templates | #991 | shape contract for non-CLI callers |
+| tests/test_cli_api.py::test_the_template_listing_is_rendered_from_list_templates | yes | yes | cli_api._new list_ branch | #991 | printed listing cannot drift from the data |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@
   `cli_api.create_project(..., no_input=True)` creates the directory instead of
   prompting, so it can be driven from a script, a GUI, or an MCP tool. (#990)
 
+* `cli_api.list_templates()` returns the batch templates as data (default,
+  registered, local, and the template directory), and `cellpy new --list`
+  renders its listing from that same dictionary so the two cannot drift
+  apart. (#991)
+
 ## [2.1.3.post2] - 2026-09-02
 
 Post-release of 2.1.3 — one `IcaOptions` recipe for collect and verbs, ICA/DVA

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -1506,7 +1506,8 @@ def _new(
         cookie_directory: name of the directory for your cookie (inside the repository or zip file).
         local_templates_with_sub_directories: use sub-directories in local templates if True.
     Returns:
-        None
+        The `cellpy.cli_api.list_templates` dictionary when ``list_`` is True,
+        else None.
     """
 
     try:
@@ -1525,25 +1526,22 @@ def _new(
     ui = _ui()
 
     if list_:
-        default_template = _get_default_template()
-        local_templates = _read_local_templates()
-        local_templates_path = config.paths.templatedir
-        registered_templates = REGISTERED_TEMPLATES
+        templates = list_templates()
 
         ui.title("batch templates")
-        ui.detail("default", str(default_template))
+        ui.detail("default", str(templates["default"]))
         ui.blank()
         ui.step("registered (on github)")
-        for label, link in registered_templates.items():
-            ui.detail(label, _template_location(link))
-        ui.step(f"local ({local_templates_path})")
-        if local_templates:
-            for label, link in local_templates.items():
-                ui.detail(label, _template_location(link))
+        for label, link in templates["registered"].items():
+            ui.detail(label, link)
+        ui.step(f"local ({templates['templatedir']})")
+        if templates["local"]:
+            for label, link in templates["local"].items():
+                ui.detail(label, link)
         else:
             ui.detail("none", "-")
 
-        return
+        return templates
 
     if project_dir is None or session_id is None:
         no_input = False
@@ -2000,6 +1998,38 @@ def pull_resources(
                     "nothing selected",
                     hint="pick one of --tests, --examples or --clone",
                 )
+
+
+def list_templates() -> dict:
+    """The batch templates ``cellpy new`` knows about, as data.
+
+    The library form of ``cellpy new --list``: enough to name every template,
+    say which one is the default, and tell registered from local apart without
+    reaching for private helpers.
+
+    Returns:
+        dict: ``default`` (the template used when none is given), ``registered``
+        (the GitHub-hosted templates as ``{name: location}``), ``local`` (the
+        same shape for templates found in the template directory), and
+        ``templatedir`` (where the local ones are looked up).
+
+    Example:
+        >>> templates = list_templates()
+        >>> templates["default"] in templates["registered"]
+        True
+    """
+    return {
+        "default": _get_default_template(),
+        "registered": {
+            label: _template_location(entry)
+            for label, entry in REGISTERED_TEMPLATES.items()
+        },
+        "local": {
+            label: _template_location(entry)
+            for label, entry in _read_local_templates().items()
+        },
+        "templatedir": str(config.paths.templatedir),
+    }
 
 
 def create_project(

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -336,6 +336,30 @@ def test_create_project_returns_when_cookiecutter_missing(monkeypatch, capsys):
 
 
 @pytest.mark.essential
+def test_list_templates_returns_the_templates_as_data():
+    """`cellpy new --list` only printed; callers had to use private helpers (#991)."""
+    templates = cli_api.list_templates()
+
+    assert set(templates) == {"default", "registered", "local", "templatedir"}
+    assert templates["default"] in templates["registered"]
+    for group in ["registered", "local"]:
+        assert all(isinstance(location, str) for location in templates[group].values())
+    assert isinstance(templates["templatedir"], str)
+
+
+@pytest.mark.essential
+def test_the_template_listing_is_rendered_from_list_templates(capsys):
+    """The printed listing and the data cannot drift apart (#991)."""
+    listed = cli_api.create_project(list_=True, echo=print)
+    out = capsys.readouterr().out
+
+    assert listed == cli_api.list_templates()
+    assert listed["default"] in out
+    for label in listed["registered"]:
+        assert label in out
+
+
+@pytest.mark.essential
 def test_create_project_with_no_input_creates_the_project_dir(monkeypatch, tmp_path):
     """no_input=True used to prompt for the missing project dir (#990)."""
     import cookiecutter.main


### PR DESCRIPTION
`cellpy new --list` printed the templates and returned nothing, so any non-CLI caller — a GUI, a script, an MCP tool — had to read `template_registry.REGISTERED_TEMPLATES` plus the private `cli_api._get_default_template()` and `cli_api._read_local_templates()` to offer the same choice. Listing was the last `cellpy new` capability without a library form.

## What changed

- `cellpy/cli_api.py`: new public `list_templates()` returning

  ```python
  {
      "default": "standard",
      "registered": {"standard": "<location>", "ife": "...", "single": "..."},
      "local": {},
      "templatedir": "/path/to/templates",
  }
  ```

  Locations go through the existing `_template_location()` helper, so a caller can name every template, say which is the default, and tell registered from local apart without a private import. It needs no cookiecutter import.
- The `list_` branch of `_new()` renders its `ui` output from that dictionary and returns it, so the printed listing and the data cannot drift apart. `create_project(list_=True)` therefore hands the same dictionary back; the typer command ignores the return value, and `cellpy new --list` output is unchanged (verified against the previous rendering).

## How to test

```bash
uv run pytest tests/test_cli_api.py -q
uv run cellpy new --list
```

Two new essential tests cover the returned shape and that the printed listing is rendered from the data. Full suite locally: 1578 passed, 172 skipped, 13 xfailed.

Closes #991

Made with [Cursor](https://cursor.com)