### PR TITLE
fix(batch): warn when a cached journal shadows the db or a db column is missing (#1008)

### DIFF
--- a/.issueflows/03-solved-issues/issue1008_original.md
+++ b/.issueflows/03-solved-issues/issue1008_original.md
@@ -1,0 +1,7 @@
+# Issue #1008: nom cap specific lost
+
+Source: https://github.com/jepegit/cellpy/issues/1008
+
+## Original issue text
+
+When loading from xlsx database (batch), it did not pick up the nom cap specific value (gravimetric)

--- a/.issueflows/03-solved-issues/issue1008_plan.md
+++ b/.issueflows/03-solved-issues/issue1008_plan.md
@@ -1,0 +1,82 @@
+# Plan — issue #1008: nom cap specific lost (batch, xlsx db)
+
+Branch: `1008-batch-nom-cap-specifics`. Milestone `v2.1.4.post`.
+
+## Diagnosis (2026-09-08)
+
+Traced db → journal → spec → `cellpy.get` on master with the reporter's own
+config (`cellpy.toml`: `db_cols.nom_cap_specifics = "nom_cap_specifics"`) and db
+(`2025_Cell_Analysis_db_001.xlsx`, 976 gravimetric / 28 areal rows):
+
+- `Reader.get_nom_cap_specifics(id)` returns the sheet value.
+- `_dbengine._create_pages_dict` → `Journal.pages["nom_cap_specifics"]` →
+  `policy.resolve_specs` → `runner._get_kwargs` → `cellpy.get(nom_cap_specifics=…)`
+  keeps the value; journal JSON round-trip keeps it.
+- `batch.load()` end-to-end on the test db with an `areal` column: cells get
+  `nom_cap_specifics="areal"`, `cellpy_units.nominal_capacity="mAh/cm**2"` on
+  raw load, `.cellpy` AUTO reload and journal autoload.
+
+So the value is not lost by the pipeline itself. Two ways it shows up as `null`
+in `b.pages`, both silent today:
+
+1. **Journal autoload shadows the db.** `batch.load(name, project, …)` with
+   `allow_from_journal=True` (default) reuses `cwd/cellpy_batch_<name>.json`
+   when present and never opens the xlsx — logged at INFO only. A journal
+   written before the db column was filled (or by an older cellpy that did not
+   emit the column, e.g. `cellpy_batch_celf_mar.json` from July has no
+   `nom_cap_specifics` key) reads back as a `null` column. Even when the user
+   passes `db_reader=` / `batch_col=`, the stale journal still wins.
+2. **Configured column name ≠ sheet header.** `Reader._pick_info` swallows the
+   `KeyError` at `logging.debug` and returns `None` for every cell → `null`
+   column → default `gravimetric` at load. No warning.
+
+Side finding (out of scope, file follow-up): `journal_from_db(…, skip_file_search=True)`
+with the Excel reader crashes in `simple_db_engine` (`pd.DataFrame(pages_dict)`:
+`All arrays must be of the same length` — `raw_file_names` / `cellpy_file_name`
+stay `[]`).
+
+## Approach (KISS, no behaviour change on the happy path)
+
+1. `cellpy/readers/dbreader.py` — `_pick_info`: on missing column emit
+   `warnings.warn(...)` **once per column per reader instance** (keep the
+   `None` return so batches still build). Message names the configured key
+   (`config.db_cols.<field>`) and the sheet header it expected.
+2. `cellpy/batch/facade.py` — `_load_after_progress`: when the journal is
+   autoloaded **and** the caller signalled a db read (`db`, `db_reader`,
+   `reader`, `batch_col` or `reader_path` given), `warnings.warn` that the
+   database was not consulted and that `allow_from_journal=False` re-reads it.
+   Plain `batch.load(name, project)` keeps the INFO log (fast-path reopen).
+3. Tests (essential):
+   - `tests/test_batch_v3_facade.py`: autoload + `db_reader=` → `UserWarning`;
+     autoload without db args → no warning.
+   - `tests/test_dbreader.py` (or nearest existing dbreader test module):
+     `Reader(db_frame=…)` missing the configured column → one `UserWarning`,
+     second pick of same column silent; and a regression check that a present
+     `nominal_capacity_specifics` column flows into `_create_pages_dict`.
+4. Docs: `HISTORY.md` bullet (close step); one line in
+   `docs/getting_started/agents.md` batch bullet + `AGENTS.md` mirror:
+   "`batch.load` reuses `cellpy_batch_<name>.json` in cwd when present;
+   `allow_from_journal=False` forces a db read."
+5. Follow-up GitHub issue for the `skip_file_search=True` Excel crash.
+
+## Files
+
+- `cellpy/readers/dbreader.py`, `cellpy/batch/facade.py`
+- `tests/test_batch_v3_facade.py`, `tests/test_dbreader*.py`
+- `docs/getting_started/agents.md`, `AGENTS.md`, `HISTORY.md`
+
+## Constraints
+
+- No change to journal schema or defaults; `null` stays `null` (honest).
+- Warnings, not exceptions — batches must still build with a partial db.
+
+### Prior art
+
+- `_dbengine.find_files` filefinder-miss `UserWarning` (#964) — same style.
+- `#1000` journal `version` warning path in `journal.read_journal`.
+
+## Open questions
+
+- Should `db_reader=`/`batch_col=` given explicitly make the db **win** over the
+  autoloaded journal instead of just warning? Plan says warn only (smaller,
+  no surprise reload); flip to "db wins" if preferred.

--- a/.issueflows/03-solved-issues/issue1008_status.md
+++ b/.issueflows/03-solved-issues/issue1008_status.md
@@ -1,0 +1,28 @@
+# Issue #1008 status — nom cap specific lost (batch, xlsx db)
+
+- [x] Done
+
+Branch: `1008-batch-nom-cap-specifics`. Plan accepted 2026-09-08 (warn-only variant).
+
+## What's done
+
+- Diagnosis: pipeline keeps the value (verified db → journal → spec →
+  `cellpy.get` → cell, incl. `.cellpy` reload and journal autoload). `null`
+  in `b.pages` comes from a cached `cellpy_batch_<name>.json` shadowing the
+  db (INFO-only before), or from a configured-vs-sheet column-name mismatch
+  swallowed in `Reader._pick_info`.
+- `cellpy/readers/dbreader.py`: `_warn_missing_column` — one `UserWarning`
+  per missing sheet header per reader, naming the `config.db_cols.<key>`.
+- `cellpy/batch/facade.py`: `_load_after_progress` warns when the journal is
+  autoloaded but `db` / `db_reader` / `batch_col` / `reader_path` / other db
+  kwargs were given.
+- Tests (essential): `test_dbreader.py::test_missing_column_warns_once`,
+  `::test_nom_cap_specifics_column_reaches_pages`;
+  `test_batch_v3_facade.py::test_load_warns_when_journal_autoload_shadows_db`,
+  `::test_load_autoload_without_db_args_is_quiet`.
+- Docs: `docs/getting_started/agents.md` batch recipe + `AGENTS.md` mirror.
+- Follow-up filed: #1017 (`skip_file_search=True` crashes with Excel reader).
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -173,6 +173,10 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_incremental_update.py::test_gap_append_on_boundary_equals_full_load | yes | yes | CellpyCellCore.update_core_data | #778 | step/cycle boundary cuts |
 | tests/test_incremental_update.py::test_gap_append_mid_step_equals_full_load | yes | yes | cellpycore.merge.update_data | #778 | strict xfail → core#148 |
 | tests/test_incremental_update.py::test_empty_tail_is_noop | yes | yes | CellpyCellCore.update_core_data | #778 | strict xfail → core#147 |
+| tests/test_dbreader.py::test_missing_column_warns_once | yes | yes | readers.dbreader.Reader._pick_info | #1008 | warn-once per missing header |
+| tests/test_dbreader.py::test_nom_cap_specifics_column_reaches_pages | yes | yes | batch._dbengine._create_pages_dict | #1008 | db value → pages |
+| tests/test_batch_v3_facade.py::test_load_warns_when_journal_autoload_shadows_db | yes | yes | batch.facade.load | #1008 | cached journal + db args |
+| tests/test_batch_v3_facade.py::test_load_autoload_without_db_args_is_quiet | yes | yes | batch.facade.load | #1008 | no false warning |
 
 **Columns**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,10 @@ Quick facts:
 - Batch: `batch.load(name=..., project=...)`; `executor="threads"` speeds up
   reopening local `.cellpy` files (first remote load stays serial on the wire).
   `progress=None` auto-shows tqdm (TTY / Jupyter); `False` off.
+  An existing `cellpy_batch_<name>.json` in cwd/`journal_dir` is reused and
+  the db is not re-read (warns when db args were passed);
+  `allow_from_journal=False` rebuilds from the db. A configured `db_cols`
+  header missing from the sheet warns once (values become empty).
   After load: `b.summaries`, `b.cells[label]`, `b.plot()`, `b.result.report()`.
   Text in the cellpy_db `group` column becomes journal `group_label` (default
   legend for `summary_collector(..., group_it=True)`); `custom_group_labels=`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+* `batch.load` warns when a cached `cellpy_batch_<name>.json` is reused while
+  db arguments were passed (the database is not re-read; use
+  `allow_from_journal=False`). The Excel db reader warns once per configured
+  `db_cols` header that is missing from the sheet instead of silently
+  returning empty values. (#1008)
+
 * Golden equality test for incremental updates (L6): head + tail through
   `update_core_data` must equal a full load on raw/steps/summary. Two strict
   xfails pin cellpycore gaps (core#147 empty-tail no-op, core#148 gap-append

--- a/cellpy/batch/facade.py
+++ b/cellpy/batch/facade.py
@@ -1036,6 +1036,16 @@ def _load_after_progress(
             candidate = _journal_path(name, journal_dir)
             if candidate.is_file():
                 _log.info("loading journal %s", candidate)
+                if db is not None or db_reader is not None or db_kwargs:
+                    # The caller asked for a db read, but the cached journal wins;
+                    # stale journals then show up as empty/old meta (#1008).
+                    warnings.warn(
+                        f"batch.load: reusing journal {candidate} — the database was "
+                        "not read. Pass allow_from_journal=False (or delete the "
+                        "journal file) to rebuild the journal from the database.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
                 batch = Batch(read_journal(candidate), policy=resolved)
                 journal_path = candidate
 

--- a/cellpy/readers/dbreader.py
+++ b/cellpy/readers/dbreader.py
@@ -63,6 +63,7 @@ class Reader(core.BaseSimpleDbReader):
 
         self.db_sheet_cols = DbSheetCols()
         self.selected_batch = None
+        self._missing_columns_warned = set()
 
         if not db_datadir:
             self.db_datadir = config.paths.rawdatadir
@@ -365,13 +366,35 @@ class Reader(core.BaseSimpleDbReader):
         try:
             x = self._select_col(row, column_name)
         except KeyError:
-            logging.debug(f"your database is missing the following key: {column_name}")
+            self._warn_missing_column(column_name)
             return None
         else:
             x = x.values
             if len(x) == 1:
                 x = x[0]
             return x
+
+    def _warn_missing_column(self, column_name):
+        """Warn once per missing sheet column (values silently become ``None``, #1008)."""
+        if column_name in self._missing_columns_warned:
+            return
+        self._missing_columns_warned.add(column_name)
+        key = next(
+            (
+                k
+                for k in self.db_sheet_cols.keys
+                if getattr(self.db_sheet_cols, k) == column_name
+            ),
+            None,
+        )
+        via = f" (config.db_cols.{key})" if key else ""
+        warnings.warn(
+            f"cellpy db {self.db_filename!r} has no column {column_name!r}{via}; "
+            "the corresponding journal values will be empty. Rename the sheet header "
+            "or set the matching key under [db_cols] in cellpy.toml.",
+            UserWarning,
+            stacklevel=4,
+        )
 
     def select_serial_number_row(self, serial_number):
         """Select row for identification number serial_number

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -271,6 +271,10 @@ fig = b.plot()                   # cycle-life summary (cap / CE)
 fig = b.plot(ir=True, rate=True, direction="discharge")
 # If filefinder found no raw files, those cells are FAILED (not empty
 # LOADED). Check b.result.report() / the UserWarning from load.
+# A cellpy_batch_<name>.json in cwd (or journal_dir) is reused as-is: the
+# database is NOT re-read (a UserWarning fires if you also passed db args).
+# Use allow_from_journal=False to rebuild the journal from the db.
+b = batch.load(name="my_experiment", project="my_project", allow_from_journal=False)
 ```
 
 Dropping cells:

--- a/tests/test_batch_v3_facade.py
+++ b/tests/test_batch_v3_facade.py
@@ -245,6 +245,37 @@ def test_batch_from_db(db_env):
     assert set(b.cell_names) == _DB_CELLS
 
 
+def _stale_journal(tmp_path):
+    """A pre-existing ``cellpy_batch_t.json`` in ``tmp_path`` (autoload target)."""
+    return _one_cell_batch().save(tmp_path / "cellpy_batch_t.json")
+
+
+@pytest.mark.essential
+def test_load_warns_when_journal_autoload_shadows_db(db_env, tmp_path):
+    """Explicit db args + cached journal: the journal wins, so say so (#1008)."""
+    _stale_journal(tmp_path)
+    with pytest.warns(UserWarning, match="database was not read"):
+        b = load(
+            "t",
+            "p",
+            db_reader="simple_excel_reader",
+            journal_dir=tmp_path,
+            save_cellpy=False,
+            progress=False,
+        )
+    assert b.cell_names == ["c45"]
+
+
+@pytest.mark.essential
+def test_load_autoload_without_db_args_is_quiet(db_env, tmp_path):
+    _stale_journal(tmp_path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        b = load("t", "p", journal_dir=tmp_path, save_cellpy=False, progress=False)
+    assert b.cell_names == ["c45"]
+    assert not [w for w in caught if "database was not read" in str(w.message)]
+
+
 def test_create_journal_reads_db(db_env):
     # the legacy init() -> create_journal() flow via deferred _db config
     b = Batch(

--- a/tests/test_dbreader.py
+++ b/tests/test_dbreader.py
@@ -191,6 +191,33 @@ def test_get_total_mass(db_reader):
     assert pytest.approx(output, 0.1) == test_total_mass
 
 
+@pytest.mark.essential
+def test_missing_column_warns_once(db_reader):
+    """The test db has no nominal_capacity_specifics column: warn once, return None (#1008)."""
+    import warnings
+
+    col = db_reader.db_sheet_cols.nom_cap_specifics
+    assert col not in db_reader.table.columns
+    with pytest.warns(UserWarning, match=f"no column {col!r}.*db_cols.nom_cap_specifics"):
+        assert db_reader.get_nom_cap_specifics(test_serial_number_one) is None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        assert db_reader.get_nom_cap_specifics(test_serial_number_two) is None
+
+
+@pytest.mark.essential
+def test_nom_cap_specifics_column_reaches_pages(db_reader):
+    """A present specifics column flows into the journal pages dict (#1008)."""
+    from cellpy.batch import _dbengine
+
+    frame = db_reader.table.copy()
+    frame[db_reader.db_sheet_cols.nom_cap_specifics] = "areal"
+    reader = type(db_reader)(db_frame=frame)
+    ids = [test_serial_number_one, test_serial_number_two]
+    pages = _dbengine._create_pages_dict(reader, ids)
+    assert pages["nom_cap_specifics"] == ["areal", "areal"]
+
+
 #
 # def test_get_all(db_reader):
 #     assert True


### PR DESCRIPTION
Closes #1008

## Diagnosis

`nom_cap_specifics` read from the Excel db showed up as `null` in `b.pages`. Traced db → `_dbengine._create_pages_dict` → `Journal.pages` → `policy.resolve_specs` → `runner._get_kwargs` → `cellpy.get` → cell (raw load, `.cellpy` AUTO reload, journal autoload): the value is carried through everywhere. It ends up empty in two silent ways:

1. `batch.load(name, project, …)` reuses an existing `cellpy_batch_<name>.json` in cwd/`journal_dir` and never opens the database — logged at INFO only, even when `db_reader=` / `batch_col=` were passed. A journal written before the db column was filled (or by an older cellpy that did not emit it) reads back as a `null` column.
2. `Reader._pick_info` swallows the `KeyError` for a configured `db_cols` header that is missing from the sheet (debug log) and returns `None` for every cell.

## Change

- `cellpy/batch/facade.py`: `UserWarning` when the journal is autoloaded while db arguments were given, pointing at `allow_from_journal=False`. Plain `batch.load(name, project)` reopen stays quiet.
- `cellpy/readers/dbreader.py`: warn once per missing sheet column per reader, naming the `config.db_cols.<key>`.
- No change on the happy path; no schema/default changes.
- Docs: autoload note in `docs/getting_started/agents.md` + `AGENTS.md`; `HISTORY.md` bullet.
- Follow-up: #1017 (`skip_file_search=True` crashes with the Excel reader).

## Tests (essential)

- `tests/test_dbreader.py::test_missing_column_warns_once`, `::test_nom_cap_specifics_column_reaches_pages`
- `tests/test_batch_v3_facade.py::test_load_warns_when_journal_autoload_shadows_db`, `::test_load_autoload_without_db_args_is_quiet`

```bash
uv run pytest tests/test_dbreader.py tests/test_batch_v3_facade.py
uv run pytest -m essential   # 843 passed, 2 xfailed locally
```

Made with [Cursor](https://cursor.com)