### PR TITLE
Add a version field to batch journal JSON files

### DIFF
--- a/.issueflows/03-solved-issues/issue1000_original.md
+++ b/.issueflows/03-solved-issues/issue1000_original.md
@@ -1,0 +1,9 @@
+# Issue #1000: prepare for changes in batch journal json file
+
+Source: https://github.com/jepegit/cellpy/issues/1000
+
+## Original issue text
+
+We do not have any version label for the batch journal file. We should add it. Let us say that if the file misses the version label, it is version 1 (i.e. 1). It can also have the version label with 1 (and new files should be saved with the version number. Then when we decide to change the format, we can bump the version number.
+
+Obviously, we also need to implement reading and saving the version number and prepare for possible version bumps.

--- a/.issueflows/03-solved-issues/issue1000_plan.md
+++ b/.issueflows/03-solved-issues/issue1000_plan.md
@@ -1,0 +1,38 @@
+# Issue #1000 — plan: journal JSON version field
+
+## Goal
+
+Batch journal JSON files carry a format `version`. Missing → 1. New writes
+use `JOURNAL_FORMAT_VERSION` (currently 1). Reads store it and warn when the
+file is newer than this cellpy.
+
+## Constraints
+
+- Existing journals without `version` keep loading.
+- Do not implement a v2 schema in this issue — only the hook.
+
+### Prior art
+
+- `JOURNAL_FORMAT_VERSION = 1` already in `cellpy/batch/journal.py` but unused.
+- `read_journal` / `write_journal` — top-level `info_df` / `metadata` / `session`.
+
+## Approach
+
+1. Top-level JSON key `"version"` (integer).
+2. `Journal.version` defaults to 1; `read_journal` fills it (`raw.get("version", 1)`).
+3. `write_journal` always writes `JOURNAL_FORMAT_VERSION`.
+4. If file version > `JOURNAL_FORMAT_VERSION`, `UserWarning` and still load.
+
+## Files to touch
+
+- `cellpy/batch/journal.py`
+- `tests/test_batch_v3.py`
+- `HISTORY.md` (close)
+
+## Test strategy
+
+`uv run pytest tests/test_batch_v3.py` plus `uv run pytest -m essential`.
+
+## Open questions
+
+None.

--- a/.issueflows/03-solved-issues/issue1000_status.md
+++ b/.issueflows/03-solved-issues/issue1000_status.md
@@ -1,0 +1,13 @@
+# Issue #1000 status
+
+- [x] Done
+
+## What's done
+
+- Journal JSON `version` key; missing → 1; writes `JOURNAL_FORMAT_VERSION`.
+- Newer file version warns and still loads.
+- Tests, docs, HISTORY.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -50,6 +50,8 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_batch_v3_runner.py::test_newest_passes_both_paths | yes | yes | batch.runner._get_kwargs NEWEST | #825 | freshness check |
 | tests/test_batch_v3_runner.py::test_recalc_remakes_steps_and_summary | yes | yes | batch.runner.load_cell recalc | #825 | force_recalc |
 | tests/test_batch_v3_runner.py::test_no_recalc_skips_remake | yes | yes | batch.runner.load_cell | #825 | |
+| tests/test_batch_v3.py::test_journal_missing_version_is_version_one | yes | yes | batch.journal.read_journal | #1000 | missing version → 1 |
+| tests/test_batch_v3.py::test_journal_newer_version_warns_and_still_loads | yes | yes | batch.journal.read_journal | #1000 | future version warns |
 | tests/test_batch.py::test_persist_skips_rewrite_when_loaded_from_cellpy | yes | yes | batch.facade._persist_cells | #825 | skip redundant save |
 | tests/test_batch.py::test_persist_rewrites_when_loaded_from_raw | yes | yes | batch.facade._persist_cells | #825 | |
 | tests/test_batch.py::test_export_project_writes_cells_and_relative_journal | yes | yes | batch.facade.Batch.export_project | #878 | relative posix journal paths |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,7 +332,8 @@ Quick facts:
   `mark_as_bad` is a session flag (unknown cell name → `ValueError`); `drop` /
   `drop_cells_marked_bad` remove now
   (plot/summaries work without `update()`). `save()` then next `load` (default
-  `drop_bad_cells=True`) drops marked cells before update. Missing raw files
+  `drop_bad_cells=True`) drops marked cells before update. Journal JSON has a
+  top-level `version` (missing means 1; this cellpy writes 1). Missing raw files
   (filefinder miss) mark the cell `FAILED` and warn; see `b.result.report()`.
 - In-memory batch: `from_cells({label: cell})` takes cells, not paths — a
   non-cell value raises `ValueError` naming the offending keys. When

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Batch journal JSON files have a top-level `version` (missing means 1).
+  New writes store 1; a newer file version warns and still loads. (#1000)
+
 * Text in the cellpy_db `group` column is kept as journal `group_label`, so
   `summary_collector(..., group_it=True)` uses those names as default legend
   labels. Numeric group ids stay unlabeled; `custom_group_labels=` still

--- a/cellpy/batch/journal.py
+++ b/cellpy/batch/journal.py
@@ -7,14 +7,16 @@ class mixing data model, three file formats, path fixing, selection state and
 folder generation). Folder layout lives in `layout`.
 
 The on-disk JSON format is preserved for compatibility: a top-level object with
