### PR TITLE
Document how [db_cols] maps cellpy names to Excel headers

### DIFF
--- a/.issueflows/03-solved-issues/issue1038_original.md
+++ b/.issueflows/03-solved-issues/issue1038_original.md
@@ -1,0 +1,7 @@
+# Issue #1038: old excel db col renamed
+
+Source: https://github.com/jepegit/cellpy/issues/1038
+
+## Original issue text
+
+Is it properly documented how the settings in the config (toml) file guides the user to set correct header names?

--- a/.issueflows/03-solved-issues/issue1038_plan.md
+++ b/.issueflows/03-solved-issues/issue1038_plan.md
@@ -1,0 +1,89 @@
+# Issue #1038 — plan
+
+## Goal
+
+Answer the issue: yes, `[db_cols]` in `cellpy.toml` is how you map cellpy's
+internal names onto whatever headers your Excel sheet actually uses — and
+make that obvious with a worked example. An old workbook whose columns were
+renamed should work by editing those strings, not by renaming the sheet back.
+
+## Constraints
+
+- Docs (and maybe a one-line model docstring). No reader/code behaviour
+  change unless we find a real mapping bug while writing the example.
+- Do **not** hand-edit `configuration_reference.md` — it is generated
+  (`uv run python -m cellpy.config.reference`). The generator uses only the
+  **first line** of each section model's docstring.
+- Keep the batch-database column table on the *default sheet names*
+  (`cell`, `mass_active_material`, …). The remap story sits next to it, not
+  instead of it.
+
+### Prior art
+
+- [`docs/guides/batch_database.md`](../../docs/guides/batch_database.md) —
+  sheet layout and the one-liner that `[db_cols]` is configurable; no toml
+  example, no “I renamed a column” walkthrough.
+- [`docs/getting_started/configuration.md`](../../docs/getting_started/configuration.md)
+  — example toml has `[paths]` / `[reader]` only.
+- [`docs/getting_started/configuration_reference.md`](../../docs/getting_started/configuration_reference.md)
+  `## db_cols` — key → default header table; no left-vs-right explanation.
+- [`DbColsConfig`](../../cellpy/config/models.py) — left-hand keys are
+  cellpy names; values are the Excel header strings.
+- [`docs/how_do_i.md`](../../docs/how_do_i.md) — “set up the database”
+  points at the guide; no “my column names differ / I renamed a column”.
+- Toolbox + graph: none (`00-tools/` is AST/header scanners; no
+  `GRAPH_REPORT.md`).
+
+## Approach
+
+1. **Confirm the mapping.** Key in `[db_cols]` = cellpy field
+   (`cell_name`, `mass_active`, `file_name_indicator`, …). Value = exact
+   header string in row 1 of the sheet. Defaults already match the example
+   workbook (`cell_name = "cell"`).
+2. **Worked toml** in `configuration.md` next to the existing example:
+
+   ```toml
+   [db_cols]
+   cell_name = "sample"                 # sheet header used to be "cell"
+   file_name_indicator = "raw_stem"
+   mass_active = "mass_active_material" # default; omit if unchanged
+   ```
+
+3. **`batch_database.md`** — short subsection after “The columns that
+   actually matter”: if you renamed (or never used) a default header, set
+   `[db_cols]` rather than editing every notebook. Point at the toml
+   example. Keep the existing missing-header warning note.
+4. **`how_do_i.md`** — one question under “Work on many cells”:
+   “…use a spreadsheet whose column names are not the defaults?”
+5. **`DbColsConfig` docstring first line** — only if we can say the
+   left/right rule in one sentence without breaking the generated table
+   (optional; the how-to is the user-facing fix).
+6. **Agents** — one line in `agents.md` / `AGENTS.md` only if the public
+   “how do I point batch at my sheet” recipe changes (likely just the
+   how-do-I link).
+
+## Files to touch
+
+- [`docs/getting_started/configuration.md`](../../docs/getting_started/configuration.md)
+- [`docs/guides/batch_database.md`](../../docs/guides/batch_database.md)
+- [`docs/how_do_i.md`](../../docs/how_do_i.md)
+- Optionally [`cellpy/config/models.py`](../../cellpy/config/models.py)
+  (`DbColsConfig.__doc__` first line) + regenerate the reference if that
+  line changes.
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_config_secrets.py::test_configuration_reference_matches_the_models -m essential
+uv run pytest -m essential
+```
+
+No new Python tests unless the docstring/reference is regenerated. Docs
+preview locally with `uv run --group docs zensical serve` if a page looks
+off.
+
+## Open questions
+
+- The issue does not name *which* column was renamed. The plan treats it
+  as the general remap story. If you have the old and new header strings,
+  put them in the example instead of the placeholders above.

--- a/.issueflows/03-solved-issues/issue1038_status.md
+++ b/.issueflows/03-solved-issues/issue1038_status.md
@@ -1,0 +1,15 @@
+# Issue #1038 — status
+
+- [x] Done
+
+## What's done
+
+- `[db_cols]` example in `configuration.md`.
+- “If you renamed a column” in `batch_database.md`.
+- How-do-I question under “Work on many cells”.
+- `DbColsConfig` docstring + regenerated `configuration_reference.md`.
+- `uv run pytest -m essential`: 858 passed, 70 skipped.
+
+## Remaining work
+
+- None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,11 @@
   still skipped, and `setup -i` with an existing config no longer crashes on
   `instrumentdir`. (#1037)
 
+* Docs: `[db_cols]` in `cellpy.toml` maps cellpy field names to the Excel
+  db's row-1 headers, so a renamed (or never-default) column is a config
+  edit rather than a sheet rewrite. Worked snippet, batch-database
+  subsection, and a How-do-I entry. (#1038)
+
 ## [2.1.5] - 2026-09-09
 
 Patch release — docs on-ramp and How-do-I index (#1023),

--- a/cellpy/config/models.py
+++ b/cellpy/config/models.py
@@ -131,7 +131,7 @@ class DbConfig(BaseModel):
 
 
 class DbColsConfig(BaseModel):
-    """Column names for the simple excel database reader."""
+    """Maps cellpy field names to Excel header strings for the simple reader."""
 
     id: str = "id"
     exists: str = "exists"

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -116,10 +116,22 @@ env_file = "/home/you/.env_cellpy"
 [reader]
 cycle_mode = "anode"
 sep = ";"
+
+# Left-hand keys are cellpy's names; values are the exact headers in row 1
+# of your Excel db. Omit any key whose sheet header still matches the default.
+[db_cols]
+cell_name = "sample"                  # sheet used to say "cell"
+file_name_indicator = "raw_stem"
+mass_active = "mass_active_material"  # default — you can leave this out
 ```
 
 `rawdatadir` (and optionally `cellpydatadir`) may be a remote URI — see
 [Work with remote files](remote_paths.md).
