### PR TITLE
Stop cellpy setup from writing a new legacy .conf file

### DIFF
--- a/.issueflows/03-solved-issues/issue960_original.md
+++ b/.issueflows/03-solved-issues/issue960_original.md
@@ -1,0 +1,7 @@
+# Issue #960: Possible bugs in cellpy setup and configuration
+
+Source: https://github.com/jepegit/cellpy/issues/960
+
+## Original issue text
+
+Might be a coincidence, but it seems like cellpy setup still creates the old format config file.

--- a/.issueflows/03-solved-issues/issue960_plan.md
+++ b/.issueflows/03-solved-issues/issue960_plan.md
@@ -1,0 +1,42 @@
+# Issue #960 — plan: setup writes `cellpy.toml` only
+
+## Goal
+
+`cellpy setup` must write (or refresh) `cellpy.toml`, not the legacy YAML
+`.cellpy_prms_*.conf`.
+
+## Constraints
+
+- Existing `.conf` files keep working through the loader fallback; `cellpy setup migrate` stays the one-time converter.
+- Do not reset paths on every re-run: “config exists” must look at `cellpy.toml` (and treat a leftover `.conf` as already-set-up).
+- Docs already claim setup writes TOML (`docs/getting_started/configuration.md`).
+
+### Prior art
+
+- `_write_toml_config_file` / `_write_config_file` in `cellpy/cli_api.py` — setup currently calls both (dual-write leftover from #454).
+- `config.loader.user_config_path` / `CONFIG_FILENAME` — canonical TOML location.
+- `config.loader.active_config_file` — toml before legacy YAML (#851).
+- `tests/test_cellpy_cmd.py::test_cli_setup` — dry-run counts three “would write” lines (conf, toml, env).
+- `tests/test_cellpy_cmd.py::test_cli_setup_creates_dirs_and_files` — asserts the `.conf` was written.
+
+## Approach
+
+1. Stop calling `_write_config_file` from `setup_config` (interactive and silent).
+2. Resolve the TOML path the same way `_write_toml_config_file` does (`test_user` → next to the old dst; else `user_config_path()`).
+3. Set `reset` when **neither** that TOML nor the legacy dst `.conf` exists.
+4. Drop `_write_config_file` if it has no remaining callers.
+5. Update the setup tests so they require TOML and forbid a new `.conf`.
+
+## Files to touch
+
+- `cellpy/cli_api.py` — stop legacy write; existence check uses TOML.
+- `tests/test_cellpy_cmd.py` — dry-run count 2; create-files asserts toml, not conf.
+- `HISTORY.md` — unreleased bullet (close).
+
+## Test strategy
+
+`uv run pytest -m essential` plus `tests/test_cellpy_cmd.py` setup tests.
+
+## Open questions
+
+None — the issue names the leftover dual-write.

--- a/.issueflows/03-solved-issues/issue960_status.md
+++ b/.issueflows/03-solved-issues/issue960_status.md
@@ -1,0 +1,14 @@
+# Issue #960 status
+
+- [x] Done
+
+## What's done
+
+- `cellpy setup` writes `cellpy.toml` only; dropped `_write_config_file`.
+- Existence check uses TOML (legacy `.conf` still counts as already-set-up).
+- Tests: dry-run writes toml+env; create-files asserts no new `.conf`.
+- Docs: `configuration.md`, `AGENTS.md` smoke note, test-registry.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -74,7 +74,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_surface.py::test_the_global_options_are_unchanged | yes | yes | root CLI options | #891 | snapshot now covers root params |
 | tests/test_cli_info.py::test_a_failing_check_exits_non_zero | yes | yes | cli_api._check / cli.info exit code | #891 | --check was always exit 0 |
 | tests/test_cli_setup_output.py (module) | yes | yes | cli_api.setup_config / cli_api._ui / cli.pull / cli.edit | #891 | no parameter dump, real --silent, usage exit 2 |
-| tests/test_cellpy_cmd.py::test_cli_setup | yes | no | cli.setup dry-run reporting | #891 | isolated user dir; was reading the real ~/.cellpy_prms_*.conf |
+| tests/test_cellpy_cmd.py::test_cli_setup | yes | yes | cli.setup dry-run reporting | #891 #960 | toml+env only; no legacy .conf |
+| tests/test_cellpy_cmd.py::test_cli_setup_creates_dirs_and_files | yes | yes | cli.setup writes cellpy.toml | #960 | no new .conf; toml + env + dirs |
 | tests/test_cli_info.py::test_check_does_not_shout_or_draw_banners | yes | yes | cli_api._check rendering | #891 | no ===/---/!!!! |
 | tests/test_cli_info.py::test_check_keeps_the_probe_narration_for_verbose | yes | yes | cli_api._debug gating | #891 | diagnostics only under --verbose |
 | tests/test_cli_info.py::test_quiet_reports_only_what_is_broken | yes | yes | check rendering under --quiet | #891 | failures survive quiet |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,8 +377,9 @@ resolves from PyPI). No manual install is normally needed.
   `uv-dynamic-versioning`, so a shallow/tagless checkout reports a `0.0.0`-style dev
   version — harmless for dev).
 - **CLI smoke check:** `uv run cellpy setup --silent` then `uv run cellpy info --check`.
-  `cellpy setup` writes a runtime `.env_cellpy` in the repo root and a
-  `~/.cellpy_prms_*.conf` in $HOME — these are local runtime files, do not commit them.
+  `cellpy setup` writes a runtime `.env_cellpy` and a user `cellpy.toml`
+  (legacy installs may still have `~/.cellpy_prms_*.conf`) — these are local
+  runtime files, do not commit them.
 - **Example data** (`cellpy.utils.example_data`, e.g. `raw_file()`) downloads small
   fixtures from GitHub on first use, so those helpers need network access.
 - **Dual-repo dev** with a sibling `../cellpy-core` checkout is optional (see

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* `cellpy setup` writes (or refreshes) `cellpy.toml` only. It no longer
+  creates a new legacy `.cellpy_prms_*.conf`; convert an existing one with
+  `cellpy setup migrate`. (#960)
+
 * Missing `mdb-export` on Linux/macOS raises `OptionalDependencyError` naming
   mdbtools (`apt` / `brew`). `list_instruments()` still lists loaders that
   fail to import, with `available=False` and a `reason` a UI can show, and

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -611,22 +611,30 @@ def echo_missing_modules():
 
 
 # -- write toml --
+def _setup_toml_path(dst_file, test_user=None):
+    """Where ``cellpy setup`` writes ``cellpy.toml``.
+
+    Test-user (DEV) mode lands next to the legacy dest path instead of the
+    real platform config dir.
+    """
+    from cellpy.config import loader as config_loader
+
+    if test_user:
+        return pathlib.Path(dst_file).with_name("cellpy.toml")
+    return config_loader.user_config_path()
+
+
 def _write_toml_config_file(dst_file, dry_run, test_user=None):
-    """Write the ``cellpy.toml`` twin generated from the config models.
+    """Write the user ``cellpy.toml`` generated from the config models.
 
     The TOML is the single source of truth going forward (config plan Step 5):
     it is *generated* from the resolved ``CellpyConfig`` models (secrets
-    excluded), so adding a field is a one-file change in the models. In
-    test-user (DEV) mode the file lands next to the legacy conf instead of the
-    real platform config dir.
+    excluded), so adding a field is a one-file change in the models.
     """
     from cellpy import config as cellpy_config
     from cellpy.config import loader as config_loader
 
-    if test_user:
-        toml_path = pathlib.Path(dst_file).with_name("cellpy.toml")
-    else:
-        toml_path = config_loader.user_config_path()
+    toml_path = _setup_toml_path(dst_file, test_user)
 
     ui = _ui()
     if dry_run:
@@ -1176,44 +1184,6 @@ def _check(dry_run=False, full_check=True) -> int:
 
     ui.summary(len(checks) - failed, len(checks))
     return failed
-
-
-def _write_config_file(user_dir, dst_file, init_filename, dry_run):
-    """Write the user config file, reporting one line per real action (#891)."""
-    from cellpy.exceptions import ConfigFileNotWritten
-
-    ui = _ui()
-    _debug(f"user directory: {user_dir}")
-
-    if dry_run:
-        ui.step(f"dry-run: would write {dst_file}")
-        return
-
-    if os.path.isfile(dst_file):
-        _debug(f"{dst_file} exists - keeping the settings it already holds")
-
-    try:
-        save_prm_file(dst_file)
-    except ConfigFileNotWritten:
-        ui.warn(
-            "configuration file",
-            f"could not write {dst_file}",
-            hint=f"retrying as {prmreader.DEFAULT_FILENAME}",
-        )
-        try:
-            user_dir, dst_file = prmreader.get_user_dir_and_dst(init_filename)
-            save_prm_file(dst_file)
-        except ConfigFileNotWritten as exc:
-            ui.fail(
-                "configuration file",
-                f"could not write {dst_file} ({exc})",
-                hint="check the directory permissions, then report this at "
-                "https://github.com/jepegit/cellpy/issues",
-            )
-            return
-
-    ui.ok("configuration file", str(dst_file))
-    ui.hint("edit it with:  cellpy edit config")
 
 
 def _write_env_file(user_dir, dst_file, dry_run):
@@ -1803,8 +1773,9 @@ def setup_config(
             dst_file = get_dst_file(user_dir, init_filename)
             _debug(f"test user {test_user}: user_dir={user_dir} dst_file={dst_file}")
 
-        if not pathlib.Path(dst_file).is_file():
-            ui.step(f"no configuration file yet - writing {dst_file}")
+        toml_path = _setup_toml_path(dst_file, test_user)
+        if not pathlib.Path(toml_path).is_file() and not pathlib.Path(dst_file).is_file():
+            ui.step(f"no configuration file yet - writing {toml_path}")
             reset = True
 
         if not pathlib.Path(env_file).is_file():
@@ -1819,7 +1790,6 @@ def setup_config(
                 reset=reset,
                 interactive=True,
             )
-            _write_config_file(user_dir, dst_file, init_filename, dry_run)
             _write_toml_config_file(dst_file, dry_run, test_user=test_user)
             _write_env_file(user_dir, env_file, dry_run)
         else:
@@ -1833,7 +1803,6 @@ def setup_config(
                     interactive=False,
                     silent=silent,
                 )
-            _write_config_file(user_dir, dst_file, init_filename, dry_run)
             _write_toml_config_file(dst_file, dry_run, test_user=test_user)
             _write_env_file(user_dir, env_file, dry_run)
 

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -26,7 +26,9 @@ cellpy setup -i -d /Users/you/cellpy_data
 
 `cellpy setup` writes (or refreshes) a user **`cellpy.toml`**, tries to create
 the usual directory layout, and creates a `.env_cellpy` file for secrets /
-remote credentials (edit that file before using SSH remotes).
+remote credentials (edit that file before using SSH remotes). It does **not**
+write a new legacy `.cellpy_prms_*.conf` — convert an existing one with
+`cellpy setup migrate`.
 
 Typical directories:
 

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -39,8 +39,9 @@ def isolated_filesystem():
     setup`` writes into it — and that is all this provides.
 
     Note what it does **not** provide: a throwaway *user* directory. ``cellpy
-    setup`` reads and writes ``~/.cellpy_prms_<user>.conf``, not the cwd, so a
-    test that asserts on setup's output also needs ``isolated_user_dir``.
+    setup`` writes ``cellpy.toml`` (and ``.env_cellpy``) into the user config
+    location, not the cwd, so a test that asserts on setup's output also needs
+    ``isolated_user_dir``.
     """
     previous = os.getcwd()
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
@@ -56,7 +57,7 @@ def isolated_user_dir(tmp_path, monkeypatch, config_guard):
     """Point ``cellpy setup`` at a throwaway user directory.
 
     Without this, setup finds (or does not find) the *developer's* real config
-    and behaves differently: with one present it writes three files, with none
+    and behaves differently: with one present it writes toml + env, with none
     it also resets the paths and reports ten directories it would create. A
     test counting those lines therefore passes on one machine and fails on the
     next — which is how ``test_cli_setup`` came to pass locally and fail on CI
@@ -353,16 +354,19 @@ def test_cli_setup_help():
     assert result.exit_code == 0
 
 
+@pytest.mark.essential
 def test_cli_setup(isolated_user_dir):
     runner = CliRunner()
     with isolated_filesystem():
         result = runner.invoke(cli.cli, ["setup", "--dry-run"])
         print(result.output)
         assert result.exit_code == 0
-        # one line per file it would write (config, toml, env) and no claim
-        # that anything was written (#891)
-        assert result.output.count("dry-run: would write") == 3
+        # one line per file it would write (toml, env) and no claim
+        # that anything was written (#891, #960)
+        assert result.output.count("dry-run: would write") == 2
         assert "written" not in result.output
+        assert "cellpy.toml" in result.output
+        assert ".cellpy_prms_" not in result.output
 
 
 def test_cli_setup_interactive(isolated_user_dir):
@@ -389,7 +393,10 @@ def test_cli_setup_custom_dir(isolated_user_dir):
         assert result.exit_code == 0
 
 
+@pytest.mark.essential
 def test_cli_setup_creates_dirs_and_files(isolated_user_dir):
+    import tomllib
+
     runner = CliRunner()
     test_user = "inventory_user"
     # was assigning config.paths.env_file directly and never putting it back,
@@ -421,9 +428,12 @@ def test_cli_setup_creates_dirs_and_files(isolated_user_dir):
 
     conf_name = prmreader.create_custom_init_filename(test_user)
     conf_path = tmp_path / conf_name
-    assert conf_path.is_file()
-    parsed = prmreader._read_prm_file_without_updating(conf_path)
-    assert "Paths" in parsed
+    assert not conf_path.is_file(), "setup must not write a legacy .conf (#960)"
+
+    toml_path = tmp_path / "cellpy.toml"
+    assert toml_path.is_file()
+    data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    assert "paths" in data
 
     env_path = tmp_path / ".env_cellpy"
     assert env_path.is_file()
@@ -582,7 +592,7 @@ def test_cli_new_different_and_missing_default(tmp_path):
 
 
 def test_setup_writes_toml_twin(tmp_path):
-    """The setup TOML twin is generated from the config models (#454).
+    """The setup TOML is generated from the config models (#454, #960).
 
     The helper is exercised directly: the full ``cellpy setup`` flow is
     interactive when a custom root dir is given, which a CliRunner cannot

--- a/tests/test_cli_setup_output.py
+++ b/tests/test_cli_setup_output.py
@@ -62,8 +62,8 @@ def test_setup_states_a_dry_run_fact_once(isolated_home):
     )
     assert result.exit_code == 0
     assert "skipping actual saving" not in result.output
-    # one line per file it would write: the conf, the toml and the env file
-    assert result.output.count("dry-run: would write") == 3
+    # one line per file it would write: the toml and the env file (#960)
+    assert result.output.count("dry-run: would write") == 2
 
 
 @pytest.mark.essential


### PR DESCRIPTION
## Summary
- `cellpy setup` now writes (or refreshes) `cellpy.toml` only. It no longer creates a new `.cellpy_prms_*.conf`.
- An existing YAML conf still counts as already-set-up so re-running setup does not reset paths; convert it with `cellpy setup migrate`.
- Tests assert the dry-run writes toml+env and that a silent setup does not leave a `.conf`.

Closes #960

## Test plan
- [x] `uv run pytest tests/test_cellpy_cmd.py tests/test_cli_setup_output.py`
- [x] `uv run pytest -m essential`


Made with [Cursor](https://cursor.com)