-``info_df`` (pages, pandas ``to_json`` "columns" orient), ``metadata`` and
-``session``. Pages follow the keys-in-columns law (polars report section 1.3):
-the cell label lives in the ``filename`` *column*, never in an index.
+``version`` (missing means 1), ``info_df`` (pages, pandas ``to_json`` "columns"
+orient), ``metadata`` and ``session``. Pages follow the keys-in-columns law
+(polars report section 1.3): the cell label lives in the ``filename`` *column*,
+never in an index.
 """
 
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -50,6 +52,7 @@ class Journal:
         session: mutable session state (starred/bad_cells/bad_cycles/notes).
         meta: free-form metadata carried through save/load (name, project,
             time_stamp, project_dir, ...).
+        version: on-disk journal format version (missing file key → 1).
     """
 
     name: str | None = None
@@ -57,6 +60,7 @@ class Journal:
     pages: pl.DataFrame = field(default_factory=pl.DataFrame)
     session: dict = field(default_factory=_empty_session)
     meta: dict = field(default_factory=dict)
+    version: int = JOURNAL_FORMAT_VERSION
 
     @property
     def cell_names(self) -> list[str]:
@@ -125,6 +129,23 @@ def _pages_to_info_df(pages: pl.DataFrame) -> dict:
     return json.loads(pdf.to_json(default_handler=str))
 
 