+
+If you renamed a column in an older workbook, point `[db_cols]` at the new
+header instead of renaming the sheet back. The full key list is under
+[`db_cols`](configuration_reference.md#db_cols). How the sheet is read:
+[Set up the cellpy database](../guides/batch_database.md).
 
 ## Runtime overrides
 

--- a/docs/getting_started/configuration_reference.md
+++ b/docs/getting_started/configuration_reference.md
@@ -95,7 +95,7 @@ Settings for the simple database.
 
 ## db_cols
 
-Column names for the simple excel database reader.
+Maps cellpy field names to Excel header strings for the simple reader.
 
 | Setting | Type | Default |
 | --- | --- | --- |

--- a/docs/guides/batch_database.md
+++ b/docs/guides/batch_database.md
@@ -72,6 +72,30 @@ own lab or reserved for later. Leaving them blank is fine.
     for half cells and `full_cell` for full cells — not a material name. See
     [Units, mass, area and C-rates](units.md) for what it changes.
 
+## If you renamed a column
+
+The table above uses the **default sheet headers** (what the example
+workbook ships). Those strings are not hard-coded. `[db_cols]` in
+`cellpy.toml` maps each *cellpy field* (left) to the *header in row 1*
+(right):
+
+```toml
+[db_cols]
+cell_name = "sample"      # you renamed "cell" → "sample"
+file_name_indicator = "raw_stem"
+```
+
+You do not have to rename the sheet back, or edit notebooks that call
+`batch.load`. Only list the columns that differ; omitted keys keep the
+defaults (`cell_name` → `cell`, `mass_active` → `mass_active_material`,
+…). Full table:
+[configuration reference — db_cols](../getting_started/configuration_reference.md#db_cols).
+A worked snippet lives in
+[Setup and configuration](../getting_started/configuration.md#example-cellpytoml).
+
+A configured header that is missing from the sheet warns once and comes
+back empty rather than failing the load.
+
 ## Batch columns — how cells are grouped into a batch
 
 `b01` through `b07` are seven independent selectors, so the same cell can

--- a/docs/how_do_i.md
+++ b/docs/how_do_i.md
@@ -314,6 +314,17 @@ b.summaries.to_pandas().to_excel("summaries.xlsx")
 **…set up the database the batch utility reads?**
 → [Set up the cellpy database](guides/batch_database.md)
 
+**…use a spreadsheet whose column names are not the defaults?**
+
+```toml
+[db_cols]
+cell_name = "sample"              # cellpy field = your Excel header
+file_name_indicator = "raw_stem"
+```
+
+→ [If you renamed a column](guides/batch_database.md#if-you-renamed-a-column)
+and the [`[db_cols]` example](getting_started/configuration.md#example-cellpytoml)
+
 **…load a batch?**
 
 ```python


### PR DESCRIPTION
## Summary
- `[db_cols]` in `cellpy.toml` maps cellpy field names (left) to the Excel db's row-1 headers (right). A renamed column is a config edit, not a sheet rewrite.
- Worked snippet in Setup and configuration, a subsection on the batch-database guide, and a How-do-I question.
- `DbColsConfig` docstring regenerated into the configuration reference.

## Test plan
- [x] `uv run pytest tests/test_config_secrets.py::test_configuration_reference_matches_the_models -m essential`
- [x] `uv run pytest -m essential` (858 passed)
- [ ] CI essential + docs build

Closes #1038


Made with [Cursor](https://cursor.com)