### PR TITLE
test: golden equality oracle for incremental updates (L6, #778)

### DIFF
--- a/.issueflows/03-solved-issues/issue778_original.md
+++ b/.issueflows/03-solved-issues/issue778_original.md
@@ -1,0 +1,9 @@
+# Issue #778: L6: golden equality test — incremental update() == full load
+
+Source: https://github.com/jepegit/cellpy/issues/778
+
+## Original issue text
+
+Epic L of **cellpy 2.2 (Stage 5)**. Design: [live-incremental](https://github.com/cellpy/architecture-plan/blob/main/cellpy2-live-incremental-design.md) §7 item 6. **Author first** — this is the correctness anchor for the whole epic.
+
+Load a truncated file, append the tail, and assert `update()` == a full load of the whole file (summary equality). *Incremental refresh of a split file must equal a full load of the whole file.*

--- a/.issueflows/03-solved-issues/issue778_plan.md
+++ b/.issueflows/03-solved-issues/issue778_plan.md
@@ -1,0 +1,129 @@
+# Issue #778 plan — L6: golden equality test (incremental update == full load)
+
+## Goal
+
+Add the Stage 5 Epic L correctness anchor: a test proving that loading a
+**truncated** tester file and then feeding the **tail rows** through the
+incremental-update path yields the same `raw` / `steps` / `summary` as one
+**full load** of the whole file. Written first, against the shipped core
+primitive (`update_core_data`), so L1–L5 (#779/#780/#164/#781/#782) have an
+oracle to land against.
+
+## Constraints
+
+- Test-only issue: **no library code changes**. `CellpyCell.update()` and
+  `load_since()` do not exist yet (L3/L2); the test drives the seam that does
+  exist — `c.core.update_core_data(data, new_raw, …)` (cellpycore 0.2.5
+  `merge.update_data`). The helper that produces the "tail" is written so L3
+  can swap it for `c.update()` in one place.
+- Must run on the merge gate (`@pytest.mark.essential`) → fast, no mdbtools:
+  use a **text** fixture. `testdata/data/neware_uio.csv` (`instrument="neware_txt"`,
+  `model="UIO"`): 1 header line + 9064 rows, 4 cycles / 32 steps, `datapoint_num`
+  1…9065, loads in ~0.4 s. (`maccor_001.txt` is 5 s and has 1 cycle — not the
+  anchor; `custom_data_001.csv` has non-integer `datapoint_num` — unsuitable.)
+- Truncated files are written to `tmp_path`, never into `testdata/` (input data
+  read-only).
+- `update_data` contract (core): `new_raw` may **overlap** the tail; overlap is
+  trimmed on `source_datapoint_num` → falls back to `datapoint_num` (cellpy
+  loaders set no `source_datapoint_num`). Rejects `new_raw` starting at/before
+  the existing range. Both branches (`gap_append` vs overlap) exercised.
+- Per-cell frames are **pandas** in cellpy; `update_core_data` converts.
+  Comparisons use `pandas.testing` with a small float tolerance, columns
+  aligned by name, `test_id` normalised.
+- Summary scope **now**: `update_core_data(refresh_derived=True)` produces the
+  *core* summary (cycle-end columns + C-rates + IR). cellpy's `make_summary`
+  additionally runs `add_scaled_summary_columns` (gravimetric/areal, equivalent
+  cycles). Until L3 defines what `c.update()` does after the core step, the
+  summary assertion compares the **intersection of columns**; the test records
+  the missing columns so L3 flips it to full-column equality. `raw` and `steps`
+  are compared on the **full** column set.
+
+### Prior art
+
+- `cellpycore.merge.update_data` / `CellpyCellCore.update_core_data`
+  (`../cellpy-core/src/cellpycore/merge.py:173`, `cell_core.py:528`) — the
+  engine under test; core has its own unit tests on synthetic frames, none
+  through a real loader.
+- `CellpyCell.merge(cells, mode="campaign")` (`cellpy/readers/cellreader.py:1852`)
+  — the *campaign* merge (renumber cycles); not the incremental path. Coexist.
+- `tests/parity.py::assert_value_parity` — legacy↔native comparator with
+  named exceptions; heavier than needed here (same-schema frames). Mirror its
+  spirit (explicit tolerance, no silent widening) with `pandas.testing`.
+- `tests/loader_golden_support.py` / `tests/golden_support.py` — committed
+  golden snapshots. **Not** used: this oracle is *self-referential* (full load
+  is the reference), so no new golden files and no `regenerate_goldens.py`
+  suite.
+- `tests/test_cellpy_splitting.py` (`cell.split`, `drop_to`) — cycle-level
+  splitting of a loaded cell; different axis (cycles, not file rows). Coexist.
+- `.issueflows/00-tools/` — nothing applicable (AST scanners, prms migrator).
+
+## Approach
+
+1. **`tests/incremental_support.py`** (small, reused by L2/L3/L5 tests later):
+   - `truncate_text_file(src, dst, *, n_data_rows, header_lines=1)` → writes
+     header + first `n_data_rows` data lines. Returns `dst`.
+   - `tail_rows(full_raw, *, since, overlap, datapoint_col)` → pandas slice
+     `datapoint_num > since - overlap` — this is what a future `load_since`
+     returns for marker `since`; the only place L3 has to replace.
+   - `incremental_update(head_cell, new_raw)` → today:
+     `head_cell.core.update_core_data(head_cell.data, new_raw, nom_cap_abs=…,
+     current_conversion_factor=…)` with the same factors cellpy's
+     `make_summary` computes (`core_units.calculate_current_conversion_factor`,
+     nominal capacity from `head_cell.data.meta`). Returns the new `Data`.
+   - `assert_frames_equal(left, right, *, columns=None, rtol)` thin wrapper
+     over `pandas.testing.assert_frame_equal` (reset index, sort by
+     `datapoint_num` / `cycle_num`, `check_dtype=False`).
+2. **`tests/test_incremental_update.py`**:
+   - Fixtures: `full_cell` (module-scoped load of `neware_uio.csv`);
+     `head_cell(tmp_path, n)` via `truncate_text_file` + `cellpy.get`.
+   - `test_head_matches_full_prefix` — sanity: head `raw` == first `n` rows of
+     full `raw` (proves the truncation + `datapoint_num` assignment are
+     deterministic; without this the oracle proves nothing).
+   - `test_incremental_update_equals_full_load[cut]` — parametrised over cut
+     points: **mid-step** inside cycle 2, **on a step boundary**, **on a cycle
+     boundary**; `overlap=0` (gap-append branch). Assert `raw` full equality,
+     `steps` full equality, `summary` equality on shared columns.
+   - `test_incremental_update_with_overlap` — same cut, `overlap=50` rows
+     (trim branch).
+   - `test_incremental_update_noop_on_empty_tail` — empty `new_raw` returns an
+     equal copy (poll tick with nothing new).
+   - `test_summary_column_gap_is_documented` — asserts the set of full-summary
+     columns missing after the core-only update equals a **named** list
+     (`add_scaled_summary_columns` outputs). When L3 lands and closes the gap,
+     this test is deleted and the main test flips to full-column equality.
+   - Marker `@pytest.mark.essential` on the equality tests (golden-oracle rule
+     in `this-project.md`); whole file well under 5 s.
+3. **`tests/README.md`** — one short subsection "Incremental-update oracle
+   (Stage 5 L6)" stating the invariant, the fixture, and the L3 flip rule.
+4. **Status file** `issue778_status.md`; HISTORY entry at close (test-only —
+   a one-liner under Unreleased is enough).
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `tests/incremental_support.py` | new — truncate / tail / update / compare helpers |
+| `tests/test_incremental_update.py` | new — the L6 oracle tests (essential) |
+| `tests/README.md` | add "Incremental-update oracle" subsection |
+| `.issueflows/01-current-issues/issue778_status.md` | new |
+
+No changes under `cellpy/`.
+
+## Test strategy
+
+- `uv run pytest tests/test_incremental_update.py -q` during build.
+- `uv run pytest -m essential` before close (merge gate).
+- If a cut point exposes a real `update_data` defect (e.g. step-table rows at
+  the cut not refreshed identically), **do not** widen tolerance or drop the
+  case: record it in the status file and open a `cellpy-core` issue — that is
+  precisely what the oracle is for.
+
+## Open questions
+
+1. Summary scope: OK to compare **shared columns only** now (with the
+   documented gap test) and defer full-column equality to L3 (#164)? The
+   alternative — calling cellpy `make_summary()` after the core update — would
+   make the summary assertion trivially true and is rejected.
+2. Second fixture: add `maccor_001.txt` as a non-essential parametrisation
+   (5 s, single cycle) for loader diversity, or keep neware-only? Proposal:
+   neware-only now; L2 (#780) adds per-loader cases when `load_since` exists.

--- a/.issueflows/03-solved-issues/issue778_status.md
+++ b/.issueflows/03-solved-issues/issue778_status.md
@@ -1,0 +1,38 @@
+# Issue #778 status — L6 golden equality test
+
+- [x] Done
+
+Branch: `778-l6-golden-equality-update`. Plan: `issue778_plan.md` (accepted 2026-09-08).
+
+## What's done
+
+- `tests/incremental_support.py`: `truncate_text_file`, `tail_rows`,
+  `incremental_update` (test-side prototype of L3 `c.update()`: drives
+  `update_core_data` with `nom_cap_abs`, current factor, `raw_limits`,
+  `find_ir=False`; copies frames back; re-applies `_add_summary_extras` and
+  `_refresh_scaled_summary_columns`), `assert_cell_frames_equal`.
+- `tests/test_incremental_update.py` (essential, ~6 s): cut points derived
+  from the full step table (mid-step / step end / cycle end).
+  - overlap re-read (≥1 row) → **full equality** on raw/steps/summary, all
+    columns (better than plan's shared-column fallback).
+  - gap-append on step/cycle boundary → equal.
+  - gap-append mid-step → strict xfail, cellpy/cellpy-core#148 (partial
+    trailing step kept → spanning step split, C-rate drift).
+  - empty tail → strict xfail, cellpy/cellpy-core#147 (`refresh_derived`
+    re-joins C-rate columns → `*_right` duplicates).
+- `tests/README.md` subsection.
+- `uv run pytest -m essential`: 839 passed, 2 xfailed.
+
+## Findings for L3 (#164)
+
+- `update_core_data` returns a bare cellpycore `Data` (polars frames); cellpy
+  must copy frames into its metadata-bearing `Data`, add summary extras
+  (`native_core._add_summary_extras` with `core.schema`), then refresh scaled
+  columns. `_refresh_scaled_summary_columns` fails on bare core `Data`
+  (`no attribute 'tests'`).
+- Always re-read from ≥1 already-seen row (ideally start of last step) until
+  cellpy-core#148 lands.
+
+## Remaining work
+
+- None here. Drop the two xfail markers when cellpy-core#147 / #148 ship.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -169,6 +169,10 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_instrument_registering.py::test_list_instruments_is_quiet | yes | yes | data_structures.list_instruments | #786 | WARNING contract |
 | tests/test_instrument_registering.py::test_list_instruments_includes_failed_sql_create | yes | yes | data_structures.list_instruments | #938 | import-fail row |
 | tests/test_instrument_registering.py::test_list_instruments_marks_arbin_res_when_mdb_export_missing | yes | yes | data_structures.list_instruments | #938 | mdbtools probe |
+| tests/test_incremental_update.py::test_overlap_reread_equals_full_load | yes | yes | CellpyCellCore.update_core_data (L6 oracle) | #778 | 3 cut points; full raw/steps/summary equality |
+| tests/test_incremental_update.py::test_gap_append_on_boundary_equals_full_load | yes | yes | CellpyCellCore.update_core_data | #778 | step/cycle boundary cuts |
+| tests/test_incremental_update.py::test_gap_append_mid_step_equals_full_load | yes | yes | cellpycore.merge.update_data | #778 | strict xfail → core#148 |
+| tests/test_incremental_update.py::test_empty_tail_is_noop | yes | yes | CellpyCellCore.update_core_data | #778 | strict xfail → core#147 |
 
 **Columns**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+* Golden equality test for incremental updates (L6): head + tail through
+  `update_core_data` must equal a full load on raw/steps/summary. Two strict
+  xfails pin cellpycore gaps (core#147 empty-tail no-op, core#148 gap-append
+  mid-step). Test-only. (#778)
+
 ## [2.1.4] - 2026-09-08
 
 Patch release — the last of the `v2.1.x` reactive stream before Stage 5 (2.2)

--- a/tests/README.md
+++ b/tests/README.md
@@ -140,6 +140,25 @@ allowed to differ; unlisted mismatches always fail.
 uv run pytest tests/test_value_parity.py -m essential
 ```
 
+## Incremental-update golden equality (L6, #778)
+
+[`test_incremental_update.py`](test_incremental_update.py) loads a truncated head of
+`testdata/data/neware_uio.csv`, appends the tail through
+`CellpyCellCore.update_core_data`, and asserts `raw` / `steps` / `summary` equal a
+single full `cellpy.get` (all columns, order-insensitive, dtype-insensitive). Helpers in
+[`incremental_support.py`](incremental_support.py); `incremental_update` is a test-side
+prototype of the future `CellpyCell.update()` (L3, #164) — it also re-applies the
+cellpy-side summary extras and scaled columns.
+
+Cut points are derived from the full step table (mid-step, step end, cycle end). Two
+strict `xfail`s pin known cellpycore gaps: gap-append mid-step
+(cellpy/cellpy-core#148) and empty-tail no-op (cellpy/cellpy-core#147). When those are
+fixed the xfails turn into failures — drop the markers then.
+
+```bash
+uv run pytest tests/test_incremental_update.py
+```
+
 ## `essential` marker
 
 Fast smoke tests — read → step table → summary pipeline and cellpy/cellpy-core parity —

--- a/tests/incremental_support.py
+++ b/tests/incremental_support.py
@@ -1,0 +1,92 @@
+"""Helpers for the incremental-update golden equality oracle (issue #778, L6).
+
+The oracle: loading a *head* of a raw file and then appending the *tail* through
+``update_core_data`` must produce the same ``raw`` / ``steps`` / ``summary`` as a
+single full load.
+
+``incremental_update`` is a test-side prototype of what L3 (#164) will expose as
+``CellpyCell.update()``: it drives ``update_core_data`` with the cellpy-owned
+by-value inputs (nominal capacity, current factor, instrument raw limits) and then
+re-applies the cellpy-side summary extras and the scaled (mass/area) columns.
+Replace this helper with the public API once L3 lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+from cellpycore import units as core_units
+
+from cellpy.readers.native_core import _add_summary_extras
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NEWARE_UIO = REPO_ROOT / "testdata" / "data" / "neware_uio.csv"
+NEWARE_KWARGS = {"instrument": "neware_txt", "model": "UIO"}
+
+
+def truncate_text_file(src: Path, dst: Path, n_rows: int, header_lines: int = 1) -> Path:
+    """Write the first ``n_rows`` data rows of ``src`` (plus header) to ``dst``."""
+    with open(src, encoding="utf-8", errors="replace") as fh:
+        lines = fh.readlines()
+    dst.write_text("".join(lines[: header_lines + n_rows]), encoding="utf-8")
+    return dst
+
+
+def tail_rows(raw: pd.DataFrame, datapoint_col: str, since: int, overlap: int = 0) -> pd.DataFrame:
+    """Rows of ``raw`` after ``since``; ``overlap`` re-includes that many trailing rows."""
+    return raw[raw[datapoint_col] > since - overlap]
+
+
+def _to_pandas(frame):
+    return frame.to_pandas() if hasattr(frame, "to_pandas") else frame
+
+
+def incremental_update(cell, new_raw: pd.DataFrame, find_ir: bool = False):
+    """Append ``new_raw`` to ``cell`` in place via ``update_core_data``.
+
+    Mirrors the cellpy-side orchestration in ``make_step_table`` /
+    ``make_summary`` so the result is comparable with a full ``cellpy.get``.
+    """
+    factor = core_units.calculate_current_conversion_factor(cell.data.raw_units["current"], to_units=cell.cellpy_units)
+    nom_cap_abs = cell._resolve_nom_cap_abs(cell.data)
+    out = cell.core.update_core_data(
+        cell.data,
+        new_raw,
+        nom_cap_abs=nom_cap_abs,
+        current_conversion_factor=factor,
+        find_ir=find_ir,
+        raw_limits=cell.raw_limits,
+    )
+    # ``update_core_data`` returns a bare cellpycore ``Data``; copy the frames back
+    # so cellpy's metadata-bearing ``Data`` stays the owner.
+    cell.data.raw = _to_pandas(out.raw)
+    cell.data.steps = _to_pandas(out.steps)
+    cell.data.summary = _add_summary_extras(_to_pandas(out.summary), cell.core.schema)
+    cell._refresh_scaled_summary_columns()
+    return cell
+
+
+def _normalize(frame: pd.DataFrame, sort_by) -> pd.DataFrame:
+    return frame.sort_values(sort_by).reset_index(drop=True)
+
+
+def assert_frames_equal(left: pd.DataFrame, right: pd.DataFrame, sort_by, label: str) -> None:
+    """Order-insensitive equality on the full column set; dtype differences allowed."""
+    assert set(left.columns) == set(
+        right.columns
+    ), f"{label}: column mismatch: {set(left.columns) ^ set(right.columns)}"
+    left = _normalize(left, sort_by)
+    right = _normalize(right, sort_by)[left.columns]
+    assert len(left) == len(right), f"{label}: {len(left)} rows vs {len(right)} rows"
+    pdt.assert_frame_equal(left, right, check_dtype=False, rtol=1e-9, atol=1e-12, obj=label)
+
+
+def assert_cell_frames_equal(updated, full) -> None:
+    """``raw`` / ``steps`` / ``summary`` of ``updated`` must equal those of ``full``."""
+    dp = full.schema.raw.datapoint_num
+    st = full.schema.steps
+    assert_frames_equal(updated.data.raw, full.data.raw, dp, "raw")
+    assert_frames_equal(updated.data.steps, full.data.steps, [st.cycle_num, st.step_num], "steps")
+    assert_frames_equal(updated.data.summary, full.data.summary, full.schema.summary.cycle_num, "summary")

--- a/tests/test_incremental_update.py
+++ b/tests/test_incremental_update.py
@@ -1,0 +1,97 @@
+"""L6 golden equality: incremental update == full load (issue #778).
+
+Head + tail through ``update_core_data`` must match a single ``cellpy.get`` of the
+whole file on ``raw`` / ``steps`` / ``summary``. Fixture: ``neware_uio.csv``
+(9065 rows, 4 cycles, 32 steps).
+"""
+
+import pytest
+
+import cellpy
+from tests.incremental_support import (
+    NEWARE_KWARGS,
+    NEWARE_UIO,
+    assert_cell_frames_equal,
+    assert_frames_equal,
+    incremental_update,
+    tail_rows,
+    truncate_text_file,
+)
+
+pytestmark = pytest.mark.skipif(not NEWARE_UIO.is_file(), reason="neware_uio.csv fixture missing")
+
+
+@pytest.fixture(scope="module")
+def full():
+    return cellpy.get(NEWARE_UIO, testing=True, **NEWARE_KWARGS)
+
+
+@pytest.fixture(scope="module")
+def cut_points(full):
+    """Datapoint numbers derived from the full step table: mid-step, step end, cycle end."""
+    st = full.schema.steps
+    steps = full.data.steps
+    first_cycle = steps[steps[st.cycle_num] == steps[st.cycle_num].min()]
+    step_end = int(first_cycle[st.datapoint_num_last].iloc[-3])
+    cycle_end = int(first_cycle[st.datapoint_num_last].iloc[-1])
+    later = steps[steps[st.cycle_num] == steps[st.cycle_num].min() + 1].iloc[0]
+    mid_step = (int(later[st.datapoint_num_first]) + int(later[st.datapoint_num_last])) // 2
+    return {"mid_step": mid_step, "step_end": step_end, "cycle_end": cycle_end}
+
+
+def _head(tmp_path, n_rows):
+    path = truncate_text_file(NEWARE_UIO, tmp_path / "head.csv", n_rows)
+    return cellpy.get(path, testing=True, **NEWARE_KWARGS)
+
+
+def _run(tmp_path, full, cut, overlap):
+    head = _head(tmp_path, cut)
+    dp = full.schema.raw.datapoint_num
+    assert int(head.data.raw[dp].max()) == cut
+    tail = tail_rows(full.data.raw, dp, since=cut, overlap=overlap)
+    return incremental_update(head, tail)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("cut", ["mid_step", "step_end", "cycle_end"])
+def test_overlap_reread_equals_full_load(tmp_path, full, cut_points, cut):
+    """Tail re-reads at least one already-seen row: the spanning step is rebuilt."""
+    updated = _run(tmp_path, full, cut_points[cut], overlap=1)
+    assert_cell_frames_equal(updated, full)
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize("cut", ["step_end", "cycle_end"])
+def test_gap_append_on_boundary_equals_full_load(tmp_path, full, cut_points, cut):
+    """No overlap is fine when the head ends exactly on a step / cycle boundary."""
+    updated = _run(tmp_path, full, cut_points[cut], overlap=0)
+    assert_cell_frames_equal(updated, full)
+
+
+@pytest.mark.essential
+@pytest.mark.xfail(
+    strict=True,
+    reason="cellpy/cellpy-core#148: gap-append keeps the partial trailing step, so the "
+    "step spanning the cut is split in two (extra step row, C-rate drift). Until fixed, "
+    "L3 (#164) must re-read from the start of the last step.",
+)
+def test_gap_append_mid_step_equals_full_load(tmp_path, full, cut_points):
+    updated = _run(tmp_path, full, cut_points["mid_step"], overlap=0)
+    assert_cell_frames_equal(updated, full)
+
+
+@pytest.mark.essential
+@pytest.mark.xfail(
+    strict=True,
+    reason="cellpy/cellpy-core#147: empty new_raw short-circuits update_data but "
+    "refresh_derived still re-joins the C-rate columns (*_right duplicates).",
+)
+def test_empty_tail_is_noop(tmp_path, full, cut_points):
+    head = _head(tmp_path, cut_points["mid_step"])
+    before = {k: getattr(head.data, k).copy() for k in ("raw", "steps", "summary")}
+    updated = incremental_update(head, full.data.raw.iloc[0:0])
+    dp = full.schema.raw.datapoint_num
+    st = full.schema.steps
+    assert_frames_equal(updated.data.raw, before["raw"], dp, "raw")
+    assert_frames_equal(updated.data.steps, before["steps"], [st.cycle_num, st.step_num], "steps")
+    assert_frames_equal(updated.data.summary, before["summary"], full.schema.summary.cycle_num, "summary")


### PR DESCRIPTION
Closes #778

## What

Test-only. Adds `tests/test_incremental_update.py` (marked `essential`, ~6 s) plus helpers in `tests/incremental_support.py`.

A truncated head of `testdata/data/neware_uio.csv` is loaded with `cellpy.get`, the tail is appended through `CellpyCellCore.update_core_data`, and `raw` / `steps` / `summary` are asserted equal (all columns, order- and dtype-insensitive) to a single full load. Cut points are derived from the full step table: mid-step, step end, cycle end.

`incremental_update` is a test-side prototype of the orchestration L3 (#164) will need for `CellpyCell.update()`: pass `nom_cap_abs`, current conversion factor and `raw_limits` by value, copy the returned core frames back into cellpy's metadata-bearing `Data`, re-add the summary extras (`native_core._add_summary_extras`), then `_refresh_scaled_summary_columns()`.

## Findings (pinned as strict `xfail`)

- Gap-append with a mid-step cut keeps the partial trailing step, so the spanning step is split in two and the summary C-rate drifts — cellpy/cellpy-core#148. With >= 1 overlapping row the result is identical to a full load.
- Empty `new_raw` short-circuits `update_data` but `refresh_derived` re-joins the C-rate columns (`*_right` duplicates) — cellpy/cellpy-core#147.

Both xfails are `strict=True`; when the core fixes land they fail loudly and the markers should be dropped.

## Docs

- `tests/README.md` subsection, test-registry rows, `HISTORY.md` bullet under Unreleased.

## Test

```bash
uv run pytest tests/test_incremental_update.py
uv run pytest -m essential   # 839 passed, 2 xfailed locally
```

Made with [Cursor](https://cursor.com)