### PR TITLE
docs: promote HISTORY to 2.1.4 and record cellpycore 0.2.5 pin

### DIFF
--- a/.issueflows/04-designs-and-guides/v2-cellpycore-pin-gate.md
+++ b/.issueflows/04-designs-and-guides/v2-cellpycore-pin-gate.md
@@ -12,8 +12,9 @@ legacy-bridge stripping of `test_id` on steps/summary and the legacy-schema
 `merge_data` story; releasing against `0.2.1` would have frozen the #507
 workaround.
 
-**Current pin (master).** `cellpycore==0.2.4` in `[project.dependencies]` /
-`uv.lock` (EFC summary columns from core #138/#141). Keep an exact
+**Current pin (master).** `cellpycore==0.2.5` in `[project.dependencies]` /
+`uv.lock` (since cellpy v2.1.4, 2026-09-08; core #143 legacy `cycle_mode`
+unwrapping on top of the 0.2.4 EFC columns, core #138/#141). Keep an exact
 `==` pin on every release commit; bump only via the F9 order (core release →
 cellpy re-pin → cellpy release).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [2.1.4] - 2026-09-08
+
+Patch release — the last of the `v2.1.x` reactive stream before Stage 5 (2.2)
+work starts. Additive, no breaking changes; one behaviour change on load
+(#989, below). Ships on `cellpycore==0.2.5` (legacy `cycle_mode` list
+unwrapping, core #143).
+
 * Batch journal JSON files have a top-level `version` (missing means 1).
   New writes store 1; a newer file version warns and still loads. (#1000)
 


### PR DESCRIPTION
Post-release housekeeping for v2.1.4: promote HISTORY [Unreleased] to a dated 2.1.4 section (tag was cut before promotion; ships on cellpycore==0.2.5) and update the pin-gate guide. Docs only.

Made with [Cursor](https://cursor.com)