### PR TITLE
Pin cellpycore 0.2.6 and drop incremental-update xfails

### DIFF
--- a/.issueflows/01-current-issues/issue_fix_cellpycore026_original.md
+++ b/.issueflows/01-current-issues/issue_fix_cellpycore026_original.md
@@ -1,0 +1,14 @@
+# Iterative fixes: New cellpy-core release
+
+Source: local `/iflow-fix` session (GitHub issue create blocked in this Cloud
+Agent environment — `gh` is read-only). Session name: New cellpy-core release.
+
+## Original issue text
+
+Interactive `/iflow-fix` session whose individual fixes are recorded in the
+status markdown and landed together via `/iflow-close`.
+
+**First fix (from the invoking message):** Cellpy next: bump the `cellpycore`
+pin to the new PyPI release `0.2.6`, and drop the strict xfails on
+`test_empty_tail_is_noop` (core#147) and
+`test_gap_append_mid_step_equals_full_load` (core#148).

--- a/.issueflows/01-current-issues/issue_fix_cellpycore026_status.md
+++ b/.issueflows/01-current-issues/issue_fix_cellpycore026_status.md
@@ -1,0 +1,14 @@
+# Status — Iterative fixes: New cellpy-core release
+
+Interactive `/iflow-fix` session. GitHub issue was not created (`gh` write is
+blocked in this environment). Work lands on `cursor/cellpycore-pin-0-2-6-4828`.
+
+- [ ] Done
+
+## Iterative fixes log
+
+- **2026-09-08** — Pin `cellpycore` `0.2.5`→`0.2.6` in `pyproject.toml` /
+  `uv.lock`. Drop strict xfails on `test_empty_tail_is_noop` (core#147) and
+  `test_gap_append_mid_step_equals_full_load` (core#148). Update
+  `tests/README.md`, pin-gate doc, and `HISTORY.md`. Leave conda env YAMLs on
+  `0.2.4` (conda-forge latest).

--- a/.issueflows/01-current-issues/issue_fix_cellpycore026_status.md
+++ b/.issueflows/01-current-issues/issue_fix_cellpycore026_status.md
@@ -12,3 +12,6 @@ blocked in this environment). Work lands on `cursor/cellpycore-pin-0-2-6-4828`.
   `test_gap_append_mid_step_equals_full_load` (core#148). Update
   `tests/README.md`, pin-gate doc, and `HISTORY.md`. Leave conda env YAMLs on
   `0.2.4` (conda-forge latest).
+  - `uv sync --no-sources` → `cellpycore 0.2.6`
+  - `tests/test_incremental_update.py`: 7 passed (both former xfails now pass)
+  - `pytest -m essential`: 845 passed, 64 skipped, 0 xfailed

--- a/.issueflows/04-designs-and-guides/v2-cellpycore-pin-gate.md
+++ b/.issueflows/04-designs-and-guides/v2-cellpycore-pin-gate.md
@@ -12,11 +12,11 @@ legacy-bridge stripping of `test_id` on steps/summary and the legacy-schema
 `merge_data` story; releasing against `0.2.1` would have frozen the #507
 workaround.
 
-**Current pin (master).** `cellpycore==0.2.5` in `[project.dependencies]` /
-`uv.lock` (since cellpy v2.1.4, 2026-09-08; core #143 legacy `cycle_mode`
-unwrapping on top of the 0.2.4 EFC columns, core #138/#141). Keep an exact
-`==` pin on every release commit; bump only via the F9 order (core release →
-cellpy re-pin → cellpy release).
+**Current pin (master).** `cellpycore==0.2.6` in `[project.dependencies]` /
+`uv.lock` (core #147 empty-tail no-op + #148 gap-append mid-step trim, on top
+of 0.2.5 `#143` cycle_mode unwrapping). Keep an exact `==` pin on every
+release commit; bump only via the F9 order (core release → cellpy re-pin →
+cellpy release).
 
 **`v1.x` line.** Stays on the conservative `cellpycore==0.2.1` pin unless a
 fix demands a patch bump (`cellpy-v2-branching.md`).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Pin `cellpycore==0.2.6` (empty-tail no-op, core#147; gap-append mid-step
+  trim, core#148). Drop the two strict xfails on
+  `test_empty_tail_is_noop` and `test_gap_append_mid_step_equals_full_load`.
+
 * `batch.load` warns when a cached `cellpy_batch_<name>.json` is reused while
   db arguments were passed (the database is not re-read; use
   `allow_from_journal=False`). The Excel db reader warns once per configured
@@ -9,9 +13,7 @@
   returning empty values. (#1008)
 
 * Golden equality test for incremental updates (L6): head + tail through
-  `update_core_data` must equal a full load on raw/steps/summary. Two strict
-  xfails pin cellpycore gaps (core#147 empty-tail no-op, core#148 gap-append
-  mid-step). Test-only. (#778)
+  `update_core_data` must equal a full load on raw/steps/summary. (#778)
 
 ## [2.1.4] - 2026-09-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     # a known core revision. For dual-repo development, install the sibling
     # checkout editable after sync (see CONTRIBUTING.md); do not commit a
     # [tool.uv.sources] path override — it breaks Dependabot lock updates.
-    "cellpycore==0.2.5",
+    "cellpycore==0.2.6",
     "pydantic-settings>=2.14.2",
     "platformdirs>=4.10.0",
     "universal-pathlib>=0.3.10",

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,10 +150,9 @@ single full `cellpy.get` (all columns, order-insensitive, dtype-insensitive). He
 prototype of the future `CellpyCell.update()` (L3, #164) — it also re-applies the
 cellpy-side summary extras and scaled columns.
 
-Cut points are derived from the full step table (mid-step, step end, cycle end). Two
-strict `xfail`s pin known cellpycore gaps: gap-append mid-step
-(cellpy/cellpy-core#148) and empty-tail no-op (cellpy/cellpy-core#147). When those are
-fixed the xfails turn into failures — drop the markers then.
+Cut points are derived from the full step table (mid-step, step end, cycle end).
+Gap-append mid-step (cellpy/cellpy-core#148) and empty-tail no-op
+(cellpy/cellpy-core#147) pass on `cellpycore>=0.2.6`.
 
 ```bash
 uv run pytest tests/test_incremental_update.py

--- a/tests/test_incremental_update.py
+++ b/tests/test_incremental_update.py
@@ -69,24 +69,15 @@ def test_gap_append_on_boundary_equals_full_load(tmp_path, full, cut_points, cut
 
 
 @pytest.mark.essential
-@pytest.mark.xfail(
-    strict=True,
-    reason="cellpy/cellpy-core#148: gap-append keeps the partial trailing step, so the "
-    "step spanning the cut is split in two (extra step row, C-rate drift). Until fixed, "
-    "L3 (#164) must re-read from the start of the last step.",
-)
 def test_gap_append_mid_step_equals_full_load(tmp_path, full, cut_points):
+    """Gap-append mid-step equals a full load (cellpycore 0.2.6 / core#148)."""
     updated = _run(tmp_path, full, cut_points["mid_step"], overlap=0)
     assert_cell_frames_equal(updated, full)
 
 
 @pytest.mark.essential
-@pytest.mark.xfail(
-    strict=True,
-    reason="cellpy/cellpy-core#147: empty new_raw short-circuits update_data but "
-    "refresh_derived still re-joins the C-rate columns (*_right duplicates).",
-)
 def test_empty_tail_is_noop(tmp_path, full, cut_points):
+    """Empty new_raw leaves frames unchanged (cellpycore 0.2.6 / core#147)."""
     head = _head(tmp_path, cut_points["mid_step"])
     before = {k: getattr(head.data, k).copy() for k in ("raw", "steps", "summary")}
     updated = incremental_update(head, full.data.raw.iloc[0:0])

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cellpycore", specifier = "==0.2.5" },
+    { name = "cellpycore", specifier = "==0.2.6" },
     { name = "charset-normalizer" },
     { name = "cookiecutter" },
     { name = "dateparser" },
@@ -515,16 +515,16 @@ docs = [
 
 [[package]]
 name = "cellpycore"
-version = "0.2.5"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/84/90f17fb223c80ce5b8460bc19e5436443b057a2e06561dce66091f9ed181/cellpycore-0.2.5.tar.gz", hash = "sha256:f3d5b612f98ca59f56b482f2e62149ad9ef90273df759a9ea376cbea3b269829", size = 883414, upload-time = "2026-09-08T07:59:34.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/db/8f05e83f927d3ea0d002855068b434cf3cc26877ffb9cde388cc6373feae/cellpycore-0.2.6.tar.gz", hash = "sha256:e447cd8d7c0fb3ecff2a8220598c401bc472bb2c58f11962736dc48a6e66c33d", size = 889148, upload-time = "2026-09-08T17:23:19.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d4/f114496d86d86c4b1f0b34f82831d5cb542fc44dd0ad5a56fa7ac428b0af/cellpycore-0.2.5-py3-none-any.whl", hash = "sha256:e2c02c207a9c7a3f87a3b65a6dcc635d324b0f441ece6e22444a0c879ec1ee84", size = 92750, upload-time = "2026-09-08T07:59:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/96/5aa2a78f6e30ba7db99cfbc9e8a93dfecf88191561bd2eb377cf63ac22d2/cellpycore-0.2.6-py3-none-any.whl", hash = "sha256:4fe693c061b21314117743edc31facc122c64814604a917715e90b23c81dbf14", size = 93461, upload-time = "2026-09-08T17:23:18.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the cellpy-core `v0.2.6` PyPI release (core#147 empty-tail no-op, core#148 gap-append mid-step trim).

## Changes

- Bump the exact pin `cellpycore==0.2.5` → `cellpycore==0.2.6` in `pyproject.toml` / `uv.lock` (`UV_NO_SOURCES=1 uv lock`).
- Drop the strict xfails on `test_empty_tail_is_noop` and `test_gap_append_mid_step_equals_full_load` so those L6 golden tests now assert for real.
- Update `tests/README.md`, the pin-gate note, and `HISTORY.md` (Unreleased).

Conda env YAMLs stay on `cellpycore ==0.2.4`: conda-forge has not published 0.2.5 or 0.2.6 yet.

## `/iflow-fix` session

Interactive session **New cellpy-core release**. GitHub issue create is blocked in this Cloud Agent environment (`gh` is read-only); local tracking is under `.issueflows/01-current-issues/issue_fix_cellpycore026_*`. Further small fixes can land on this branch; leave `- [ ] Done` unchecked until `/iflow-close`.

## Local test results

- `uv sync --no-sources` installed `cellpycore 0.2.6`.
- `uv run pytest tests/test_incremental_update.py` — **7 passed**, including both former xfails.
- `MPLBACKEND=Agg uv run pytest -m essential` — **845 passed**, 64 skipped, 0 xfailed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0820d-fcfd-7231-a69f-6ad065b84828?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0820d-fcfd-7231-a69f-6ad065b84828&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

