### PR TITLE
docs: "set up the cellpy database" how-to guide (iteration 4 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* Docs: new how-to guide **Set up the cellpy database** — which of the
+  example sheet's 67 columns actually have to be filled in, that `exists > 0`
+  gates batch selection, that `cell_type` becomes the cell's `cycle_mode`, how
+  `b01`-`b07` batch columns work, how `file_name_indicator` is globbed into raw
+  paths, the `argument` column's `key=value;key=value` form, the db-column →
+  journal-column map, and why cached-journal reuse makes spreadsheet edits look
+  like they did nothing. (#1023)
+
 * Docs: new how-to guide **Plot one cell** — what `summary_plot`,
   `cycles_plot`, `raw_plot` and `cycle_info_plot` are each for, the
   returns-a-figure vs shows-it-itself split, discovering plot families with

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -25,6 +25,8 @@ folder](https://github.com/jepegit/cellpy/tree/master/examples) in the cellpy Gi
 - [Incremental capacity analysis](04_incremental_capacity_analysis.md)
 - [GITT](05_GITT.md)
 - [Batch processing](batch_utility/cellpy_batch_processing.md)
+  (the sheet it reads is documented in
+  [Set up the cellpy database](../guides/batch_database.md))
 - [Templates](templates/tutorial_templates.md)
 
 ## About these pages

--- a/docs/guides/batch_database.md
+++ b/docs/guides/batch_database.md
@@ -1,0 +1,237 @@
+# Set up the cellpy database
+
+To work on many cells at once, cellpy needs a small **database**: an Excel
+sheet with one row per cell. The shipped example has 67 columns, which is
+intimidating — but you only have to fill in about ten of them.
+
+This page is about the sheet itself. For what to *do* with a loaded batch, see
+the [Batch processing tutorial](../examples/batch_utility/cellpy_batch_processing.md).
+
+## What the sheet looks like
+
+Three kinds of row:
+
+| Row | Contents |
+| --- | --- |
+| row 1 | column **names** (`id`, `cell`, `mass_active_material`, …) |
+| row 2 | column **types** (`int`, `str`, `float`, `bol`, `categorical`, `list`) |
+| row 3 onwards | one **cell** per row |
+
+A ready-made file is in the repository at
+[`examples/batch_utility/cellpy_db.xlsx`](https://github.com/jepegit/cellpy/tree/master/examples/batch_utility).
+Start from that rather than building one from scratch — the extra columns cost
+you nothing, and you can leave them empty.
+
+Tell cellpy where it is:
+
+```python
+import cellpy.config as config
+
+config.paths.db_path = "."                    # folder holding the sheet
+config.paths.db_filename = "cellpy_db.xlsx"   # its name
+config.paths.rawdatadir = "data/raw"          # where the tester files live
+config.paths.cellpydatadir = "data/cellpyfiles"
+```
+
+or set the same four in your `cellpy.toml` so you never think about it again
+(see [Setup and configuration](../getting_started/configuration.md)).
+
+## The columns that actually matter
+
+| Column in the sheet | What it does | Leave empty? |
+| --- | --- | --- |
+| `id` | row key — a **unique integer** per row | no |
+| `exists` | row is only used when this is **> 0** | no — set it to `1` |
+| `b01` … `b07` | batch selectors; you name one when you load | no — fill the one you use |
+| `cell` | the cell's name, and its label in the batch | no |
+| `file_name_indicator` | what cellpy globs for when finding raw files | falls back to `cell` |
+| `instrument` | which loader to use (`arbin_res`, `maccor_txt`, …) | no |
+| `cell_type` | becomes the cell's **`cycle_mode`** — `anode` or `full_cell` | no |
+| `mass_active_material` | active mass in mg | only if you never look at gravimetric capacity |
+| `area` | electrode area in cm² | only if you never look at areal capacity |
+| `nominal_capacity` | for C-rates and equivalent full cycles | yes, if you do not need those |
+| `nominal_capacity_specifics` | `gravimetric` (default) / `areal` / `absolute` | usually |
+| `group` | groups cells for plotting and legends | yes |
+| `label` | display name in plots, instead of the file name | yes |
+| `loading_active_material`, `mass_total` | carried into the journal | yes |
+| `comment_general`, `comment_cell`, `comment_slurry` | your notes | yes |
+| `argument` | per-cell loader keywords (see below) | yes |
+
+Every other column in the example file is either bookkeeping for the authors'
+own lab or reserved for later. Leaving them blank is fine.
+
+!!! warning "`exists` is not optional"
+    Batch selection is `batch column matches` **and** `exists > 0`. A row with
+    an empty `exists` is silently skipped, which looks exactly like a broken
+    file path. If a cell you expected is missing from the batch, check this
+    column first.
+
+!!! tip "`cell_type` is really `cycle_mode`"
+    The value in `cell_type` is used as the cell's `cycle_mode`, which decides
+    whether the first step of a cycle counts as a discharge. Put `anode` there
+    for half cells and `full_cell` for full cells — not a material name. See
+    [Units, mass, area and C-rates](units.md) for what it changes.
+
+## Batch columns — how cells are grouped into a batch
+
+`b01` through `b07` are seven independent selectors, so the same cell can
+belong to several batches at once. Put a batch name in one of them:
+
+| `id` | `cell` | `b01` | `b02` |
+| --- | --- | --- | --- |
+| 1070 | `20180418_sf033_2_cc` | `paper01` | |
+| 1071 | `20180418_sf033_3_cc` | `paper01` | `rate_study` |
+| 1072 | `20180420_sf036_2_cc` | `paper01` | `rate_study` |
+
+Then load by naming both the batch and the column:
+
+```python
+from cellpy.utils import batch
+
+b = batch.load(name="paper01", project="cool_project", batch_col="b01")
+```
+
+`batch_col` defaults to `"b01"`, so you can leave it out if that is the column
+you used. Matching is **case-sensitive**.
+
+`project` is the campaign the batch belongs to; it decides where the journal
+file is written and, if you turn on `config.batch.auto_use_file_list`, it must
+match the folder name under `rawdatadir` exactly.
+
+## How cellpy finds the raw files
+
+You do not put file paths in the sheet. cellpy builds them:
+
+- **raw files** — globs `<file_name_indicator>*.<raw_extension>` under
+  `paths.rawdatadir`, including sub-folders. With
+  `file_name_indicator = "20180418_sf033_2_cc"` and the default
+  `raw_extension = "res"`, that matches
+  `20180418_sf033_2_cc_01.res`, `..._02.res`, and so on — several files for one
+  cell are merged automatically.
+- **cellpy files** — looks for `<file_name_indicator>.<cellpy_file_extension>`
+  in `paths.cellpydatadir`, and reuses it instead of re-reading the raw file
+  when it is there.
+
+So the naming convention is doing real work: the indicator has to be a prefix
+of the tester's file names.
+
+If a cell's raw file is not found, cellpy warns, marks the cell, and carries
+on with the rest of the batch:
+
+```text
+UserWarning: filefinder found no raw files for 1 cell(s): 20180418_sf033_9_cc.
+Check paths.rawdatadir (and OtherPath hosts) plus the filename indicators in
+the database.
+```
+
+`b.result.report()` lists which cells failed.
+
+## Per-cell loader arguments
+
+The `argument` column takes loader keywords for that one cell, as
+`key=value` pairs separated by semicolons:
+
+```text
+model=ONE;dataset_number=1
+```
+
+These are merged on top of the values from the other columns, so it is the
+place for the one Maccor file in an otherwise Arbin batch, or the one cell
+where you need to skip a data set.
+
+## Loading and checking the result
+
+```python
+from cellpy.utils import batch
+
+b = batch.load(name="paper01", project="cool_project", batch_col="b01")
+
+print(list(b.cells.keys()))
+b.journal.pages          # one row per cell — what cellpy resolved
+b.summaries              # all the per-cycle summaries, stacked
+```
+
+The journal is where you check that the sheet was read the way you meant:
+
+```python
+b.journal.pages.select(
+    ["filename", "mass", "cell_type", "instrument", "group", "label"]
+)
+```
+
+```text
+{'filename': '20180418_sf033_2_cc', 'mass': 0.337, 'cell_type': 'anode',
+ 'instrument': 'arbin_res', 'group': 1, 'label': 'sf033_2'}
+```
+
+The journal columns come from the sheet like this:
+
+| Journal column | Comes from |
+| --- | --- |
+| `filename` | `cell` |
+| `mass` | `mass_active_material` |
+| `total_mass` | `mass_total` |
+| `file_name_indicator` | `file_name_indicator` (or `cell`) |
+| `nom_cap` / `nom_cap_specifics` | `nominal_capacity` / `nominal_capacity_specifics` |
+| `cell_type` | `cell_type` — and becomes `cycle_mode` |
+| `experiment` | `experiment_type` |
+| `group` / `group_label` | `group` |
+| `raw_file_names` / `cellpy_file_name` | filled in by the file search |
+
+## The journal file, and why your edits sometimes do nothing
+
+The first successful load writes `cellpy_batch_<name>.json` into
+`journal_dir` — by default the directory you started the kernel in, so usually
+next to your notebook. (`save_cellpy=False` skips that write, along with the
+`.cellpy` files.) On the **next** load cellpy finds that file and reuses it: it
+does not re-read the Excel sheet, and it warns about that if you passed
+database arguments.
+
+That is a feature (fast reloads, and a record of exactly what a figure was made
+from), but it is also the single most confusing thing about the batch utility:
+you edit a mass in the spreadsheet, re-run, and nothing changes.
+
+To rebuild from the database:
+
+```python
+b = batch.load(
+    name="paper01",
+    project="cool_project",
+    allow_from_journal=False,     # ignore the cached journal
+)
+```
+
+Deleting the `cellpy_batch_<name>.json` file has the same effect.
+
+If you only changed metadata that affects derived numbers (mass, nominal
+capacity, cycle mode), add `force_recalc=True` so the summaries are rebuilt
+too.
+
+## Common problems
+
+| Symptom | Likely cause |
+| --- | --- |
+| a cell is missing from the batch | `exists` is empty or 0, or the batch name does not match exactly (case-sensitive) |
+| every cell is `FAILED` | `paths.rawdatadir` is wrong, or `file_name_indicator` does not prefix the real file names |
+| capacities are absurd | `mass_active_material` empty → the 1.0 mg default |
+| charge and discharge swapped | `cell_type` is not `anode` / `full_cell` |
+| edits to the sheet have no effect | the cached journal — use `allow_from_journal=False` |
+| `UnderDefined: db_file is not provided` | `paths.db_path` / `db_filename` not set |
+
+## Using a different database
+
+The Excel sheet is only the default. `batch.load` takes `db_reader=` /
+`reader=` to select another reader, and `reader_path=` to point at its file —
+a JSON-backed database, for instance. The column names cellpy looks for in the
+Excel sheet are themselves configurable, under `[db_cols]` in `cellpy.toml`;
+see the [configuration reference](../getting_started/configuration_reference.md#db_cols).
+A configured column that is missing from your sheet warns once and comes back
+empty rather than failing the load.
+
+## See also
+
+- [Batch processing tutorial](../examples/batch_utility/cellpy_batch_processing.md)
+  — the full worked notebook
+- [Units, mass, area and C-rates](units.md) — what `mass`, `area` and
+  `nominal_capacity` change
+- [Troubleshooting](../troubleshooting.md) — batch failures and journal reuse

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,6 +13,8 @@ something specific.
   by, and how to change it
 - [Plot one cell](plotting.md) — capacity fade, voltage curves, raw traces,
   and how to save the figure
+- [Set up the cellpy database](batch_database.md) — the Excel sheet the
+  batch utility reads, and which columns you actually have to fill in
 - [Compute incremental capacity and differential voltage](ica.md) — dQ/dV
   (`dqdv`) and dV/dQ (`dvdq`), plus plot and collect
 - [Write an instrument loader plugin](../other/writing_a_loader_plugin.md) —

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -350,6 +350,12 @@ The batch needs to know which database (Excel sheet) to read. Either pass
 `db_file=` explicitly, or set the database path and filename in your
 configuration — see [Setup and configuration](getting_started/configuration.md).
 
+### A cell in my spreadsheet never turns up in the batch
+
+Batch selection needs **both** a matching batch name and `exists > 0` on that
+row. An empty `exists` column silently drops the cell. See
+[Set up the cellpy database](guides/batch_database.md).
+
 ---
 
 ## Installation and the command line

--- a/zensical.toml
+++ b/zensical.toml
@@ -57,6 +57,7 @@ nav = [
         { "Work with remote files" = "getting_started/remote_paths.md" },
         { "Units, mass, area and C-rates" = "guides/units.md" },
         { "Plot one cell" = "guides/plotting.md" },
+        { "Set up the cellpy database" = "guides/batch_database.md" },
         { "Compute ICA / DVA" = "guides/ica.md" },
         { "Write an instrument loader plugin" = "other/writing_a_loader_plugin.md" },
     ] },


### PR DESCRIPTION
Fourth iteration of the documentation push tracked by #1023.

**Persona:** a battery scientist setting up their first batch. They open the
example `cellpy_db.xlsx`, find **67 columns**, and have no way to tell which
ones are load-bearing.

**What the docs said:** the batch tutorial describes the database in two
paragraphs ("you must always have the columns colored green filled out" — the
colours are not in the rendered docs), and the configuration reference lists
the `db_cols` *config keys*. Nothing stated which spreadsheet columns are
required, what values they accept, or how a row turns into a loaded cell.

## Added — `docs/guides/batch_database.md`

- The three-row layout (names / types / one row per cell).
- **A required-vs-optional table** for the ~15 columns that matter, with what
  each one does.
- **`exists` gates selection.** The reader filters on `batch column matches`
  **and** `exists > 0`, so a row with an empty `exists` is silently skipped —
  which looks exactly like a broken file path.
- **`cell_type` is really `cycle_mode`.** `batch/policy.py` uses `cell_type` as
  the cell's `cycle_mode` when none is set, so it takes `anode` / `full_cell`,
  not a material name. Getting this wrong flips charge/discharge and CE for a
  whole batch.
- **`b01`–`b07`** as seven independent selectors, `batch_col` defaulting to
  `"b01"`, and that matching is case-sensitive.
- **How raw files are found**: `<file_name_indicator>*.<raw_extension>` globbed
  under `rawdatadir` including sub-folders (so multi-part `_01.res`, `_02.res`
  files merge), and `<indicator>.<cellpy_file_extension>` in `cellpydatadir`.
- The `argument` column's `key=value;key=value` per-cell loader overrides.
- The **db-column → journal-column map**, so a reader can check what cellpy
  actually resolved.
- **Cached journal reuse** — the single most confusing behaviour in the batch
  utility: you edit a mass in the sheet, re-run, and nothing changes.
  `allow_from_journal=False`, and `force_recalc=True` when derived numbers need
  rebuilding.
- A symptom → cause table.

Verified by loading the bundled example database end to end: 7 cells, journal
columns and values exactly as documented in the page.

## Wiring

Added under **How-to guides**, cross-linked from the guides index, the examples
index and Troubleshooting (which gains an entry for the `exists` trap).

Deliberately *not* linked from the batch tutorial page itself — that file is
generated from the notebook by `dev/render_example_notebooks.py` and would lose
the edit on the next render.

Local `zensical build --clean` is link-clean.

## Related findings

Two code issues found while verifying this page, filed separately rather than
folded in: #1026 (`cycles_plot` matplotlib crash) and #1028 (the default
`cellpy_file_extension` is still `"h5"` while the native v2 format is
`".cellpy"`, which affects exactly the fresh-install batch path this guide
describes).

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)