+def _journal_file_version(raw: dict) -> int:
+    """Format version of a journal JSON object.
+
+    A missing ``version`` key is version 1 (files written before #1000).
+    """
+    value = raw.get("version", 1)
+    if value is None:
+        return 1
+    try:
+        version = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"journal version must be an integer, got {value!r}") from exc
+    if version < 1:
+        raise ValueError(f"journal version must be >= 1, got {version}")
+    return version
+
+
 def read_journal(path: Path | str) -> Journal:
     """Load a journal into the `Journal` model.
 
@@ -140,6 +161,15 @@ def read_journal(path: Path | str) -> Journal:
     if "info_df" not in raw:
         raise ValueError(f"not a cellpy journal (missing 'info_df'): {path}")
 
+    version = _journal_file_version(raw)
+    if version > JOURNAL_FORMAT_VERSION:
+        warnings.warn(
+            f"journal file {path} is version {version}; this cellpy reads "
+            f"version {JOURNAL_FORMAT_VERSION}. Newer fields may be ignored.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     meta = raw.get("metadata") or {}
     session = raw.get("session") or _empty_session()
     for key in keys_journal_session:
@@ -152,6 +182,7 @@ def read_journal(path: Path | str) -> Journal:
         pages=pages,
         session=session,
         meta=meta,
+        version=version,
     )
 
 
@@ -237,6 +268,7 @@ def write_journal(journal: Journal, path: Path | str) -> Path:
     meta.setdefault("name", journal.name)
     meta.setdefault("project", journal.project)
     top_level = {
+        "version": JOURNAL_FORMAT_VERSION,
         "info_df": _pages_to_info_df(journal.pages),
         "metadata": meta,
         "session": journal.session,

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -284,7 +284,8 @@ Dropping cells:
   no `update()` required. Call `b.save()` to persist the thinner journal.
 - Next `batch.load(...)` (default `drop_bad_cells=True`) drops
   `session["bad_cells"]` **before** it loads, so a saved mark is enough if
-  you reload instead of dropping in the same session.
+  you reload instead of dropping in the same session. Saved journals include
+  a top-level `version` (missing on old files means 1).
 
 Building a batch from cells you already hold (a GUI, a notebook, a file
 picker) goes through `from_cells`, which takes cells — not paths:

--- a/tests/test_batch_v3.py
+++ b/tests/test_batch_v3.py
@@ -1,5 +1,6 @@
 """Unit tests for the batch v3 package (#698): journal model + layout."""
 
+import json
 import pathlib
 
 import polars as pl
@@ -15,7 +16,7 @@ from cellpy.batch import (
     read_journal,
     write_journal,
 )
-from cellpy.batch.journal import FILENAME
+from cellpy.batch.journal import FILENAME, JOURNAL_FORMAT_VERSION
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 
@@ -34,6 +35,7 @@ def test_read_journal_json(parameters):
     assert len(j.cell_names) == 5
     # session always carries the four canonical keys
     assert set(j.session) >= {"starred", "bad_cells", "bad_cycles", "notes"}
+    assert j.version == 1
 
 
 def test_journal_json_roundtrip(parameters, tmp_path):
@@ -43,6 +45,9 @@ def test_journal_json_roundtrip(parameters, tmp_path):
     assert returned == out and out.is_file()
 
     j2 = read_journal(out)
+    dumped = json.loads(out.read_text(encoding="utf-8"))
+    assert dumped["version"] == JOURNAL_FORMAT_VERSION
+    assert j2.version == JOURNAL_FORMAT_VERSION
     # value parity on the pages after a write -> read cycle
     assert j2.cell_names == j1.cell_names
     assert set(j2.pages.columns) == set(j1.pages.columns)
@@ -72,6 +77,45 @@ def test_read_journal_rejects_non_journal(tmp_path):
     bad.write_text('{"hello": "world"}', encoding="utf-8")
     with pytest.raises(ValueError, match="not a cellpy journal"):
         read_journal(bad)
+
+
+@pytest.mark.essential
+def test_journal_missing_version_is_version_one(tmp_path):
+    """Files written before #1000 have no version key and load as 1."""
+    path = tmp_path / "legacy.json"
+    path.write_text(
+        json.dumps(
+            {
+                "info_df": {FILENAME: {"0": "cell_a"}},
+                "metadata": {"name": "legacy"},
+                "session": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    j = read_journal(path)
+    assert j.version == 1
+    assert j.cell_names == ["cell_a"]
+
+
+@pytest.mark.essential
+def test_journal_newer_version_warns_and_still_loads(tmp_path):
+    path = tmp_path / "future.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": JOURNAL_FORMAT_VERSION + 1,
+                "info_df": {FILENAME: {"0": "cell_a"}},
+                "metadata": {"name": "future"},
+                "session": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.warns(UserWarning, match="version"):
+        j = read_journal(path)
+    assert j.version == JOURNAL_FORMAT_VERSION + 1
+    assert j.cell_names == ["cell_a"]
 
 
 # ---- custom JSON (#345) -------------------------------------------------


### PR DESCRIPTION
## Summary
- Journal JSON now has a top-level `version`. A missing key is version 1 (pre-#1000 files).
- New writes store `JOURNAL_FORMAT_VERSION` (currently 1). A newer file version warns and still loads.

Closes #1000

## Test plan
- [x] `uv run pytest tests/test_batch_v3.py`
- [x] `uv run pytest -m essential`


Made with [Cursor](https://cursor.com)