### PR TITLE
fix: show IR on b.plot for discharge direction

### DIFF
--- a/.issueflows/03-solved-issues/issue949_original.md
+++ b/.issueflows/03-solved-issues/issue949_original.md
@@ -1,0 +1,9 @@
+# Issue #949: b.plot not showing ir
+
+Source: https://github.com/jepegit/cellpy/issues/949
+
+## Original issue text
+
+`b.plot(rate=True, ir=True, direction="discharge")`
+
+does not display the IR. The plot looks fine otherwise, and other optional parameters I know of works.

--- a/.issueflows/03-solved-issues/issue949_plan.md
+++ b/.issueflows/03-solved-issues/issue949_plan.md
@@ -1,0 +1,126 @@
+# Plan: #949 `b.plot` not showing IR
+
+## Goal
+
+Make `b.plot(ir=True, direction="discharge")` show an IR panel when the
+summaries contain IR, and tell the user when they do not — instead of dropping
+the panel with a debug log.
+
+## Constraints
+
+- Stay inside `cellpy.plotting.batch_summary` (the `Batch.plot` delegate). Do
+  **not** rebase onto collectors / `collected_plot` (Epic B / #708).
+- Do not change `make_summary(find_ir=…)` defaults in this issue (see open
+  question 2).
+- `ir=True` is already the plotly default; the reporter's call is the
+  `direction="discharge"` combination.
+- New merge-gating tests: `@pytest.mark.essential` + a row in
+  [test-registry.md](../04-designs-and-guides/test-registry.md).
+- Test command is `uv run pytest`; no conda.
+- Public batch-plot surface: one line in
+  [`docs/getting_started/agents.md`](../../docs/getting_started/agents.md) if
+  the warning/fallback is user-visible.
+- `HISTORY.md` `[Unreleased]` bullet at `/iflow-close`.
+
+### Prior art
+
+- `plot_cycle_life_summary_plotly` —
+  [`cellpy/plotting/batch_summary.py`](../../cellpy/plotting/batch_summary.py):
+  `direction` picks capacity **and** IR (`ir_discharge` vs `ir_charge`); if
+  that header is missing from `summaries.variable.unique()`, IR is skipped at
+  `logging.debug("no ir data available")`. Rate uses the same pattern.
+- `generate_summary_frame_for_plotting` (same file): optional IR/rate columns
+  are included when present. Synthetic farms with `ir_charge` /
+  `ir_discharge` melt correctly; `'ir_discharge' in unique` is True. Frame
+  prep is not the bug when the columns exist.
+- Matplotlib renderer (same file): ignores `ir=` / `direction=`; always tries
+  `summaries.ir_charge`. Honour the same pick/fallback if cheap.
+- `cellpycore.summarizers.ir_to_summary` + `LastIRExtractor`: both
+  `ir_charge` and `ir_discharge` are added only when `find_ir` is True **and**
+  raw has `internal_resistance`. A cycle without a discharge step gets NaN
+  `ir_discharge`, not a missing column. A summary built with `find_ir=False`
+  (public `CellpyCell.make_summary` default; `batch.runner` recalc) has **no**
+  IR columns at all.
+- Design doc:
+  [plotting-batch-summary.md](../04-designs-and-guides/plotting-batch-summary.md)
+  (#658). Update the IR/`direction` contract there.
+- Existing tests `test_issue668_batch_plot_variants` /
+  `test_batch_plot_delegates_without_batch_plotters` (`tests/test_batch.py`)
+  already call `ir=True, direction="discharge"` but are **xfail** (Epic B
+  `.plotter` holder). Leave them; do not un-xfail. New tests assert on the
+  figure `Batch.plot` / `plot_cycle_life_summary_plotly` returns.
+- Toolbox: nothing in `.issueflows/00-tools/` applies. Graph: no
+  `graphify-out/`, so grep-only.
+- #950 (same notebook line) deliberately left this as a separate plotting
+  issue.
+
+## Approach
+
+Verified on this branch (synthetic farms, not assumed from the issue text):
+
+1. When both IR columns exist, `direction="discharge"` **does** select
+   `ir_discharge` and would put `"IR (discharge)"` in the plotly title.
+2. The reported miss is therefore either (a) `ir_discharge` absent from the
+   melted `variable` column while `ir_charge` (and discharge capacity / rate)
+   are present, or (b) **neither** IR column present, skipped at debug.
+
+Fix in `plot_cycle_life_summary_plotly` (and matplotlib if the same helper
+fits):
+
+1. Small helper `_pick_optional_summary(available, preferred, fallback)`:
+   return `preferred` if it is in `available`, else `fallback`, else `None`.
+   Pass `list(available)` so ArrowStringArray membership is not a factor.
+2. When `ir=True`:
+   - preferred = direction's IR (`ir_discharge` / `ir_charge`);
+   - fallback = the other IR column;
+   - if a column is picked, append it;
+   - if we used the fallback, `warnings.warn` once (preferred missing, using
+     the other);
+   - if neither exists, `warnings.warn` (not debug) naming both headers.
+   Same for `rate=True` only if it is a one-liner with the same helper;
+   otherwise leave rate as-is (reporter said rate works).
+3. Do **not** treat all-NaN as missing: if the column exists, keep the panel
+   (autorange). Empty traces are a data issue, not a plotter skip.
+4. Tests use a tiny fake `experiment` (`memory_dumped["summary_engine"]` +
+   journal pages) — no `populated_batch`. Assert on the plotly title /
+   y-axis texts:
+   - both IR columns + `direction="discharge"` → `"IR (discharge)"`;
+   - only `ir_charge` + `direction="discharge"` + `ir=True` → still an IR
+     panel (`"IR (charge)"`) and a `UserWarning`;
+   - no IR columns + `ir=True` → `UserWarning`, no IR in title;
+   - `ir=False` → no IR even when columns exist.
+5. Record the pick/fallback/warn contract in
+   `plotting-batch-summary.md`. One sentence on `b.plot(ir=…, direction=…)`
+   in `agents.md` if the warning is part of the public recipe.
+
+## Files to touch
+
+| Path | Change |
+| --- | --- |
+| `cellpy/plotting/batch_summary.py` | `_pick_optional_summary`; IR (and optionally rate) pick/fallback/warn; matplotlib uses the same pick if cheap. |
+| `tests/test_batch_summary_ir.py` | New essential tests on synthetic farms (above cases). |
+| `.issueflows/04-designs-and-guides/plotting-batch-summary.md` | IR/`direction` contract. |
+| `.issueflows/04-designs-and-guides/test-registry.md` | Rows for the new tests. |
+| `docs/getting_started/agents.md` | One line on `ir=` / `direction=` if user-visible. |
+| `HISTORY.md` | `[Unreleased]` bullet (written at close). |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_batch_summary_ir.py -m essential
+uv run pytest -m essential
+```
+
+Do not un-xfail the Epic B `populated_batch.plotter` tests.
+
+## Open questions
+
+1. **Fallback or strict direction IR?** Recommended: **fallback + warning** —
+   `direction="discharge"` still selects discharge capacity; IR shows the
+   charge column when that is all the summary has. Strict (warn and omit)
+   matches today's silent skip and keeps the reporter's plot IR-less.
+2. **Also pass `find_ir=True` from `batch.runner` recalc / flip
+   `make_summary` default?** Recommended: **not in this issue.** Plotter
+   warnings cover "no IR in the frame". Changing summary defaults is a
+   behaviour change for every recalc. Follow-up if we confirm the reporter's
+   summaries lack IR columns entirely.

--- a/.issueflows/03-solved-issues/issue949_status.md
+++ b/.issueflows/03-solved-issues/issue949_status.md
@@ -1,0 +1,18 @@
+# Issue #949 status
+
+- [x] Done
+
+## What's done
+
+- `batch_summary.py`: `_pick_optional_summary` / `_select_ir_column`.
+  `direction="discharge"` prefers `ir_discharge`, falls back to `ir_charge`
+  with a `UserWarning`, warns and skips when neither column exists.
+  Matplotlib uses the same pick.
+- Essential tests in `tests/test_batch_summary_ir.py` (8 passed with plotly;
+  4 skip on essential `uv sync` without `--extra batch`).
+- Design doc, test-registry, `agents.md`, `AGENTS.md`, `HISTORY.md`.
+- Essential suite: 817 passed, 64 skipped.
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/plotting-batch-summary.md
+++ b/.issueflows/04-designs-and-guides/plotting-batch-summary.md
@@ -15,6 +15,12 @@ and deleting `batch_plotters.py`.
 - Facade: thin `_BatchPlotterHolder` keeps `b.plotter.figure` / `.farms`.
 - Frame prep names an unnamed summary index `cycle_index` before `reset_index`
   (join_summaries farms often leave the index unnamed).
+- **IR + `direction=` (#949):** `ir=True` (plotly default) picks
+  `ir_discharge` when `direction="discharge"`, else `ir_charge`. If that
+  column is missing, the other IR column is used and a `UserWarning` names
+  both. If neither column is in the melted frame, warn and skip the panel
+  (no debug-only skip). `ir=False` omits IR even when the columns exist.
+  All-NaN values still keep the panel.
 
 ## Links
 

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -140,6 +140,14 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_api.py::test_the_template_listing_is_rendered_from_list_templates | yes | yes | cli_api._new list_ branch | #991 | printed listing cannot drift from the data |
 | tests/test_doc_cross_references.py::test_every_see_reference_names_an_importable_target | yes | yes | cellpy/**/*.py docstring `See `…`` targets | #993 | guards the targets; test_no_sphinx_doc_roles guards the syntax |
 | tests/test_doc_cross_references.py::test_the_thinnest_delegates_point_at_their_documentation | yes | yes | CellpyCell.get_cap / to_csv / to_excel | #993 | the three pointers carrying the most undocumented arguments |
+| tests/test_batch_summary_ir.py::test_pick_optional_summary_prefers_then_falls_back | yes | yes | plotting.batch_summary._pick_optional_summary | #949 | |
+| tests/test_batch_summary_ir.py::test_select_ir_falls_back_and_warns | yes | yes | plotting.batch_summary._select_ir_column | #949 | discharge missing → ir_charge |
+| tests/test_batch_summary_ir.py::test_select_ir_warns_when_neither_column_exists | yes | yes | plotting.batch_summary._select_ir_column | #949 | |
+| tests/test_batch_summary_ir.py::test_select_ir_false_is_silent | yes | yes | plotting.batch_summary._select_ir_column | #949 | ir=False must not warn |
+| tests/test_batch_summary_ir.py::test_discharge_direction_uses_ir_discharge_when_present | yes | yes | plotting.batch_summary plotly title | #949 | skip if no plotly |
+| tests/test_batch_summary_ir.py::test_discharge_direction_falls_back_to_ir_charge | yes | yes | plotting.batch_summary plotly fallback | #949 | skip if no plotly |
+| tests/test_batch_summary_ir.py::test_ir_false_omits_the_panel_even_when_columns_exist | yes | yes | plotting.batch_summary ir=False | #949 | skip if no plotly |
+| tests/test_batch_summary_ir.py::test_missing_ir_columns_warn_and_skip_the_panel | yes | yes | plotting.batch_summary missing IR | #949 | skip if no plotly |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,8 @@ Quick facts:
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
   After load: `b.summaries`, `b.cells[label]`, `b.plot()`, `b.result.report()`.
+  `b.plot(ir=True, direction="discharge")` uses `ir_discharge`, or `ir_charge`
+  with a warning if that column is missing.
   `mark_as_bad` is a session flag (unknown cell name → `ValueError`); `drop` /
   `drop_cells_marked_bad` remove now
   (plot/summaries work without `update()`). `save()` then next `load` (default

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* `b.plot(ir=True, direction="discharge")` shows an IR panel: it prefers
+  `ir_discharge`, falls back to `ir_charge` with a warning if that column is
+  missing, and warns instead of silently skipping when neither IR column is
+  in the summary. (#949)
+
 * `summary_collector(..., custom_group_labels=...).plot(spread=True)` keeps
   those labels in the Plotly legend (same as the non-spread plot). Per-panel
   y-limits stay `y_ranges=` — do not reuse `fig.update_yaxes(..., row=N)`

--- a/cellpy/plotting/batch_summary.py
+++ b/cellpy/plotting/batch_summary.py
@@ -32,6 +32,64 @@ hdr_summary = get_headers_summary()
 SUPPORTED_BATCH_PLOT_BACKENDS = ("plotly", "matplotlib")
 
 
+def _pick_optional_summary(available, preferred, fallback=None):
+    """Pick ``preferred`` from ``available``, else ``fallback``, else ``None``.
+
+    ``available`` is copied to a list so membership works for numpy / Arrow
+    unique() results as well as plain sequences (#949).
+    """
+    names = list(available)
+    if preferred in names:
+        return preferred
+    if fallback is not None and fallback in names:
+        return fallback
+    return None
+
+
+def _ir_headers_for_direction(direction: str) -> tuple[str, str]:
+    """Return ``(preferred, fallback)`` IR summary headers for ``direction``."""
+    hdr_ir_charge = hdr_summary["ir_charge"]
+    hdr_ir_discharge = hdr_summary["ir_discharge"]
+    if direction == "discharge":
+        return hdr_ir_discharge, hdr_ir_charge
+    return hdr_ir_charge, hdr_ir_discharge
+
+
+def _select_ir_column(available, direction: str, *, ir: bool):
+    """Choose an IR summary column or warn when ``ir=True`` cannot plot one.
+
+    Args:
+        available: Column / variable names present in the plot frame.
+        direction: ``"charge"`` or ``"discharge"`` (anything else uses charge).
+        ir: If False, skip IR and do not warn.
+
+    Returns:
+        The preferred IR header, the other direction's header (fallback), or
+        ``None`` when IR is off or both headers are missing.
+    """
+    if not ir:
+        return None
+    preferred, fallback = _ir_headers_for_direction(direction)
+    picked = _pick_optional_summary(available, preferred, fallback)
+    if picked == preferred:
+        return picked
+    if picked is not None:
+        warnings.warn(
+            f"b.plot(ir=True, direction={direction!r}) has no {preferred} in "
+            f"the summary; using {picked}.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return picked
+    warnings.warn(
+        "b.plot(ir=True) found neither ir_charge nor ir_discharge in the "
+        "summary; skipping the IR panel.",
+        UserWarning,
+        stacklevel=3,
+    )
+    return None
+
+
 def resolve_batch_plot_backend(backend: Optional[str]) -> str:
     """Normalize Batch.plot backend names."""
     if backend is None:
@@ -394,8 +452,6 @@ def plot_cycle_life_summary_plotly(summaries: pd.DataFrame, **kwargs):
     hdr_charge, hdr_discharge = _get_capacity_columns(capacity_specifics)
 
     hdr_ce = hdr_summary["coulombic_efficiency"]
-    hdr_ir_charge = hdr_summary["ir_charge"]
-    hdr_ir_discharge = hdr_summary["ir_discharge"]
     hdr_charge_rate = hdr_summary["charge_c_rate"]
     hdr_discharge_rate = hdr_summary["discharge_c_rate"]
     hdr_group = hdr_journal.group
@@ -414,19 +470,15 @@ def plot_cycle_life_summary_plotly(summaries: pd.DataFrame, **kwargs):
         color_selector, symbol_selector = symbol_selector, color_selector
 
     if direction == "discharge":
-        hdr_ir = hdr_ir_discharge
         hdr_rate = hdr_discharge_rate
         selected_summaries = [hdr_cycle, hdr_ce, hdr_discharge]
     else:
         selected_summaries = [hdr_cycle, hdr_ce, hdr_charge]
-        hdr_ir = hdr_ir_charge
         hdr_rate = hdr_charge_rate
 
-    if ir:
-        if hdr_ir in available_summaries:
-            selected_summaries.append(hdr_ir)
-        else:
-            logging.debug("no ir data available")
+    picked_ir = _select_ir_column(available_summaries, direction, ir=ir)
+    if picked_ir is not None:
+        selected_summaries.append(picked_ir)
     if rate:
         if hdr_rate in available_summaries:
             selected_summaries.append(hdr_rate)
@@ -578,14 +630,17 @@ def plot_cycle_life_summary_matplotlib(
     # convert from bokeh to matplotlib - figsize - inch-ish
     width /= 80
     height /= 120
+    ir = kwargs.pop("ir", True)
+    direction = kwargs.pop("direction", "charge")
     discharge_capacity = summaries[hdr_summary["discharge_capacity_gravimetric"]]
     charge_capacity = summaries[hdr_summary["charge_capacity_gravimetric"]]
     coulombic_efficiency = summaries.coulombic_efficiency
-    try:
-        ir_charge = summaries.ir_charge
-    except AttributeError:
-        logging.debug("the data is missing ir charge")
-        ir_charge = None
+    if isinstance(summaries.columns, pd.MultiIndex):
+        available = summaries.columns.get_level_values(0).unique()
+    else:
+        available = summaries.columns
+    picked_ir = _select_ir_column(available, direction, ir=ir)
+    ir_frame = summaries[picked_ir] if picked_ir is not None else None
 
     plt.rcParams["figure.figsize"] = (10, 10)
     marker_types = [
@@ -614,7 +669,7 @@ def plot_cycle_life_summary_matplotlib(
     group_styles, sub_group_styles = create_plot_option_dicts(
         info, marker_types=marker_types, size=marker_size
     )
-    if ir_charge is None:
+    if ir_frame is None:
         canvas, (ax_ce, ax_cap) = plt.subplots(
             2,
             1,
@@ -669,10 +724,10 @@ def plot_cycle_life_summary_matplotlib(
             markerfacecolor=c,
         )
 
-        if ir_charge is not None:
+        if ir_frame is not None:
             try:
                 ax_ir.plot(
-                    ir_charge[label], color=c, label=name, marker=m, markerfacecolor=c
+                    ir_frame[label], color=c, label=name, marker=m, markerfacecolor=c
                 )
             except Exception as e:
                 logging.debug(f"Could not plot IR for {label} ({e})")
@@ -682,8 +737,8 @@ def plot_cycle_life_summary_matplotlib(
     ax_ce.set_ylim((0, 110))
     ax_cap.set_ylabel("Capacity\n(mAh/g)")
 
-    if ir_charge is not None:
-        ax_ir.set_ylabel("IR\n(charge)")
+    if ir_frame is not None:
+        ax_ir.set_ylabel(_make_labels().get(picked_ir, "IR").replace(" ", "\n"))
         ax_ir.set_xlabel("Cycle")
         ax_all.append(ax_ir)
     else:

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -256,7 +256,10 @@ from cellpy import batch
 b = batch.load(name="my_experiment", project="my_project")
 summaries = b.summaries          # polars frame across cells
 c = b.cells["my_cell_01"]        # a CellpyCell
-fig = b.plot()                   # summary plot
+fig = b.plot()                   # cycle-life summary (cap / CE)
+# ir=True is the default. direction="discharge" uses ir_discharge, and
+# falls back to ir_charge with a UserWarning if that column is missing.
+fig = b.plot(ir=True, rate=True, direction="discharge")
 # If filefinder found no raw files, those cells are FAILED (not empty
 # LOADED). Check b.result.report() / the UserWarning from load.
 ```

--- a/tests/test_batch_summary_ir.py
+++ b/tests/test_batch_summary_ir.py
@@ -1,0 +1,135 @@
+"""Batch cycle-life IR panel: direction pick, fallback, warn (#949)."""
+
+from __future__ import annotations
+
+import importlib.util
+import warnings
+
+import pandas as pd
+import pytest
+
+from cellpy.parameters.internal_settings import get_headers_journal, get_headers_summary
+from cellpy.plotting.batch_summary import (
+    _pick_optional_summary,
+    _select_ir_column,
+    generate_summary_frame_for_plotting,
+    plot_cycle_life_summary_plotly,
+)
+
+plotly_available = importlib.util.find_spec("plotly") is not None
+
+hdr = get_headers_summary()
+hdr_journal = get_headers_journal()
+
+
+def _farms(*variables: str) -> list[pd.DataFrame]:
+    idx = pd.Index([1, 2, 3], name=hdr.cycle_index)
+    farms = []
+    for var in variables:
+        farm = pd.DataFrame({"cell_a": [1.0, 2.0, 3.0], "cell_b": [1.5, 2.5, 3.5]}, index=idx)
+        farm.name = var
+        farms.append(farm)
+    return farms
+
+
+def _pages() -> pd.DataFrame:
+    cells = ["cell_a", "cell_b"]
+    return pd.DataFrame(
+        {
+            hdr_journal.group: [1, 1],
+            hdr_journal.sub_group: [1, 2],
+            hdr_journal.mass: [1.0, 1.0],
+            hdr_journal.total_mass: [1.0, 1.0],
+            hdr_journal.loading: [1.0, 1.0],
+            hdr_journal.nom_cap: [1.0, 1.0],
+            hdr_journal.area: [1.0, 1.0],
+            hdr_journal.label: cells,
+            hdr_journal.cell_type: ["x", "x"],
+            hdr_journal.instrument: ["a", "a"],
+        },
+        index=pd.Index(cells, name="cell"),
+    )
+
+
+class _Experiment:
+    def __init__(self, farms: list[pd.DataFrame]) -> None:
+        self.memory_dumped = {"summary_engine": farms}
+
+
+_CORE = (
+    hdr.coulombic_efficiency,
+    hdr["charge_capacity_gravimetric"],
+    hdr["discharge_capacity_gravimetric"],
+)
+
+
+def _frame(*extra: str) -> pd.DataFrame:
+    return generate_summary_frame_for_plotting(_pages(), _Experiment(_farms(*_CORE, *extra)))
+
+
+def _title(fig) -> str:
+    return fig.layout.title.text or ""
+
+
+@pytest.mark.essential
+def test_pick_optional_summary_prefers_then_falls_back():
+    available = [hdr.ir_charge]
+    assert _pick_optional_summary(available, hdr.ir_discharge, hdr.ir_charge) == hdr.ir_charge
+    assert _pick_optional_summary(available, hdr.ir_charge, hdr.ir_discharge) == hdr.ir_charge
+    assert _pick_optional_summary(available, hdr.ir_discharge, None) is None
+
+
+@pytest.mark.essential
+def test_select_ir_falls_back_and_warns():
+    with pytest.warns(UserWarning, match="has no ir_discharge"):
+        picked = _select_ir_column([hdr.ir_charge], "discharge", ir=True)
+    assert picked == hdr.ir_charge
+
+
+@pytest.mark.essential
+def test_select_ir_warns_when_neither_column_exists():
+    with pytest.warns(UserWarning, match="skipping the IR panel"):
+        assert _select_ir_column(["coulombic_efficiency"], "discharge", ir=True) is None
+
+
+@pytest.mark.essential
+def test_select_ir_false_is_silent():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        assert _select_ir_column([hdr.ir_charge], "discharge", ir=False) is None
+    assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not plotly_available, reason="plotly extra not installed")
+def test_discharge_direction_uses_ir_discharge_when_present():
+    frame = _frame(hdr.ir_charge, hdr.ir_discharge)
+    fig = plot_cycle_life_summary_plotly(frame, ir=True, direction="discharge")
+    assert "IR (discharge)" in _title(fig)
+    assert "IR (charge)" not in _title(fig)
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not plotly_available, reason="plotly extra not installed")
+def test_discharge_direction_falls_back_to_ir_charge():
+    frame = _frame(hdr.ir_charge)
+    with pytest.warns(UserWarning, match="has no ir_discharge"):
+        fig = plot_cycle_life_summary_plotly(frame, ir=True, direction="discharge")
+    assert "IR (charge)" in _title(fig)
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not plotly_available, reason="plotly extra not installed")
+def test_ir_false_omits_the_panel_even_when_columns_exist():
+    frame = _frame(hdr.ir_charge, hdr.ir_discharge)
+    fig = plot_cycle_life_summary_plotly(frame, ir=False, direction="discharge")
+    assert "IR (" not in _title(fig)
+
+
+@pytest.mark.essential
+@pytest.mark.skipif(not plotly_available, reason="plotly extra not installed")
+def test_missing_ir_columns_warn_and_skip_the_panel():
+    frame = _frame()
+    with pytest.warns(UserWarning, match="skipping the IR panel"):
+        fig = plot_cycle_life_summary_plotly(frame, ir=True, direction="discharge")
+    assert "IR (" not in _title(fig)


### PR DESCRIPTION
## Summary
- `b.plot(ir=True, direction="discharge")` now keeps an IR panel: it prefers `ir_discharge`, falls back to `ir_charge` with a `UserWarning` when that column is missing, and warns instead of silently skipping when neither IR column is in the summary.
- Matplotlib uses the same pick. Collectors / Epic B are untouched.

Closes #949

## Test plan
- [x] `uv run pytest tests/test_batch_summary_ir.py` (8 passed with plotly)
- [x] `uv run pytest -m essential` (817 passed, 64 skipped; 4 plotly IR tests skip without `--extra batch`)
- [ ] CI essential + full (linux / uv)


Made with [Cursor](https://cursor.com)