### PR TITLE
Create missing local folders on every cellpy setup run

### DIFF
--- a/.issueflows/03-solved-issues/issue1037_original.md
+++ b/.issueflows/03-solved-issues/issue1037_original.md
@@ -1,0 +1,7 @@
+# Issue #1037: look into possible missing creation of raw folder
+
+Source: https://github.com/jepegit/cellpy/issues/1037
+
+## Original issue text
+
+Experienced user noticed that the raw folder was not created during cellpy setup

--- a/.issueflows/03-solved-issues/issue1037_plan.md
+++ b/.issueflows/03-solved-issues/issue1037_plan.md
@@ -1,0 +1,97 @@
+# Issue #1037 — plan
+
+## Goal
+
+Find why an experienced user can run `cellpy setup` and still have no `raw/`
+folder, then close that hole so setup creates the local `raw` directory
+(unless the configured path is a remote `OtherPath`).
+
+## Constraints
+
+- Do not create remote `ssh`/`sftp`/`scp` raw paths locally (`_create_dir`
+  already skips `OtherPath.is_external`).
+- First-time `--silent` setup must keep creating the default
+  `~/cellpy_data/{out,raw,cellpyfiles,...}` tree
+  (`test_cli_setup_creates_dirs_and_files`).
+- `--reset` still means “ignore current config and use the default layout”.
+- Setup stays light by default (no reader import) — [cli-light-startup.md](../04-designs-and-guides/cli-light-startup.md).
+- Docs already promise that setup “tries to create the usual directory
+  layout” including `raw/` ([configuration.md](../../docs/getting_started/configuration.md)).
+
+### Prior art
+
+- `setup_config` / `_update_paths` / `_create_dir` in
+  [`cellpy/cli_api.py`](../../cellpy/cli_api.py) — only non-interactive
+  path that mkdir’s is `if reset: _update_paths(...)`. First missing
+  `cellpy.toml` forces `reset = True`; a later `cellpy setup` does not.
+- `_create_dir` — mkdir local paths; return immediately for external
+  `OtherPath`. Confirm prompt only fires when the *parent* is missing.
+- [`tests/test_cellpy_cmd.py`](../../tests/test_cellpy_cmd.py)
+  `test_cli_setup_creates_dirs_and_files` — first-time `--silent` +
+  `--test_user` asserts `cellpy_data/raw` exists. No test for “config
+  already present, folders missing”.
+- Related: #960 (setup writes toml, not legacy `.conf`), #891 (setup
+  output / `--silent`), #990 (`cellpy new` create-dir without prompt).
+- Toolbox + graph: none that create setup folders
+  (`00-tools/` helpers are AST/header scanners; no `GRAPH_REPORT.md`).
+
+## Approach
+
+1. **Treat the skip as the bug.** Non-interactive `cellpy setup` with an
+   existing `cellpy.toml` never calls `_update_paths`, so it rewrites
+   toml/env and creates **no** directories. That matches an experienced
+   user (already configured, or just ran `cellpy setup migrate`). Docs
+   say re-run setup after upgrades; that path currently cannot create
+   `raw/`.
+2. **Always ensure local dirs.** Call `_update_paths` from both the
+   interactive and non-interactive branches. Keep `reset` as “use default
+   names under `cellpy_data`”; when `reset` is false, mkdir the paths
+   already in config (after the existing `h / path` join and optional
+   `-i` prompts). Still skip remotes.
+3. **Fix the `instrumentsdir` typo** in the non-reset branch
+   (`config.paths.instrumentsdir` → `instrumentdir`). Today
+   `cellpy setup -i` with an existing config raises `AttributeError`
+   before any mkdir.
+4. **Do not invent a second raw location.** If the existing config points
+   `rawdatadir` at cwd or another existing path, do not also create
+   `~/cellpy_data/raw` unless `--reset` / first-time. Missing *configured*
+   `raw` is what we create.
+5. **Regression tests** (essential): existing first-time test stays;
+   add “toml exists, `raw/` absent → `cellpy setup --silent` creates it”;
+   add “external `rawdatadir` is not mkdir’d”; add “`-i` with existing
+   config does not crash on `instrumentdir`” (dry-run is enough).
+6. **Docs:** one sentence that a re-run creates any missing *configured*
+   local folders, and that `--reset` rebuilds the default `cellpy_data`
+   tree (including `raw/`).
+
+## Files to touch
+
+- [`cellpy/cli_api.py`](../../cellpy/cli_api.py) — always call
+  `_update_paths`; fix `instrumentsdir` typo.
+- [`tests/test_cellpy_cmd.py`](../../tests/test_cellpy_cmd.py) — new
+  essential cases above (reuse `isolated_user_dir`).
+- [`docs/getting_started/configuration.md`](../../docs/getting_started/configuration.md)
+  — re-run / `--reset` behaviour.
+- [`docs/getting_started/agents.md`](../../docs/getting_started/agents.md)
+  + root `AGENTS.md` only if the setup surface agents rely on changes
+  (likely a one-line “setup creates missing local path dirs”).
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_cellpy_cmd.py tests/test_cli_setup_output.py -m essential
+uv run pytest -m essential
+```
+
+No new fixtures beyond the existing isolated user-dir pattern.
+
+## Open questions
+
+- **Re-run policy (recommended: yes):** should `cellpy setup` without
+  `--reset` create missing configured local directories? Alternative:
+  leave the skip and only document `--reset`. The issue title is “look
+  into possible missing creation”, so the recommended fix is to create
+  them.
+- If you have the reporter’s exact command (`setup`, `setup -i`,
+  `setup migrate`, already had toml?), that would confirm the skip
+  path — not required to start if the policy above is accepted.

--- a/.issueflows/03-solved-issues/issue1037_status.md
+++ b/.issueflows/03-solved-issues/issue1037_status.md
@@ -1,0 +1,17 @@
+# Issue #1037 — status
+
+- [x] Done
+
+## What's done
+
+- Non-interactive `cellpy setup` with an existing config now creates
+  missing configured local folders (including `raw/`).
+- `_join_under_home` keeps remote `OtherPath`s off the local mkdir path.
+- `config.paths.instrumentsdir` → `instrumentdir`.
+- Essential tests + registry rows.
+- Docs: `configuration.md`, `agents.md`, root `AGENTS.md`.
+- `uv run pytest -m essential`: 858 passed, 70 skipped.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/test-registry.md
+++ b/.issueflows/04-designs-and-guides/test-registry.md
@@ -80,6 +80,9 @@ current issue**. `/iflow-doctor` may audit the whole suite against this table.
 | tests/test_cli_setup_output.py (module) | yes | yes | cli_api.setup_config / cli_api._ui / cli.pull / cli.edit | #891 | no parameter dump, real --silent, usage exit 2 |
 | tests/test_cellpy_cmd.py::test_cli_setup | yes | yes | cli.setup dry-run reporting | #891 #960 | toml+env only; no legacy .conf |
 | tests/test_cellpy_cmd.py::test_cli_setup_creates_dirs_and_files | yes | yes | cli.setup writes cellpy.toml | #960 | no new .conf; toml + env + dirs |
+| tests/test_cellpy_cmd.py::test_cli_setup_rerun_creates_missing_raw | yes | yes | cli_api.setup_config re-run mkdir | #1037 | existing toml used to skip _update_paths |
+| tests/test_cellpy_cmd.py::test_cli_setup_does_not_mkdir_remote_raw | yes | yes | cli_api._join_under_home / _create_dir | #1037 | sftp URI must not become a local path |
+| tests/test_cellpy_cmd.py::test_cli_setup_interactive_existing_config_uses_instrumentdir | yes | yes | cli_api._update_paths instrumentdir | #1037 | instrumentsdir typo crashed setup -i |
 | tests/test_cli_info.py::test_check_does_not_shout_or_draw_banners | yes | yes | cli_api._check rendering | #891 | no ===/---/!!!! |
 | tests/test_cli_info.py::test_check_keeps_the_probe_narration_for_verbose | yes | yes | cli_api._debug gating | #891 | diagnostics only under --verbose |
 | tests/test_cli_info.py::test_quiet_reports_only_what_is_broken | yes | yes | check rendering under --quiet | #891 | failures survive quiet |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,8 +426,9 @@ resolves from PyPI). No manual install is normally needed.
   version — harmless for dev).
 - **CLI smoke check:** `uv run cellpy setup --silent` then `uv run cellpy info --check`.
   `cellpy setup` writes a runtime `.env_cellpy` and a user `cellpy.toml`
-  (legacy installs may still have `~/.cellpy_prms_*.conf`) — these are local
-  runtime files, do not commit them.
+  (legacy installs may still have `~/.cellpy_prms_*.conf`) and creates any
+  missing configured local folders (remote path URIs are skipped) — these
+  are local runtime files, do not commit them.
 - **Example data** (`cellpy.utils.example_data`, e.g. `raw_file()`) downloads small
   fixtures from GitHub on first use, so those helpers need network access.
 - **Dual-repo dev** with a sibling `../cellpy-core` checkout is optional (see

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,11 @@
   by ≤ 2.1.5 keep the un-rebased raw; regenerate them from raw
   (`force_raw_file=True`). (#989)
 
+* `cellpy setup` creates missing configured local folders (including `raw/`)
+  on a re-run, not only on first-time `--reset`. Remote `OtherPath` URIs are
+  still skipped, and `setup -i` with an existing config no longer crashes on
+  `instrumentdir`. (#1037)
+
 ## [2.1.5] - 2026-09-09
 
 Patch release — docs on-ramp and How-do-I index (#1023),

--- a/cellpy/cli_api.py
+++ b/cellpy/cli_api.py
@@ -531,6 +531,21 @@ def _using_echo(echo: Optional[Echo] = None):
         _echo_var.reset(token)
 
 
+def _join_under_home(home, path):
+    """Join ``path`` onto ``home`` unless it is already a remote ``OtherPath``.
+
+    ``pathlib.Path / OtherPath`` stringifies the right-hand side. A remote
+    URI then becomes a junk local path (``~/sftp:/host/raw``) and would be
+    mkdir'd. Leave remotes untouched so ``_create_dir`` can skip them.
+    Absolute local paths are unchanged by ``home / path`` already.
+    """
+    from cellpy.internals.otherpath import OtherPath
+
+    if isinstance(path, OtherPath) and path.is_external:
+        return path
+    return home / path
+
+
 def _create_dir(path, confirm=True, parents=True, exist_ok=True):
     from cellpy.internals.otherpath import OtherPath
 
@@ -745,7 +760,7 @@ def _update_paths(
         notebookdir = pathlib.Path(config.paths.notebookdir)
         batchfiledir = pathlib.Path(config.paths.batchfiledir)
         templatedir = pathlib.Path(config.paths.templatedir)
-        instrumentdir = pathlib.Path(config.paths.instrumentsdir)
+        instrumentdir = pathlib.Path(config.paths.instrumentdir)
     else:
         outdatadir = "out"
         rawdatadir = "raw"
@@ -759,16 +774,16 @@ def _update_paths(
         templatedir = "templates"
         instrumentdir = "instruments"
 
-    outdatadir = h / outdatadir
-    rawdatadir = h / rawdatadir
-    cellpydatadir = h / cellpydatadir
-    filelogdir = h / filelogdir
-    examplesdir = h / examplesdir
-    db_path = h / db_path
-    notebookdir = h / notebookdir
-    batchfiledir = h / batchfiledir
-    templatedir = h / templatedir
-    instrumentdir = h / instrumentdir
+    outdatadir = _join_under_home(h, outdatadir)
+    rawdatadir = _join_under_home(h, rawdatadir)
+    cellpydatadir = _join_under_home(h, cellpydatadir)
+    filelogdir = _join_under_home(h, filelogdir)
+    examplesdir = _join_under_home(h, examplesdir)
+    db_path = _join_under_home(h, db_path)
+    notebookdir = _join_under_home(h, notebookdir)
+    batchfiledir = _join_under_home(h, batchfiledir)
+    templatedir = _join_under_home(h, templatedir)
+    instrumentdir = _join_under_home(h, instrumentdir)
 
     _debug(f"base directory: {h}")
 
@@ -1800,6 +1815,17 @@ def setup_config(
                     default_dir=folder_name,
                     dry_run=dry_run,
                     reset=True,
+                    interactive=False,
+                    silent=silent,
+                )
+            else:
+                # Existing config: still create any missing *configured*
+                # local folders (e.g. raw/). Do not pass custom_dir — that
+                # forces reset=True and would rebuild the default tree (#1037).
+                _update_paths(
+                    default_dir=folder_name,
+                    dry_run=dry_run,
+                    reset=False,
                     interactive=False,
                     silent=silent,
                 )

--- a/docs/getting_started/agents.md
+++ b/docs/getting_started/agents.md
@@ -373,7 +373,8 @@ Other measured knobs for a slow first batch load:
   never assume repo `testdata/` exists for end users.
 - **Committing secrets / local config** — `cellpy setup` writes
   `.env_cellpy` and a user `cellpy.toml` (legacy installs may still have
-  `~/.cellpy_prms_*.conf`); do not commit those.
+  `~/.cellpy_prms_*.conf`) and creates any missing configured local
+  folders (remote path URIs are skipped); do not commit those.
 - **Plot backends in headless CI** — set `MPLBACKEND=Agg` when running tests
   or batch plot export without a display.
 

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -24,11 +24,12 @@ Optional root folder for the directory tree:
 cellpy setup -i -d /Users/you/cellpy_data
 ```
 
