### PR TITLE
docs: "How do I…?" task index, and a get_ocv fix (iteration 10 of #1023)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+* Docs: new top-level **How do I…?** page — the whole documentation set
+  indexed by question, with the shortest working snippet under each and a link
+  to the detail. Fixes `c.get_ocv(ocv_type=..., cycle_number=...)` in Basic
+  usage: the real signature is `get_ocv(cycles=..., direction="up"|"down", …)`,
+  so the documented call raised `TypeError`. (#1023)
+
 * Docs: new **Your first hour with cellpy** on-ramp — a linear, verified
   walkthrough on the bundled example data (install, check, load, read the
   summary, plot, one cycle's curve, save/export) that ends by switching to the

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -80,7 +80,7 @@ cycles = c.get_cycle_numbers()
 print(f"{len(cycles)} cycles")
 
 cap = c.get_cap(5)  # capacity–voltage for cycle 5
-ocv = c.get_ocv(ocv_type="ocvrlx_up", cycle_number=44)
+ocv = c.get_ocv(cycles=5, direction="up")  # direction: "up" or "down"
 ```
 
 More extractors (`get_current`, `get_voltage`, `split`, `merge`, …) are on

--- a/docs/getting_started/first_hour.md
+++ b/docs/getting_started/first_hour.md
@@ -274,4 +274,5 @@ Depending on what you are actually trying to do:
 | find out why a number looks wrong | [Troubleshooting](../troubleshooting.md) |
 
 Longer worked examples, with real analysis rather than a tour, are in
-[Tutorials](../examples/index.md).
+[Tutorials](../examples/index.md). For a shorter answer to a specific question,
+[How do I…?](../how_do_i.md) is indexed by exactly that.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,7 +5,8 @@ icon: material/wrench
 # How-to guides
 
 Task-focused recipes for when you already know the basics and need to do
-something specific.
+something specific. If you just want the one-liner, start with
+[How do I…?](../how_do_i.md).
 
 - [Work with remote files](../getting_started/remote_paths.md) — load raw data
   and cellpy files over SSH / SFTP

--- a/docs/how_do_i.md
+++ b/docs/how_do_i.md
@@ -1,0 +1,401 @@
+---
+icon: material/help-circle
+---
+
+# How do I…?
+
+An index by question. Find what you are trying to do, get the shortest answer
+that works, and follow the link when you need the detail.
+
+Throughout, `c` is a loaded cell (`c = cellpy.get(...)`) and `b` is a loaded
+batch (`b = batch.load(...)`).
+
+---
+
+## Get started
+
+**…install cellpy so it can also plot?**
+
+```console
+python -m pip install "cellpy[batch]"
+```
+
+→ [Installation](getting_started/installation.md#optional-extras)
+
+**…try cellpy without having a data file?**
+
+```python
+from cellpy.utils import example_data
+
+c = example_data.raw_file()
+```
+
+→ [Your first hour](getting_started/first_hour.md)
+
+**…check that my installation is healthy?**
+
+```console
+cellpy info --check
+```
+
+→ [Check your installation](getting_started/checkup.md)
+
+**…find my configuration file?**
+
+```console
+cellpy info --configloc
+cellpy edit config
+```
+
+→ [Setup and configuration](getting_started/configuration.md)
+
+---
+
+## Load data
+
+**…load a file from my cycler?**
+
+```python
+c = cellpy.get("my_cell.res", instrument="arbin_res", mass=0.85)
+```
+
+→ [Basic usage](getting_started/basic_usage.md)
+
+**…see which instruments cellpy supports?**
+
+```python
+cellpy.print_instruments()
+```
+
+**…load a file format cellpy does not know?**
+Describe it in a YAML file and pass `instrument_file=`, or write a loader
+plugin.
+→ [Writing a custom loader](examples/07_custom_loaders.md) ·
+[Loader plugin](other/writing_a_loader_plugin.md)
+
+**…load several raw files as one cell?**
+
+```python
+c = cellpy.get(["run_01.res", "run_02.res", "run_03.res"])
+```
+
+**…load only some of the data sets in an Arbin file?**
+
+```python
+c = cellpy.get("my_cell.res", dataset_number=1)
+```
+
+**…load files from a server?**
+Use an `scp://` path in `rawdatadir` or in `cellpy.get`.
+→ [Work with remote files](getting_started/remote_paths.md)
+
+**…see a cellpy file's metadata without loading the data?**
+
+```python
+meta = cellpy.read_meta("my_cell.cellpy")
+meta["cell"]["mass"]
+```
+
+**…open an old `.h5` file from cellpy 1.x?**
+
+```console
+python -m pip install "cellpy[legacy-files]"
+cellpy convert old_cell.h5 new_cell.cellpy
+```
+
+→ [File formats](fundamentals/file_formats.md)
+
+---
+
+## Set the cell up correctly
+
+**…set the active mass?**
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704)   # mg
+```
+
+**…change the mass after loading?**
+
+```python
+c.mass = 0.704
+c.refresh_after("mass")
+```
+
+**…tell cellpy this is a full cell, not a half cell?**
+
+```python
+c = cellpy.get("my_cell.res", cycle_mode="full_cell")
+```
+
+**…set the electrode area, for areal capacities?**
+
+```python
+c = cellpy.get("my_cell.res", mass=0.704, area=1.77)   # cm²
+```
+
+**…give a nominal capacity, so C-rates mean something?**
+
+```python
+c = cellpy.get("my_cell.res", nominal_capacity="3579 mAh/g")
+```
+
+→ all four: [Units, mass, area and C-rates](guides/units.md)
+
+---
+
+## Find the numbers
+
+**…get capacity per gram / per cm² / not normalised?**
+
+```python
+c.data.summary["charge_capacity_gravimetric"]   # mAh/g
+c.data.summary["charge_capacity_areal"]         # mAh/cm²
+c.data.summary["charge_capacity_absolute"]      # mAh
+```
+
+The name with **no** postfix is in the tester's units, not yours.
+→ [Summary columns](reference/summary_columns.md)
+
+**…know what a summary column means?**
+→ [Summary columns](reference/summary_columns.md)
+
+**…look up a column name without hard-coding it?**
+
+```python
+c.data.raw[c.schema.raw.potential]
+c.data.summary[c.schema.summary.coulombic_efficiency]
+```
+
+**…translate a column name from cellpy 1.x?**
+→ [Legacy header map](other/header_migration_map.md)
+
+**…get a capacity–voltage curve for one cycle?**
+
+```python
+curve = c.get_cap(5)                       # potential, capacity
+curve = c.get_cap(5, mode="absolute")      # not normalised
+```
+
+**…get the OCV relaxation after a cycle?**
+
+```python
+ocv = c.get_ocv(cycles=5, direction="up")   # cycle_num, step_num, step_time, potential
+```
+
+`direction` is `"up"` or `"down"`.
+
+**…compute dQ/dV or dV/dQ?**
+
+```python
+from cellpy import ica
+
+ica_frame = ica.dqdv(c, cycles=[2, 3])
+dva_frame = ica.dvdq(c, cycles=2, direction="charge")
+```
+
+→ [Compute ICA / DVA](guides/ica.md)
+
+**…pick out only the cycles run at a given C-rate?**
+
+```python
+c.get_cycle_numbers(rate=0.061, rate_on="charge", rate_std=0.005)
+c.get_cycle_numbers(rate=0.061, rate_on="charge", rate_std=0.005, inverse=True)
+```
+
+Needs a `nominal_capacity` to be meaningful.
+
+**…select all the discharge steps?**
+
+```python
+c.data.steps.query(f"{c.schema.steps.step_type}=='discharge'")
+```
+
+→ [Understand the step table](guides/step_table.md)
+
+---
+
+## Plot
+
+**…plot capacity against cycle number?**
+
+```python
+from cellpy.utils.plotutils import summary_plot
+
+fig = summary_plot(c, y="capacities_gravimetric_coulombic_efficiency")
+fig.show()
+```
+
+**…see what else `summary_plot` can draw?**
+
+```python
+from cellpy.plotting import families
+
+for name, description in families():
+    print(name, "-", description)
+```
+
+**…plot voltage curves for a few cycles?**
+
+```python
+from cellpy.utils.plotutils import cycles_plot
+
+cycles_plot(c, cycles=[5, 10, 15])
+```
+
+**…check how cellpy labelled the steps in a cycle?**
+
+```python
+from cellpy.utils.plotutils import cycle_info_plot
+
+cycle_info_plot(c, cycle=3)
+```
+
+**…get the numbers behind a plot?**
+
+```python
+fig, data = summary_plot(c, y="capacities_gravimetric", return_data=True)
+```
+
+**…save a figure?**
+
+```python
+from cellpy.plotting import write_image
+
+open("fig.png", "wb").write(write_image(fig, "png"))   # plotly
+fig.write_html("fig.html")                             # interactive
+fig.savefig("fig.png", dpi=300)                        # matplotlib
+```
+
+→ all six: [Plot one cell](guides/plotting.md)
+
+---
+
+## Get data out
+
+**…save the cell so I can reopen it quickly?**
+
+```python
+c.save("my_cell.cellpy")
+```
+
+**…get it into Excel?**
+
+```python
+c.to_excel("my_cell.xlsx")                 # a file, not a folder
+c.to_excel("my_cell.xlsx", cycles=[1, 5])  # plus curve sheets
+```
+
+**…get CSV files for Origin or MATLAB?**
+
+```python
+c.to_csv("out_folder")                     # a folder, not a file
+```
+
+**…export in a standard format for a paper or repository?**
+
+```python
+c.to_bdf("my_cell.bdf.csv")
+```
+
+**…export a batch's summaries?**
+
+```python
+b.summaries.write_csv("summaries.csv")             # polars, not pandas
+b.summaries.to_pandas().to_excel("summaries.xlsx")
+```
+
+→ all five: [Get your data out](guides/exporting.md)
+
+---
+
+## Work on many cells
+
+**…set up the database the batch utility reads?**
+→ [Set up the cellpy database](guides/batch_database.md)
+
+**…load a batch?**
+
+```python
+from cellpy.utils import batch
+
+b = batch.load(name="paper01", project="cool_project", batch_col="b01")
+```
+
+**…make my spreadsheet edits actually take effect?**
+
+```python
+b = batch.load(name="paper01", project="cool_project", allow_from_journal=False)
+```
+
+The cached journal is reused otherwise.
+
+**…see which cells failed to load?**
+
+```python
+b.result.report()
+```
+
+**…get one cell out of a batch?**
+
+```python
+c = b.cells["20180418_sf033_2_cc"]
+```
+
+**…hand a colleague a working copy of the batch?**
+
+```python
+b.export_project("bundle")
+```
+
+**…start a project folder with notebooks already wired up?**
+
+```console
+cellpy new -p my_project -e paper01
+```
+
+→ [Command line](reference/cli.md#cellpy-new) ·
+[Batch processing](examples/batch_utility/cellpy_batch_processing.md)
+
+---
+
+## When something is wrong
+
+**…find out why a file will not load?**
+
+```python
+c = cellpy.get("my_cell.res", logging_mode="INFO")
+```
+
+**…find the log file?**
+
+```console
+cellpy info --config     # look for filelogdir
+```
+
+**…fix capacities that are off by a factor of hundreds?**
+The mass defaults to 1.0 mg. Set it, then `c.refresh_after("mass")`.
+
+**…fix charge and discharge being swapped?**
+`cycle_mode` defaults to `"anode"`. Set `cycle_mode="full_cell"`, then
+`c.refresh_after("cycle_mode")`.
+
+**…fix a step cellpy classified wrongly?**
+
+```python
+c.make_step_table(override_step_types={5: "rest"})
+c.make_summary()
+```
+
+→ [Understand the step table](guides/step_table.md)
+
+**…anything else that looks wrong?**
+→ [Troubleshooting](troubleshooting.md)
+
+---
+
+## Not answered here?
+
+If your question is not on this page and you could not find it in the docs, it
+is worth telling us — a question that is hard to look up is a documentation
+bug. [Open an issue](https://github.com/jepegit/cellpy/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ c.data.summary[c.schema.summary.charge_capacity]
   frames relate — [Concepts](fundamentals/index.md).
 - **Looking for a signature?** Generated from the docstrings —
   [API reference](api/index.md).
+- **Know what you want, not where it is?** One page, indexed by question —
+  [How do I…?](how_do_i.md).
 - **Something not working?** Symptom-by-symptom fixes —
   [Troubleshooting](troubleshooting.md).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,8 @@ Things that commonly go wrong, and what to do about them. Find your symptom in
 the list below — most entries are one or two lines of code away from a fix.
 
 If your problem is not here, jump to [Reporting a problem](#reporting-a-problem)
-at the end.
+at the end. If nothing is broken and you just cannot find how to do something,
+try [How do I…?](how_do_i.md) instead.
 
 ---
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -38,6 +38,7 @@ nav = [
         { "Coming from cellpy 1.x" = "getting_started/migration_v1_to_v2.md" },
         { "Coming from cellpy 2.0" = "getting_started/migration_v2.0_to_2.1.md" },
     ] },
+    { "How do I…?" = "how_do_i.md" },
     { "Troubleshooting" = "troubleshooting.md" },
     { "Tutorials" = [
         "examples/index.md",


### PR DESCRIPTION
Tenth and final iteration of the documentation push tracked by #1023.

**Persona:** someone who knows exactly what they want — "plot cycle life", "get
mAh/cm²", "export for Origin" — and has to guess which of five top-level
sections it lives in.

Discoverability was one of the gaps named in #1023, and after nine iterations of
adding pages it had arguably got *worse*: there is far more good material now,
and still no front door keyed on intent rather than on structure.

## Added — `docs/how_do_i.md`

The whole documentation set indexed by question, in seven groups: get started,
load data, set the cell up correctly, find the numbers, plot, get data out,
work on many cells, and when something is wrong. Each entry is the shortest
snippet that actually works, plus a link to the page that explains it.

Every snippet in the page was executed. Two features that were previously
reachable only by reading source get an entry:

- `cellpy.plotting.families()` — discovering what `summary_plot(y=...)` accepts.
- `c.get_cycle_numbers(rate=0.061, rate_on="charge", rate_std=0.005)` — and its
  `inverse=True` complement, for splitting a rate test into its rate blocks.

## Also fixed — a documented call that raises `TypeError`

`docs/getting_started/basic_usage.md` had:

```python
ocv = c.get_ocv(ocv_type="ocvrlx_up", cycle_number=44)
```

Neither parameter exists. The real signature is:

```python
get_ocv(cycles=None, direction="up", remove_first=False,
        interpolated=False, dx=None, number_of_points=None)
```

Corrected to `c.get_ocv(cycles=5, direction="up")` and verified against the
bundled example cell (returns `cycle_num`, `step_num`, `step_time`,
`potential`).

I swept every other `c.<method>(...)` call in the non-notebook documentation
against its actual signature — `get_cap`, `get_cycle_numbers`, `load`,
`make_step_table`, `make_summary`, `refresh_after`, `save`, `to_bdf`, `to_csv`,
`to_excel`, `get_converter_to_specific` — and this was the only one that was
wrong.

## Wiring

Added as a top-level nav entry between Getting started and Troubleshooting,
promoted on the landing page, and linked from the guides index, Troubleshooting
and the end of Your first hour.

Local `zensical build --clean` is link-clean.

Closes the ten-iteration series on #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)