### PR TITLE
docs: units, mass, area and C-rates guide (iteration 2 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+* Docs: new how-to guide **Units, mass, area and C-rates** — `raw_units` vs
+  `cellpy_units`, the default unit table, changing units per load (`units=`),
+  per session (`[units]` in `cellpy.toml`) and on a loaded cell
+  (`refresh_after`), the `units_label` / `with_cellpy_unit` label helpers,
+  mass / area / loading, the gravimetric-areal-absolute column split, and
+  nominal capacity with `nom_cap_specifics`. Fixes a wrong schema name in the
+  data-structure page (`cumulated_capacity_throughput` →
+  `test_cumulated_capacity_throughput`). (#1023)
+
 * Docs: new symptom-indexed **Troubleshooting** page covering the
   `get`-returns-`None` trap, choosing the right loader, Arbin `.res` drivers,
   legacy `.h5` files, the 1.0 mg default mass, the `anode` default

--- a/docs/fundamentals/data_structure.md
+++ b/docs/fundamentals/data_structure.md
@@ -200,11 +200,16 @@ discharge_steps = c.data.steps.query(
 | charge / discharge capacity | `charge_capacity` / `discharge_capacity` |
 | coulombic efficiency | `coulombic_efficiency` |
 | C-rates | `charge_c_rate` / `discharge_c_rate` |
-| capacity throughput / EFC | `cumulated_capacity_throughput` / `equivalent_full_cycles` |
+| capacity throughput / EFC | `test_cumulated_capacity_throughput` / `equivalent_full_cycles` |
 
 Specific (mass-/area-normalized) columns still use postfixes such as
-`_gravimetric` and `_areal`. The summary frame has more native-only columns
-than 1.x (durations, energies, per-direction stats); see the migration map.
+`_gravimetric`, `_areal` and `_absolute`. `c.schema.summary` resolves the
+**base** name only, so build the specific one from it —
+`f"{c.schema.summary.charge_capacity}_gravimetric"`. Which postfix means what,
+and what each is divided by, is covered in
+[Units, mass, area and C-rates](../guides/units.md). The summary frame has more
+native-only columns than 1.x (durations, energies, per-direction stats); see
+the migration map.
 
 ### Batch journal columns
 

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -89,6 +89,8 @@ More extractors (`get_current`, `get_voltage`, `split`, `merge`, …) are on
 
 - [Incremental capacity analysis](../examples/04_incremental_capacity_analysis.md)
   (tutorial) and [Compute ICA / DVA](../guides/ica.md) (short recipe)
+- [Units, mass, area and C-rates](../guides/units.md) before you trust a
+  specific capacity
 - [Using cellpy from an agent](agents.md) if you are wiring a GUI or app
 - [Check your installation](checkup.md) if something failed to load
 - [Troubleshooting](../troubleshooting.md) if a file will not load or a

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,8 @@ something specific.
 
 - [Work with remote files](../getting_started/remote_paths.md) — load raw data
   and cellpy files over SSH / SFTP
+- [Units, mass, area and C-rates](units.md) — what a capacity is divided
+  by, and how to change it
 - [Compute incremental capacity and differential voltage](ica.md) — dQ/dV
   (`dqdv`) and dV/dQ (`dvdq`), plus plot and collect
 - [Write an instrument loader plugin](../other/writing_a_loader_plugin.md) —

--- a/docs/guides/units.md
+++ b/docs/guides/units.md
@@ -1,0 +1,274 @@
+# Units, mass, area and C-rates
+
+A capacity is only meaningful once you know what it is divided by. This page
+covers the three things that decide the numbers cellpy hands back:
+
+1. the **unit policy** (`mAh` or `Ah`? per `g` or per `mg`?),
+2. the **cell metadata** you supply (mass, area, nominal capacity),
+3. the **normalisation** you read off the summary (gravimetric, areal,
+   absolute).
+
+Get these right once and every downstream plot and table is right too.
+
+## The short version
+
+```python
+import cellpy
+
+c = cellpy.get(
+    "my_cell.res",
+    mass=0.704,                     # mg of active material
+    area=1.77,                      # cm² of electrode
+    nominal_capacity="3579 mAh/g",  # for C-rates and equivalent full cycles
+    cycle_mode="anode",             # "full_cell" for a full cell
+)
+
+grav = c.data.summary["charge_capacity_gravimetric"]   # mAh/g
+areal = c.data.summary["charge_capacity_areal"]        # mAh/cm²
+```
+
+## Two sets of units
+
+cellpy keeps the units the *instrument* wrote separately from the units *you*
+want to work in.
+
+| | What it is | Where it comes from |
+| --- | --- | --- |
+| `c.data.raw_units` | the units in the raw frame, as the tester wrote them | set by the loader |
+| `c.cellpy_units` | the units cellpy converts to when it builds the summary | your configuration, or `units=` |
+
+```python
+print(c.data.raw_units.charge)   # e.g. "Ah"  — what the Arbin file contained
+print(c.cellpy_units.charge)     # "mAh"      — what the summary is in
+```
+
+You normally never touch `raw_units`; it is the loader's business. Changing
+`cellpy_units` is how you change the output.
+
+### The defaults
+
+| Quantity | Field | Default |
+| --- | --- | --- |
+| current | `current` | `A` |
+| charge / capacity | `charge` | `mAh` |
+| potential | `voltage` | `V` |
+| time | `time` | `sec` |
+| energy | `energy` | `Wh` |
+| power | `power` | `W` |
+| resistance | `resistance` | `ohm` |
+| mass | `mass` | `mg` |
+| nominal capacity | `nominal_capacity` | `mAh/g` |
+| gravimetric denominator | `specific_gravimetric` | `g` |
+| areal denominator | `specific_areal` | `cm**2` |
+| length / area / volume | `length` / `area` / `volume` | `cm` / `cm**2` / `cm**3` |
+| temperature | `temperature` | `C` |
+| pressure | `pressure` | `bar` |
+
+So a gravimetric capacity is `charge / specific_gravimetric` = **mAh/g**, and
+an areal capacity is `charge / specific_areal` = **mAh/cm²**, out of the box.
+
+The full list, including everything else that lives in the configuration file,
+is in the [configuration reference](../getting_started/configuration_reference.md#units).
+
+### Changing units for one load
+
+Pass `units=` to `cellpy.get`. It is applied before the summary is built, so
+the summary comes out in the units you asked for:
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, units=dict(charge="Ah"))
+
+c.data.summary["charge_capacity_gravimetric"]   # now Ah/g, not mAh/g
+```
+
+Change the denominator the same way — here, capacity per **milligram**:
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, units=dict(specific_gravimetric="mg"))
+```
+
+### Changing units on a cell that is already loaded
+
+The summary does not recompute itself. Update the units, then rebuild the
+scaled columns:
+
+```python
+c.cellpy_units.update(dict(charge="Ah"))
+c.refresh_after()          # or c.make_summary() for a full rebuild
+```
+
+Without that second line the numbers stay in the old units while
+`c.cellpy_units` claims the new one — a quiet way to mislabel a plot.
+
+### Changing units for every load
+
+Put them in your `cellpy.toml` under `[units]`:
+
+```toml
+[units]
+charge = "Ah"
+specific_gravimetric = "mg"
+```
+
+See [Setup and configuration](../getting_started/configuration.md) for where
+that file lives.
+
+### Writing the unit on a plot label
+
+Do not build the string by hand — the mode is easy to get wrong, and a wrong
+label is a silent error rather than a crash:
+
+```python
+from cellpy.units import units_label, with_cellpy_unit
+
+units_label("charge", "gravimetric", units=c.cellpy_units)   # "mAh/g"
+units_label("charge", "areal", units=c.cellpy_units)         # "mAh/cm**2"
+units_label("charge", units=c.cellpy_units)                  # "mAh"
+
+with_cellpy_unit("Capacity", "charge", "gravimetric", units=c.cellpy_units)
+# "Capacity (mAh/g)"
+```
+
+Pass `units=c.cellpy_units` whenever the label describes a particular cell.
+Without it the helpers use the session default, which may not be what that cell
+was built with.
+
+## Mass, area and loading
+
+These three are metadata on the cell, and they are what turn a raw capacity
+into a specific one.
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, area=1.77)
+```
+
+| Argument | Meaning | Unit (default) |
+| --- | --- | --- |
+| `mass` | active material mass | mg |
+| `area` | active electrode area | cm² |
+| `loading` | mass per area | mg/cm² |
+| `nominal_capacity` | theoretical / rated capacity | mAh/g |
+
+You can attach the unit to the value as a string, which overrides the
+configured unit for that one argument:
+
+```python
+c = cellpy.get("my_cell.res", mass="0.704 mg", area="1.77 cm**2")
+```
+
+!!! warning "The default mass is 1.0 mg"
+    If you do not pass `mass=` and the file does not carry one, cellpy uses
+    **1.0 mg**. Every gravimetric number is then wrong by the ratio between
+    1.0 mg and your real mass — usually by a factor of a few hundred to a few
+    thousand, which is easy to spot, but only if you look.
+
+### `loading` instead of `area`
+
+If you know the loading but not the area, give the loading and cellpy derives
+the area as `mass / loading`:
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, loading=1.5)
+print(c.data.active_electrode_area)   # 0.4693... cm²
+```
+
+If you pass both `area` and `loading`, `area` wins. Pass
+`estimate_area=False` to switch the derivation off entirely.
+
+### Changing the metadata after loading
+
+Setting the attribute is not enough — the summary has to be rebuilt:
+
+```python
+c.mass = 0.704
+c.refresh_after("mass")
+```
+
+`refresh_after` accepts `"mass"`, `"area"`, `"nominal_capacity"` and
+`"cycle_mode"` (and their aliases), or nothing at all to refresh everything
+meta-dependent. It only rebuilds the scaled part of the summary, so it is much
+cheaper than a full `make_summary()`.
+
+## Which capacity column?
+
+Every capacity-like quantity in the summary exists in several normalisations,
+distinguished by a postfix:
+
+| Column | Normalised by | Unit (defaults) |
+| --- | --- | --- |
+| `charge_capacity` | nothing | mAh |
+| `charge_capacity_gravimetric` | `mass` | mAh/g |
+| `charge_capacity_areal` | `area` | mAh/cm² |
+| `charge_capacity_absolute` | nothing (explicit name) | mAh |
+
+The same postfixes apply to `discharge_capacity`, the `*_loss` columns, the
+`coulombic_difference` columns and their `test_cumulated_*` counterparts.
+
+`c.schema.summary` gives you the **base** name only. Build the specific name
+from it:
+
+```python
+base = c.schema.summary.charge_capacity        # "charge_capacity"
+grav = f"{base}_gravimetric"
+
+c.data.summary[grav].head()
+```
+
+An areal column is only meaningful if you gave an `area` (or a `loading`);
+otherwise the default area of 1.0 cm² makes it numerically identical to the
+absolute column.
+
+## Nominal capacity, C-rates and equivalent full cycles
+
+`nominal_capacity` is what cellpy divides the measured current by to get a
+C-rate, and what it divides throughput by to get equivalent full cycles. Give
+it when you want either of those to mean something:
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, nominal_capacity="3579 mAh/g")
+
+c.data.summary[["cycle_num", "charge_c_rate", "discharge_c_rate"]].head()
+c.data.summary["equivalent_full_cycles"].head()
+```
+
+```text
+   cycle_num  charge_c_rate  discharge_c_rate
+0          1        0.06097           0.06041
+1          2        0.06097           0.06045
+2          3        0.06096           0.06045
+```
+
+By default the nominal capacity is read as **gravimetric** (per mass). If yours
+is per area — or an absolute cell capacity — say so with `nom_cap_specifics`:
+
+```python
+c = cellpy.get("my_cell.res", area=1.77, nominal_capacity=3.0,
+               nom_cap_specifics="areal")            # mAh/cm²
+
+c = cellpy.get("my_cell.res", nominal_capacity=2500,
+               nom_cap_specifics="absolute")         # mAh for the whole cell
+```
+
+!!! note
+    Passing `nominal_capacity` as a string with a unit (`"3579 mAh/g"`) also
+    sets `cellpy_units["nominal_capacity"]`, and can therefore override a
+    `nom_cap_specifics` you gave alongside it. Pass a plain number together
+    with `nom_cap_specifics=` when you want the mode to be unambiguous.
+
+## Checklist
+
+Before you trust a specific capacity, check that:
+
+- [ ] `c.data.mass` is your real mass, not 1.0
+- [ ] `c.data.active_electrode_area` is your real area, if you use areal columns
+- [ ] `c.cycle_mode` matches your cell (`"anode"` vs `"full_cell"`)
+- [ ] `c.data.nom_cap` is set, if you read C-rates or equivalent full cycles
+- [ ] you rebuilt the summary (`refresh_after`) after changing any of them
+
+## See also
+
+- [Troubleshooting](../troubleshooting.md) — when the numbers still look wrong
+- [The data structure](../fundamentals/data_structure.md) — what else is in the
+  frames
+- [Configuration reference](../getting_started/configuration_reference.md#units)
+  — every unit setting and its default

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -252,7 +252,8 @@ c.data.summary[grav].head()
 ```
 
 The areal columns need an electrode area (`area=` on `cellpy.get`, in cm²) to
-mean anything.
+mean anything. [Units, mass, area and C-rates](guides/units.md) explains the
+whole normalisation story, including how to change the units themselves.
 
 ### My capacity used to look twice as large in cellpy 1.x
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,6 +55,7 @@ nav = [
     { "How-to guides" = [
         "guides/index.md",
         { "Work with remote files" = "getting_started/remote_paths.md" },
+        { "Units, mass, area and C-rates" = "guides/units.md" },
         { "Compute ICA / DVA" = "guides/ica.md" },
         { "Write an instrument loader plugin" = "other/writing_a_loader_plugin.md" },
     ] },


### PR DESCRIPTION
Second iteration of the documentation push tracked by #1023.

**Persona:** a battery scientist who has successfully loaded a cell and now
wants a capacity in mAh/cm² instead of mAh/g — and cannot find out what unit
the numbers are in to begin with.

**What the docs said:** `cellpy_units` appeared exactly once, inside a rendered
notebook output dump; `raw_units` appeared only in loader-authoring material.
The `[units]` table in the configuration reference listed the fields but not
what they do. There was no page explaining what a "specific capacity" in cellpy
is divided by.

## Added — `docs/guides/units.md`

- **Two sets of units.** `c.data.raw_units` is what the tester wrote (loader's
  business); `c.cellpy_units` is what the summary is converted to (yours).
- **The default table**, and the arithmetic that follows from it: gravimetric =
  `charge / specific_gravimetric` = mAh/g, areal = mAh/cm².
- **Changing them** three ways: `units=` on `cellpy.get` (applied before the
  summary is built), `[units]` in `cellpy.toml` for every load, and
  `cellpy_units.update(...)` + `refresh_after()` on a loaded cell. The last one
  matters: without the refresh the values stay in the old unit while
  `cellpy_units` reports the new one — a silent mislabel.
- **Label helpers.** `units_label("charge", "gravimetric", units=c.cellpy_units)`
  and `with_cellpy_unit(...)` instead of composing the string by hand, and why
  passing the cell's own units matters.
- **Mass, area, loading.** What each is in, string-with-unit values
  (`mass="0.704 mg"`), the 1.0 mg default, `area` derived from `loading` as
  `mass / loading`, and `estimate_area=False`.
- **Which capacity column** — the `_gravimetric` / `_areal` / `_absolute` split,
  and that `c.schema.summary` resolves only the *base* name so the postfix has
  to be appended.
- **Nominal capacity, C-rates, equivalent full cycles**, including
  `nom_cap_specifics` for areal and absolute nominal capacities, and the caveat
  that a string-with-unit `nominal_capacity` also rewrites
  `cellpy_units["nominal_capacity"]`.
- A short pre-flight checklist.

Everything was executed in a live interpreter first — the default and changed
unit values, the `refresh_after` behaviour, the derived area, the `absolute`
nominal-capacity mode, and the C-rate table shown in the page.

## Also fixed

`docs/fundamentals/data_structure.md` listed `cumulated_capacity_throughput` as
a `c.schema.summary` field. That attribute does not exist — the real name is
`test_cumulated_capacity_throughput`. Verified by attribute lookup on a loaded
cell.

## Wiring

Added under **How-to guides** in `zensical.toml`, and cross-linked from the
guides index, Basic usage, the data-structure page and Troubleshooting.

Local `zensical build --clean` is link-clean.

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)