-`cellpy setup` writes (or refreshes) a user **`cellpy.toml`**, tries to create
-the usual directory layout, and creates a `.env_cellpy` file for secrets /
-remote credentials (edit that file before using SSH remotes). It does **not**
-write a new legacy `.cellpy_prms_*.conf` — convert an existing one with
-`cellpy setup migrate`.
+`cellpy setup` writes (or refreshes) a user **`cellpy.toml`**, creates any
+missing *configured* local folders (including `raw/`), and creates a
+`.env_cellpy` file for secrets / remote credentials (edit that file before
+using SSH remotes). Remote `rawdatadir` / `cellpydatadir` URIs are left
+alone. It does **not** write a new legacy `.cellpy_prms_*.conf` — convert an
+existing one with `cellpy setup migrate`.
 
 Typical directories:
 
@@ -46,7 +47,9 @@ templates/
 ```
 
 !!! tip
-    Re-run setup after upgrading cellpy if paths or defaults changed.
+    Re-run setup after upgrading cellpy if paths or defaults changed. A
+    re-run creates any missing configured local folders. Use `--reset` to
+    rebuild the default `cellpy_data` tree (including `raw/`).
 
 Where is my config?
 

--- a/tests/test_cellpy_cmd.py
+++ b/tests/test_cellpy_cmd.py
@@ -440,6 +440,65 @@ def test_cli_setup_creates_dirs_and_files(isolated_user_dir):
     assert "CELLPY_PASSWORD" in env_path.read_text(encoding="utf-8")
 
 
+@pytest.mark.essential
+def test_cli_setup_rerun_creates_missing_raw(isolated_user_dir):
+    """A later ``cellpy setup`` used to skip mkdir when toml already existed (#1037)."""
+    runner = CliRunner()
+    test_user = "rerun_raw_user"
+    tmp_path = isolated_user_dir
+
+    first = runner.invoke(
+        cli.cli, ["setup", "--test_user", test_user, "--silent"]
+    )
+    assert first.exit_code == 0
+
+    raw = tmp_path / "cellpy_data" / "raw"
+    assert raw.is_dir()
+    raw.rmdir()
+    assert not raw.exists()
+
+    second = runner.invoke(
+        cli.cli, ["setup", "--test_user", test_user, "--silent"]
+    )
+    assert second.exit_code == 0
+    assert raw.is_dir(), "re-run setup must create a missing configured raw/"
+
+
+@pytest.mark.essential
+def test_cli_setup_does_not_mkdir_remote_raw(isolated_user_dir):
+    """Remote rawdatadir must stay a no-op, not become ~/sftp:/… (#1037)."""
+    from cellpy.internals.otherpath import OtherPath
+
+    tmp_path = isolated_user_dir
+    (tmp_path / "cellpy.toml").write_text("[paths]\n", encoding="utf-8")
+    remote = "sftp://example.invalid/data/raw"
+    config.paths.rawdatadir = remote
+
+    result = CliRunner().invoke(
+        cli.cli, ["setup", "--test_user", "remote_raw_user", "--silent"]
+    )
+    assert result.exit_code == 0
+    assert OtherPath(config.paths.rawdatadir).is_external
+    junk = [p for p in tmp_path.rglob("*") if "sftp:" in p.as_posix()]
+    assert junk == [], f"setup mkdir'd a remote URI locally: {junk}"
+
+
+@pytest.mark.essential
+def test_cli_setup_interactive_existing_config_uses_instrumentdir(
+    isolated_user_dir,
+):
+    """Non-reset ``-i`` read ``instrumentsdir`` and crashed (#1037)."""
+    tmp_path = isolated_user_dir
+    (tmp_path / "cellpy.toml").write_text("[paths]\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli.cli,
+        ["setup", "-i", "--dry-run", "--test_user", "typo_user"],
+        input=NUMBER_OF_DIRS * "\n",
+    )
+    assert result.exit_code == 0, result.exception
+
+
 @pytest.mark.slowtest
 def test_cli_new_list():
     logging.debug("\nSTARTING TEST")


### PR DESCRIPTION
## Summary
- `cellpy setup` with an existing `cellpy.toml` used to skip directory creation, so an experienced user could end up with no `raw/` folder.
- A re-run now creates any missing *configured* local folders. `--reset` / first-time still builds the default `cellpy_data` tree.
- Remote `OtherPath` URIs are not mkdir'd locally. `setup -i` with an existing config no longer crashes on `instrumentdir`.

## Test plan
- [x] `uv run pytest tests/test_cellpy_cmd.py tests/test_cli_setup_output.py -m essential`
- [x] `uv run pytest -m essential` (858 passed)
- [ ] CI essential + Linux full suite

Closes #1037


Made with [Cursor](https://cursor.com)