### PR TITLE
fix: warn when load rebases capacity so each cycle starts at 0

### DIFF
--- a/.issueflows/03-solved-issues/issue989_original.md
+++ b/.issueflows/03-solved-issues/issue989_original.md
@@ -1,0 +1,15 @@
+# Issue #989: Check capacity calculation behavior
+
+Source: https://github.com/jepegit/cellpy/issues/989
+
+## Original issue text
+
+I have some data which directly imported into cellpy 1.x produced this plot (the problem existed both for charge and discharge):
+
+<img width="1905" height="501" alt="Image" src="https://github.com/user-attachments/assets/01b53418-3f4c-408c-960a-2a49014d07c3" />
+
+In cellpy 2.1.3.post 2, I get this:
+
+<img width="897" height="328" alt="Image" src="https://github.com/user-attachments/assets/aba3b5c5-63ea-4345-9669-ef096492f787" />
+
+The initial double capacity was caused by forgetting to reset the capacity in a given step where it should have been reset. Somehow cellpy 2.x handles this automatically. Is this documented? Additionally, a message indicating that this correction was performed would be nice to have.

--- a/.issueflows/03-solved-issues/issue989_status.md
+++ b/.issueflows/03-solved-issues/issue989_status.md
@@ -1,0 +1,16 @@
+# Issue #989 status
+
+Interactive `/iflow-fix` session: check capacity calculation behavior
+(2.x auto-corrects a forgotten tester capacity reset vs 1.x double-capacity
+plot). Reuses existing GitHub #989 rather than creating a duplicate.
+
+- [x] Done
+
+## Iterative fixes log
+
+- 2026-09-07: Docs + `UserWarning` when `normalize_reset_granularity` actually
+  rebases `PER_TEST` / `PER_STEP` columns (silent on identity / `PER_CYCLE`).
+  Tests in `tests/test_harmonize.py`; note in `get_cap` / agents.md /
+  `harmonized-raw-default.md` / migration guide.
+- 2026-09-07: Warning/docs no longer say 2.x unique bit is "last datapoint"
+  (1.x did that too). Copy now: rebase so each cycle **starts at 0**.

--- a/.issueflows/04-designs-and-guides/harmonized-raw-default.md
+++ b/.issueflows/04-designs-and-guides/harmonized-raw-default.md
@@ -34,3 +34,24 @@ on the single-cell Arbin benchmark (CI gate fail at +100%).
   double-read.
 
 **Refs.** jepegit/cellpy#560; PR #623; loader plan in `cellpy-design-and-development/archive/foundations/cellpy2-loader-port-and-extraction-plan.md`.
+
+## Cycle-cumulative capacity rebase (#989)
+
+1.x kept the vendor capacity column as-is. If a tester step forgot to
+reset, `get_cap` / cycle plots showed doubled capacity. Both 1.x and 2.x
+still take the cycle's last point for per-cycle summary capacity.
+
+2.x `harmonize()` always runs `normalize_reset_granularity` so **each
+cycle starts at 0**:
+
+- `PER_CYCLE` — already cycle-cumulative, untouched (silent).
+- `PER_TEST` — subtract the first value of each cycle (that first point
+  becomes 0).
+- `PER_STEP` — re-accumulate completed steps within the cycle.
+
+When a `PER_TEST` / `PER_STEP` rebase actually changes values, one
+`UserWarning` names the columns. Identity rebases (already starting at 0
+each cycle) stay silent.
+
+This is cellpy-only (loader declarations). Do not confuse with
+`cellpycore.summarizers.normalize_capacity_granularity`.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -148,6 +148,11 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_summary_ir.py::test_discharge_direction_falls_back_to_ir_charge | yes | yes | plotting.batch_summary plotly fallback | #949 | skip if no plotly |
 | tests/test_batch_summary_ir.py::test_ir_false_omits_the_panel_even_when_columns_exist | yes | yes | plotting.batch_summary ir=False | #949 | skip if no plotly |
 | tests/test_batch_summary_ir.py::test_missing_ir_columns_warn_and_skip_the_panel | yes | yes | plotting.batch_summary missing IR | #949 | skip if no plotly |
+| tests/test_harmonize.py::test_per_cycle_is_the_target_and_is_untouched | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | PER_CYCLE silent |
+| tests/test_harmonize.py::test_per_test_is_rebased_at_each_cycle_boundary | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | PER_TEST warns |
+| tests/test_harmonize.py::test_per_step_accumulates_completed_steps_within_the_cycle | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | PER_STEP warns |
+| tests/test_harmonize.py::test_per_cycle_capacity_is_the_cycle_last_value | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | summary last-datapoint invariant |
+| tests/test_harmonize.py::test_per_test_already_cycle_cumulative_is_silent | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | identity PER_TEST no UserWarning |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,9 @@ Quick facts:
 - Metadata peek (no frames): `cellpy.read_meta(path)` → dict with `cell` / `tests`.
 - Ingestion form fields: `cellpy.instrument_meta_schema(instrument)` → `fields` / `units`.
 - Frames: `c.data.raw` / `.steps` / `.summary`; columns via `c.schema.*`.
