### PR TITLE
docs: summary-column reference, and a units correction (iteration 7 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+* Docs: new reference page **Summary columns** documenting all 58 columns of
+  a default `c.data.summary` — identity, capacities, the `cycle_mode`-dependent
+  coulombic efficiency/difference, losses, shifted capacities, the RIC family,
+  rate/throughput/equivalent-full-cycles, end-of-cycle potentials, and the
+  schema fields the engine does not populate. Formulas verified numerically.
+  Also corrects the units guide and Troubleshooting: the **bare**
+  `charge_capacity` column is in `raw_units` (the tester's unit) while
+  `charge_capacity_absolute` is in `cellpy_units` — for an Arbin `.res` file
+  that is a factor of 1000. (#1023)
+
 * Docs: new how-to guide **Get your data out** — a chooser table plus
   per-format detail for `save` (.cellpy), `to_excel`, `to_csv`, `to_bdf`,
   the raw pandas frames, `b.summaries` and `b.export_project`, with a

--- a/docs/fundamentals/data_structure.md
+++ b/docs/fundamentals/data_structure.md
@@ -207,7 +207,8 @@ Specific (mass-/area-normalized) columns still use postfixes such as
 **base** name only, so build the specific one from it —
 `f"{c.schema.summary.charge_capacity}_gravimetric"`. Which postfix means what,
 and what each is divided by, is covered in
-[Units, mass, area and C-rates](../guides/units.md). The summary frame has more
+[Units, mass, area and C-rates](../guides/units.md); every summary column is
+listed in [Summary columns](../reference/summary_columns.md). The summary frame has more
 native-only columns than 1.x (durations, energies, per-direction stats); see
 the migration map.
 

--- a/docs/guides/units.md
+++ b/docs/guides/units.md
@@ -194,12 +194,26 @@ cheaper than a full `make_summary()`.
 Every capacity-like quantity in the summary exists in several normalisations,
 distinguished by a postfix:
 
-| Column | Normalised by | Unit (defaults) |
+| Column | Normalised by | Unit |
 | --- | --- | --- |
-| `charge_capacity` | nothing | mAh |
-| `charge_capacity_gravimetric` | `mass` | mAh/g |
-| `charge_capacity_areal` | `area` | mAh/cm² |
-| `charge_capacity_absolute` | nothing (explicit name) | mAh |
+| `charge_capacity` | nothing | **`raw_units`** — what the tester wrote |
+| `charge_capacity_absolute` | nothing | `cellpy_units`, e.g. mAh |
+| `charge_capacity_gravimetric` | `mass` | e.g. mAh/g |
+| `charge_capacity_areal` | `area` | e.g. mAh/cm² |
+
+!!! warning "The bare column name is in the tester's units"
+    Only the three postfixed columns get the raw → cellpy unit conversion; the
+    base column is left as the summary engine produced it. For an Arbin `.res`
+    file (Ah) with the default cellpy unit (mAh), `charge_capacity` and
+    `charge_capacity_absolute` are a factor of 1000 apart:
+
+    ```python
+    print(c.data.raw_units.charge, "->", c.cellpy_units.charge)   # Ah -> mAh
+    print(c.get_converter_to_specific(mode="absolute"))           # 1000.0
+    ```
+
+    Reach for `_absolute` whenever you want an un-normalised capacity in the
+    unit you configured.
 
 The same postfixes apply to `discharge_capacity`, the `*_loss` columns, the
 `coulombic_difference` columns and their `test_cumulated_*` counterparts.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,8 @@ Lookup material — settings, deprecations, column names, and the generated API.
 - [Command line](cli.md) — every `cellpy` sub-command and its options
 - [Configuration settings](../getting_started/configuration_reference.md) —
   every config key, defaults, and environment-variable forms
+- [Summary columns](summary_columns.md) — what every column in
+  `c.data.summary` means, and which units it is in
 - [Deprecations](deprecations.md) — what is scheduled for removal and what
   replaces it
 - [Legacy header map](../other/header_migration_map.md) — 1.x column names to

--- a/docs/reference/summary_columns.md
+++ b/docs/reference/summary_columns.md
@@ -1,0 +1,222 @@
+# Summary columns explained
+
+`c.data.summary` has one row per cycle and — for a plain Arbin file with no
+extra options — **58 columns**. This page says what each one means, how it is
+computed, and which units it is in.
+
+```python
+print(len(c.data.summary.columns))   # 58
+```
+
+For the raw and step frames, see
+[the data structure](../fundamentals/data_structure.md).
+
+---
+
+## Read this first: the base column is not in your units
+
+Every capacity-like quantity appears in four forms:
+
+| Column | Normalised by | Units |
+| --- | --- | --- |
+| `charge_capacity` | nothing | **the tester's units** (`c.data.raw_units`) |
+| `charge_capacity_absolute` | nothing | your units (`c.cellpy_units`) |
+| `charge_capacity_gravimetric` | active mass | your units, per `specific_gravimetric` |
+| `charge_capacity_areal` | electrode area | your units, per `specific_areal` |
+
+The three postfixed columns are the base column multiplied by a conversion
+factor that includes the raw → cellpy unit change. The **base column does
+not** get that conversion.
+
+For an Arbin `.res` file, which records charge in Ah, with the default cellpy
+unit of mAh:
+
+```python
+c.data.summary["charge_capacity"]            # 0.00163   <- Ah, the tester's unit
+c.data.summary["charge_capacity_absolute"]   # 1.63      <- mAh
+c.data.summary["charge_capacity_gravimetric"]# 2308.8    <- mAh/g
+```
+
+!!! warning "Use `_absolute`, not the bare name, when you want mAh"
+    `charge_capacity` and `charge_capacity_absolute` differ by exactly the
+    raw → cellpy unit factor. They happen to be equal only when your tester
+    already wrote the unit cellpy is configured for. Reaching for the bare name
+    and assuming mAh is the easiest way to be off by a factor of 1000.
+
+Check the factor for your cell:
+
+```python
+print(c.data.raw_units.charge, "->", c.cellpy_units.charge)
+print(c.get_converter_to_specific(mode="absolute"))     # e.g. 1000.0
+```
+
+The columns that come in all four forms are:
+
+`charge_capacity`, `discharge_capacity`, `charge_capacity_loss`,
+`discharge_capacity_loss`, `coulombic_difference`,
+`test_cumulated_charge_capacity`, `test_cumulated_discharge_capacity`,
+`test_cumulated_charge_capacity_loss`,
+`test_cumulated_discharge_capacity_loss`,
+`test_cumulated_coulombic_difference`.
+
+More on the unit machinery: [Units, mass, area and C-rates](../guides/units.md).
+
+---
+
+## Identity
+
+| Column | Meaning |
+| --- | --- |
+| `cycle_num` | cycle number |
+| `test_id` | which test this cycle belongs to (0 for a single, unmerged run) |
+| `datapoint_num_last` | index of the last raw point in the cycle |
+| `last_test_time` | test time at the end of the cycle |
+
+`test_id` matters for campaign merges: every cumulated column below is
+accumulated **within** a test, so a merged object never carries capacity from
+one test into the next.
+
+## Capacities
+
+| Column | Meaning |
+| --- | --- |
+| `charge_capacity` | capacity delivered on charge in this cycle |
+| `discharge_capacity` | capacity delivered on discharge in this cycle |
+| `test_cumulated_charge_capacity` | running sum of `charge_capacity` |
+| `test_cumulated_discharge_capacity` | running sum of `discharge_capacity` |
+
+Each cycle's capacity starts at zero: cellpy rebases the tester's cumulative
+column per cycle on load. A tester that forgot a reset used to look like
+doubled capacity in cellpy 1.x; you get a `UserWarning` when this rebasing
+actually changed values.
+
+## Efficiency and losses
+
+`coulombic_efficiency` and `coulombic_difference` are referenced to the
+**first** step of the cycle, so they depend on `cycle_mode`:
+
+| `cycle_mode` | `coulombic_efficiency` | `coulombic_difference` |
+| --- | --- | --- |
+| `anode` (half cell — starts on discharge) | `100 · charge / discharge` | `discharge − charge` |
+| `full_cell` / `cathode` / `normal` | `100 · discharge / charge` | `charge − discharge` |
+
+Get this wrong and your CE is upside down. See
+[Troubleshooting](../troubleshooting.md#charge-and-discharge-look-swapped-and-the-coulombic-efficiency-is-upside-down).
+
+| Column | Computed as |
+| --- | --- |
+| `coulombic_efficiency` | above; a percentage |
+| `coulombic_difference` | above |
+| `charge_capacity_loss` | `charge_capacity[n−1] − charge_capacity[n]` |
+| `discharge_capacity_loss` | `discharge_capacity[n−1] − discharge_capacity[n]` |
+| `test_cumulated_coulombic_difference` | running sum of `coulombic_difference` |
+| `test_cumulated_charge_capacity_loss` | running sum of `charge_capacity_loss` |
+| `test_cumulated_discharge_capacity_loss` | running sum of `discharge_capacity_loss` |
+| `cumulated_coulombic_efficiency` | running sum of `coulombic_efficiency` |
+
+The loss columns are per-direction and do **not** depend on `cycle_mode`. The
+first cycle's loss is `NaN` — there is no previous cycle.
+
+## Shifted capacities
+
+| Column | Computed as |
+| --- | --- |
+| `shifted_charge_capacity` | cumulative sum of `charge_capacity − discharge_capacity` |
+| `shifted_discharge_capacity` | `shifted_charge_capacity + charge_capacity` |
+
+These offset each cycle's curve by the irreversible capacity accumulated so
+far, so that a stack of voltage curves lines up the way the electrode actually
+drifted. Handy for silicon and other high-loss electrodes.
+
+## RIC — relative irreversible capacity
+
+Three cumulative ageing indicators, each a running sum over cycles
+(`cc` = charge capacity, `dc` = discharge capacity):
+
+| Column | Computed as |
+| --- | --- |
+| `cumulated_ric` | Σ `(cc[n−1] − dc[n]) / dc[n−1]` |
+| `cumulated_ric_sei` | Σ `(cc[n] − dc[n−1]) / dc[n−1]` |
+| `cumulated_ric_disconnect` | Σ `(dc[n−1] − dc[n]) / dc[n−1]` |
+
+The split is diagnostic: `_sei` tracks loss consistent with continued
+surface-film growth, `_disconnect` tracks loss consistent with material losing
+electrical contact, and `cumulated_ric` is the overall figure. They are ratios,
+so they carry no unit and get no specific variants.
+
+The first cycle is `NaN` in all three.
+
+## Rate and throughput
+
+| Column | Meaning |
+| --- | --- |
+| `charge_c_rate` | mean charge current expressed as a C-rate |
+| `discharge_c_rate` | mean discharge current expressed as a C-rate |
+| `test_cumulated_capacity_throughput` | total charge passed, both directions |
+| `equivalent_full_cycles` | `test_cumulated_capacity_throughput / (2 · nominal capacity)` |
+| `normalized_cycle_index` | `test_cumulated_charge_capacity / nominal capacity` |
+
+All five need a **nominal capacity** to mean anything:
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, nominal_capacity="3579 mAh/g")
+```
+
+Without one, `nom_cap` defaults to 1.0 and these columns come out with
+plausible-looking but meaningless values — they are not `NaN`, so nothing warns
+you. `equivalent_full_cycles` counts a full charge *and* discharge as one
+cycle, which is why the denominator has the factor 2.
+
+## End-of-cycle potentials
+
+| Column | Meaning |
+| --- | --- |
+| `potential_end_charge` | potential at the end of the charge step |
+| `potential_end_discharge` | potential at the end of the discharge step |
+
+Useful as a cheap health check: a drifting end-of-discharge potential often
+shows up before capacity fade does.
+
+## Columns you may not see
+
+The schema declares more than the summary engine currently fills in. These are
+in `c.schema.summary` but are **not** in a default summary frame:
+
+- per-direction current / potential / power statistics
+  (`current_charge_mean`, `potential_discharge_max`, …)
+- `cv_share`, `cv_charge_capacity`, `cc_charge_capacity` and the CV/CC split
+- `voltage_efficiency`
+- `ir_charge` / `ir_discharge` and the four `ir_start_*` / `ir_end_*` columns
+- cell-temperature statistics
+
+Always check before you index:
+
+```python
+"cv_share" in c.data.summary.columns    # False, for a plain load
+```
+
+The CV/non-CV split is available through the plotting families
+(`summary_plot(c, y="capacities_gravimetric_split_constant_voltage")`), which
+compute it on the way to the figure.
+
+## Listing what you actually have
+
+```python
+for name in c.data.summary.columns:
+    print(name)
+```
+
+and, for the schema-resolved names your code should use:
+
+```python
+[a for a in dir(c.schema.summary) if not a.startswith("_")]
+```
+
+## See also
+
+- [Units, mass, area and C-rates](../guides/units.md) — the unit and
+  normalisation machinery
+- [The data structure](../fundamentals/data_structure.md) — the raw and step
+  frames
+- [Legacy header map](../other/header_migration_map.md) — the 1.x names
+- [Troubleshooting](../troubleshooting.md) — when a number looks wrong

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -234,12 +234,17 @@ You can also change the default for every load — see `cycle_mode` in the
 
 The summary carries the same quantity in several normalisations:
 
-| Column | Meaning | Typical unit |
+| Column | Meaning | Unit |
 | --- | --- | --- |
-| `charge_capacity` | as recorded, not normalised | mAh |
-| `charge_capacity_gravimetric` | per active mass | mAh/g |
-| `charge_capacity_areal` | per electrode area | mAh/cm² |
-| `charge_capacity_absolute` | not normalised, explicit name | mAh |
+| `charge_capacity` | as recorded, not normalised | **the tester's unit** (`c.data.raw_units`) |
+| `charge_capacity_absolute` | not normalised | your unit (`c.cellpy_units`), e.g. mAh |
+| `charge_capacity_gravimetric` | per active mass | e.g. mAh/g |
+| `charge_capacity_areal` | per electrode area | e.g. mAh/cm² |
+
+The bare name is **not** the one in your units. An Arbin `.res` file records
+charge in Ah, so `charge_capacity` comes out in Ah while
+`charge_capacity_absolute` is in mAh — a factor of 1000 apart. Use
+`_absolute` when you want an un-normalised capacity in the unit you configured.
 
 The same split exists for discharge, capacity loss, coulombic difference and
 the cumulated variants. `c.schema.summary` gives you the **base** name; add the

--- a/zensical.toml
+++ b/zensical.toml
@@ -72,6 +72,7 @@ nav = [
         "reference/index.md",
         { "Command line" = "reference/cli.md" },
         { "Configuration settings" = "getting_started/configuration_reference.md" },
+        { "Summary columns" = "reference/summary_columns.md" },
         { "Deprecations" = "reference/deprecations.md" },
         { "Legacy header map" = "other/header_migration_map.md" },
         { "API" = [


### PR DESCRIPTION
Seventh iteration of the documentation push tracked by #1023.

**Persona:** a battery scientist who runs `print(c.data.summary.columns)`, gets
**58 names**, and has to guess which one is the capacity they want.

## Added — `docs/reference/summary_columns.md`

Every column in a default summary, with what it means and how it is computed:

- **Identity** — `cycle_num`, `test_id`, and the fact that every cumulated
  column accumulates *within* a test, so a campaign merge never leaks capacity
  across tests.
- **Capacities**, and the per-cycle rebasing that made cellpy 1.x look like it
  reported double.
- **Coulombic efficiency and difference**, with the `cycle_mode` table:
  `anode` gives `100·charge/discharge`, the normal convention gives
  `100·discharge/charge`. The loss columns are per-direction and mode-independent.
- **Shifted capacities**, **the three RIC columns** (overall, `_sei`,
  `_disconnect`) with their exact cumulative-sum definitions.
- **Rate and throughput** — `equivalent_full_cycles = throughput / (2 · nominal
  capacity)`, `normalized_cycle_index = cumulated charge / nominal capacity`,
  and the warning that with no `nominal_capacity` these come out
  plausible-looking rather than `NaN`.
- **End-of-cycle potentials.**
- **Columns you may not see** — `cv_share` and the CC/CV split,
  `voltage_efficiency`, `ir_charge` / `ir_discharge`, the per-direction
  current/potential/power statistics and the temperature columns are declared
  in the schema but not populated by the summary engine. Readers were otherwise
  left hunting for them.

Every formula was verified numerically against the bundled example cell — the
shifted, cumulated, CE and loss columns all reproduce to 0.0 difference.

## Correction to earlier pages in this series

While checking `charge_capacity` against `charge_capacity_absolute` I found
they are **not** the same column in different clothing:

```python
c.data.raw_units.charge                      # 'Ah'   (what the Arbin file wrote)
c.cellpy_units.charge                        # 'mAh'  (what you configured)
c.get_converter_to_specific(mode="absolute") # 1000.0

c.data.summary["charge_capacity"]            # 0.00163  <- Ah
c.data.summary["charge_capacity_absolute"]   # 1.63     <- mAh
```

Only the `_absolute` / `_gravimetric` / `_areal` variants carry the raw →
cellpy unit conversion; the base column is left in the tester's units. The
units guide (iteration 2) and Troubleshooting (iteration 1) both said the bare
column was in mAh. Both are corrected here, with a warning admonition pointing
at `_absolute`.

## Wiring

Added under **Reference** in `zensical.toml`, cross-linked from the reference
index and the data-structure page.

Local `zensical build --clean` is link-clean.

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)