### PR TITLE
docs: "get your data out" export guide (iteration 6 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+* Docs: new how-to guide **Get your data out** — a chooser table plus
+  per-format detail for `save` (.cellpy), `to_excel`, `to_csv`, `to_bdf`,
+  the raw pandas frames, `b.summaries` and `b.export_project`, with a
+  what-survives-which-format matrix. Flags that batch frames are polars while
+  per-cell frames are pandas. Fixes `c.to_excel(out_folder)` in the file-formats
+  page — `to_excel` takes a file name, `to_csv` takes a directory. (#1023)
+
 * Docs: new **command-line reference** covering every `cellpy` sub-command
   and option (`setup` incl. `setup migrate`, `info`, `edit`, `new`, `run`,
   `serve`, `pull`, `convert`, `mcp`) plus the global `-q` / `--verbose` /

--- a/docs/fundamentals/file_formats.md
+++ b/docs/fundamentals/file_formats.md
@@ -34,5 +34,7 @@ Full support matrix and convert recipes:
 
 ## Tabular exports
 
-Simple exports to CSV (`c.to_csv(out_folder)`) or Excel
-(`c.to_excel(out_folder)`) are also available.
+Simple exports to CSV (`c.to_csv(out_folder)` — a **directory**) or Excel
+(`c.to_excel("cell.xlsx")` — a **file**) are also available, along with a
+Battery Data Format export (`c.to_bdf(...)`) for sharing. What each one keeps
+and what it drops: [Get your data out](../guides/exporting.md).

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -69,7 +69,9 @@ c.to_csv("out/csv_export")
 
 Frames are pandas DataFrames, so you can also use `DataFrame.to_excel` /
 `to_csv` on `c.data.raw`, `.steps`, or `.summary` directly. `CellpyCell`
-also exposes `to_excel` for a packaged export.
+also exposes `to_excel("cell.xlsx")` for a packaged multi-sheet export, and
+`to_bdf` for the Battery Data Format. See
+[Get your data out](../guides/exporting.md).
 
 ## Cycles and curves
 

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -1,0 +1,223 @@
+# Get your data out
+
+Sooner or later you want the numbers somewhere else — in Excel, in Origin, in
+a colleague's hands, or in a data repository. cellpy has a different answer for
+each of those.
+
+## Which one do you want?
+
+| You want to… | Use |
+| --- | --- |
+| come back to this cell in cellpy later | `c.save("cell.cellpy")` |
+| open it in Excel | `c.to_excel("cell.xlsx")` |
+| open it in Origin, MATLAB, or anything else | `c.to_csv("out_folder")` |
+| do your own analysis in Python | the frames on `c.data` |
+| share or archive it in a standard format | `c.to_bdf("cell.bdf.csv")` |
+| get the whole batch's cycle summaries | `b.summaries` |
+| hand a colleague a working batch | `b.export_project("bundle")` |
+| save a figure | see [Plot one cell](plotting.md#saving-a-figure) |
+
+## A cellpy file — the one that keeps everything
+
+```python
+c.save("my_run.cellpy")
+```
+
+This is the only format that round-trips: frames, metadata, units, step table
+and summary all come back with `cellpy.get("my_run.cellpy")`. It is a zip of
+parquet tables plus a `meta.json`, so it is compact and fast to reopen — much
+faster than re-reading the tester's raw file.
+
+Writing is atomic: an interrupted save leaves the existing file intact rather
+than truncating it.
+
+To write the legacy HDF5 layout instead (only if a collaborator is still on
+cellpy 1.x):
+
+```python
+c.save("my_run.h5")                                # suffix decides
+c.save("out.cellpy", cellpy_file_format="hdf5")    # or say so explicitly
+```
+
+That path needs `pip install "cellpy[legacy-files]"`. See
+[File formats](../fundamentals/file_formats.md).
+
+## Excel
+
+```python
+c.to_excel("my_run.xlsx")
+```
+
+One workbook, several sheets:
+
+```text
+meta_common          cell metadata, plus cellpy_units and raw_units
+meta_test_dependent  per-test metadata
+summary              the per-cycle summary
+steps                the step table
+```
+
+Add the voltage–capacity curves as one sheet per cycle:
+
+```python
+c.to_excel("my_run.xlsx", cycles=[1, 2, 5, 10])
+```
+
+```text
+meta_common  meta_test_dependent  summary  steps  cycle_001  cycle_002  cycle_005  cycle_010
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `filename` | the `.xlsx` file to write. Leave it out and cellpy names it `<timestamp>_cellpy.xlsx` |
+| `cycles` | `None` (no curve sheets), `True`, or a list of cycle numbers |
+| `raw` | add the raw frame too (default `False`) |
+| `steps` | include the step table (default `True`) |
+| `nice` | formatting (default `True`) |
+| `get_cap_kwargs` | passed to `get_cap` — how the curves are built |
+| `to_excel_kwargs` | passed to pandas' `DataFrame.to_excel` |
+
+!!! warning "`to_excel` takes a file name, not a folder"
+    `c.to_excel("out_folder")` fails. It is `c.to_csv` that takes a directory.
+
+Excel tops out at 1 048 576 rows, so a large raw frame is skipped rather than
+truncated (with a warning in the log). For raw data, use CSV.
+
+## CSV
+
+```python
+c.to_csv("out_folder")
+```
+
+Writes several files, named after the file the cell was loaded from:
+
+```text
+20160805_test001_45_cc_01_normal.csv   the raw frame
+20160805_test001_45_cc_01_steps.csv    the step table
+20160805_test001_45_cc_01_stats.csv    the per-cycle summary
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `datadir` | folder to write into (current folder if omitted) |
+| `sep` | column separator (defaults to the configured `sep`) |
+| `raw` | write the raw and step files (default `True`) |
+| `summary` | write the summary file (default `True`) |
+| `cycles` | also write a voltage–capacity file (default `False`) |
+| `method` | how the curves are laid out: `"back-and-forth"`, `"forth"`, `"forth-and-forth"` |
+| `shifted`, `shift` | cumulate the shift between cycles, starting at `shift` |
+| `last_cycle` | stop after this cycle |
+
+If your locale expects a semicolon separator and a comma decimal mark, set
+`sep=";"` here (and check `[reader] sep` in your configuration for the
+default).
+
+## Straight to pandas
+
+The per-cell frames *are* pandas DataFrames, so you never have to go through
+cellpy's exporters:
+
+```python
+c.data.summary.to_csv("summary.csv")
+c.data.raw.to_excel("raw.xlsx")
+c.data.steps.head()
+```
+
+Use `c.schema` for the column names, as in
+[the data structure](../fundamentals/data_structure.md).
+
+## Battery Data Format (BDF) — for sharing and archiving
+
+[BDF](https://github.com/battery-data-alliance/battery-data-format) is a
+community format for battery cycling data, with spelled-out column names and
+units in the header. It is the right choice when the data is leaving your group
+— a supplementary file for a paper, or a deposit in a repository.
+
+```python
+c.to_bdf("my_run.bdf.csv")
+```
+
+```text
+Test Time / s,Voltage / V,Current / A,Unix Time / s,Cycle Count / 1,Step Index / 1,
+Charging Capacity / Ah,Discharging Capacity / Ah,Charging Energy / Wh,...
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `filename` | output path; a missing suffix becomes `<cell_name>.bdf.<format>` |
+| `format` | `"csv"` (default) or `"parquet"` |
+| `cycles` / `last_cycle` | export a subset |
+| `header_style` | `"preferred"` (BDF spec, `"Test Time / s"`) or `"machine"` (`test_time_second`) |
+| `extras` | append raw columns that BDF does not define. The file is then no longer strictly BDF-compliant |
+| `bdf_units` | write in units other than the BDF defaults (also breaks strict compliance) |
+| `preprocess_fn` | a function applied to the raw frame before export |
+
+cellpy can also *read* BDF files — see
+[BatMo BDF files](../examples/08_batmo_bdf.md).
+
+## A whole batch
+
+### The combined summaries
+
+```python
+from cellpy.utils import batch
+
+b = batch.load(name="paper01", project="cool_project")
+
+b.summaries          # every cell's per-cycle summary, stacked
+```
+
+!!! warning "Batch frames are polars, not pandas"
+    `c.data.summary` on a single cell is a **pandas** DataFrame, but
+    `b.summaries`, `b.journal.pages` and `b.tests` are **polars** DataFrames.
+    They look similar and behave differently — `.to_csv()` does not exist on a
+    polars frame.
+
+    ```python
+    b.summaries.write_csv("summaries.csv")           # polars
+    b.summaries.to_pandas().to_excel("summaries.xlsx")   # via pandas
+    ```
+
+    `write_excel()` exists on polars too, but needs `pip install xlsxwriter`.
+    Going through `to_pandas()` uses the openpyxl that cellpy already has.
+
+### A shareable bundle
+
+```python
+journal = b.export_project("bundle")
+```
+
+Writes one `<label>.cellpy` per cell into `bundle/`, rewrites the journal so it
+points at those files, and saves the journal JSON. A colleague can then
+`batch.load(...)` the journal without access to your raw files or your database.
+
+Every cell has to be loaded first — `export_project` raises `ValueError` and
+names the unloaded cells otherwise. It does **not** copy the raw files.
+
+To write only the journal:
+
+```python
+b.save()                   # cellpy_batch_<name>.json
+b.export_journal(path)     # the same thing, to a chosen path
+```
+
+## What survives which format
+
+| | frames | metadata | units | step table | reopens in cellpy |
+| --- | --- | --- | --- | --- | --- |
+| `.cellpy` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Excel | summary + steps (+ raw, curves) | ✅ (own sheets) | ✅ (own sheet) | ✅ | ❌ |
+| CSV | ✅ | ❌ | ❌ | ✅ | ❌ |
+| BDF | raw only | header only | ✅ (in headers) | ❌ | ✅ (as raw) |
+
+Keep the `.cellpy` file as your working copy and treat the rest as output. If
+you only ever export CSV, you will be re-reading raw tester files — and
+re-entering masses — forever.
+
+## See also
+
+- [File formats](../fundamentals/file_formats.md) — what a cellpy file contains
+- [Plot one cell](plotting.md#saving-a-figure) — saving figures
+- [Set up the cellpy database](batch_database.md) — where batch cells come from
+- [Command line](../reference/cli.md#cellpy-convert) — `cellpy convert` for old
+  files

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,6 +15,8 @@ something specific.
   and how to save the figure
 - [Set up the cellpy database](batch_database.md) — the Excel sheet the
   batch utility reads, and which columns you actually have to fill in
+- [Get your data out](exporting.md) — cellpy files, Excel, CSV, BDF, and
+  batch bundles
 - [Compute incremental capacity and differential voltage](ica.md) — dQ/dV
   (`dqdv`) and dV/dQ (`dvdq`), plus plot and collect
 - [Write an instrument loader plugin](../other/writing_a_loader_plugin.md) —

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
         { "Units, mass, area and C-rates" = "guides/units.md" },
         { "Plot one cell" = "guides/plotting.md" },
         { "Set up the cellpy database" = "guides/batch_database.md" },
+        { "Get your data out" = "guides/exporting.md" },
         { "Compute ICA / DVA" = "guides/ica.md" },
         { "Write an instrument loader plugin" = "other/writing_a_loader_plugin.md" },
     ] },


### PR DESCRIPTION
Sixth iteration of the documentation push tracked by #1023.

**Persona:** a battery scientist who has the analysis they want, and now needs
the numbers in Excel for a colleague, in Origin for a figure, and as a
supplementary file for a paper.

**What the docs said:** exports were mentioned in passing on four pages and
explained on none. `to_bdf` — the Battery Data Format export, the right answer
when data leaves the group — appeared only in the API reference and one BatMo
tutorial.

## Added — `docs/guides/exporting.md`

- **A chooser table** mapping intent ("open it in Excel", "archive it") to
  method.
- **`.cellpy`** as the only round-tripping format, and the atomic write.
- **`to_excel`** — the actual sheet layout (`meta_common`,
  `meta_test_dependent`, `summary`, `steps`, `cycle_00N`), the `cycles=` curve
  sheets, the full argument table, and the 1 048 576-row Excel cap that causes
  a large raw frame to be skipped rather than truncated.
- **`to_csv`** — the three files it writes and how they are named, plus `sep`
  for a semicolon/comma locale.
- **The pandas frames directly**, for people who would rather not learn an
  exporter API.
- **`to_bdf`** — with a real header line, `header_style`, and the note that
  `extras` / `bdf_units` produce a file that is no longer strictly
  BDF-compliant.
- **Batch** — `b.summaries` and `b.export_project`.
- A **what-survives-which-format** matrix, ending on the point that a CSV-only
  workflow means re-reading raw files and re-entering masses forever.

Every export in the page was executed — against the bundled example cell and
the example batch database.

## Two real traps documented (and one doc bug fixed)

1. **`to_excel` takes a file name, not a folder.**
   `docs/fundamentals/file_formats.md` said `c.to_excel(out_folder)`; passing a
   directory raises `PermissionError`. It is `to_csv` that takes a directory.
   Fixed there and documented as a warning in the guide.

2. **Batch frames are polars; per-cell frames are pandas.**
   `c.data.summary` is a pandas DataFrame, but `b.summaries`,
   `b.journal.pages` and `b.tests` are polars — so the `.to_csv()` a reader
   just learned does not exist on them. The guide gives `write_csv()` and
   `to_pandas().to_excel()`, and notes that polars' `write_excel()` needs
   `xlsxwriter` while the pandas route uses the openpyxl cellpy already has.

## Wiring

Added under **How-to guides**, cross-linked from the guides index, File formats
and Basic usage.

Local `zensical build --clean` is link-clean.

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)