+  After `get`, each cycle's raw capacity starts at 0. A forgotten tester
+  reset that 1.x plotted as doubled capacity is rebased on load; a
+  `UserWarning` fires when values actually change (#989).
 - Example data: `from cellpy.utils import example_data` → `example_data.raw_file()`.
 - ICA/DVA: `from cellpy import ica` then `ica.dqdv(c)` / `ica.dvdq(c)`.
   Recipe: `opts = ica.IcaOptions(...)` then `options=opts` (or one-off kwargs).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* After load, vendor capacity/energy that does not already start at 0 each
+  cycle is rebased so it does; a `UserWarning` names the columns when values
+  actually change (1.x kept the tester column as-is). (#989)
+
 * `b.plot(ir=True, direction="discharge")` shows an IR panel: it prefers
   `ir_discharge`, falls back to `ir_charge` with a warning if that column is
   missing, and warns instead of silently skipping when neither IR column is

--- a/cellpy/readers/capacity_curves.py
+++ b/cellpy/readers/capacity_curves.py
@@ -187,6 +187,13 @@ def get_cap(
         ``pandas.DataFrame`` ((cycle) voltage, capacity, (direction (-1, 1)))
         unless split is explicitly set to True. Then it returns a tuple
         with capacity and voltage.
+
+    Note:
+        Raw capacity columns are cycle-cumulative after load: each cycle
+        starts at 0. Testers that never reset (or reset per step) are
+        rebased in ``normalize_reset_granularity``; a ``UserWarning`` names
+        the columns when values actually change. 1.x kept the tester column
+        as-is, so a forgotten reset looked like doubled capacity (#989).
     """
 
     # TODO: allow for fixing the interpolation range (so that it is possible

--- a/cellpy/readers/instruments/harmonize.py
+++ b/cellpy/readers/instruments/harmonize.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Any
 
@@ -64,6 +65,11 @@ def normalize_reset_granularity(
         Resets each step, so within a cycle we must re-accumulate: add the
         running total of the *completed* steps of that cycle.
 
+    When a ``PER_TEST`` / ``PER_STEP`` rebase actually changes values, a
+    ``UserWarning`` names the columns. A no-op (already cycle-cumulative) is
+    silent. 1.x kept the tester column as-is, so a forgotten reset looked
+    like doubled capacity; 2.x resets each cycle to start at 0 (#989).
+
     Args:
         raw: frame already renamed to native columns.
         declarations: carries ``reset_granularity`` per column.
@@ -83,6 +89,7 @@ def normalize_reset_granularity(
         )
 
     out = raw
+    rebased: list[str] = []
     for column, granularity in declarations.reset_granularity.items():
         if column not in out.columns:
             # Declared but absent: the file simply did not carry it.
@@ -91,6 +98,7 @@ def normalize_reset_granularity(
         if granularity is ResetGranularity.PER_CYCLE:
             continue
 
+        before = out.get_column(column)
         if granularity is ResetGranularity.PER_TEST:
             # Value entering the cycle = the column's first value in the cycle.
             # Subtracting it rebases each cycle to start at zero.
@@ -99,9 +107,7 @@ def normalize_reset_granularity(
                     column
                 )
             )
-            continue
-
-        if granularity is ResetGranularity.PER_STEP:
+        elif granularity is ResetGranularity.PER_STEP:
             step_column = schema.step_num
             if step_column not in out.columns:
                 raise LoaderError(
@@ -128,10 +134,20 @@ def normalize_reset_granularity(
                 .with_columns((pl.col(column) + pl.col("_offset")).alias(column))
                 .drop("_offset")
             )
-            continue
+        else:
+            raise LoaderError(f"unknown reset granularity {granularity!r} for {column!r}")
+        if not out.get_column(column).equals(before):
+            rebased.append(f"{column} ({granularity})")
 
-        raise LoaderError(f"unknown reset granularity {granularity!r} for {column!r}")
-
+    if rebased:
+        warnings.warn(
+            "cellpy rebased vendor capacity/energy so each cycle starts at 0: "
+            + ", ".join(rebased)
+            + ". 1.x kept the tester column as-is (a forgotten reset then "
+            "looks like doubled capacity).",
+            UserWarning,
+            stacklevel=2,
+        )
     return out
 
 

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -118,7 +118,10 @@ cellpy.get(path, ...)  →  CellpyCell
 Useful methods on `CellpyCell` (non-exhaustive):
 
 - `get_cycle_numbers()` — list of cycle indices
-- `get_cap(...)` / capacity–voltage style extracts (see API / examples)
+- `get_cap(...)` / capacity–voltage style extracts (see API / examples).
+  After `get`, each cycle's raw capacity starts at 0. Testers that forgot
+  a reset (1.x plotted doubled capacity) are rebased on load; a
+  `UserWarning` names the columns when that happens (#989).
 - ICA / DVA — `from cellpy import ica` then `ica.dqdv(c)` / `ica.dvdq(c)`
   (see [Compute ICA / DVA](../guides/ica.md))
 - `make_step_table()` / `make_summary()` — usually already run by `get`

--- a/docs/getting_started/migration_v1_to_v2.md
+++ b/docs/getting_started/migration_v1_to_v2.md
@@ -120,6 +120,16 @@ def update_cell(c):
 If you index the `get_cap` result directly, rename. In-repo consumers
 (`plotutils.cycles_plot`, collectors, `ica`, CSV/Excel exporters) are updated.
 
+### Capacity reset granularity (#989)
+
+1.x kept the tester capacity column as-is. If a step forgot to reset,
+cycle plots showed doubled capacity. Both 1.x and 2.x still take the
+cycle's last point for per-cycle summary capacity.
+
+2.x additionally rebases vendor capacity/energy so **each cycle starts at
+0** (`normalize_reset_granularity`). When that rebase actually changes
+values, a `UserWarning` names the columns. Identity rebases stay silent.
+
 ## Configuration: `prms` → `cellpy.config`
 
 - Runtime config is the pydantic-settings stack under **`cellpy.config`**

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -9,6 +9,7 @@ to know the right answer independently.
 from __future__ import annotations
 
 import logging
+import warnings
 
 import polars as pl
 import pytest
@@ -119,7 +120,11 @@ def test_per_cycle_is_the_target_and_is_untouched():
         steps=[1, 1, 2, 1, 1, 2],
         values=[0.0, 1.0, 3.0, 0.0, 2.0, 5.0],
     )
-    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_CYCLE))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        out = normalize_reset_granularity(
+            frame, _declarations(ResetGranularity.PER_CYCLE)
+        )
     assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
         0.0,
         1.0,
@@ -139,7 +144,8 @@ def test_per_test_is_rebased_at_each_cycle_boundary():
         steps=[1, 1, 2, 1, 1, 2],
         values=[0.0, 1.0, 3.0, 3.0, 5.0, 8.0],
     )
-    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_TEST))
+    with pytest.warns(UserWarning, match="rebased vendor capacity"):
+        out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_TEST))
     assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
         0.0,
         1.0,
@@ -163,7 +169,8 @@ def test_per_step_accumulates_completed_steps_within_the_cycle():
         steps=[1, 1, 1, 2, 2, 1, 1, 2, 2],
         values=[0.0, 1.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 1.0],
     )
-    out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_STEP))
+    with pytest.warns(UserWarning, match="rebased vendor capacity"):
+        out = normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_STEP))
     assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
         0.0,
         1.0,
@@ -191,7 +198,10 @@ def test_per_cycle_capacity_is_the_cycle_last_value():
         steps=[1, 1, 2, 1, 1, 2],
         values=[0.0, 1.0, 3.0, 3.0, 5.0, 8.0],
     )
-    out = normalize_reset_granularity(per_test, _declarations(ResetGranularity.PER_TEST))
+    with pytest.warns(UserWarning, match="rebased vendor capacity"):
+        out = normalize_reset_granularity(
+            per_test, _declarations(ResetGranularity.PER_TEST)
+        )
     last = (
         out.group_by(SCHEMA.cycle_num, maintain_order=True)
         .agg(pl.col(SCHEMA.cumulative_charge_capacity).last().alias("cap"))
@@ -210,6 +220,29 @@ def test_per_step_without_a_step_column_fails_loudly():
     )
     with pytest.raises(LoaderError, match="needs"):
         normalize_reset_granularity(frame, _declarations(ResetGranularity.PER_STEP))
+
+
+@pytest.mark.essential
+def test_per_test_already_cycle_cumulative_is_silent():
+    # Same values as PER_CYCLE: subtracting each cycle's first value is a no-op.
+    frame = _frame(
+        cycles=[1, 1, 1, 2, 2, 2],
+        steps=[1, 1, 2, 1, 1, 2],
+        values=[0.0, 1.0, 3.0, 0.0, 2.0, 5.0],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        out = normalize_reset_granularity(
+            frame, _declarations(ResetGranularity.PER_TEST)
+        )
+    assert out[SCHEMA.cumulative_charge_capacity].to_list() == [
+        0.0,
+        1.0,
+        3.0,
+        0.0,
+        2.0,
+        5.0,
+    ]
 
 
 # -- harmonize -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- After load, vendor capacity/energy that does not already start at 0 each cycle is rebased so it does (`normalize_reset_granularity`).
- A `UserWarning` names the columns when that rebase actually changes values; identity / `PER_CYCLE` stays silent.
- Docs (`get_cap`, agents.md, 1.x→2.x migration) describe the 2.x difference as **each cycle starts at 0**, not “last datapoint” (1.x already used the last point).

Closes #989

## Test plan
- [x] `uv run pytest tests/test_harmonize.py -m essential`
- [x] `uv run pytest -m essential` (818 passed, 64 skipped)
- [x] Full suite belongs on schedule/release CI


Made with [Cursor](https://cursor.com)