### PR TITLE
docs: step-table guide (iteration 8 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* Docs: new how-to guide **Understand the step table** — what a step row
+  holds, the step types the classifier actually emits (uncategorized is `""`,
+  not `not_known`), the ordered classification rules and the `raw_limits`
+  thresholds behind them, and the three ways to correct a misclassification
+  (`override_raw_limits`, `override_step_types`, `step_specifications` — the
+  last of which replaces the classifier rather than extending it). Corrects the
+  stale step-type list in the data-structure page. (#1023)
+
 * Docs: new reference page **Summary columns** documenting all 58 columns of
   a default `c.data.summary` — identity, capacities, the `cycle_mode`-dependent
   coulombic efficiency/difference, losses, shifted capacities, the RIC family,

--- a/docs/fundamentals/data_structure.md
+++ b/docs/fundamentals/data_structure.md
@@ -174,15 +174,22 @@ full list.
 
 #### Step types
 
-Step-type labels are written to the **`step_type`** column. Typical values:
+Step-type labels are written to the **`step_type`** column. The built-in
+classifier emits these:
 
 ```python
 ['charge', 'discharge',
  'cv_charge', 'cv_discharge',
- 'charge_cv', 'discharge_cv',
- 'ocvrlx_up', 'ocvrlx_down', 'ir',
- 'rest', 'not_known']
+ 'ocvrlx_up', 'ocvrlx_down',
+ 'rest', 'ir',
+ '']            # '' = uncategorized (no rule matched)
 ```
+
+The schema defines four more (`taper_charge`, `taper_discharge`, `charge_cv`,
+`discharge_cv`) plus `not_known`, but the classifier never produces them — they
+come from explicit step specifications, overrides, or older data. How the
+classification works, and how to correct it, is in
+[Understand the step table](../guides/step_table.md).
 
 Example:
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,6 +15,8 @@ something specific.
   and how to save the figure
 - [Set up the cellpy database](batch_database.md) — the Excel sheet the
   batch utility reads, and which columns you actually have to fill in
+- [Understand the step table](step_table.md) — how cellpy decides what a
+  step is, and how to correct it when it gets it wrong
 - [Get your data out](exporting.md) — cellpy files, Excel, CSV, BDF, and
   batch bundles
 - [Compute incremental capacity and differential voltage](ica.md) — dQ/dV

--- a/docs/guides/step_table.md
+++ b/docs/guides/step_table.md
@@ -1,0 +1,224 @@
+# Understand the step table
+
+Before cellpy can tell you a charge capacity, it has to decide which parts of
+the run *were* a charge. That decision lives in the **step table**, and every
+per-cycle number is built on top of it.
+
+Most of the time it is right and you never think about it. When a capacity
+looks wrong and the mass is fine, this is the next place to look.
+
+```python
+c.data.steps          # one row per step, 64 columns
+c.data.steps[c.schema.steps.step_type].value_counts()
+```
+
+```text
+ir             33
+ocvrlx_down    18
+discharge      18
+ocvrlx_up      17
+charge         17
+```
+
+## What a row is
+
+One row per (cycle, step, sub-step). The identity columns are:
+
+| Column | Meaning |
+| --- | --- |
+| `cycle_num` | cycle number |
+| `step_num` | the tester's step number within the cycle |
+| `sub_step_num` | sub-step, when the tester splits one step |
+| `step_type` | what cellpy decided this step is |
+| `c_rate` | C-rate estimate for the step |
+
+Everything else is a statistic, named `<quantity>_<stat>`:
+
+```text
+current_mean   current_std   current_min   current_max   current_first   current_last
+potential_mean potential_std potential_min potential_max potential_first potential_last
+charge_capacity_mean  …  charge_capacity_delta
+step_time_mean …
+```
+
+`_delta` (last − first) is the one the classifier leans on.
+
+## The step types
+
+| `step_type` | Meaning |
+| --- | --- |
+| `charge` | current positive, charge capacity increasing |
+| `discharge` | current negative, discharge capacity increasing |
+| `cv_charge` | constant-voltage part of a charge |
+| `cv_discharge` | constant-voltage part of a discharge |
+| `ocvrlx_up` | open-circuit relaxation, potential rising |
+| `ocvrlx_down` | open-circuit relaxation, potential falling |
+| `rest` | no current, potential stable |
+| `ir` | nothing changed at all — an internal-resistance point |
+| `""` (empty) | **uncategorized** — no rule matched |
+
+The schema also defines `taper_charge`, `taper_discharge`, `charge_cv`,
+`discharge_cv` and `not_known`. The built-in classifier never emits those; they
+only appear if you supply them yourself, or in data written by an older cellpy.
+
+!!! note "Uncategorized is `\"\"`, not `\"not_known\"`"
+    A step that matched no rule gets the empty string. Filter for it with
+    `c.data.steps[c.schema.steps.step_type] == ""`.
+
+## How cellpy decides
+
+Each step is classified from its own aggregates, against thresholds in
+`c.data.raw_limits`. In order — **later rules win**:
+
+| Condition | Label |
+| --- | --- |
+| no current, potential stable | `rest` |
+| no current, potential rose | `ocvrlx_up` |
+| no current, potential fell | `ocvrlx_down` |
+| discharge capacity changed, current negative | `discharge` |
+| charge capacity changed, current positive | `charge` |
+| potential stable, current negative and falling | `cv_discharge` |
+| potential stable, current positive and falling | `cv_charge` |
+| nothing changed at all | `ir` |
+
+"No current", "stable" and "changed" are all threshold questions, because no
+instrument reads exactly zero:
+
+```python
+print(c.data.raw_limits)
+```
+
+```text
+CellpyLimits(current_hard=1e-13, current_soft=1e-05,
+             stable_current_hard=2.0, stable_current_soft=4.0,
+             stable_voltage_hard=2.0, stable_voltage_soft=4.0,
+             stable_charge_hard=0.9, stable_charge_soft=5.0,
+             ir_change=1e-05)
+```
+
+| Limit | Used for |
+| --- | --- |
+| `current_hard` | below this, the current counts as zero |
+| `stable_voltage_hard` | potential change smaller than this counts as stable |
+| `stable_current_soft` | current drop larger than this counts as falling (CV) |
+| `stable_charge_hard` | capacity change larger than this counts as real |
+
+## Looking at what it decided
+
+The quickest check is visual — raw traces with the step labels drawn on:
+
+```python
+from cellpy.utils.plotutils import cycle_info_plot
+
+cycle_info_plot(c, cycle=3)
+```
+
+Or count them, and look at the ones that fell through:
+
+```python
+sc = c.schema.steps
+steps = c.data.steps
+
+print(steps[sc.step_type].value_counts())
+steps[steps[sc.step_type] == ""]        # uncategorized
+```
+
+To pull out one kind of step:
+
+```python
+discharges = c.data.steps.query(f"{c.schema.steps.step_type}=='discharge'")
+```
+
+## Fixing a misclassification
+
+Three tools, in increasing order of bluntness.
+
+### 1. Nudge the thresholds
+
+If a whole class of steps is wrong — a low-current cell whose CV tails read as
+rests, say — the thresholds are the honest fix:
+
+```python
+c.make_step_table(override_raw_limits={"current_hard": 1e-9})
+c.make_summary()          # the summary is built on the step table
+```
+
+Only the limits you name are overridden; the rest keep their values. Note that
+`0` is respected as an override rather than falling back to the default.
+
+### 2. Override individual step numbers
+
+If the tester's step 5 is always a rest but cellpy reads it as a relaxation:
+
+```python
+c.make_step_table(override_step_types={5: "rest"})
+c.make_summary()
+```
+
+The key is the **step number**, and it applies in every cycle.
+
+### 3. Declare the whole schedule
+
+If you know the schedule, you can hand cellpy the answer and skip the
+classifier entirely:
+
+```python
+import pandas as pd
+
+spec = pd.DataFrame({
+    "step": [1, 2, 3],
+    "type": ["charge", "rest", "discharge"],
+})
+
+c.make_step_table(step_specifications=spec, short=True)
+```
+
+!!! warning "Specifications replace the classifier — they do not extend it"
+    Any step you do not list ends up **uncategorized** (`""`), not classified
+    by the usual rules. On a cell whose steps run 1–8, a three-row
+    specification leaves the other five blank, and the summary that follows
+    will be missing capacities. List every step you have.
+
+    `short=True` matches by step number alone. Leave it out to match on
+    `(cycle, step)` pairs, and add a `cycle` column.
+
+    An optional `info` column is carried through to the step table as free text.
+
+### Always rebuild the summary
+
+`make_step_table` does not touch `c.data.summary`. After any of the three:
+
+```python
+c.make_step_table(...)
+c.make_summary()
+```
+
+## Repeated steps in one cycle — GITT
+
+A GITT cycle has the same tester step number many times over. By default cellpy
+collapses them; `usteps=True` keeps them apart and adds a `ustep` column:
+
+```python
+c.make_step_table(usteps=True)
+c.data.steps["ustep"]
+```
+
+See the [GITT tutorial](../examples/05_GITT.md) for the full workflow.
+
+## Other `make_step_table` options
+
+| Argument | Effect |
+| --- | --- |
+| `add_c_rate` | include the `c_rate` estimate (default `True`) |
+| `sort_rows` | sort the resulting rows (default `True`) |
+| `from_data_point` | start from this raw data point |
+| `nom_cap_specifics` | `"gravimetric"` / `"areal"` / `"absolute"` for the C-rate basis |
+| `profiling` | print timings |
+
+## See also
+
+- [Summary columns](../reference/summary_columns.md) — what the step table
+  feeds into
+- [The data structure](../fundamentals/data_structure.md) — all three frames
+- [Plot one cell](plotting.md) — `cycle_info_plot` and the rest
+- [GITT](../examples/05_GITT.md) — the main user of `usteps`

--- a/docs/reference/summary_columns.md
+++ b/docs/reference/summary_columns.md
@@ -218,5 +218,7 @@ and, for the schema-resolved names your code should use:
   normalisation machinery
 - [The data structure](../fundamentals/data_structure.md) — the raw and step
   frames
+- [Understand the step table](../guides/step_table.md) — where these
+  numbers come from
 - [Legacy header map](../other/header_migration_map.md) — the 1.x names
 - [Troubleshooting](../troubleshooting.md) — when a number looks wrong

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -261,6 +261,21 @@ The areal columns need an electrode area (`area=` on `cellpy.get`, in cm²) to
 mean anything. [Units, mass, area and C-rates](guides/units.md) explains the
 whole normalisation story, including how to change the units themselves.
 
+### A capacity is missing or too small for some cycles
+
+cellpy works out charge and discharge capacities from the **step table**, so a
+step it could not classify contributes nothing. Count the labels:
+
+```python
+sc = c.schema.steps
+print(c.data.steps[sc.step_type].value_counts())
+print((c.data.steps[sc.step_type] == "").sum())   # uncategorized steps
+```
+
+An empty `step_type` means no classification rule matched. The fixes —
+threshold overrides, per-step overrides, or a full schedule specification — are
+in [Understand the step table](guides/step_table.md).
+
 ### My capacity used to look twice as large in cellpy 1.x
 
 That is deliberate. Some testers do not reset their cumulative capacity column

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
         { "Units, mass, area and C-rates" = "guides/units.md" },
         { "Plot one cell" = "guides/plotting.md" },
         { "Set up the cellpy database" = "guides/batch_database.md" },
+        { "Understand the step table" = "guides/step_table.md" },
         { "Get your data out" = "guides/exporting.md" },
         { "Compute ICA / DVA" = "guides/ica.md" },
         { "Write an instrument loader plugin" = "other/writing_a_loader_plugin.md" },


### PR DESCRIPTION
Eighth iteration of the documentation push tracked by #1023.

**Persona:** a battery scientist whose discharge capacity is missing for some
cycles. The mass is right, the file loaded fine — and they have no idea that a
step-classification table stands between the raw file and the summary.

**What the docs said:** `docs/fundamentals/data_structure.md` listed some step
types and showed how to query them. Nothing explained how the labels are
assigned, what happens when no rule matches, or how to correct it.

## Added — `docs/guides/step_table.md`

- What one row is, and the `<quantity>_<stat>` column naming — including that
  the `_delta` columns are what the classifier actually reads.
- **The step types the classifier really emits**, and that uncategorized is the
  **empty string**, not `"not_known"`. `taper_charge`, `taper_discharge`,
  `charge_cv` and `discharge_cv` exist in the schema but are never produced by
  the built-in classifier.
- **The ordered rule table** (later rules win, so `ir` beats `rest`) and the
  `raw_limits` thresholds each rule tests against, with what each limit is for.
- Inspecting the result: `cycle_info_plot`, `value_counts`, and filtering for
  the uncategorized steps.
- **Three fixes**, in increasing bluntness:
  1. `override_raw_limits` — and that an explicit `0` is honoured rather than
     silently falling back to the default.
  2. `override_step_types={5: "rest"}` — keyed on step number, applies in every
     cycle.
  3. `step_specifications` — with a warning that it **replaces** the classifier
     rather than extending it, so any step you leave out ends up uncategorized
     and the summary that follows is missing capacities. That one is easy to
     walk into.
- That `make_step_table` never updates `c.data.summary`, so `make_summary()`
  has to follow.
- `usteps=True` for GITT.

All three correction paths were run against the bundled example cell, including
the partial-specification failure mode (98 of 103 steps left uncategorized).

## Also fixed

- `docs/fundamentals/data_structure.md` advertised `charge_cv`,
  `discharge_cv` and `not_known` as typical `step_type` values and omitted the
  empty string. Corrected, with a note on where the extra schema members come
  from.
- `docs/troubleshooting.md` gains an entry for a capacity that is missing or
  too small for some cycles, pointing at the uncategorized-step check.

## Wiring

Added under **How-to guides**, cross-linked from the guides index, the
data-structure page, the summary-column reference and Troubleshooting.

Local `zensical build --clean` is link-clean.

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)