### PR TITLE
docs: full command-line reference (iteration 5 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+* Docs: new **command-line reference** covering every `cellpy` sub-command
+  and option (`setup` incl. `setup migrate`, `info`, `edit`, `new`, `run`,
+  `serve`, `pull`, `convert`, `mcp`) plus the global `-q` / `--verbose` /
+  `--no-color` flags. The Check-your-installation page's sub-command table was
+  incomplete and listed `migrate` as a top-level command. (#1023)
+
 * Docs: new how-to guide **Set up the cellpy database** — which of the
   example sheet's 67 columns actually have to be filled in, that `exists > 0`
   gates batch selection, that `cell_type` becomes the cell's `cycle_mode`, how

--- a/docs/getting_started/checkup.md
+++ b/docs/getting_started/checkup.md
@@ -36,16 +36,24 @@ Typical subcommands:
 | --- | --- |
 | `setup` | Create / refresh `cellpy.toml` and folders |
 | `info` | Version, config location, checks |
-| `migrate` | Convert a legacy `.conf` to `cellpy.toml` |
-| `pull` | Download examples or tests (needs git) |
+| `edit` | Open the config, database or environment file |
+| `new` | Start a batch experiment from a template |
+| `run` | Run a batch job from the shell |
 | `serve` | Start Jupyter |
-| `edit` / `new` / `run` | Config/db editing, batch setup, batch runs |
+| `pull` | Download examples or tests (needs git) |
+| `convert` | Upgrade a legacy cellpy file |
+| `mcp` | Run cellpy as an MCP server |
 
 Help for a subcommand:
 
 ```console
 cellpy info --help
 ```
+
+Every sub-command and option is listed in the
+[command-line reference](../reference/cli.md). Note that
+`cellpy setup migrate` (legacy `.conf` → `cellpy.toml`) is a sub-command of
+`setup`, not a top-level command.
 
 ## Upgrade
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,7 +5,8 @@ the scientific stack and awkward native deps handled for you; use **pip** when
 you want a lean install and can manage system packages yourself.
 
 After installing, continue to [Setup and configuration](configuration.md) and
-[Check your installation](checkup.md).
+[Check your installation](checkup.md). The `cellpy` command you get with the
+package is documented in the [command-line reference](../reference/cli.md).
 
 ## Install by platform
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,299 @@
+# Command-line reference
+
+Installing cellpy also installs a `cellpy` command. It is the shortest route to
+setting things up, checking that they work, and starting a batch experiment
+from a template — no Python needed.
+
+```console
+cellpy --help
+```
+
+| Command | What it is for |
+| --- | --- |
+| [`setup`](#cellpy-setup) | create folders and `cellpy.toml` |
+| [`info`](#cellpy-info) | version, paths, and health checks |
+| [`edit`](#cellpy-edit) | open the config, database or environment file |
+| [`new`](#cellpy-new) | start a batch experiment from a template |
+| [`run`](#cellpy-run) | run a batch job without opening a notebook |
+| [`serve`](#cellpy-serve) | start Jupyter |
+| [`pull`](#cellpy-pull) | download the examples or test data |
+| [`convert`](#cellpy-convert) | upgrade an old cellpy file |
+| [`mcp`](#cellpy-mcp) | run cellpy as an MCP server |
+
+Three options work everywhere:
+
+| Option | Effect |
+| --- | --- |
+| `-q`, `--quiet` | only problems and what you asked for |
+| `--verbose` | extra detail |
+| `--no-color` | plain output (`NO_COLOR` is honoured too) |
+
+---
+
+## `cellpy setup`
+
+Creates the `cellpy_data` folder tree and writes `cellpy.toml`. Run it once
+after installing.
+
+```console
+cellpy setup
+```
+
+| Option | Effect |
+| --- | --- |
+| `-i`, `--interactive` | ask about each folder instead of using defaults |
+| `-s`, `--silent` | ask nothing |
+| `-d`, `--root-dir <path>` | put the folders under this directory instead of your home directory |
+| `-n`, `--folder-name <path>` | name of the folder to create |
+| `-nr`, `--not-relative` | with `--root-dir`, place it at the root rather than under your home directory |
+| `-r`, `--reset` | ignore your current config when suggesting defaults |
+| `-dr`, `--dry-run` | print what would happen, change nothing |
+| `--deps` | report which optional extras are missing |
+| `-c`, `--check` | run the sanity checks afterwards |
+
+`cellpy setup` writes (or refreshes) `cellpy.toml` only. It does not create a
+legacy `.cellpy_prms_*.conf`.
+
+### `cellpy setup migrate`
+
+Converts a legacy `.conf` file to `cellpy.toml`:
+
+```console
+cellpy setup migrate --dry-run
+cellpy setup migrate
+```
+
+| Option | Effect |
+| --- | --- |
+| `--src <path>` | the legacy file (auto-detected when not given) |
+| `--dst <path>` | where to write the TOML (defaults to the user-config location) |
+| `-dr`, `--dry-run` | print only |
+| `-f`, `--force` | overwrite an existing `cellpy.toml` |
+
+The old file is left untouched; the TOML wins once it exists.
+
+---
+
+## `cellpy info`
+
+```console
+cellpy info --version
+cellpy info --check
+```
+
+| Option | Shows |
+| --- | --- |
+| `-v`, `--version` | the installed version |
+| `-c`, `--check` | import, Arbin-driver and configuration checks |
+| `-l`, `--configloc` | full path to the config file |
+| `-C`, `--config` | the resolved settings, with where each came from |
+| `-p`, `--params` | a dump in the legacy parameter style |
+
+`--check` is the one to run when something is not working, and the one to paste
+into a bug report:
+
+```text
+cellpy 2.1.4 - checking your setup
+
+  ✓ imports             cellpy, log, cellreader
+  ✓ arbin .res support  Microsoft Access Driver (*.mdb, *.accdb)
+  ✓ configuration       .../cellpy.toml
+      cellpydatadir     .../cellpy_data/cellpyfiles
+      rawdatadir        .../cellpy_data/raw
+      db_path           .../cellpy_data/db
+      db_filename       cellpy_db.xlsx
+      ...
+
+  3 of 3 checks passed
+```
+
+Not every check has to pass — they cover optional features. A failing Arbin
+check only matters if you read `.res` files.
+
+`--config` is the fastest way to find `filelogdir` when you are hunting for
+`cellpy_debug.log`.
+
+---
+
+## `cellpy edit`
+
+Opens one of your cellpy files in an editor.
+
+```console
+cellpy edit           # the config file
+cellpy edit config
+cellpy edit db        # the batch database spreadsheet
+cellpy edit env       # the environment file
+```
+
+| Option | Effect |
+| --- | --- |
+| `-e`, `--default-editor <str>` | use this editor, e.g. `cellpy edit env -e notepad.exe` |
+| `-d`, `--debug` / `-s`, `--silent` | more or less output |
+
+`cellpy edit db` is a convenient shortcut once you have a
+[cellpy database](../guides/batch_database.md) configured — no hunting for the
+spreadsheet.
+
+---
+
+## `cellpy new`
+
+Creates a project folder with notebooks already wired to your database, from a
+[cookiecutter](https://cookiecutter.readthedocs.io/) template.
+
+```console
+cellpy new --list
+cellpy new -p my_project -e paper01
+```
+
+```text
+batch templates
+
+      default           standard
+
+  · registered (on github)
+      standard          https://github.com/jepegit/cellpy_cookies.git
+      ife               https://github.com/jepegit/cellpy_cookies.git
+      single            https://github.com/jepegit/cellpy_cookies.git
+  · local (.../cellpy_data/templates)
+```
+
+| Option | Effect |
+| --- | --- |
+| `-l`, `--list` | list templates and exit |
+| `-t`, `--template <str>` | which template to use |
+| `-p`, `--project <str>` | project name (the sub-directory) |
+| `-e`, `--experiment <str>` | experiment name (the batch lookup value) |
+| `-d`, `--directory <str>` | create it somewhere other than the default |
+| `-u`, `--local-user-template` | use a template from your local templates folder |
+| `-s`, `--serve` | start Jupyter afterwards |
+| `-j`, `--lab` | use Jupyter Lab rather than Notebook when serving |
+| `-r`, `--run` | execute the template notebooks with PaperMill |
+| `--jupyter-executable <str>` | Jupyter to use, if it is in another environment |
+
+Fetching a registered template needs git and network access.
+
+---
+
+## `cellpy run`
+
+Runs a batch job from the shell — useful for a long re-processing job, or from
+a scheduler.
+
+```console
+cellpy run --list
+cellpy run -j cellpy_batch_paper01.json
+```
+
+| Option | Effect |
+| --- | --- |
+| `-l`, `--list` | list the batch (journal) files it can see |
+| `-j`, `--journal` | run the batch described by a journal file |
+| `-k`, `--key` | run the batch with this name |
+| `-f`, `--folder` | run every batch job in a folder |
+| `-p`, `--cellpy-project` | run a project folder's notebooks with PaperMill |
+| `--raw` / `--cellpyfile` | force loading from raw files / from cellpy files |
+| `--minimal` | minimal processing |
+| `--nom-cap <float>` | nominal capacity, for rates |
+| `--batch_col <str>` / `--project <str>` | batch column and project, when running from the database |
+| `-d`, `--debug` / `-s`, `--silent` | more or less output |
+
+!!! note "Windows paths"
+    `--cellpy-project` interprets the name as a Python string, so a single
+    backslash is an escape character. Use `/` or `\\`.
+
+---
+
+## `cellpy serve`
+
+Starts a Jupyter server. cellpy is a library, not a web service — this is the
+only thing it "serves".
+
+```console
+cellpy serve --lab
+```
+
+| Option | Effect |
+| --- | --- |
+| `-l`, `--lab` | Jupyter Lab instead of Notebook |
+| `-d`, `--directory <str>` | start in this directory |
+| `-e`, `--executable <str>` | Jupyter from another environment |
+
+---
+
+## `cellpy pull`
+
+Downloads the example notebooks or the test data from GitHub. Needs git.
+
+```console
+cellpy pull --examples
+cellpy pull --tests
+cellpy pull --clone -d some_dir
+```
+
+| Option | Effect |
+| --- | --- |
+| `-e`, `--examples` | the example notebooks and their data |
+| `-t`, `--tests` | the test files |
+| `-c`, `--clone` | the whole repository |
+| `-d`, `--directory <str>` | download into this directory |
+| `-p`, `--password <str>` | repository password, if needed |
+
+---
+
+## `cellpy convert`
+
+Upgrades a cellpy file written by an older version.
+
+```console
+cellpy convert old_cell.h5 new_cell.cellpy
+```
+
+| Argument / option | Meaning |
+| --- | --- |
+| `OLD_H5` (required) | the file to convert |
+| `NEW_H5` | where to write it |
+| `--to <str>` | `v9` (zip-of-parquet `.cellpy`) or `v8` (legacy HDF5). Inferred from the new file's suffix, otherwise `v9` |
+
+Reading the old HDF5 layout needs the HDF5 stack:
+`pip install "cellpy[legacy-files]"`. Converting once means you do not need it
+again.
+
+---
+
+## `cellpy mcp`
+
+Runs cellpy as an [MCP](https://modelcontextprotocol.io/) server, so a chat
+client can load and inspect cell data.
+
+```console
+cellpy mcp status
+cellpy mcp install
+cellpy mcp serve
+```
+
+| Sub-command | Effect |
+| --- | --- |
+| `status` | whether the server is installed, and what it would serve |
+| `install` | register the server with a chat client |
+| `serve` | run the server over stdio (clients normally do this themselves) |
+
+The server itself lives in a separate package:
+
+```console
+python -m pip install cellpy-mcp
+```
+
+---
+
+## See also
+
+- [Check your installation](../getting_started/checkup.md) — the short version
+  of `cellpy info`
+- [Setup and configuration](../getting_started/configuration.md) — what
+  `cellpy setup` writes, and how to change it afterwards
+- [Configuration reference](../getting_started/configuration_reference.md) —
+  every setting
+- [Troubleshooting](../troubleshooting.md) — including
+  `cellpy: command not found`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,6 +6,7 @@ icon: material/book-open-page-variant
 
 Lookup material — settings, deprecations, column names, and the generated API.
 
+- [Command line](cli.md) — every `cellpy` sub-command and its options
 - [Configuration settings](../getting_started/configuration_reference.md) —
   every config key, defaults, and environment-variable forms
 - [Deprecations](deprecations.md) — what is scheduled for removal and what

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,7 +38,8 @@ cellpy info --config
 
 Look for the `filelogdir` entry in the output. See
 [Setup and configuration](getting_started/configuration.md) if you want to move
-it somewhere more convenient.
+it somewhere more convenient, and the
+[command-line reference](reference/cli.md) for the rest of `cellpy info`.
 
 **Check that the installation itself is healthy:**
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -69,6 +69,7 @@ nav = [
     ] },
     { "Reference" = [
         "reference/index.md",
+        { "Command line" = "reference/cli.md" },
         { "Configuration settings" = "getting_started/configuration_reference.md" },
         { "Deprecations" = "reference/deprecations.md" },
         { "Legacy header map" = "other/header_migration_map.md" },


### PR DESCRIPTION
Fifth iteration of the documentation push tracked by #1023.

**Persona:** a user who would rather type a command than open a notebook — the
CLI is the natural front door for setup, health checks, and starting a batch
experiment from a template.

**What the docs said:** a six-row "typical subcommands" table on
[Check your installation](https://cellpy.readthedocs.io/en/latest/getting_started/checkup/),
and nothing else. It omitted `convert` and `mcp` entirely, and listed `migrate`
as a top-level command when it is actually `cellpy setup migrate`. No option was
documented anywhere in the docs.

## Added — `docs/reference/cli.md`

Every sub-command and every option, transcribed from the installed CLI's own
`--help`:

- **`setup`** — including `--deps` (probe missing extras), `--check`, and the
  `setup migrate` sub-command for converting a legacy `.conf`.
- **`info`** — what each flag prints, a sample `--check` report, and the point
  that a failing optional check (Arbin drivers, say) only matters if you need
  that feature. Also notes that `--config` is how you find `filelogdir` when
  hunting for `cellpy_debug.log`.
- **`edit`** — `config` / `db` / `env`, and `-e` for a specific editor.
- **`new`** — the template listing, and what `--project` / `--experiment` map
  to.
- **`run`** — including the Windows backslash caveat on `--cellpy-project`
  (the name goes through Python string interpretation).
- **`serve`**, **`pull`**, **`convert`** (with the `--to v9` / `v8` target and
  the `legacy-files` extra), and **`mcp`** (separate `cellpy-mcp` package).
- The global `-q` / `--verbose` / `--no-color` flags.

## Also fixed

`docs/getting_started/checkup.md`'s sub-command table: added the missing
commands and corrected `migrate` to `cellpy setup migrate`.

## Wiring

Added under **Reference** in `zensical.toml`, cross-linked from the reference
index, Installation, Check your installation and Troubleshooting.

Local `zensical build --clean` is link-clean.

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)