### PR TITLE
Move matplotlib and ipykernel to optional extras

### DIFF
--- a/.issueflows/01-current-issues/cycle_status.md
+++ b/.issueflows/01-current-issues/cycle_status.md
@@ -1,0 +1,17 @@
+# Cycle status
+
+- queue: yolo
+- resolved: label:yolo
+- repo: jepegit/cellpy
+- onfail: stop
+- started: 2026-09-07T19:33:00Z
+
+## Queue
+
+- [x] #937 — Notebook tooling (ipykernel, matplotlib) is a hard runtime dependency — ~90 MB in a headless server image — closing
+- [ ] #938 — Missing external tools fail silently: mdb-export raises bare FileNotFoundError, pyodbc ImportError hides two loaders — pending
+- [ ] #960 — Possible bugs in cellpy setup and configuration — pending
+- [ ] #982 — Default group name from cellpy_db — pending
+- [ ] #1000 — prepare for changes in batch journal json file — pending
+
+- [ ] Done

--- a/.issueflows/03-solved-issues/issue937_original.md
+++ b/.issueflows/03-solved-issues/issue937_original.md
@@ -1,0 +1,61 @@
+# Issue #937: Notebook tooling (ipykernel, matplotlib) is a hard runtime dependency — ~90 MB in a headless server image
+
+Source: https://github.com/jepegit/cellpy/issues/937
+
+## Original issue text
+
+Found while building a container image for a cellpy-based web app
+([cellpy-simple-gui#121](https://github.com/cellpy/cellpy-simple-gui/issues/121)).
+Not a bug — a packaging pain-point for anyone deploying cellpy headless.
+
+## What we measured
+
+The app plots with plotly, runs FastAPI, and never opens a notebook. Yet the
+image carries an interactive-notebook stack, traced with `importlib.metadata`
+rather than guessed:
+
+```
+debugpy      <- ipykernel
+ipykernel    <- cellpy
+ipython      <- ipykernel
+jedi         <- ipython
+matplotlib   <- cellpy
+```
+
+Sizes in the built image (`python:3.13-slim-bookworm`, 128 packages, 1.18 GB venv):
+
+| package | MB |
+|---|---|
+| `matplotlib` | 35 |
+| `jedi` | 34 |
+| `debugpy` | 22 |
+
+~90 MB, plus `ipython`, `ipykernel`, `pyzmq`, `tornado`, `fontTools` (27 MB) and
+friends behind them. None of it is reachable from the code paths a headless
+server actually uses.
+
+## Why it matters beyond size
+
+- **Container images and frozen apps.** The same weight lands in a PyInstaller
+  bundle, where it is also ~4000 extra files to scan on first run.
+- **Attack surface.** `debugpy` in a server image is not something a deployer
+  would choose.
+- **Cold start.** Not import-time cost (these are lazy), but real disk and pull time.
+
+## Suggestion
+
+Move the interactive pieces to extras and import them where they are used:
+
+```toml
+[project.optional-dependencies]
+notebook = ["ipykernel", "ipython"]
+plotting-mpl = ["matplotlib"]
+```
+
+`cellpy[notebook]` would keep the current experience for notebook users — who
+are surely the majority — while letting an app or a container install the
+analysis core alone. If some module imports `matplotlib` at module scope, a
+local import inside the plotting function would be enough to make the extra
+genuinely optional.
+
+Happy to test a branch against our container build and report the delta.

--- a/.issueflows/03-solved-issues/issue937_plan.md
+++ b/.issueflows/03-solved-issues/issue937_plan.md
@@ -1,0 +1,44 @@
+# Issue #937 plan
+
+## Goal
+
+Drop `ipykernel` and `matplotlib` from the required pip install so a headless
+app image does not pay ~90 MB for notebook/debug tooling it never uses.
+
+## Constraints
+
+- Do not change conda env files (conda-forge still ships the full stack).
+- `uv sync` (dev group) must still install matplotlib so tests/CI keep working.
+- Typed `OptionalDependencyError` naming the extra, same pattern as `legacy-files`.
+- ### Prior art
+  - `require_hdf5_support` in `cellpy/readers/cellpy_file/format.py` + `OptionalDependencyError`
+  - `test_dependency_budget.py` manifest pins for extras moved out of required
+  - `cellpy.plotting.collected` already `try/except ImportError` around matplotlib
+  - `ipykernel` is never imported by library code; only listed in `[project.dependencies]`
+
+## Approach
+
+1. Remove `matplotlib` and `ipykernel` from `[project.dependencies]`.
+2. Add extras `notebook = ["ipykernel", "ipython"]` and `plotting-mpl = ["matplotlib"]`.
+3. Add both packages to the `all` extra; add `matplotlib` to the `dev` group (`ipykernel` is already there).
+4. Add `require_matplotlib(context)` next to the matplotlib backend; call it from `get_backend("matplotlib")`.
+5. Guard the four remaining module-scope matplotlib imports (`figures.py`, `batch_summary.py`, `plotutils.py`, `ocv_rlx.py`) with `try/except ImportError`.
+6. Extend the dependency-budget tests; do not rewrite conda manifests.
+
+## Files to touch
+
+- `pyproject.toml` / `uv.lock` — extras + lock
+- `cellpy/plotting/backends/mpl.py` — `require_matplotlib`
+- `cellpy/plotting/backends/__init__.py` — call it from `get_backend`
+- `cellpy/plotting/figures.py`, `cellpy/plotting/batch_summary.py`, `cellpy/utils/plotutils.py`, `cellpy/utils/ocv_rlx.py` — optional import
+- `tests/test_dependency_budget.py` — pin the new extras
+- `docs/getting_started/agents.md` — one install note
+- `.issueflows/04-designs-and-guides/optional-plotting-notebook.md` — short decision
+
+## Test strategy
+
+`uv run pytest -m essential` plus the new dependency-budget tests. Full suite stays on CI.
+
+## Open questions
+
+None — extras names match the issue (`notebook`, `plotting-mpl`).

--- a/.issueflows/03-solved-issues/issue937_status.md
+++ b/.issueflows/03-solved-issues/issue937_status.md
@@ -1,0 +1,16 @@
+# Issue #937 status
+
+- [x] Done
+
+## What's done
+
+- Removed `matplotlib` and `ipykernel` from `[project.dependencies]`.
+- Added extras `plotting-mpl` and `notebook`; both included in `all`.
+- `matplotlib` stays in the `dev` group so `uv sync` / CI keep Agg tests.
+- `require_matplotlib` raises `OptionalDependencyError` naming `cellpy[plotting-mpl]`.
+- Guarded the four remaining module-scope matplotlib imports.
+- Dependency-budget tests + docs (`agents.md`, installation extras table).
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/optional-plotting-notebook.md
+++ b/.issueflows/04-designs-and-guides/optional-plotting-notebook.md
@@ -1,0 +1,25 @@
+# Optional matplotlib and notebook extras (#937)
+
+## Context
+
+A headless cellpy consumer (plotly + FastAPI) still pulled `matplotlib` and
+`ipykernel` (and thus `debugpy` / `jedi`) because both were hard pip
+dependencies. ~90 MB in a slim image, unused on the server path.
+
+## Decision
+
+- Required pip install no longer includes `matplotlib` or `ipykernel`.
+- Extras: `cellpy[plotting-mpl]` (`matplotlib`) and `cellpy[notebook]`
+  (`ipykernel`, `ipython`). `cellpy[all]` includes both.
+- Dev / CI (`uv sync`) still gets matplotlib via the `dev` group so tests
+  keep the Agg backend.
+- Missing matplotlib on `backend="matplotlib"` raises
+  `OptionalDependencyError` naming `cellpy[plotting-mpl]`.
+- Conda env files still list both packages (full scientific stack).
+
+## Alternatives
+
+- Put matplotlib on the `batch` extra: rejected — `cellpy[batch]` is how
+  plotly/kaleido apps install, and they should not pay for matplotlib.
+- Keep matplotlib required, drop only ipykernel: rejected — both were in
+  the measured 90 MB.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -153,6 +153,11 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_harmonize.py::test_per_step_accumulates_completed_steps_within_the_cycle | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | PER_STEP warns |
 | tests/test_harmonize.py::test_per_cycle_capacity_is_the_cycle_last_value | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | summary last-datapoint invariant |
 | tests/test_harmonize.py::test_per_test_already_cycle_cumulative_is_silent | yes | yes | instruments.harmonize.normalize_reset_granularity | #989 | identity PER_TEST no UserWarning |
+| tests/test_dependency_budget.py::test_matplotlib_and_ipykernel_left_the_required_set | yes | yes | pyproject required deps | #937 | pip extras |
+| tests/test_dependency_budget.py::test_matplotlib_lives_in_the_plotting_mpl_extra | yes | yes | pyproject plotting-mpl extra | #937 | |
+| tests/test_dependency_budget.py::test_ipykernel_lives_in_the_notebook_extra | yes | yes | pyproject notebook extra | #937 | |
+| tests/test_dependency_budget.py::test_matplotlib_stays_in_the_dev_group | yes | yes | pyproject dev group | #937 | CI uv sync |
+| tests/test_dependency_budget.py::test_require_matplotlib_names_the_extra | yes | yes | plotting.backends.mpl.require_matplotlib | #937 | OptionalDependencyError |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,7 @@ Quick facts:
   `collect_summaries` leaves a cell out (no summary, or filtered away) it
   warns and names it; `collection.meta.cells_included` is authoritative.
 - Persist: `c.save("out.cellpy")`, `c.to_csv("out_dir")`.
-  Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido).
+    Collected figure bytes: `collection.to_image("png")` / `cellpy.plotting.write_image(fig, "svg")` (needs `cellpy[batch]` / kaleido). Matplotlib plots need `cellpy[plotting-mpl]` (#937).
 - Prefer schema-resolved names over hard-coded 1.x header strings.
 - When changing public get/save/schema/CLI surface, update
   `docs/getting_started/agents.md` and this section in the same PR.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* `matplotlib` and `ipykernel` are no longer required pip dependencies.
+  Use `cellpy[plotting-mpl]` / `cellpy[notebook]` (or `cellpy[all]`) when you
+  need them; a missing matplotlib backend raises `OptionalDependencyError`.
+  (#937)
+
 * After load, vendor capacity/energy that does not already start at 0 each
   cycle is rebased so it does; a `UserWarning` names the columns when values
   actually change (1.x kept the tester column as-is). (#989)

--- a/cellpy/plotting/backends/__init__.py
+++ b/cellpy/plotting/backends/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from cellpy.plotting.backends.base import Backend
-from cellpy.plotting.backends.mpl import MatplotlibBackend
+from cellpy.plotting.backends.mpl import MatplotlibBackend, require_matplotlib
 from cellpy.plotting.backends.plotly import (
     PlotlyBackend,
     configure_formation_layout,
@@ -15,6 +15,7 @@ from cellpy.plotting.backends.plotly import (
 __all__ = [
     "Backend",
     "MatplotlibBackend",
+    "require_matplotlib",
     "PlotlyBackend",
     "configure_formation_layout",
     "configure_fullcell_standard_domains",
@@ -28,6 +29,7 @@ def get_backend(name: str) -> Any:
     if key == "plotly":
         return PlotlyBackend()
     if key == "matplotlib":
+        require_matplotlib("backend='matplotlib'")
         return MatplotlibBackend()
     raise ValueError(
         f"unknown plotting backend {name!r} (known: plotly, matplotlib)"

--- a/cellpy/plotting/backends/mpl.py
+++ b/cellpy/plotting/backends/mpl.py
@@ -20,6 +20,31 @@ from cellpy.units import units_label
 logger = logging.getLogger(__name__)
 
 
+def require_matplotlib(context: str) -> None:
+    """Raise a typed error when matplotlib is missing and *context* needs it.
+
+    ``matplotlib`` moved from a required dependency to the ``plotting-mpl``
+    extra (#937) so a plain install does not pull the notebook/font stack.
+
+    Args:
+        context: what the caller was trying to do, for the error message.
+
+    Raises:
+        OptionalDependencyError: naming the extra to install.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("matplotlib") is not None:
+        return
+
+    from cellpy.exceptions import OptionalDependencyError
+
+    raise OptionalDependencyError(
+        f"{context} needs matplotlib, which is not installed. "
+        "Install the extra with:  pip install cellpy[plotting-mpl]"
+    )
+
+
 def _seaborn_available() -> bool:
     import importlib.util
 

--- a/cellpy/plotting/batch_summary.py
+++ b/cellpy/plotting/batch_summary.py
@@ -14,7 +14,10 @@ import logging
 import warnings
 from typing import Any, Optional
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
 import pandas as pd
 
 import cellpy.config as config
@@ -149,6 +152,9 @@ def batch_summary_plot(
             canvas.show()
         return canvas
 
+    from cellpy.plotting.backends.mpl import require_matplotlib
+
+    require_matplotlib("Batch.plot(backend='matplotlib')")
     # matplotlib — wide MultiIndex frame (legacy cycle-life layout)
     width = kwargs.pop("width", config.batch.summary_plot_width)
     height = kwargs.pop("height", config.batch.summary_plot_height)

--- a/cellpy/plotting/figures.py
+++ b/cellpy/plotting/figures.py
@@ -19,7 +19,10 @@ import logging
 import pickle as pkl
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
 
 plotly_available = importlib.util.find_spec("plotly") is not None
 
@@ -61,6 +64,9 @@ def load_figure(filename, backend=None):
 
 def save_matplotlib_figure(fig, filename):
     """Pickle a matplotlib figure to *filename*."""
+    from cellpy.plotting.backends.mpl import require_matplotlib
+
+    require_matplotlib("saving a matplotlib figure")
     with open(filename, "wb") as handle:
         pkl.dump(fig, handle)
 
@@ -72,6 +78,9 @@ def make_matplotlib_manager(fig):
     from a throwaway figure is the standard workaround
     (https://stackoverflow.com/a/54579616/8508004).
     """
+    from cellpy.plotting.backends.mpl import require_matplotlib
+
+    require_matplotlib("showing a matplotlib figure")
     dummy = plt.figure()
     new_manager = dummy.canvas.manager
     new_manager.canvas.figure = fig

--- a/cellpy/utils/ocv_rlx.py
+++ b/cellpy/utils/ocv_rlx.py
@@ -13,8 +13,12 @@ except ImportError as e:
 
 import math
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+try:
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+except ImportError:
+    mpl = None
+    plt = None
 import numpy as np
 import pandas as pd
 
@@ -489,6 +493,9 @@ class MultiCycleOcvFit:
 
     @staticmethod
     def create_colormap(name="plasma", cycles=None):
+        from cellpy.plotting.backends.mpl import require_matplotlib
+
+        require_matplotlib("OCV relaxation plots")
         if cycles is None:
             cycles = np.arange(1, 101)
         colormap_proxy = np.array(cycles)
@@ -502,6 +509,9 @@ class MultiCycleOcvFit:
 
     def plot_summary(self, cycles=None):
         """Convenience function for plotting the summary of the fit"""
+        from cellpy.plotting.backends.mpl import require_matplotlib
+
+        require_matplotlib("OCV relaxation plots")
         if cycles is None:
             cycles = self.get_fit_cycles()
         fig1 = plt.figure(tight_layout=True)
@@ -543,6 +553,9 @@ class MultiCycleOcvFit:
     def plot_summary_translated(self):
         """Convenience function for plotting the summary of the
         fit (translated)"""
+        from cellpy.plotting.backends.mpl import require_matplotlib
+
+        require_matplotlib("OCV relaxation plots")
 
         fig2 = plt.figure()
         ax1 = fig2.add_subplot(221)

--- a/cellpy/utils/plotutils.py
+++ b/cellpy/utils/plotutils.py
@@ -15,7 +15,10 @@ from typing import Any, Callable, Optional, Union
 import warnings
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
 import pandas as pd
 import numpy as np
 

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -30,6 +30,8 @@ Consumer install:
 
 ```bash
 pip install cellpy
+# matplotlib backend: pip install cellpy[plotting-mpl]
+# Jupyter kernel:     pip install cellpy[notebook]
 # or: conda install -c conda-forge cellpy
 ```
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -157,9 +157,10 @@ Conda and `environment.yml` / the project lockfile (`uv.lock`, driven by
 | --- | --- |
 | Core science stack | `numpy`, `scipy`, `pandas` |
 | cellpy files (HDF5 path) | `tables` (PyTables) |
-| Fitting helpers | `lmfit` |
+| Fitting helpers | `lmfit` (`cellpy[fit]`) |
 | Templates | `jinja2-time`, and `git` on `PATH` |
-| Tutorials / notebooks | `jupyter`, `seaborn`, `plotly` |
+| Tutorials / notebooks | `cellpy[notebook]` (`ipykernel`); conda still ships Jupyter |
+| Matplotlib plots | `cellpy[plotting-mpl]` (plotly lives in `cellpy[batch]`) |
 
 Optional extras and plotting backends evolve with the release — prefer the
 conda-forge package or the repo env file over hand-picking versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "numpy",
     "pandas>=3.0.3,<4",
     "setuptools",
-    "matplotlib",
     "openpyxl",
     "PyGithub",
     "tqdm",
@@ -43,7 +42,6 @@ dependencies = [
     "cookiecutter",
     "pyyaml",
     "jinja2_time",
-    "ipykernel",
     "rich",
     "charset-normalizer",
     "polars",
@@ -69,7 +67,9 @@ dependencies = [
 batch = ["ipython", "jupyter", "plotly", "seaborn", "kaleido>=0.1,<1.4"]
 fit = ["lmfit"]
 legacy-files = ["tables"]
-all = ["ipython", "jupyter", "plotly", "seaborn", "kaleido>=0.1,<1.4", "lmfit", "tables"]
+notebook = ["ipykernel", "ipython"]
+plotting-mpl = ["matplotlib"]
+all = ["ipython", "jupyter", "plotly", "seaborn", "kaleido>=0.1,<1.4", "lmfit", "tables", "ipykernel", "matplotlib"]
 
 [project.scripts]
 cellpy = "cellpy.cli:cli"
@@ -89,6 +89,7 @@ dev = [
     "coverage",
     "flake8",
     "ipykernel",
+    "matplotlib",
     "nox",
     "lmfit",
     "pytest",

--- a/tests/test_dependency_budget.py
+++ b/tests/test_dependency_budget.py
@@ -87,6 +87,57 @@ def test_tables_stays_in_the_dev_group(pyproject):
 
 
 @pytest.mark.essential
+def test_matplotlib_and_ipykernel_left_the_required_set(pyproject):
+    declared = _bare_names(pyproject["project"]["dependencies"])
+    assert "matplotlib" not in declared
+    assert "ipykernel" not in declared
+
+
+@pytest.mark.essential
+def test_matplotlib_lives_in_the_plotting_mpl_extra(pyproject):
+    extras = pyproject["project"]["optional-dependencies"]
+    assert _bare_names(extras["plotting-mpl"]) == {"matplotlib"}
+    assert "matplotlib" in _bare_names(extras["all"])
+
+
+@pytest.mark.essential
+def test_ipykernel_lives_in_the_notebook_extra(pyproject):
+    extras = pyproject["project"]["optional-dependencies"]
+    assert "ipykernel" in _bare_names(extras["notebook"])
+    assert "ipython" in _bare_names(extras["notebook"])
+    assert "ipykernel" in _bare_names(extras["all"])
+
+
+@pytest.mark.essential
+def test_matplotlib_stays_in_the_dev_group(pyproject):
+    """Essential CI runs `uv sync` (dev group, no extras). Plot tests use Agg
+    and still need matplotlib even though a plain pip install does not."""
+    dev = _bare_names(pyproject["dependency-groups"]["dev"])
+    assert "matplotlib" in dev
+    assert "ipykernel" in dev
+
+
+@pytest.mark.essential
+def test_require_matplotlib_names_the_extra(monkeypatch):
+    import importlib.util as ilu
+
+    from cellpy.exceptions import OptionalDependencyError
+    from cellpy.plotting.backends.mpl import require_matplotlib
+
+    real_find_spec = ilu.find_spec
+
+    def missing_matplotlib(name, *args, **kwargs):
+        if name == "matplotlib":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(ilu, "find_spec", missing_matplotlib)
+
+    with pytest.raises(OptionalDependencyError, match=r"plotting-mpl"):
+        require_matplotlib("a matplotlib plot")
+
+
+@pytest.mark.essential
 @pytest.mark.parametrize(
     "manifest",
     [

--- a/uv.lock
+++ b/uv.lock
@@ -351,10 +351,8 @@ dependencies = [
     { name = "cookiecutter" },
     { name = "dateparser" },
     { name = "defusedxml" },
-    { name = "ipykernel" },
     { name = "isal" },
     { name = "jinja2-time" },
-    { name = "matplotlib" },
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -382,10 +380,12 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "ipykernel" },
     { name = "ipython" },
     { name = "jupyter" },
     { name = "kaleido" },
     { name = "lmfit" },
+    { name = "matplotlib" },
     { name = "plotly" },
     { name = "seaborn" },
     { name = "tables" },
@@ -403,6 +403,13 @@ fit = [
 legacy-files = [
     { name = "tables" },
 ]
+notebook = [
+    { name = "ipykernel" },
+    { name = "ipython" },
+]
+plotting-mpl = [
+    { name = "matplotlib" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -413,6 +420,7 @@ dev = [
     { name = "ipykernel" },
     { name = "issue-flow" },
     { name = "lmfit" },
+    { name = "matplotlib" },
     { name = "nox" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -434,9 +442,11 @@ requires-dist = [
     { name = "cookiecutter" },
     { name = "dateparser" },
     { name = "defusedxml" },
-    { name = "ipykernel" },
+    { name = "ipykernel", marker = "extra == 'all'" },
+    { name = "ipykernel", marker = "extra == 'notebook'" },
     { name = "ipython", marker = "extra == 'all'" },
     { name = "ipython", marker = "extra == 'batch'" },
+    { name = "ipython", marker = "extra == 'notebook'" },
     { name = "isal" },
     { name = "jinja2-time" },
     { name = "jupyter", marker = "extra == 'all'" },
@@ -445,7 +455,8 @@ requires-dist = [
     { name = "kaleido", marker = "extra == 'batch'", specifier = ">=0.1,<1.4" },
     { name = "lmfit", marker = "extra == 'all'" },
     { name = "lmfit", marker = "extra == 'fit'" },
-    { name = "matplotlib" },
+    { name = "matplotlib", marker = "extra == 'all'" },
+    { name = "matplotlib", marker = "extra == 'plotting-mpl'" },
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas", specifier = ">=3.0.3,<4" },
@@ -476,7 +487,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xmltodict" },
 ]
-provides-extras = ["all", "batch", "fit", "legacy-files"]
+provides-extras = ["all", "batch", "fit", "legacy-files", "notebook", "plotting-mpl"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -487,6 +498,7 @@ dev = [
     { name = "ipykernel" },
     { name = "issue-flow", specifier = ">=0.4.2" },
     { name = "lmfit" },
+    { name = "matplotlib" },
     { name = "nox" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -2591,7 +2603,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3788,9 +3800,9 @@ name = "sqlalchemy-access"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyodbc" },
-    { name = "pywin32" },
-    { name = "sqlalchemy" },
+    { name = "pyodbc", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sqlalchemy", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/e3/02801e7b150342be8b7146227beb7943723511eb2f074bb836eae05e7578/sqlalchemy_access-2.0.3.tar.gz", hash = "sha256:89174a94e0ebd6c32470282d143aef0c0fbe3aafdee2c40956cd417648cb317e", size = 18011, upload-time = "2024-09-08T14:16:16.866Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- `matplotlib` and `ipykernel` are no longer required pip dependencies, so a headless install does not pull ~90 MB of unused notebook/debug tooling (`debugpy`, `jedi`, fonts).
- New extras: `cellpy[plotting-mpl]` and `cellpy[notebook]` (both included in `cellpy[all]`). Dev/CI still get matplotlib via the `dev` group.
- `backend="matplotlib"` without the extra raises `OptionalDependencyError` naming `cellpy[plotting-mpl]`.

Closes #937

## Test plan
- [x] `uv run pytest -m essential` (823 passed)
- [x] Dependency-budget tests pin the extras and the typed error
- [ ] CI essential + full on the PR


Made with [Cursor](https://cursor.com)