### PR TITLE
Keep cellpy_db group text as journal group_label

### DIFF
--- a/.issueflows/03-solved-issues/issue982_original.md
+++ b/.issueflows/03-solved-issues/issue982_original.md
@@ -1,0 +1,7 @@
+# Issue #982: Default group name from cellpy_db
+
+Source: https://github.com/jepegit/cellpy/issues/982
+
+## Original issue text
+
+In cellpy_db, there is a column called group. I often use it to describe what makes a few cells in one batrch different from some of the others in the same batch. The name I use, is often what I would end up setting as `custom_group_labels` in the `summary_collector` function later. Therefore, it would be very nice if cellpy could just read the text given in the "group" column in cellpy_db and use that as default.

--- a/.issueflows/03-solved-issues/issue982_plan.md
+++ b/.issueflows/03-solved-issues/issue982_plan.md
@@ -1,0 +1,39 @@
+# Issue #982 — plan: db group text as default group labels
+
+## Goal
+
+Text in the cellpy_db `group` column becomes the journal `group_label`, so
+`summary_collector` uses it as the default legend labels without
+`custom_group_labels`.
+
+## Constraints
+
+- Numeric group cells stay unlabeled (today’s plot still shows 1, 2, 3).
+- Explicit `custom_group_labels=` still wins (`collect/summary.py` already merges).
+- `fix_groups` still renumbers to consecutive ints; do not change grouping ids.
+
+### Prior art
+
+- `cellpy/batch/_dbengine.py::fix_groups` — discards original values while numbering.
+- `HeadersJournal.group_label` — already on the journal frame.
+- `collect/summary.py` — `group_it` already maps `group` → `group_label` from pages.
+
+## Approach
+
+1. Before `fix_groups`, copy each raw group cell through a small helper: non-numeric text → `group_label`, else `None`.
+2. Write that list onto `pages_dict[hdr_journal.group_label]`.
+3. Leave `collect_summaries` / `custom_group_labels` as they are.
+
+## Files to touch
+
+- `cellpy/batch/_dbengine.py` — preserve text group labels.
+- `tests/test_batch.py` — helper + numbering tests.
+- `HISTORY.md` — unreleased bullet (close).
+
+## Test strategy
+
+`uv run pytest tests/test_batch.py -q` plus `uv run pytest -m essential`.
+
+## Open questions
+
+None.

--- a/.issueflows/03-solved-issues/issue982_status.md
+++ b/.issueflows/03-solved-issues/issue982_status.md
@@ -1,0 +1,13 @@
+# Issue #982 status
+
+- [x] Done
+
+## What's done
+
+- Db journal engine copies text `group` cells onto `group_label` before `fix_groups`.
+- Numeric group ids stay unlabeled; `custom_group_labels=` still wins.
+- Tests, docs, HISTORY.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -55,6 +55,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch.py::test_export_project_writes_cells_and_relative_journal | yes | yes | batch.facade.Batch.export_project | #878 | relative posix journal paths |
 | tests/test_batch.py::test_export_project_force_rewrites_existing_cellpy | yes | yes | batch.facade._persist_cells force_rewrite | #878 | export overwrites |
 | tests/test_batch.py::test_export_project_raises_on_unloaded_cells | yes | yes | batch.facade.Batch.export_project | #878 | fail fast |
+| tests/test_batch.py::test_group_labels_from_raw_keeps_text_and_drops_numbers | yes | yes | batch._dbengine.group_labels_from_raw | #982 | db group text → group_label |
+| tests/test_batch.py::test_fix_groups_renumbers_text_but_labels_keep_the_names | yes | yes | batch._dbengine.fix_groups | #982 | numbering vs labels |
 | tests/test_cli_light_import.py::test_info_version_avoids_cellreader_import | yes | yes | cellpy.__init__ / cli / cli_api light path | #837 | subprocess; cellreader must stay out of sys.modules |
 | tests/test_cli_light_import.py::test_setup_default_avoids_cellreader_and_optional_deps | yes | yes | cli_api.setup_config default light | #839 | no cellreader / lmfit |
 | tests/test_cli_light_import.py::test_setup_check_imports_cellreader | yes | yes | cli_api.setup_config --check | #839 | opt-in check loads readers |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,9 @@ Quick facts:
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
   After load: `b.summaries`, `b.cells[label]`, `b.plot()`, `b.result.report()`.
+  Text in the cellpy_db `group` column becomes journal `group_label` (default
+  legend for `summary_collector(..., group_it=True)`); `custom_group_labels=`
+  still overrides. Numeric group ids stay unlabeled.
   `b.plot(ir=True, direction="discharge")` uses `ir_discharge`, or `ir_charge`
   with a warning if that column is missing.
   `mark_as_bad` is a session flag (unknown cell name → `ValueError`); `drop` /

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* Text in the cellpy_db `group` column is kept as journal `group_label`, so
+  `summary_collector(..., group_it=True)` uses those names as default legend
+  labels. Numeric group ids stay unlabeled; `custom_group_labels=` still
+  overrides. (#982)
+
 * `cellpy setup` writes (or refreshes) `cellpy.toml` only. It no longer
   creates a new legacy `.cellpy_prms_*.conf`; convert an existing one with
   `cellpy setup migrate`. (#960)

--- a/cellpy/batch/_dbengine.py
+++ b/cellpy/batch/_dbengine.py
@@ -226,6 +226,35 @@ def find_files(
     return info_dict
 
 
+def _group_label_from_raw(value):
+    """Keep a display label when the db ``group`` cell is text, not a number.
+
+    ``fix_groups`` renumbers every distinct value to 1..N, so a name such as
+    ``"Si-rich"`` would otherwise vanish. Numeric cells (``1``, ``1.0``,
+    ``"2"``) stay unlabeled so plots keep showing the group id.
+    """
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    text = str(value).strip()
+    if not text or text.lower() in ("none", "nan"):
+        return None
+    try:
+        float(text)
+    except ValueError:
+        return text
+    return None
+
+
+def group_labels_from_raw(groups):
+    """Map a raw db ``group`` column to journal ``group_label`` values."""
+    return [_group_label_from_raw(g) for g in groups]
+
+
 def fix_groups(groups):
     """Renumber arbitrary group labels to consecutive ints starting at 1."""
     _groups = []
@@ -448,6 +477,7 @@ def simple_db_engine(
     del reader
 
     _groups = pages_dict[hdr_journal["group"]]
+    pages_dict[hdr_journal["group_label"]] = group_labels_from_raw(_groups)
     groups = fix_groups(_groups)
     pages_dict[hdr_journal["group"]] = groups
 

--- a/cellpy/collect/collector.py
+++ b/cellpy/collect/collector.py
@@ -231,7 +231,9 @@ def summary_collector(
         group_it (bool, optional): Average per journal group -> tidy long frame
             ``(group, cycle_num, variable, mean, std)``.
         custom_group_labels (mapping, optional): ``group id -> display label``,
-            used for the plot legend (int or str keys both match).
+            used for the plot legend (int or str keys both match). When omitted,
+            text in the cellpy_db ``group`` column (stored as journal
+            ``group_label``) is the default.
         rate (float, optional): Keep only cycles run at this C-rate (see
             ``rate_on`` / ``rate_std`` / ``rate_inverted`` on
             `SummaryOptions`).

--- a/docs/examples/batch_utility/cellpy_batch_processing.md
+++ b/docs/examples/batch_utility/cellpy_batch_processing.md
@@ -228,7 +228,7 @@ The *collectors* in `cellpy.collect` are meant to simplify plotting and exportin
     [collect API reference](../../api/collect.md).
 
 ### Summaries
-`summary_collector` collects and shows summaries, including, e.g., the option to show statistical variations in the data (`spread=True`). Facet rows follow `columns=` top → bottom; default y-axis titles include units. `custom_group_labels=` is what the legend shows when `group_it=True`:
+`summary_collector` collects and shows summaries, including, e.g., the option to show statistical variations in the data (`spread=True`). Facet rows follow `columns=` top → bottom; default y-axis titles include units. When `group_it=True`, the legend uses journal `group_label` (text from the cellpy_db `group` column) unless you pass `custom_group_labels=`:
 
 
 ```python

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -262,6 +262,8 @@ from cellpy import batch
 
 b = batch.load(name="my_experiment", project="my_project")
 summaries = b.summaries          # polars frame across cells
+# Text in the cellpy_db group column is journal group_label (legend default
+# for summary_collector(..., group_it=True)). custom_group_labels= overrides.
 c = b.cells["my_cell_01"]        # a CellpyCell
 fig = b.plot()                   # cycle-life summary (cap / CE)
 # ir=True is the default. direction="discharge" uses ir_discharge, and

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -705,6 +705,25 @@ def test_query():
     assert ";" in out[1]
 
 
+@pytest.mark.essential
+def test_group_labels_from_raw_keeps_text_and_drops_numbers():
+    """Db ``group`` text survives as group_label; numeric ids stay unlabeled (#982)."""
+    labels = _dbengine.group_labels_from_raw(
+        ["Si-rich", "Si-rich", "graphite", 1, 2.0, "3", None]
+    )
+    assert labels == ["Si-rich", "Si-rich", "graphite", None, None, None, None]
+
+
+@pytest.mark.essential
+def test_fix_groups_renumbers_text_but_labels_keep_the_names():
+    raw = ["high loading", "low loading", "high loading"]
+    numbered = _dbengine.fix_groups(raw)
+    labels = _dbengine.group_labels_from_raw(raw)
+    assert set(numbered) == {1, 2}
+    assert numbered[0] == numbered[2]
+    assert labels == ["high loading", "low loading", "high loading"]
+
+
 @pytest.mark.skip(reason="shaky test - fails intermittently in CI")
 def test_cycling_summary_plotter(populated_batch):
     populated_batch.combine_summaries()


### PR DESCRIPTION
## Summary
- Text in the cellpy_db `group` column is stored as journal `group_label` before groups are renumbered.
- `summary_collector(..., group_it=True)` uses those names as default legend labels. Numeric ids stay unlabeled; `custom_group_labels=` still overrides.

Closes #982

## Test plan
- [x] `uv run pytest tests/test_batch.py -k "json or db_engine or group_label or fix_groups"`
- [x] `uv run pytest -m essential`


Made with [Cursor](https://cursor.com)